### PR TITLE
Add status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The Stripe CLI is a command-line interface for Stripe that can:
 2. `listen` for webhooks and forward them to a local server
 3. Run `get`, `post`, and `delete` commands to the Stripe API
 4. `trigger` a limited set of webhook events
+5. Pull Stripe status from status.stripe.com
 
 The main focus for this initial release is to improve the developer experience while integrating and testing webhooks. Interactions through the CLI are currently limited to test mode only.
 
@@ -26,6 +27,7 @@ The main focus for this initial release is to improve the developer experience w
     * [listen](#listen)
     * [get, post, and delete](#get-post-and-delete)
     * [trigger](#trigger)
+    * [status](#status)
   * [Developing the Stripe CLI](#developing-the-stripe-cli)
     * [Installation](#installation-1)
     * [Tests](#tests)
@@ -221,6 +223,24 @@ To trigger an event, run:
 ```sh
 $ stripe trigger <event>
 ```
+
+### `status`
+
+You can load Stripe status from the CLI instead of going to status.stripe.com. The CLI status loads from the status site, which is the canonical source of truth.
+
+To load status, run:
+```
+$ stripe status
+✅ All services are online.
+As of: July 23, 2019 @ 07:52PM +00:00
+```
+
+The status command supports several different flags:
+1. `--verbose` lists out individual Stripe system status using.
+2. `--format json` has the CLI render the status as a JSON blob for easier grepping and for using with tools like `jq`.
+3. `--poll` will continuously check the status site for changes
+4. `--poll-rate` let's you specify how often to check the status site. The default is once every 60 seconds and this can be modified down to once every 5 seconds.
+5. `--hide-spinner` will hide the spinner that's shown when polling.
 
 ## Developing the Stripe CLI
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/briandowns/spinner v0.0.0-20190319032542-ac46072a5a91
-	github.com/coreos/etcd v3.3.10+incompatible
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/gorilla/websocket v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/briandowns/spinner v0.0.0-20190319032542-ac46072a5a91
+	github.com/coreos/etcd v3.3.10+incompatible
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/gorilla/websocket v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/briandowns/spinner v0.0.0-20190319032542-ac46072a5a91 h1:GMmnK0dvr0Sf0gx3DvTbln0c8DE07B7sPVD9dgHOqo4=
 github.com/briandowns/spinner v0.0.0-20190319032542-ac46072a5a91/go.mod h1:hw/JEQBIE+c/BLI4aKM8UU8v+ZqrD3h7HC27kKt8JQU=
+github.com/coreos/etcd v3.3.10+incompatible h1:jFneRYjIvLMLhDLCzuTuU4rSJUjRplcJQ7pD7MnhC04=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -86,7 +86,11 @@ func StartSpinner(msg string, w io.Writer) *spinner.Spinner {
 
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	s.Writer = w
-	s.Suffix = " " + msg
+
+	if msg != "" {
+		s.Suffix = " " + msg
+	}
+
 	s.Start()
 	return s
 }
@@ -99,7 +103,10 @@ func StopSpinner(s *spinner.Spinner, msg string, w io.Writer) {
 		return
 	}
 
-	s.FinalMSG = "> " + msg + "\n"
+	if msg != "" {
+		s.FinalMSG = "> " + msg + "\n"
+	}
+
 	s.Stop()
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -121,6 +121,7 @@ func init() {
 	rootCmd.AddCommand(newGetCmd().reqs.Cmd)
 	rootCmd.AddCommand(newListenCmd().cmd)
 	rootCmd.AddCommand(newPostCmd().reqs.Cmd)
+	rootCmd.AddCommand(newStatusCmd().cmd)
 	rootCmd.AddCommand(newTriggerCmd().cmd)
 	rootCmd.AddCommand(newVersionCmd().cmd)
 }

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/status"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+type statusCmd struct {
+	cmd *cobra.Command
+
+	format      string
+	hideSpinner bool
+	poll        bool
+	pollRate    int
+	verbose     bool
+}
+
+func newStatusCmd() *statusCmd {
+	sc := &statusCmd{}
+	sc.cmd = &cobra.Command{
+		Use:   "status",
+		Args:  validators.NoArgs,
+		Short: "Check the status of the Stripe API",
+		RunE:  sc.runStatusCmd,
+	}
+
+	sc.cmd.Flags().StringVar(&sc.format, "format", "default", "The format to print the status as (either 'default' or 'json')")
+	sc.cmd.Flags().BoolVar(&sc.verbose, "verbose", false, "Show status for all Stripe systems")
+	sc.cmd.Flags().BoolVar(&sc.poll, "poll", false, "Keep polling for status updates")
+	sc.cmd.Flags().IntVar(&sc.pollRate, "poll-rate", 60, "How many seconds to wait between status updates (minimum: 5)")
+	sc.cmd.Flags().BoolVar(&sc.hideSpinner, "hide-spinner", false, "Hide the loading spinner when polling")
+
+	return sc
+}
+
+func (sc *statusCmd) runStatusCmd(cmd *cobra.Command, args []string) error {
+	if sc.pollRate < 5 {
+		return fmt.Errorf("poll-rate must be at least 5 seconds, received %d", sc.pollRate)
+	}
+
+	if sc.format != "default" && sc.format != "json" {
+		return fmt.Errorf("invalid format, must be one of 'default' or 'json', received %s", sc.format)
+	}
+
+	for {
+		stripeStatus, err := status.GetStatus()
+		if err != nil {
+			return err
+		}
+
+		formattedStatus, err := stripeStatus.FormattedMessage(sc.format, sc.verbose)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(formattedStatus)
+
+		if !sc.poll {
+			break
+		}
+
+		if sc.hideSpinner {
+			time.Sleep(time.Duration(sc.pollRate) * time.Second)
+		} else {
+			spinner := ansi.StartSpinner("", os.Stderr)
+			time.Sleep(time.Duration(sc.pollRate) * time.Second)
+			ansi.StopSpinner(spinner, "", os.Stderr)
+		}
+	}
+
+	return nil
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,0 +1,126 @@
+package status
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"text/template"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+)
+
+// Response contains the structure of system statuses from Stripe
+type Response struct {
+	Statuses    statuses `json:"statuses"`
+	LargeStatus string   `json:"largestatus"`
+	Message     string   `json:"message"`
+	Time        string   `json:"time"`
+}
+
+type statuses struct {
+	API        string `json:"api"`
+	Dashboard  string `json:"dashboard"`
+	Stripejs   string `json:"stripejs"`
+	Checkoutjs string `json:"checkoutjs"`
+	Webhooks   string `json:"webhooks"`
+	Emails     string `json:"emails"`
+}
+
+// GetStatus makes a request to the Stripe status site and returns all the
+// current system statuses
+func GetStatus() (Response, error) {
+	var status Response
+
+	resp, err := http.Get("https://status.stripe.com/current")
+	if err != nil {
+		return status, err
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return status, err
+	}
+
+	json.Unmarshal(respBytes, &status)
+	return status, nil
+}
+
+func (r *Response) getMap(verbose bool) map[string]interface{} {
+	responseObject := map[string]interface{}{
+		"status":  r.LargeStatus,
+		"message": r.Message,
+		"time":    r.Time,
+	}
+
+	if verbose {
+		responseObject["statuses"] = map[string]string{
+			"api":        r.Statuses.API,
+			"dashboard":  r.Statuses.Dashboard,
+			"stripejs":   r.Statuses.Stripejs,
+			"checkoutjs": r.Statuses.Checkoutjs,
+			"webhooks":   r.Statuses.Webhooks,
+		}
+	}
+
+	return responseObject
+}
+
+// FormattedMessage returns a properly structured API status response
+// in either a json structure or a templated plain text output, conditionally
+// populated with extra data depending on verbosity
+func (r *Response) FormattedMessage(format string, verbose bool) (string, error) {
+	statusData := r.getMap(verbose)
+	if format == "json" {
+		data, err := json.MarshalIndent(statusData, "", "  ")
+		if err != nil {
+			return "", err
+		}
+
+		return string(data), nil
+	}
+
+	statusString := fmt.Sprintf(`%s %s{{if .statuses}}
+%s API
+%s Dashboard
+%s StripeJS
+%s CheckoutJS
+%s Webhooks{{end}}
+As of: %s`,
+		emojifiedStatus(r.LargeStatus),
+		ansi.Bold(r.Message),
+		emojifiedStatus(r.Statuses.API),
+		emojifiedStatus(r.Statuses.Dashboard),
+		emojifiedStatus(r.Statuses.Stripejs),
+		emojifiedStatus(r.Statuses.Checkoutjs),
+		emojifiedStatus(r.Statuses.Webhooks),
+		ansi.Italic(r.Time),
+	)
+
+	tmpl, err := template.New("status").Parse(statusString)
+	if err != nil {
+		return "", err
+	}
+	var output bytes.Buffer
+	tmpl.Execute(&output, statusData)
+	if err != nil {
+		return "", nil
+	}
+
+	return output.String(), nil
+}
+
+func emojifiedStatus(status string) string {
+	if status == "up" {
+		return "✅"
+	} else if status == "degraged" {
+		return "⚠️"
+	} else if status == "down" {
+		return "🔴"
+	}
+
+	// To avoid potentially confusing users, if the status does not fit one of
+	// the three above, let's return nothing
+	return ""
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -93,7 +93,6 @@ As of: %s`,
 		emojifiedStatus(r.Statuses.Dashboard),
 		emojifiedStatus(r.Statuses.Stripejs),
 		emojifiedStatus(r.Statuses.Checkoutjs),
-		emojifiedStatus(r.Statuses.Webhooks),
 		ansi.Italic(r.Time),
 	)
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -24,8 +24,9 @@ type statuses struct {
 	Dashboard  string `json:"dashboard"`
 	Stripejs   string `json:"stripejs"`
 	Checkoutjs string `json:"checkoutjs"`
-	Webhooks   string `json:"webhooks"`
-	Emails     string `json:"emails"`
+	// These two are not used and may not be reliable
+	Webhooks string `json:"webhooks"`
+	Emails   string `json:"emails"`
 }
 
 // GetStatus makes a request to the Stripe status site and returns all the
@@ -60,7 +61,6 @@ func (r *Response) getMap(verbose bool) map[string]interface{} {
 			"dashboard":  r.Statuses.Dashboard,
 			"stripejs":   r.Statuses.Stripejs,
 			"checkoutjs": r.Statuses.Checkoutjs,
-			"webhooks":   r.Statuses.Webhooks,
 		}
 	}
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -84,9 +84,8 @@ func (r *Response) FormattedMessage(format string, verbose bool) (string, error)
 	statusString := fmt.Sprintf(`%s %s{{if .statuses}}
 %s API
 %s Dashboard
-%s StripeJS
-%s CheckoutJS
-%s Webhooks{{end}}
+%s Stripe.js
+%s Checkout.js{{end}}
 As of: %s`,
 		emojifiedStatus(r.LargeStatus),
 		ansi.Bold(r.Message),

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -1,0 +1,114 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func buildResponse() Response {
+	return Response{
+		LargeStatus: "up",
+		Message:     "All systems operational",
+		Time:        "July 21, 4:00 +0:00",
+		Statuses: statuses{
+			API:        "up",
+			Dashboard:  "up",
+			Stripejs:   "up",
+			Checkoutjs: "up",
+			Webhooks:   "up",
+			Emails:     "up",
+		},
+	}
+}
+
+func TestGetMap(t *testing.T) {
+	response := buildResponse()
+
+	responseMap := response.getMap(false)
+	assert.Equal(t, responseMap["status"], "up")
+	assert.Equal(t, responseMap["message"], "All systems operational")
+	assert.Equal(t, responseMap["time"], "July 21, 4:00 +0:00")
+	assert.Nil(t, responseMap["statuses"])
+}
+
+func TestGetMapVerbose(t *testing.T) {
+	response := buildResponse()
+
+	responseMap := response.getMap(true)
+	assert.Equal(t, responseMap["status"], "up")
+	assert.Equal(t, responseMap["message"], "All systems operational")
+	assert.Equal(t, responseMap["time"], "July 21, 4:00 +0:00")
+
+	statuses := responseMap["statuses"].(map[string]string)
+	assert.Equal(t, statuses["api"], "up")
+	assert.Equal(t, statuses["dashboard"], "up")
+	assert.Equal(t, statuses["stripejs"], "up")
+	assert.Equal(t, statuses["checkoutjs"], "up")
+	assert.Equal(t, statuses["webhooks"], "up")
+}
+
+func TestFormatJSON(t *testing.T) {
+	response := buildResponse()
+
+	expected := `{
+  "message": "All systems operational",
+  "status": "up",
+  "time": "July 21, 4:00 +0:00"
+}`
+
+	formatted, _ := response.FormattedMessage("json", false)
+	assert.Equal(t, formatted, expected)
+}
+
+func TestFormatJSONVerbose(t *testing.T) {
+	response := buildResponse()
+
+	expected := `{
+  "message": "All systems operational",
+  "status": "up",
+  "statuses": {
+    "api": "up",
+    "checkoutjs": "up",
+    "dashboard": "up",
+    "stripejs": "up",
+    "webhooks": "up"
+  },
+  "time": "July 21, 4:00 +0:00"
+}`
+
+	formatted, _ := response.FormattedMessage("json", true)
+	assert.Equal(t, formatted, expected)
+}
+
+func TestFormatDefault(t *testing.T) {
+	response := buildResponse()
+
+	expected := `✅ All systems operational
+As of: July 21, 4:00 +0:00`
+
+	formatted, _ := response.FormattedMessage("default", false)
+	assert.Equal(t, formatted, expected)
+}
+
+func TestFormatDefaultVerbose(t *testing.T) {
+	response := buildResponse()
+
+	expected := `✅ All systems operational
+✅ API
+✅ Dashboard
+✅ StripeJS
+✅ CheckoutJS
+✅ Webhooks
+As of: July 21, 4:00 +0:00`
+
+	formatted, _ := response.FormattedMessage("default", true)
+	assert.Equal(t, formatted, expected)
+}
+
+func TestEmojification(t *testing.T) {
+	assert.Equal(t, "✅", emojifiedStatus("up"))
+	assert.Equal(t, "⚠️", emojifiedStatus("degraged"))
+	assert.Equal(t, "🔴", emojifiedStatus("down"))
+	assert.Equal(t, "", emojifiedStatus("foo"))
+}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -45,7 +45,6 @@ func TestGetMapVerbose(t *testing.T) {
 	assert.Equal(t, statuses["dashboard"], "up")
 	assert.Equal(t, statuses["stripejs"], "up")
 	assert.Equal(t, statuses["checkoutjs"], "up")
-	assert.Equal(t, statuses["webhooks"], "up")
 }
 
 func TestFormatJSON(t *testing.T) {
@@ -71,8 +70,7 @@ func TestFormatJSONVerbose(t *testing.T) {
     "api": "up",
     "checkoutjs": "up",
     "dashboard": "up",
-    "stripejs": "up",
-    "webhooks": "up"
+    "stripejs": "up"
   },
   "time": "July 21, 4:00 +0:00"
 }`
@@ -97,9 +95,8 @@ func TestFormatDefaultVerbose(t *testing.T) {
 	expected := `✅ All systems operational
 ✅ API
 ✅ Dashboard
-✅ StripeJS
-✅ CheckoutJS
-✅ Webhooks
+✅ Stripe.js
+✅ Checkout.js
 As of: July 21, 4:00 +0:00`
 
 	formatted, _ := response.FormattedMessage("default", true)


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @aarongreen-stripe @brandur-stripe @auchenberg-stripe 
cc @stripe/dev-platform

 ### Summary
Let people retrieve API status through the CLI. This pulls from our status site so that is the source of truth.

The command is `stripe status` and includes several flags with:
1. `--verbose`, lists out status of individual systems
2. `--format`, let's people render the status as json
3. `--poll`, continuously checks the status site
4. `--poll-rate`, let's people check more frequently than ever 60 seconds (up to 5 seconds per poll)
5. `--hide-spinner`,  hides the spinner that's shown when polling
