### PR TITLE
Generalize websocket event type for webhooks and request logs

### DIFF
--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -44,22 +44,22 @@ type Config struct {
 
 	WriteWait time.Duration
 
-	WebhookEventHandler WebhookEventHandler
+	EventHandler EventHandler
 }
 
-// WebhookEventHandler handles a webhook event.
-type WebhookEventHandler interface {
-	ProcessWebhookEvent(*WebhookEvent)
+// EventHandler handles an event.
+type EventHandler interface {
+	ProcessEvent(IncomingMessage)
 }
 
-// WebhookEventHandlerFunc is an adapter to allow the use of ordinary
-// functions as webhook event handlers. If f is a function with the
-// appropriate signature, WebhookEventHandlerFunc(f) is a
-// WebhookEventHandler that calls f.
-type WebhookEventHandlerFunc func(*WebhookEvent)
+// EventHandlerFunc is an adapter to allow the use of ordinary
+// functions as event handlers. If f is a function with the
+// appropriate signature, EventHandlerFunc(f) is a
+// EventHandler that calls f.
+type EventHandlerFunc func(IncomingMessage)
 
-// ProcessWebhookEvent calls f(msg).
-func (f WebhookEventHandlerFunc) ProcessWebhookEvent(msg *WebhookEvent) {
+// ProcessEvent calls f(msg).
+func (f EventHandlerFunc) ProcessEvent(msg IncomingMessage) {
 	f(msg)
 }
 
@@ -239,9 +239,7 @@ func (c *Client) readPump() {
 			continue
 		}
 
-		if msg.WebhookEvent != nil {
-			go c.cfg.WebhookEventHandler.ProcessWebhookEvent(msg.WebhookEvent)
-		}
+		go c.cfg.EventHandler.ProcessEvent(msg)
 	}
 }
 
