### PR TITLE
Allow restricted API keys

### DIFF
--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -35,7 +35,7 @@ func TestAPIKeyInputEmpty(t *testing.T) {
 func TestAPIKeyInputLivemode(t *testing.T) {
 	expectedKey := ""
 	livemodeKey := "sk_live_foo123"
-	expectedErrorString := "the CLI only supports using a test mode secret key"
+	expectedErrorString := "the CLI only supports using a test mode key"
 
 	cc := newConfigureCmd()
 	keyInput := strings.NewReader(livemodeKey + "\n")

--- a/validators/validate.go
+++ b/validators/validate.go
@@ -16,8 +16,12 @@ func APIKey(input string) error {
 		return errors.New("you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
 	}
 
-	if keyParts[0] != "sk" || keyParts[1] != "test" {
-		return errors.New("the CLI only supports using a test mode secret key")
+	if keyParts[0] != "sk" && keyParts[0] != "rk" {
+		return errors.New("the CLI only supports using a secret or restricted key")
+	}
+
+	if keyParts[1] != "test" {
+		return errors.New("the CLI only supports using a test mode key")
 	}
 
 	return nil

--- a/validators/validate_test.go
+++ b/validators/validate_test.go
@@ -11,12 +11,22 @@ func TestLegacyAPIKeys(t *testing.T) {
 	assert.EqualError(t, err, "you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
 }
 
+func TestPublishableAPIKey(t *testing.T) {
+	err := APIKey("pk_test_12345")
+	assert.EqualError(t, err, "the CLI only supports using a secret or restricted key")
+}
+
 func TestLivemodeAPIKey(t *testing.T) {
 	err := APIKey("sk_live_12345")
-	assert.EqualError(t, err, "the CLI only supports using a test mode secret key")
+	assert.EqualError(t, err, "the CLI only supports using a test mode key")
 }
 
 func TestTestmodeAPIKey(t *testing.T) {
 	err := APIKey("sk_test_12345")
+	assert.Nil(t, err)
+}
+
+func TestTestmodeRestrictedAPIKey(t *testing.T) {
+	err := APIKey("rk_test_12345")
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
 ### Reviewers
r? @jmuia-stripe @brandonl-stripe 
cc @stripe/dev-platform

 ### Summary
Allow restricted API keys to be used with the CLI. Restricted API keys start with `rk_` instead of `sk_` for secret API keys.