### PR TITLE
Remove config log that displays if you don't have a config setup

### DIFF
--- a/profile/profile.go
+++ b/profile/profile.go
@@ -139,7 +139,5 @@ func (p *Profile) InitConfig() {
 			"prefix": "profile.Profile.InitConfig",
 			"path":   viper.ConfigFileUsed(),
 		}).Debug("Using config file")
-	} else {
-		log.Error(err)
 	}
 }


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
This would print out an error message whenever someone ran a cold `stripe configure` saying that the configure file was missing. This wasn't particularly helpful and might cause confusion since there's not going to be a config file.
