### PR TITLE
Truncate body and headers in webhook responses

### DIFF
--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -31,3 +31,13 @@ func TestFilterWebhookEvent(t *testing.T) {
 	assert.True(t, proxyUseLatest.filterWebhookEvent(evtDefault))
 	assert.False(t, proxyUseLatest.filterWebhookEvent(evtLatest))
 }
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, "Hello, World", truncate("Hello, World", 12, false))
+	assert.Equal(t, "Hello, Worl", truncate("Hello, World", 11, false))
+	assert.Equal(t, "Hello, W...", truncate("Hello, World", 11, true))
+
+	assert.Equal(t, "Hello, 世界", truncate("Hello, 世界", 13, false))
+	assert.Equal(t, "Hello, 世", truncate("Hello, 世界", 12, false))
+	assert.Equal(t, "Hello, ...", truncate("Hello, 世界", 12, true))
+}


### PR DESCRIPTION
 ### Reviewers
r? @aarongreen-stripe @tomer-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Truncate webhook responses so the message stays under a certain size.

Messages sent to Stripe over the websocket connection must stay under 32 KiB, otherwise the server will reply with an unclear error message ("websocket frame too large"). This PR ensures we stay under the limit:
- the `body` field is truncated to 5000 bytes
- the `headers` map is limited to 25 entries, with keys (header names) truncated to 50 bytes and values truncated to 200 bytes

Even accounting for some overhead for JSON formatting and additional attributes, this should ensure we stay well under the limit.
