### PR TITLE
Update README and fix interactive prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,29 +45,29 @@ export HOMEBREW_GITHUB_API_TOKEN=foobar
 
 ## Commands
 
-### `configure`
+### `login`
 
 The Stripe CLI runs commands using a global configuration or project-specific configuration. To configure the CLI globally, run:
 
-    $ stripe configure
+    $ stripe login
 
-It’ll prompt you for some information:
-
-    $ stripe configure
-    Enter your test mode secret API key: sk_test_foobar
-    How would you like to identify this machine in the Stripe Dashboard? [default: st-tomer1]
-    You're configured and all set to get started
+You'll be redirected to the Stripe dashboard to confirm that you want to give access to your account to the CLI. After confirming, a new API key will be created and returned to the CLI.
 
 You can create project-specific configurations with the `--project-name` flag, which can be used in any context. To create an initial configuration:
 
-    $ stripe configure --project-name=rocket-rides
-    Enter your test mode secret API key: sk_test_foobar
-    How would you like to identify this machine in the Stripe Dashboard? [default: st-tomer1]
-    You're configured and all set to get started:
+    $ stripe login --project-name=rocket-rides
 
 If you do not provide the `--project-name` flag for a command, it will default to the global configuration.
 
 All configurations are stored in `~/.config/stripe/config.toml` but you can use the `[XDG_CONFIG_HOME](https://wiki.archlinux.org/index.php/XDG_Base_Directory)` environment variable to override this location.
+
+You can also provide an API key manually by passing the `--interactive` flag:
+
+    $ stripe login --interactive
+    Enter your API key: sk_test_foobar
+    Your API key is: sk_test_**obar
+    How would you like to identify this device in the Stripe Dashboard? [default: st-tomer1]
+    You're configured and all set to get started
 
 ### `listen`
 

--- a/pkg/login/interactive_login.go
+++ b/pkg/login/interactive_login.go
@@ -37,13 +37,14 @@ func InteractiveLogin(profile profile.Profile) error {
 }
 
 func getConfigureAPIKey(input io.Reader) (string, error) {
+	fmt.Print("Enter your API key: ")
 	apiKey, err := securePrompt(input)
 	if err != nil {
 		return "", err
 	}
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
-		return "", errors.New("API key is required, please provide your test mode secret API key")
+		return "", errors.New("API key is required, please provide your API key")
 	}
 	err = validators.APIKey(apiKey)
 	if err != nil {

--- a/pkg/login/interactive_login_test.go
+++ b/pkg/login/interactive_login_test.go
@@ -20,7 +20,7 @@ func TestAPIKeyInput(t *testing.T) {
 
 func TestAPIKeyInputEmpty(t *testing.T) {
 	expectedKey := ""
-	expectedErrorString := "API key is required, please provide your test mode secret API key"
+	expectedErrorString := "API key is required, please provide your API key"
 
 	keyInput := strings.NewReader(expectedKey + "\n")
 	actualKey, err := getConfigureAPIKey(keyInput)


### PR DESCRIPTION
 ### Reviewers
r? @aarongreen-stripe @brandur-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
- Update the README file to document `login` as the primary configuration method
- Fix the interactive configuration (i.e. the old way) by adding a missing prompt (that got lost at some point during the implementation of the web login flow) and remove mentions of "test mode" and "secret" (because the CLI can also be used with restricted API keys, and will at some point support live mode keys)
