### PR TITLE
Add verbose transport

### DIFF
--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -106,6 +106,7 @@ func (rb *Base) MakeRequest(secretKey, path string, params *RequestParameters) (
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
 		APIKey:  secretKey,
+		Verbose: rb.showHeaders,
 	}
 
 	data, err := rb.buildDataForRequest(params)
@@ -129,10 +130,6 @@ func (rb *Base) MakeRequest(secretKey, path string, params *RequestParameters) (
 	if !rb.SuppressOutput {
 		if err != nil {
 			return []byte{}, err
-		}
-
-		if rb.showHeaders {
-			fmt.Println(rb.formatHeaders(resp))
 		}
 
 		result := ansi.ColorizeJSON(string(body), os.Stdout)
@@ -210,16 +207,6 @@ func encode(keys []string, values []string) string {
 		buf.WriteString(url.QueryEscape(value))
 	}
 	return buf.String()
-}
-
-func (rb *Base) formatHeaders(response *http.Response) string {
-	var allHeaders []string
-	for name, headers := range response.Header {
-		for _, h := range headers {
-			allHeaders = append(allHeaders, fmt.Sprintf("< %v: %v", name, h))
-		}
-	}
-	return strings.Join(allHeaders, "\n") + "\n"
 }
 
 func (rb *Base) setIdempotencyHeader(request *http.Request, params *RequestParameters) {

--- a/pkg/requests/base_test.go
+++ b/pkg/requests/base_test.go
@@ -110,31 +110,6 @@ func TestMakeRequest(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestFormatHeaders(t *testing.T) {
-	rb := Base{}
-
-	resp := &http.Response{
-		Header: make(http.Header, 0),
-	}
-
-	emptyHeaders := rb.formatHeaders(resp)
-	emptyExpected := "\n"
-
-	assert.Equal(t, emptyExpected, emptyHeaders)
-
-	resp.Header.Add("header-one", "header-one-value")
-	resp.Header.Add("header-two", "header-two-value")
-	resp.Header.Add("header-three", "header-three-value")
-
-	headers := rb.formatHeaders(resp)
-
-	// Since Headers are stored in a map, the order is not deterministic
-	// and we must check for contains each header vs. direct string comparison
-	assert.Contains(t, headers, "< Header-One: header-one-value\n")
-	assert.Contains(t, headers, "< Header-Two: header-two-value\n")
-	assert.Contains(t, headers, "< Header-Three: header-three-value\n")
-}
-
 func TestGetUserConfirmationRequired(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader("yes\n"))
 

--- a/pkg/stripe/verbosetransport.go
+++ b/pkg/stripe/verbosetransport.go
@@ -1,0 +1,81 @@
+package stripe
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+)
+
+// inspectHeaders is the whitelist of headers that will be printed.
+var inspectHeaders = []string{
+	"Authorization",
+	"Content-Type",
+	"Date",
+	"Idempotency-Key",
+	"Idempotency-Replayed",
+	"Request-Id",
+	"Stripe-Account",
+	"Stripe-Version",
+}
+
+type verboseTransport struct {
+	Transport *http.Transport
+	Verbose   bool
+	Out       io.Writer
+}
+
+func (t *verboseTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	if t.Verbose {
+		t.dumpRequest(req)
+	}
+
+	resp, err = t.Transport.RoundTrip(req)
+
+	if err == nil && t.Verbose {
+		t.dumpResponse(resp)
+	}
+
+	return
+}
+
+func (t *verboseTransport) dumpRequest(req *http.Request) {
+	info := fmt.Sprintf("> %s %s://%s%s", req.Method, req.URL.Scheme, req.URL.Host, req.URL.RequestURI())
+	t.verbosePrintln(info)
+	t.dumpHeaders(req.Header, ">")
+}
+
+func (t *verboseTransport) dumpResponse(resp *http.Response) {
+	info := fmt.Sprintf("< HTTP %d", resp.StatusCode)
+	t.verbosePrintln(info)
+	t.dumpHeaders(resp.Header, "<")
+}
+
+func (t *verboseTransport) dumpHeaders(header http.Header, indent string) {
+	for _, listed := range inspectHeaders {
+		for name, vv := range header {
+			if !strings.EqualFold(name, listed) {
+				continue
+			}
+			for _, v := range vv {
+				if v != "" {
+					r := regexp.MustCompile("(?i)^(basic|bearer) (.+)")
+					if r.MatchString(v) {
+						v = r.ReplaceAllString(v, "$1 [REDACTED]")
+					}
+
+					info := fmt.Sprintf("%s %s: %s", indent, name, v)
+					t.verbosePrintln(info)
+				}
+			}
+		}
+	}
+}
+
+func (t *verboseTransport) verbosePrintln(msg string) {
+	color := ansi.Color(t.Out)
+	fmt.Fprintln(t.Out, color.Cyan(msg))
+}

--- a/pkg/stripe/verbosetransport_test.go
+++ b/pkg/stripe/verbosetransport_test.go
@@ -1,0 +1,41 @@
+package stripe
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerboseTransport_Verbose(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Request-Id", "req_123")
+		w.Header().Set("Non-Whitelisted-Header", "foo")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	var b bytes.Buffer
+	httpTransport := &http.Transport{}
+	tr := &verboseTransport{
+		Transport: httpTransport,
+		Verbose:   true,
+		Out:       &b,
+	}
+	client := &http.Client{Transport: tr}
+	req, _ := http.NewRequest("POST", ts.URL+"/test", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	client.Do(req)
+
+	out := b.String()
+	assert.Regexp(t, regexp.MustCompile("> POST http://(.+)/test\n"), out)
+	assert.Contains(t, out, "> Authorization: Bearer [REDACTED]\n")
+	assert.Contains(t, out, "> Content-Type: application/x-www-form-urlencoded\n")
+	assert.Contains(t, out, "< HTTP 200\n")
+	assert.Contains(t, out, "< Request-Id: req_123\n")
+	assert.NotContains(t, out, "Non-Whitelisted-Header")
+}


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe @tomer-stripe @aarongreen-stripe 
cc @stripe/dev-platform

 ### Summary
Adds a new `verboseTransport` type that acts like a regular HTTP transport but can optionally dump headers and other information (URL, status code).

This replaces the existing code in `requests/base.go` to output headers.

Behavior changes:
- headers are printed to stderr instead of stdout
- we don't print all headers, but just a few relevant ones
- API keys are redacted
- we also output the HTTP method and URL, and the response's status code
