### PR TITLE
Prefers http package consts instead of raw strings for HTTP methods

### DIFF
--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"net/http"
 
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -14,7 +15,7 @@ type deleteCmd struct {
 func newDeleteCmd() *deleteCmd {
 	gc := &deleteCmd{}
 
-	gc.reqs.Method = "DELETE"
+	gc.reqs.Method = http.MethodDelete
 	gc.reqs.Profile = Profile
 	gc.reqs.Cmd = &cobra.Command{
 		Use:   "delete",

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"net/http"
 
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -14,7 +15,7 @@ type getCmd struct {
 func newGetCmd() *getCmd {
 	gc := &getCmd{}
 
-	gc.reqs.Method = "GET"
+	gc.reqs.Method = http.MethodGet
 	gc.reqs.Profile = Profile
 	gc.reqs.Cmd = &cobra.Command{
 		Use:   "get",

--- a/pkg/cmd/post.go
+++ b/pkg/cmd/post.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"net/http"
 
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -14,7 +15,7 @@ type postCmd struct {
 func newPostCmd() *postCmd {
 	gc := &postCmd{}
 
-	gc.reqs.Method = "POST"
+	gc.reqs.Method = http.MethodPost
 	gc.reqs.Profile = Profile
 	gc.reqs.Cmd = &cobra.Command{
 		Use:   "post",

--- a/pkg/endpoint/client.go
+++ b/pkg/endpoint/client.go
@@ -66,7 +66,7 @@ func (c *Client) Post(webhookID string, body string, headers map[string]string) 
 		"prefix": "endpoint.Client.Post",
 	}).Debug("Forwarding event to local endpoint")
 
-	req, err := http.NewRequest("POST", c.URL, bytes.NewBuffer([]byte(body)))
+	req, err := http.NewRequest(http.MethodPost, c.URL, bytes.NewBuffer([]byte(body)))
 	if err != nil {
 		return err
 	}

--- a/pkg/endpoint/client_test.go
+++ b/pkg/endpoint/client_test.go
@@ -21,7 +21,7 @@ func TestClientHandler(t *testing.T) {
 		reqBody, err := ioutil.ReadAll(r.Body)
 		assert.Nil(t, err)
 
-		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "TestAgent/v1", r.UserAgent())
 		assert.Equal(t, "t=123,v1=hunter2", r.Header.Get("Stripe-Signature"))
 		assert.Equal(t, "{}", string(reqBody))

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -111,7 +111,7 @@ func getLinks(baseURL string, deviceName string) (*Links, error) {
 	data := url.Values{}
 	data.Set("device_name", deviceName)
 
-	res, err := client.PerformRequest("POST", stripeCLIAuthPath, data, nil)
+	res, err := client.PerformRequest(http.MethodPost, stripeCLIAuthPath, data, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/login/client_login_test.go
+++ b/pkg/login/client_login_test.go
@@ -79,7 +79,7 @@ func TestGetLinks(t *testing.T) {
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
 
 		assert.NoError(t, r.ParseForm())
@@ -98,7 +98,7 @@ func TestGetLinks(t *testing.T) {
 
 func TestGetLinksHTTPStatusError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -122,7 +122,7 @@ func TestGetLinksRequestError(t *testing.T) {
 
 func TestGetLinksParseError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
 
 		w.WriteHeader(http.StatusOK)

--- a/pkg/login/poll.go
+++ b/pkg/login/poll.go
@@ -44,7 +44,7 @@ func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (string
 
 	var count = 0
 	for count < maxAttempts {
-		res, err := client.PerformRequest("GET", parsedURL.Path, parsedURL.Query(), nil)
+		res, err := client.PerformRequest(http.MethodGet, parsedURL.Path, parsedURL.Query(), nil)
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/login/poll_test.go
+++ b/pkg/login/poll_test.go
@@ -15,7 +15,7 @@ func TestRedeemed(t *testing.T) {
 	var attempts uint64
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, http.MethodGet, r.Method)
 
 		atomic.AddUint64(&attempts, 1)
 
@@ -44,7 +44,7 @@ func TestExceedMaxAttempts(t *testing.T) {
 	var attempts uint64
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, http.MethodGet, r.Method)
 
 		atomic.AddUint64(&attempts, 1)
 
@@ -68,7 +68,7 @@ func TestHTTPStatusError(t *testing.T) {
 	var attempts uint64
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, http.MethodGet, r.Method)
 
 		atomic.AddUint64(&attempts, 1)
 

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -46,7 +46,7 @@ type Base struct {
 
 var parameters RequestParameters
 
-var confirmationCommands = map[string]bool{"DELETE": true}
+var confirmationCommands = map[string]bool{http.MethodDelete: true}
 
 // RunRequestsCmd is the interface exposed for the CLI to run network requests through
 func (rb *Base) RunRequestsCmd(cmd *cobra.Command, args []string) error {
@@ -85,7 +85,7 @@ func (rb *Base) InitFlags() {
 	rb.Cmd.Flags().BoolVarP(&rb.autoConfirm, "confirm", "c", false, "Automatically confirm the command being entered. WARNING: This will result in NOT being prompted for confirmation for certain commands")
 
 	// Conditionally add flags for GET requests. I'm doing it here to keep `limit`, `start_after` and `ending_before` unexported
-	if rb.Method == "GET" {
+	if rb.Method == http.MethodGet {
 		rb.Cmd.Flags().StringVarP(&parameters.limit, "limit", "l", "", "A limit on the number of objects to be returned, between 1 and 100 (default is 10)")
 		rb.Cmd.Flags().StringVarP(&parameters.startingAfter, "starting-after", "a", "", "Retrieve the next page in the list. This is a cursor for pagination and should be an object ID")
 		rb.Cmd.Flags().StringVarP(&parameters.endingBefore, "ending-before", "b", "", "Retrieve the previous page in the list. This is a cursor for pagination and should be an object ID")
@@ -160,7 +160,7 @@ func (rb *Base) buildDataForRequest(params *RequestParameters) (url.Values, erro
 		}
 	}
 
-	if rb.Method == "GET" {
+	if rb.Method == http.MethodGet {
 		if params.limit != "" {
 			data.Add("limit", params.limit)
 		}
@@ -188,7 +188,7 @@ func (rb *Base) formatHeaders(response *http.Response) string {
 func (rb *Base) setIdempotencyHeader(request *http.Request, params *RequestParameters) {
 	if params.idempotency != "" {
 		request.Header.Set("Idempotency-Key", params.idempotency)
-		if rb.Method == "GET" || rb.Method == "DELETE" {
+		if rb.Method == http.MethodGet || rb.Method == http.MethodDelete {
 			warning := fmt.Sprintf(
 				"Warning: sending an idempotency key with a %s request has no effect and should be avoided, as %s requests are idempotent by definition.",
 				rb.Method,

--- a/pkg/requests/base_test.go
+++ b/pkg/requests/base_test.go
@@ -41,7 +41,7 @@ func TestBuildDataForRequestExpand(t *testing.T) {
 
 func TestBuildDataForRequestPagination(t *testing.T) {
 	rb := Base{}
-	rb.Method = "GET"
+	rb.Method = http.MethodGet
 
 	params := &RequestParameters{
 		limit:         "10",
@@ -58,7 +58,7 @@ func TestBuildDataForRequestPagination(t *testing.T) {
 
 func TestBuildDataForRequestGetOnly(t *testing.T) {
 	rb := Base{}
-	rb.Method = "POST"
+	rb.Method = http.MethodPost
 
 	params := &RequestParameters{
 		limit:         "10",
@@ -91,7 +91,7 @@ func TestMakeRequest(t *testing.T) {
 		reqBody, err := ioutil.ReadAll(r.Body)
 		assert.Nil(t, err)
 
-		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/foo/bar", r.URL.Path)
 		assert.Equal(t, "Bearer sk_test_1234", r.Header.Get("Authorization"))
 		assert.NotEmpty(t, r.UserAgent())
@@ -102,7 +102,7 @@ func TestMakeRequest(t *testing.T) {
 	defer ts.Close()
 
 	rb := Base{APIBaseURL: ts.URL}
-	rb.Method = "GET"
+	rb.Method = http.MethodGet
 
 	params := &RequestParameters{
 		data:   []string{"bender=robot", "fry=human"},
@@ -142,7 +142,7 @@ func TestGetUserConfirmationRequired(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader("yes\n"))
 
 	rb := Base{}
-	rb.Method = "DELETE"
+	rb.Method = http.MethodDelete
 	rb.autoConfirm = false
 
 	confirmed, err := rb.getUserConfirmation(reader)
@@ -154,7 +154,7 @@ func TestGetUserConfirmationNotRequired(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader(""))
 
 	rb := Base{}
-	rb.Method = "GET"
+	rb.Method = http.MethodGet
 	rb.autoConfirm = false
 
 	confirmed, err := rb.getUserConfirmation(reader)
@@ -166,7 +166,7 @@ func TestGetUserConfirmationAutoConfirm(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader(""))
 
 	rb := Base{}
-	rb.Method = "DELETE"
+	rb.Method = http.MethodDelete
 	rb.autoConfirm = true
 
 	confirmed, err := rb.getUserConfirmation(reader)
@@ -178,7 +178,7 @@ func TestGetUserConfirmationNoConfirm(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader("blah\n"))
 
 	rb := Base{}
-	rb.Method = "DELETE"
+	rb.Method = http.MethodDelete
 	rb.autoConfirm = false
 
 	confirmed, err := rb.getUserConfirmation(reader)

--- a/pkg/requests/examples.go
+++ b/pkg/requests/examples.go
@@ -3,6 +3,7 @@ package requests
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/stripe/stripe-cli/pkg/profile"
 )
@@ -60,7 +61,7 @@ func (ex *Examples) performStripeRequest(req *Base, endpoint string, params *Req
 }
 
 func (ex *Examples) tokenCreated(card string) (map[string]interface{}, error) {
-	req, params := ex.buildRequest("POST", []string{
+	req, params := ex.buildRequest(http.MethodPost, []string{
 		fmt.Sprintf("card[number]=%s", card),
 		"card[exp_month]=12",
 		"card[exp_year]=2020",
@@ -76,7 +77,7 @@ func (ex *Examples) chargeCreated(card string, data []string) (map[string]interf
 	}
 	paymentSource := fmt.Sprintf("source=%s", paymentToken["id"])
 
-	req, params := ex.buildRequest("POST", append(data, paymentSource))
+	req, params := ex.buildRequest(http.MethodPost, append(data, paymentSource))
 	return ex.performStripeRequest(req, "/v1/charges", params)
 }
 
@@ -93,7 +94,7 @@ func (ex *Examples) ChargeCaptured() error {
 		return err
 	}
 
-	req, params := ex.buildRequest("POST", []string{})
+	req, params := ex.buildRequest(http.MethodPost, []string{})
 	reqURL := fmt.Sprintf("/v1/charges/%s/capture", charge["id"])
 
 	_, err = ex.performStripeRequest(req, reqURL, params)
@@ -119,7 +120,7 @@ func (ex *Examples) ChargeSucceeded() error {
 }
 
 func (ex *Examples) customerCreated(data []string) (map[string]interface{}, error) {
-	req, params := ex.buildRequest("POST", data)
+	req, params := ex.buildRequest(http.MethodPost, data)
 	return ex.performStripeRequest(req, "/v1/customers", params)
 }
 
@@ -136,7 +137,7 @@ func (ex *Examples) CustomerUpdated() error {
 	if err != nil {
 		return err
 	}
-	req, params := ex.buildRequest("POST", []string{
+	req, params := ex.buildRequest(http.MethodPost, []string{
 		"metadata[foo]=bar",
 	})
 	reqURL := fmt.Sprintf("/v1/customers/%s", customer["id"])
@@ -157,7 +158,7 @@ func (ex *Examples) CustomerSourceCreated() error {
 		return err
 	}
 
-	req, params := ex.buildRequest("POST", []string{
+	req, params := ex.buildRequest(http.MethodPost, []string{
 		fmt.Sprintf("source=%s", token["id"]),
 	})
 
@@ -179,7 +180,7 @@ func (ex *Examples) CustomerSourceUpdated() error {
 		return err
 	}
 
-	req, params := ex.buildRequest("POST", []string{
+	req, params := ex.buildRequest(http.MethodPost, []string{
 		fmt.Sprintf("source=%s", token["id"]),
 	})
 
@@ -189,7 +190,7 @@ func (ex *Examples) CustomerSourceUpdated() error {
 		return err
 	}
 
-	req, params = ex.buildRequest("POST", []string{
+	req, params = ex.buildRequest(http.MethodPost, []string{
 		"metadata[foo]=bar",
 	})
 	reqURL = fmt.Sprintf("/v1/customers/%s/sources/%s", customer["id"], card["id"])
@@ -212,7 +213,7 @@ func (ex *Examples) CustomerSubscriptionUpdated() error {
 		return err
 	}
 
-	req, params := ex.buildRequest("POST", []string{
+	req, params := ex.buildRequest(http.MethodPost, []string{
 		"currency=usd",
 		"interval=month",
 		"amount=2000",
@@ -223,7 +224,7 @@ func (ex *Examples) CustomerSubscriptionUpdated() error {
 		return err
 	}
 
-	req, params = ex.buildRequest("POST", []string{
+	req, params = ex.buildRequest(http.MethodPost, []string{
 		fmt.Sprintf("items[0][plan]=%s", plan["id"]),
 		fmt.Sprintf("customer=%s", customer["id"]),
 	})
@@ -232,7 +233,7 @@ func (ex *Examples) CustomerSubscriptionUpdated() error {
 		return err
 	}
 
-	req, params = ex.buildRequest("POST", []string{
+	req, params = ex.buildRequest(http.MethodPost, []string{
 		"metadata[foo]=bar",
 	})
 	reqURL := fmt.Sprintf("/v1/subscriptions/%s", subscription["id"])
@@ -241,12 +242,12 @@ func (ex *Examples) CustomerSubscriptionUpdated() error {
 }
 
 func (ex *Examples) createInvoiceItem(data []string) (map[string]interface{}, error) {
-	req, params := ex.buildRequest("POST", data)
+	req, params := ex.buildRequest(http.MethodPost, data)
 	return ex.performStripeRequest(req, "/v1/invoiceitems", params)
 }
 
 func (ex *Examples) invoiceCreated(data []string) (map[string]interface{}, error) {
-	req, params := ex.buildRequest("POST", data)
+	req, params := ex.buildRequest(http.MethodPost, data)
 	return ex.performStripeRequest(req, "/v1/invoices", params)
 }
 
@@ -301,7 +302,7 @@ func (ex *Examples) InvoiceFinalized() error {
 		return err
 	}
 
-	req, params := ex.buildRequest("POST", []string{})
+	req, params := ex.buildRequest(http.MethodPost, []string{})
 	reqURL := fmt.Sprintf("/v1/invoices/%s/finalize", invoice["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
 	return err
@@ -338,7 +339,7 @@ func (ex *Examples) InvoicePaymentSucceeded() error {
 		return err
 	}
 
-	req, params := ex.buildRequest("POST", []string{})
+	req, params := ex.buildRequest(http.MethodPost, []string{})
 	reqURL := fmt.Sprintf("/v1/invoices/%s/pay", invoice["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
 	return err
@@ -368,7 +369,7 @@ func (ex *Examples) InvoiceUpdated() error {
 		return err
 	}
 
-	req, params := ex.buildRequest("POST", []string{
+	req, params := ex.buildRequest(http.MethodPost, []string{
 		"metadata[foo]=bar",
 	})
 
@@ -378,7 +379,7 @@ func (ex *Examples) InvoiceUpdated() error {
 }
 
 func (ex *Examples) paymentIntentCreated(data []string) (map[string]interface{}, error) {
-	req, params := ex.buildRequest("POST", data)
+	req, params := ex.buildRequest(http.MethodPost, data)
 	return ex.performStripeRequest(req, "/v1/payment_intents", params)
 }
 
@@ -431,7 +432,7 @@ func (ex *Examples) PaymentIntentFailed() error {
 }
 
 func (ex *Examples) paymentMethodCreated(card string) (map[string]interface{}, error) {
-	req, params := ex.buildRequest("POST", []string{
+	req, params := ex.buildRequest(http.MethodPost, []string{
 		"type=card",
 		fmt.Sprintf("card[number]=%s", card),
 		"card[exp_month]=12",
@@ -454,7 +455,7 @@ func (ex *Examples) PaymentMethodAttached() error {
 		return err
 	}
 
-	req, params := ex.buildRequest("POST", []string{
+	req, params := ex.buildRequest(http.MethodPost, []string{
 		fmt.Sprintf("customer=%s", customer["id"]),
 	})
 	reqURL := fmt.Sprintf("/v1/payment_methods/%s/attach", paymentMethod["id"])
@@ -471,7 +472,7 @@ func (ex *Examples) WebhookEndpointsList() WebhookEndpointList {
 
 	base := &Base{
 		Profile:        ex.Profile,
-		Method:         "GET",
+		Method:         http.MethodGet,
 		SuppressOutput: true,
 	}
 	resp, _ := base.MakeRequest(ex.SecretKey, "/webhook_endpoints", params)

--- a/pkg/requests/examples_test.go
+++ b/pkg/requests/examples_test.go
@@ -31,10 +31,10 @@ func TestBuildRequest(t *testing.T) {
 		SecretKey:  "secret-key",
 	}
 
-	req, params := ex.buildRequest("POST", []string{"foo=bar"})
+	req, params := ex.buildRequest(http.MethodPost, []string{"foo=bar"})
 
 	assert.Equal(t, []string{"foo=bar"}, params.data)
-	assert.Equal(t, "POST", req.Method)
+	assert.Equal(t, http.MethodPost, req.Method)
 }
 
 func TestChargeCaptured(t *testing.T) {

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -43,7 +43,7 @@ func (c *Client) PerformRequest(method, path string, params url.Values, configur
 	url = c.BaseURL.ResolveReference(url)
 
 	var body io.Reader
-	if method == "POST" {
+	if method == http.MethodPost {
 		body = strings.NewReader(params.Encode())
 	} else {
 		url.RawQuery = params.Encode()

--- a/pkg/stripe/client_test.go
+++ b/pkg/stripe/client_test.go
@@ -30,7 +30,7 @@ func TestPerformRequest_ParamsEncoding_Delete(t *testing.T) {
 	params.Add("key_a", "value_a")
 	params.Add("key_b", "value_b")
 
-	_, err := client.PerformRequest("DELETE", "/delete", params, nil)
+	_, err := client.PerformRequest(http.MethodDelete, "/delete", params, nil)
 	assert.NoError(t, err)
 }
 
@@ -54,7 +54,7 @@ func TestPerformRequest_ParamsEncoding_Get(t *testing.T) {
 	params.Add("key_a", "value_a")
 	params.Add("key_b", "value_b")
 
-	_, err := client.PerformRequest("GET", "/get", params, nil)
+	_, err := client.PerformRequest(http.MethodGet, "/get", params, nil)
 	assert.NoError(t, err)
 }
 
@@ -78,7 +78,7 @@ func TestPerformRequest_ParamsEncoding_Post(t *testing.T) {
 	params.Add("key_a", "value_a")
 	params.Add("key_b", "value_b")
 
-	_, err := client.PerformRequest("POST", "/post", params, nil)
+	_, err := client.PerformRequest(http.MethodPost, "/post", params, nil)
 	assert.NoError(t, err)
 }
 
@@ -94,7 +94,7 @@ func TestPerformRequest_ApiKey_Provided(t *testing.T) {
 		APIKey:  "sk_test_1234",
 	}
 
-	_, err := client.PerformRequest("GET", "/get", nil, nil)
+	_, err := client.PerformRequest(http.MethodGet, "/get", nil, nil)
 	assert.NoError(t, err)
 }
 
@@ -109,7 +109,7 @@ func TestPerformRequest_ApiKey_Omitted(t *testing.T) {
 		BaseURL: baseURL,
 	}
 
-	_, err := client.PerformRequest("GET", "/get", nil, nil)
+	_, err := client.PerformRequest(http.MethodGet, "/get", nil, nil)
 	assert.NoError(t, err)
 }
 
@@ -124,7 +124,7 @@ func TestPerformRequest_ConfigureFunc(t *testing.T) {
 		BaseURL: baseURL,
 	}
 
-	_, err := client.PerformRequest("GET", "/get", nil, func(r *http.Request) {
+	_, err := client.PerformRequest(http.MethodGet, "/get", nil, func(r *http.Request) {
 		r.Header.Add("Stripe-Version", "2019-07-10")
 	})
 	assert.NoError(t, err)

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -54,7 +54,7 @@ func (c *Client) Authorize(deviceName string) (*StripeCLISession, error) {
 		APIKey:  c.apiKey,
 	}
 
-	resp, err := client.PerformRequest("POST", stripeCLISessionPath, form, nil)
+	resp, err := client.PerformRequest(http.MethodPost, stripeCLISessionPath, form, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -21,7 +21,7 @@ func TestAuthorize(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(session)
 
-		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "Bearer sk_test_123", r.Header.Get("Authorization"))
 		assert.NotEmpty(t, r.UserAgent())
 		assert.NotEmpty(t, r.Header.Get("X-Stripe-Client-User-Agent"))


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
This PR replaces raw strings that represent HTTP methods like "GET" and "POST" with the [consts defined in the http package](https://golang.org/pkg/net/http/#pkg-constants).

This allows for more programmatic determination of various call sites, and prevents typos or inconsistent casing in string literals from introducing bugs.
