### PR TITLE
Add customized login completion messages with user's display name

### DIFF
--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -57,7 +57,7 @@ func Login(baseURL string, profile profile.Profile, input io.Reader) error {
 	}
 
 	//Call poll function
-	apiKey, accountID, err := PollForKey(links.PollURL, 0, 0)
+	apiKey, account, err := PollForKey(links.PollURL, 0, 0)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,8 @@ func Login(baseURL string, profile profile.Profile, input io.Reader) error {
 		return configErr
 	}
 
-	ansi.StopSpinner(s, fmt.Sprintf("Done! The Stripe CLI is configured for account %s\n", color.Bold(accountID)), os.Stdout)
+
+	ansi.StopSpinner(s, SuccessMessage(account, stripe.DefaultAPIBaseURL, apiKey), os.Stdout)
 
 	return nil
 }

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -72,8 +72,12 @@ func Login(baseURL string, profile profile.Profile, input io.Reader) error {
 		return configErr
 	}
 
-
-	ansi.StopSpinner(s, SuccessMessage(account, stripe.DefaultAPIBaseURL, apiKey), os.Stdout)
+	message, err := SuccessMessage(account, stripe.DefaultAPIBaseURL, apiKey)
+	if err != nil {
+		fmt.Println(fmt.Sprintf("> Error verifying the CLI was setup successfully: %s", err))
+	} else {
+		ansi.StopSpinner(s, message, os.Stdout)
+	}
 
 	return nil
 }

