### PR TITLE
Add terminal restoration on ctrl-c during interactive login to prevent hidden text

### DIFF
--- a/pkg/login/interactive_login.go
+++ b/pkg/login/interactive_login.go
@@ -98,11 +98,12 @@ func securePrompt(input io.Reader) (string, error) {
 		}
 
 		buf, err := terminal.ReadPassword(int(syscall.Stdin))
-		signal.Stop(signalChan)
-
 		if err != nil {
 			return "", err
 		}
+
+		signal.Stop(signalChan)
+
 		fmt.Print("\n")
 		return string(buf), nil
 	}


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Specifically within Bash (bug did not occur in zsh), when you ctrl-c to cancel on API key input (password-style inputs with hidden text), after the program terminates, command-line input is still hidden.

The commands can be written and run, but they will be visibly hidden in the command line.

It is a known issue with `terminal.ReadPassword` that terminal state is not restored on `SIGINT`. This provides our own handler for SIGINT to restore the terminal state.

Only visual difference is now when the user ctrl-c's to exit the CLI, the output looks like `Enter your API key: exit status 1` (where the `exit status 1` is new).

### Motivation
[Jira Ticket](https://jira.corp.stripe.com/browse/DX-4396)

### Testing
Tested manually using the CLI.
