### PR TITLE
Split --shell zsh into two strings for system call

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ brew:
     bin.install "stripe"
     rm Dir["#{bin}/{stripe-completion.bash,stripe-completion.zsh}"]
     system bin/"stripe", "completion"
-    system bin/"stripe", "completion", "--shell zsh"
+    system bin/"stripe", "completion", "--shell", "zsh"
     bash_completion.install "stripe-completion.bash"
     zsh_completion.install "stripe-completion.zsh"
     (zsh_completion/"_stripe").write <<~EOS


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Fixes an issue with the goreleaser zsh completion command, the system call should be two strings instead of one.