--- a/pkg/login/client_login_test.go
+++ b/pkg/login/client_login_test.go
@@ -55,7 +55,7 @@ func TestLogin(t *testing.T) {
 
 			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
-			data := []byte(`{"redeemed":  true, "account_id": "acct_123", "testmode_key_secret": "sk_test_1234"}`)
+			data := []byte(`{"redeemed":  true, "account_id": "acct_123", "testmode_key_secret": "sk_test_1234", "display_name": "test_disp_name"}`)
 			fmt.Println(string(data))
 			w.Write(data)
 		} else {

--- a/pkg/login/client_login_test.go
+++ b/pkg/login/client_login_test.go
@@ -55,7 +55,7 @@ func TestLogin(t *testing.T) {
 
 			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
-			data := []byte(`{"redeemed":  true, "account_id": "acct_123", "testmode_key_secret": "sk_test_1234", "display_name": "test_disp_name"}`)
+			data := []byte(`{"redeemed":  true, "account_id": "acct_123", "testmode_key_secret": "sk_test_1234", "account_display_name": "test_disp_name"}`)
 			fmt.Println(string(data))
 			w.Write(data)
 		} else {

--- a/pkg/login/interactive_login.go
+++ b/pkg/login/interactive_login.go
@@ -35,7 +35,12 @@ func InteractiveLogin(profile profile.Profile) error {
 	// The '>' character is automatically included at the end of client login
 	// due to ansi spinner. Since no spinner is used with interactive login,
 	// we need to include it manually to maintain consistency in outputs.
-	fmt.Println(fmt.Sprintf("> %s", SuccessMessage(nil, stripe.DefaultAPIBaseURL, apiKey)))
+	message, err := SuccessMessage(nil, stripe.DefaultAPIBaseURL, apiKey)
+	if err != nil {
+		fmt.Println(fmt.Sprintf("> Error verifying the CLI was setup successfully: %s", err))
+	} else {
+		fmt.Println(fmt.Sprintf("> %s", message))
+	}
 
 	return nil
 }

--- a/pkg/login/interactive_login.go
+++ b/pkg/login/interactive_login.go
@@ -14,12 +14,12 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/profile"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
 // InteractiveLogin lets the user set configuration on the command line
 func InteractiveLogin(profile profile.Profile) error {
-
 	apiKey, err := getConfigureAPIKey(os.Stdin)
 	if err != nil {
 		return err
@@ -32,7 +32,10 @@ func InteractiveLogin(profile profile.Profile) error {
 		return configErr
 	}
 
-	fmt.Println("You're configured and all set to get started")
+	// The '>' character is automatically included at the end of client login
+	// due to ansi spinner. Since no spinner is used with interactive login,
+	// we need to include it manually to maintain consistency in outputs.
+	fmt.Println(fmt.Sprintf("> %s", SuccessMessage(nil, stripe.DefaultAPIBaseURL, apiKey)))
 
 	return nil
 }

--- a/pkg/login/login_message.go
+++ b/pkg/login/login_message.go
@@ -72,7 +72,7 @@ func getUserAccount(baseURL string, apiKey string) (*Account, error) {
 		APIKey: apiKey,
 	}
 
-	resp, err := client.PerformRequest("GET", "/v1/account", url.Values{}, nil)
+	resp, err := client.PerformRequest("GET", "/v1/account", "", nil)
 
 	if err != nil {
 		return nil, err

--- a/pkg/login/login_message.go
+++ b/pkg/login/login_message.go
@@ -27,13 +27,13 @@ type Dashboard struct {
 }
 
 // SuccessMessage returns the display message for a successfully authenticated user
-func SuccessMessage(account *Account, baseURL string, apiKey string) string {
+func SuccessMessage(account *Account, baseURL string, apiKey string) (string, error) {
 
 	// Account will be nil if user did interactive login
 	if account == nil {
 		acc, err := getUserAccount(baseURL, apiKey)
 		if err != nil {
-			return fmt.Sprintf("%s", err)
+			return "", err
 		}
 		account = acc
 	}
@@ -48,17 +48,17 @@ func SuccessMessage(account *Account, baseURL string, apiKey string) string {
 			"Done! The Stripe CLI is configured for %s with account id %s\n",
 			color.Bold(displayName),
 			color.Bold(accountID),
-		)
+		), nil
 	}
 
 	if accountID != "" {
 		return fmt.Sprintf(
 			"Done! The Stripe CLI is configured for your account with account id %s\n",
 			color.Bold(accountID),
-		)
+		), nil
 	}
 
-	return fmt.Sprintf("Done! The Stripe CLI is configured\n")
+	return fmt.Sprintf("Done! The Stripe CLI is configured\n"), nil
 }
 
 func getUserAccount(baseURL string, apiKey string) (*Account, error) {

--- a/pkg/login/login_message.go
+++ b/pkg/login/login_message.go
@@ -1,0 +1,90 @@
+package login
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"net/url"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/stripe"
+)
+
+// Account is the most outer layer of the json response from Stripe
+type Account struct {
+	ID string `json:"id"`
+	Settings Settings `json:"settings"`
+}
+
+// Settings is within the Account json response from Stripe
+type Settings struct {
+	Dashboard Dashboard `json:"dashboard"`
+}
+
+// Dashboard is within the Settings json response from Stripe
+type Dashboard struct {
+	DisplayName string `json:"display_name"`
+}
+
+// SuccessMessage returns the display message for a successfully authenticated user
+func SuccessMessage(account *Account, baseURL string, apiKey string) string {
+
+	// Account will be nil if user did interactive login
+	if account == nil {
+		acc, err := getUserAccount(baseURL, apiKey)
+		if err != nil {
+			return fmt.Sprintf("%s", err)
+		}
+		account = acc
+	}
+
+	color := ansi.Color(os.Stdout)
+
+	displayName := account.Settings.Dashboard.DisplayName
+	accountID := account.ID
+
+	if displayName != "" && accountID != "" {
+		return fmt.Sprintf(
+			"Done! The Stripe CLI is configured for %s with account id %s\n",
+			color.Bold(displayName),
+			color.Bold(accountID),
+		)
+	}
+
+	if accountID != "" {
+		return fmt.Sprintf(
+			"Done! The Stripe CLI is configured for your account with account id %s\n",
+			color.Bold(accountID),
+		)
+	}
+
+	return fmt.Sprintf("Done! The Stripe CLI is configured\n")
+}
+
+func getUserAccount(baseURL string, apiKey string) (*Account, error) {
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &stripe.Client{
+		BaseURL: parsedBaseURL,
+		APIKey: apiKey,
+	}
+
+	resp, err := client.PerformRequest("GET", "/v1/account", url.Values{}, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	account := &Account{}
+	err = json.NewDecoder(resp.Body).Decode(account)
+	if err != nil {
+		return nil, err
+	}
+
+	return account, nil
+}

--- a/pkg/login/login_message_test.go
+++ b/pkg/login/login_message_test.go
@@ -15,7 +15,8 @@ func TestSuccessMessage(t *testing.T) {
 	}
 	account.Settings.Dashboard.DisplayName = "test_disp_name"
 
-	msg := SuccessMessage(account, "", "sk_test_123")
+	msg, err := SuccessMessage(account, "", "sk_test_123")
+	assert.Nil(t, err)
 	assert.Equal(
 		t,
 		"Done! The Stripe CLI is configured for test_disp_name with account id acct_123\n",
@@ -28,7 +29,8 @@ func TestSuccessMessageNoDisplayName(t *testing.T) {
 		ID: "acct_123",
 	}
 
-	msg := SuccessMessage(account, "", "sk_test_123")
+	msg, err := SuccessMessage(account, "", "sk_test_123")
+	assert.Nil(t, err)
 	assert.Equal(
 		t,
 		"Done! The Stripe CLI is configured for your account with account id acct_123\n",
@@ -38,7 +40,8 @@ func TestSuccessMessageNoDisplayName(t *testing.T) {
 
 func TestSuccessMessageBasicMessage(t *testing.T) {
 	account := &Account{}
-	msg := SuccessMessage(account, "", "sk_test_123")
+	msg, err := SuccessMessage(account, "", "sk_test_123")
+	assert.Nil(t, err)
 	assert.Equal(
 		t,
 		"Done! The Stripe CLI is configured\n",
@@ -61,7 +64,8 @@ func TestSuccessMessageGetAccount(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := SuccessMessage(nil, ts.URL, "sk_test_123")
+	msg, err := SuccessMessage(nil, ts.URL, "sk_test_123")
+	assert.Nil(t, err)
 	assert.Equal(
 		t,
 		"Done! The Stripe CLI is configured for test_disp_name with account id acct_123\n",
@@ -83,7 +87,8 @@ func TestSuccessMessageGetAccountNoDisplayName(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := SuccessMessage(nil, ts.URL, "sk_test_123")
+	msg, err := SuccessMessage(nil, ts.URL, "sk_test_123")
+	assert.Nil(t, err)
 	assert.Equal(
 		t,
 		"Done! The Stripe CLI is configured for your account with account id acct_123\n",

--- a/pkg/login/login_message_test.go
+++ b/pkg/login/login_message_test.go
@@ -1,0 +1,92 @@
+package login
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuccessMessage(t *testing.T) {
+	account := &Account{
+		ID: "acct_123",
+	}
+	account.Settings.Dashboard.DisplayName = "test_disp_name"
+
+	msg := SuccessMessage(account, "", "sk_test_123")
+	assert.Equal(
+		t,
+		"Done! The Stripe CLI is configured for test_disp_name with account id acct_123\n",
+		msg,
+	)
+}
+
+func TestSuccessMessageNoDisplayName(t *testing.T) {
+	account := &Account{
+		ID: "acct_123",
+	}
+
+	msg := SuccessMessage(account, "", "sk_test_123")
+	assert.Equal(
+		t,
+		"Done! The Stripe CLI is configured for your account with account id acct_123\n",
+		msg,
+	)
+}
+
+func TestSuccessMessageBasicMessage(t *testing.T) {
+	account := &Account{}
+	msg := SuccessMessage(account, "", "sk_test_123")
+	assert.Equal(
+		t,
+		"Done! The Stripe CLI is configured\n",
+		msg,
+	)
+}
+
+func TestSuccessMessageGetAccount(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+
+		account := &Account{
+			ID: "acct_123",
+		}
+		account.Settings.Dashboard.DisplayName = "test_disp_name"
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(account)
+	}))
+	defer ts.Close()
+
+	msg := SuccessMessage(nil, ts.URL, "sk_test_123")
+	assert.Equal(
+		t,
+		"Done! The Stripe CLI is configured for test_disp_name with account id acct_123\n",
+		msg,
+	)
+}
+
+func TestSuccessMessageGetAccountNoDisplayName(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+
+		account := &Account{
+			ID: "acct_123",
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(account)
+	}))
+	defer ts.Close()
+
+	msg := SuccessMessage(nil, ts.URL, "sk_test_123")
+	assert.Equal(
+		t,
+		"Done! The Stripe CLI is configured for your account with account id acct_123\n",
+		msg,
+	)
+}

--- a/pkg/login/poll.go
+++ b/pkg/login/poll.go
@@ -18,11 +18,12 @@ const intervalDefault = 1 * time.Second
 type pollAPIKeyResponse struct {
 	Redeemed  bool   `json:"redeemed"`
 	AccountID string `json:"account_id"`
+	DisplayName string `json:"display_name"`
 	APIKey    string `json:"testmode_key_secret"`
 }
 
 // PollForKey polls Stripe at the specified interval until either the API key is available or we've reached the max attempts.
-func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (string, string, error) {
+func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (string, *Account, error) {
 	if maxAttempts == 0 {
 		maxAttempts = maxAttemptsDefault
 	}
@@ -33,7 +34,7 @@ func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (string
 
 	parsedURL, err := url.Parse(pollURL)
 	if err != nil {
-		return "", "", err
+		return "", nil, err
 	}
 
 	baseURL := &url.URL{Scheme: parsedURL.Scheme, Host: parsedURL.Host}
@@ -46,26 +47,32 @@ func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (string
 	for count < maxAttempts {
 		res, err := client.PerformRequest(http.MethodGet, parsedURL.Path, parsedURL.Query().Encode(), nil)
 		if err != nil {
-			return "", "", err
+			return "", nil, err
 		}
 
 		bodyBytes, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return "", "", err
+			return "", nil, err
 		}
 
 		if res.StatusCode != http.StatusOK {
-			return "", "", fmt.Errorf("unexpected http status code: %d %s", res.StatusCode, string(bodyBytes))
+			return "", nil, fmt.Errorf("unexpected http status code: %d %s", res.StatusCode, string(bodyBytes))
 		}
 
 		var response pollAPIKeyResponse
 		jsonErr := json.Unmarshal(bodyBytes, &response)
 		if jsonErr != nil {
-			return "", "", jsonErr
+			return "", nil, jsonErr
 		}
 
 		if response.Redeemed {
-			return response.APIKey, response.AccountID, nil
+			account := &Account{
+				ID: response.AccountID,
+			}
+
+			account.Settings.Dashboard.DisplayName = response.DisplayName
+
+			return response.APIKey, account, nil
 		}
 
 		count++
@@ -73,5 +80,5 @@ func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (string
 
 	}
 
-	return "", "", errors.New("exceeded max attempts")
+	return "", nil, errors.New("exceeded max attempts")
 }

--- a/pkg/login/poll.go
+++ b/pkg/login/poll.go
@@ -18,7 +18,7 @@ const intervalDefault = 1 * time.Second
 type pollAPIKeyResponse struct {
 	Redeemed  bool   `json:"redeemed"`
 	AccountID string `json:"account_id"`
-	DisplayName string `json:"display_name"`
+	AccountDisplayName string `json:"account_display_name"`
 	APIKey    string `json:"testmode_key_secret"`
 }
 
@@ -70,7 +70,7 @@ func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (string
 				ID: response.AccountID,
 			}
 
-			account.Settings.Dashboard.DisplayName = response.DisplayName
+			account.Settings.Dashboard.DisplayName = response.AccountDisplayName
 
 			return response.APIKey, account, nil
 		}

--- a/pkg/login/poll_test.go
+++ b/pkg/login/poll_test.go
@@ -25,7 +25,7 @@ func TestRedeemed(t *testing.T) {
 		if atomic.LoadUint64(&attempts) == 2 {
 			response.Redeemed = true
 			response.AccountID = "acct_123"
-			response.DisplayName = "test_disp_name"
+			response.AccountDisplayName = "test_disp_name"
 			response.APIKey = "sk_test_123"
 		}
 		w.WriteHeader(http.StatusOK)
@@ -89,10 +89,10 @@ func TestExceedMaxAttempts(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	apiKey, accountID, err := PollForKey(ts.URL, 1*time.Millisecond, 3)
+	apiKey, account, err := PollForKey(ts.URL, 1*time.Millisecond, 3)
 	assert.EqualError(t, err, "exceeded max attempts")
 	assert.Empty(t, apiKey)
-	assert.Empty(t, accountID)
+	assert.Empty(t, account)
 	assert.Equal(t, uint64(3), atomic.LoadUint64(&attempts))
 }
 
@@ -108,10 +108,10 @@ func TestHTTPStatusError(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	apiKey, accountID, err := PollForKey(ts.URL, 1*time.Millisecond, 3)
+	apiKey, account, err := PollForKey(ts.URL, 1*time.Millisecond, 3)
 	assert.EqualError(t, err, "unexpected http status code: 500 ")
 	assert.Empty(t, apiKey)
-	assert.Empty(t, accountID)
+	assert.Nil(t, account)
 	assert.Equal(t, uint64(1), atomic.LoadUint64(&attempts))
 }
 
@@ -120,9 +120,9 @@ func TestHTTPRequestError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	ts.Close()
 
-	apiKey, accountID, err := PollForKey(ts.URL, 1*time.Millisecond, 3)
+	apiKey, account, err := PollForKey(ts.URL, 1*time.Millisecond, 3)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "connect: connection refused")
 	assert.Empty(t, apiKey)
-	assert.Empty(t, accountID)
+	assert.Nil(t, account)
 }

--- a/pkg/login/poll_test.go
+++ b/pkg/login/poll_test.go
@@ -25,6 +25,7 @@ func TestRedeemed(t *testing.T) {
 		if atomic.LoadUint64(&attempts) == 2 {
 			response.Redeemed = true
 			response.AccountID = "acct_123"
+			response.DisplayName = "test_disp_name"
 			response.APIKey = "sk_test_123"
 		}
 		w.WriteHeader(http.StatusOK)
@@ -33,10 +34,41 @@ func TestRedeemed(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	apiKey, accountID, err := PollForKey(ts.URL, 1*time.Millisecond, 3)
+	apiKey, account, err := PollForKey(ts.URL, 1*time.Millisecond, 3)
 	assert.NoError(t, err)
 	assert.Equal(t, "sk_test_123", apiKey)
-	assert.Equal(t, "acct_123", accountID)
+	assert.Equal(t, "acct_123", account.ID)
+	assert.Equal(t, "test_disp_name", account.Settings.Dashboard.DisplayName)
+	assert.Equal(t, uint64(2), atomic.LoadUint64(&attempts))
+}
+
+func TestRedeemedNoDisplayName(t *testing.T) {
+	var attempts uint64
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+
+		atomic.AddUint64(&attempts, 1)
+
+		response := &pollAPIKeyResponse{
+			Redeemed: false,
+		}
+		if atomic.LoadUint64(&attempts) == 2 {
+			response.Redeemed = true
+			response.AccountID = "acct_123"
+			response.APIKey = "sk_test_123"
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer ts.Close()
+
+	apiKey, account, err := PollForKey(ts.URL, 1*time.Millisecond, 3)
+	assert.NoError(t, err)
+	assert.Equal(t, "sk_test_123", apiKey)
+	assert.Equal(t, "acct_123", account.ID)
+	assert.Equal(t, "", account.Settings.Dashboard.DisplayName)
 	assert.Equal(t, uint64(2), atomic.LoadUint64(&attempts))
 }
 


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Client side implementation for showing customized login completion messages when a user successfully authenticates with the CLI.

There is a linked [pay-server PR](https://git.corp.stripe.com/stripe-internal/pay-server/pull/160275) to send the display name with the authentication response. This is necessary since security asked that we authenticate with restricted keys, and there is a known permissions issue that restricted keys cannot be used to access account settings. This will allow web login to show the display name if available.

If a user does interactive login, we can show the display name if they use a secret key, otherwise we show only the account ID.

### Testing
Added automated tests in `login_message_test.go` and tested manually with the CLI.

### Motivation
[Jira Ticket](https://jira.corp.stripe.com/browse/DX-4394)
