### PR TITLE
Remove homebrew formula folder

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,6 @@ brews:
     commit_author:
       name: stripe-ci
       email: support@stripe.com
-    folder: Formula
     homepage:  https://stripe.com
     description: Stripe CLI utility
     install: |


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
We don't need a folder for the homebrew recipe, remove that.