@@ -344,8 +342,8 @@ func NewClient(url string, webSocketID string, cfg *Config) *Client {
 	if cfg.WriteWait == 0 {
 		cfg.WriteWait = defaultWriteWait
 	}
-	if cfg.WebhookEventHandler == nil {
-		cfg.WebhookEventHandler = nullWebhookEventHandler
+	if cfg.EventHandler == nil {
+		cfg.EventHandler = nullEventHandler
 	}
 
 	return &Client{
@@ -377,7 +375,7 @@ const (
 
 var subprotocols = [...]string{"stripecli-devproxy-v1"}
 
-var nullWebhookEventHandler = WebhookEventHandlerFunc(func(*WebhookEvent) {})
+var nullEventHandler = EventHandlerFunc(func(IncomingMessage) {})
 
 //
 // Private functions

--- a/pkg/websocket/client_test.go
+++ b/pkg/websocket/client_test.go
@@ -50,8 +50,8 @@ func TestClientWebhookEventHandler(t *testing.T) {
 		url,
 		"websocket-random-id",
 		&Config{
-			WebhookEventHandler: WebhookEventHandlerFunc(func(msg *WebhookEvent) {
-				rcvMsg = msg
+			EventHandler: EventHandlerFunc(func(msg IncomingMessage) {
+				rcvMsg = msg.WebhookEvent
 				wg.Done()
 			}),
 		},

--- a/pkg/websocket/messages.go
+++ b/pkg/websocket/messages.go
@@ -5,24 +5,10 @@ import (
 	"fmt"
 )
 
-// WebhookEndpoint contains properties about the fake "endpoint" used to
-// format the webhook event.
-type WebhookEndpoint struct {
-	APIVersion *string `json:"api_version"`
-}
-
-// WebhookEvent represents incoming webhook event messages sent by Stripe.
-type WebhookEvent struct {
-	Endpoint     WebhookEndpoint   `json:"endpoint"`
-	EventPayload string            `json:"event_payload"`
-	HTTPHeaders  map[string]string `json:"http_headers"`
-	Type         string            `json:"type"`
-	WebhookID    string            `json:"webhook_id"`
-}
-
 // IncomingMessage represents any incoming message sent by Stripe.
 type IncomingMessage struct {
 	*WebhookEvent
+	*RequestLogEvent
 }
 
 // UnmarshalJSON deserializes incoming messages sent by Stripe into the
@@ -40,20 +26,16 @@ func (m *IncomingMessage) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		m.WebhookEvent = &evt
+	} else if incomingMessageTypeOnly.Type == "request_log_event" {
+		var evt RequestLogEvent
+		if err := json.Unmarshal(data, &evt); err != nil {
+			return err
+		}
+		m.RequestLogEvent = &evt
 	} else {
 		return fmt.Errorf("Unexpected message type: %s", incomingMessageTypeOnly.Type)
 	}
 	return nil
-}
-
-// WebhookResponse represents outgoing webhook response messages sent to
-// Stripe.
-type WebhookResponse struct {
-	Status      int               `json:"status"`
-	HTTPHeaders map[string]string `json:"http_headers"`
-	Body        string            `json:"body"`
-	Type        string            `json:"type"`
-	WebhookID   string            `json:"webhook_id"`
 }
 
 // MarshalJSON serializes outgoing messages sent to Stripe.
@@ -63,19 +45,6 @@ func (m OutgoingMessage) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(nil)
-}
-
-// NewWebhookResponse returns a new webhookResponse message.
-func NewWebhookResponse(webhookID string, status int, body string, headers map[string]string) *OutgoingMessage {
-	return &OutgoingMessage{
-		WebhookResponse: &WebhookResponse{
-			WebhookID:   webhookID,
-			Status:      status,
-			Body:        body,
-			HTTPHeaders: headers,
-			Type:        "webhook_response",
-		},
-	}
 }
 
 // OutgoingMessage represents any outgoing message sent to Stripe.

--- a/pkg/websocket/messages_test.go
+++ b/pkg/websocket/messages_test.go
@@ -16,9 +16,27 @@ func TestUnmarshalWebhookEvent(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.NotNil(t, msg.WebhookEvent)
-	assert.Equal(t, "foo", msg.EventPayload)
-	assert.Equal(t, "bar", msg.HTTPHeaders["Request-Header"])
-	assert.Equal(t, "wh_123", msg.WebhookID)
+	assert.Nil(t, msg.RequestLogEvent)
+
+	assert.Equal(t, "foo", msg.WebhookEvent.EventPayload)
+	assert.Equal(t, "bar", msg.WebhookEvent.HTTPHeaders["Request-Header"])
+	assert.Equal(t, "webhook_event", msg.WebhookEvent.Type)
+	assert.Equal(t, "wh_123", msg.WebhookEvent.WebhookID)
+}
+
+func TestUnmarshalRequestLogEvent(t *testing.T) {
+	var data = `{"type": "request_log_event", "event_payload": "foo", "request_log_id": "resp_123"}`
+
+	var msg IncomingMessage
+	err := json.Unmarshal([]byte(data), &msg)
+	assert.Nil(t, err)
+
+	assert.NotNil(t, msg.RequestLogEvent)
+	assert.Nil(t, msg.WebhookEvent)
+
+	assert.Equal(t, "foo", msg.RequestLogEvent.EventPayload)
+	assert.Equal(t, "resp_123", msg.RequestLogEvent.RequestLogID)
+	assert.Equal(t, "request_log_event", msg.RequestLogEvent.Type)
 }
 
 func TestUnmarshalUnknownIncomingMsg(t *testing.T) {
@@ -40,14 +58,4 @@ func TestMarshalWebhookResponse(t *testing.T) {
 	assert.Equal(t, 200, int(gjson.Get(json, "status").Num))
 	assert.Equal(t, "foo", gjson.Get(json, "body").String())
 	assert.Equal(t, "bar", gjson.Get(json, "http_headers.Response-Header").String())
-}
-
-func TestNewWebhookResponse(t *testing.T) {
-	msg := NewWebhookResponse("wh_123", 200, "foo", map[string]string{"Response-Header": "bar"})
-	assert.NotNil(t, msg.WebhookResponse)
-	assert.Equal(t, "webhook_response", msg.Type)
-	assert.Equal(t, "wh_123", msg.WebhookID)
-	assert.Equal(t, 200, msg.Status)
-	assert.Equal(t, "foo", msg.Body)
-	assert.Equal(t, "bar", msg.HTTPHeaders["Response-Header"])
 }

--- a/pkg/websocket/request_log_messages.go
+++ b/pkg/websocket/request_log_messages.go
@@ -1,0 +1,8 @@
+package websocket
+
+// RequestLogEvent represents incoming request log event messages sent by Stripe.
+type RequestLogEvent struct {
+	EventPayload string            `json:"event_payload"`
+	Type         string            `json:"type"`
+	RequestLogID string            `json:"request_log_id"`
+}

--- a/pkg/websocket/webhook_messages.go
+++ b/pkg/websocket/webhook_messages.go
@@ -1,0 +1,39 @@
+package websocket
+
+// WebhookEndpoint contains properties about the fake "endpoint" used to
+// format the webhook event.
+type WebhookEndpoint struct {
+	APIVersion *string `json:"api_version"`
+}
+
+// WebhookEvent represents incoming webhook event messages sent by Stripe.
+type WebhookEvent struct {
+	Endpoint     WebhookEndpoint   `json:"endpoint"`
+	EventPayload string            `json:"event_payload"`
+	HTTPHeaders  map[string]string `json:"http_headers"`
+	Type         string            `json:"type"`
+	WebhookID    string            `json:"webhook_id"`
+}
+
+// WebhookResponse represents outgoing webhook response messages sent to
+// Stripe.
+type WebhookResponse struct {
+	Status      int               `json:"status"`
+	HTTPHeaders map[string]string `json:"http_headers"`
+	Body        string            `json:"body"`
+	Type        string            `json:"type"`
+	WebhookID   string            `json:"webhook_id"`
+}
+
+// NewWebhookResponse returns a new webhookResponse message.
+func NewWebhookResponse(webhookID string, status int, body string, headers map[string]string) *OutgoingMessage {
+	return &OutgoingMessage{
+		WebhookResponse: &WebhookResponse{
+			WebhookID:   webhookID,
+			Status:      status,
+			Body:        body,
+			HTTPHeaders: headers,
+			Type:        "webhook_response",
+		},
+	}
+}

--- a/pkg/websocket/webhook_messages_test.go
+++ b/pkg/websocket/webhook_messages_test.go
@@ -1,0 +1,17 @@
+package websocket
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestNewWebhookResponse(t *testing.T) {
+	msg := NewWebhookResponse("wh_123", 200, "foo", map[string]string{"Response-Header": "bar"})
+	assert.NotNil(t, msg.WebhookResponse)
+	assert.Equal(t, "webhook_response", msg.Type)
+	assert.Equal(t, "wh_123", msg.WebhookID)
+	assert.Equal(t, 200, msg.Status)
+	assert.Equal(t, "foo", msg.Body)
+	assert.Equal(t, "bar", msg.HTTPHeaders["Response-Header"])
+}


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe  @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
In preparation for receiving request logs events from the StripeCLI API, we need to generalize the types of events that can be received, parsed, and handled from the websockets package. This is a small change that segments the different types of events into different files and introduces the 'RequestLogEvent' type.

### Testing
Existing automated test + new automated test for unmarshalling request log events.