### PR TITLE
Create deb and rpm packages and publish scoop bucket

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,17 +31,29 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+nfpms:
+  -
+    vendor: Stripe
+    homepage:  https://stripe.com
+    maintainer: Stripe <support@stripe.com>
+    description: Stripe CLI utility
+    license: Apache 2.0
+    formats:
+    - deb
+    - rpm
 brews:
   -
     github:
       owner: stripe
       name: homebrew-stripe-cli
     download_strategy: CustomGitHubPrivateRepositoryReleaseDownloadStrategy
+    custom_require: "../custom_download_strategy"
     commit_author:
       name: stripe-ci
       email: support@stripe.com
-    custom_require: "../custom_download_strategy"
     folder: Formula
+    homepage:  https://stripe.com
+    description: Stripe CLI utility
     install: |
       bin.install "stripe"
       rm Dir["#{bin}/{stripe-completion.bash,stripe-completion.zsh}"]
@@ -57,3 +69,13 @@ brews:
           if [[ -f $e ]]; then source $e; fi
         }
       EOS
+scoop:
+  bucket:
+    owner: stripe
+    name: scoop-stripe-cli
+  commit_author:
+    name: stripe-ci
+    email: support@stripe.com
+  homepage:  https://stripe.com
+  description: Stripe CLI utility
+  license: Apache 2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: go
 go:
 - 1.12.x
 
+addons:
+  apt:
+    packages:
+    - rpm
+
 env:
 - GO111MODULE=on
 


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe @brandur-stripe @aarongreen-stripe 
cc @stripe/dev-platform

 ### Summary
Extend `.goreleaser.yml` to create `.deb` and `.rpm` package files, and publish to a new scoop bucket repository (that I just created).

I've tested the `.deb` and `.rpm` package creation locally. The rest will have to be tested when actually publishing a new release.