### PR TITLE
Websocket generalization for feature specification

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
+const webhooksWebSocketFeature = "webhooks"
+
 type listenCmd struct {
 	cmd *cobra.Command
 
@@ -72,9 +74,6 @@ to your localhost:
 	lc.cmd.Flags().BoolVar(&lc.noWSS, "no-wss", false, "Force unencrypted ws:// protocol instead of wss://")
 	lc.cmd.Flags().MarkHidden("no-wss") // #nosec G104
 
-	lc.cmd.Flags().StringVar(&lc.webSocketURL, "ws-url", "", "Sets the websocket URL")
-	lc.cmd.Flags().MarkHidden("ws-url") // #nosec G104
-
 	return lc
 }
 
@@ -121,7 +120,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		Key:                 key,
 		EndpointsMap:        endpointsMap,
 		APIBaseURL:          lc.apiBaseURL,
-		WebSocketURL:        lc.webSocketURL,
+		WebSocketFeature:    webhooksWebSocketFeature,
 		PrintJSON:           lc.printJSON,
 		UseLatestAPIVersion: lc.latestAPIVersion,
 		Log:                 log.StandardLogger(),

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -36,7 +36,7 @@ type Client struct {
 }
 
 // Authorize sends a request to Stripe to initiate a new CLI session.
-func (c *Client) Authorize(deviceName string) (*StripeCLISession, error) {
+func (c *Client) Authorize(deviceName string, websocketFeature string) (*StripeCLISession, error) {
 	c.cfg.Log.WithFields(log.Fields{
 		"prefix": "stripeauth.client.Authorize",
 	}).Debug("Authenticating with Stripe...")
@@ -48,6 +48,7 @@ func (c *Client) Authorize(deviceName string) (*StripeCLISession, error) {
 
 	form := url.Values{}
 	form.Add("device_name", deviceName)
+	form.Add("websocket_feature", websocketFeature)
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
@@ -75,18 +76,15 @@ func (c *Client) Authorize(deviceName string) (*StripeCLISession, error) {
 	}
 
 	c.cfg.Log.WithFields(log.Fields{
-		"prefix":          "stripeauth.Client.Authorize",
-		"websocket_url":   session.WebSocketURL,
-		"websocket_id":    session.WebSocketID,
-		"reconnect_delay": session.ReconnectDelay,
+		"prefix":            "stripeauth.Client.Authorize",
+		"websocket_url":     session.WebSocketURL,
+		"websocket_id":      session.WebSocketID,
+		"websocket_authorized_feature": session.WebSocketAuthorizedFeature,
+		"reconnect_delay":   session.ReconnectDelay,
 	}).Debug("Got successful response from Stripe")
 
 	return session, nil
 }
-
-//
-// Public functions
-//
 
 // NewClient returns a new Client.
 func NewClient(key string, cfg *Config) *Client {

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -76,11 +76,11 @@ func (c *Client) Authorize(deviceName string, websocketFeature string) (*StripeC
 	}
 
 	c.cfg.Log.WithFields(log.Fields{
-		"prefix":            "stripeauth.Client.Authorize",
-		"websocket_url":     session.WebSocketURL,
-		"websocket_id":      session.WebSocketID,
+		"prefix":                       "stripeauth.Client.Authorize",
+		"websocket_url":                session.WebSocketURL,
+		"websocket_id":                 session.WebSocketID,
 		"websocket_authorized_feature": session.WebSocketAuthorizedFeature,
-		"reconnect_delay":   session.ReconnectDelay,
+		"reconnect_delay":              session.ReconnectDelay,
 	}).Debug("Got successful response from Stripe")
 
 	return session, nil

--- a/pkg/stripeauth/messages.go
+++ b/pkg/stripeauth/messages.go
@@ -3,8 +3,9 @@ package stripeauth
 // StripeCLISession is the API resource returned by Stripe when initiating
 // a new CLI session.
 type StripeCLISession struct {
-	ReconnectDelay int    `json:"reconnect_delay"`
-	Secret         string `json:"secret"`
-	WebSocketID    string `json:"websocket_id"`
-	WebSocketURL   string `json:"websocket_url"`
+	ReconnectDelay   int              `json:"reconnect_delay"`
+	Secret           string           `json:"secret"`
+	WebSocketAuthorizedFeature string `json:"websocket_authorized_feature"`
+	WebSocketID      string           `json:"websocket_id"`
+	WebSocketURL     string           `json:"websocket_url"`
 }

--- a/pkg/stripeauth/messages.go
+++ b/pkg/stripeauth/messages.go
@@ -3,9 +3,9 @@ package stripeauth
 // StripeCLISession is the API resource returned by Stripe when initiating
 // a new CLI session.
 type StripeCLISession struct {
-	ReconnectDelay   int              `json:"reconnect_delay"`
-	Secret           string           `json:"secret"`
+	ReconnectDelay             int    `json:"reconnect_delay"`
+	Secret                     string `json:"secret"`
 	WebSocketAuthorizedFeature string `json:"websocket_authorized_feature"`
-	WebSocketID      string           `json:"websocket_id"`
-	WebSocketURL     string           `json:"websocket_url"`
+	WebSocketID                string `json:"websocket_id"`
+	WebSocketURL               string `json:"websocket_url"`
 }

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -2,7 +2,6 @@ package websocket
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -162,7 +161,6 @@ func (c *Client) connect() bool {
 		"url":    url,
 	}).Debug("Dialing websocket")
 
-	fmt.Println(url)
 	conn, _, err := c.cfg.Dialer.Dial(url, header)
 	if err != nil {
 		c.cfg.Log.WithFields(log.Fields{

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -71,6 +72,9 @@ type Client struct {
 
 	// ID sent by the client in the `Websocket-Id` header when connecting
 	WebSocketID string
+
+	// Feature that the websocket is specified for
+	WebSocketAuthorizedFeature string
 
 	// Optional configuration parameters
 	cfg *Config
@@ -150,11 +154,15 @@ func (c *Client) connect() bool {
 	if c.cfg.NoWSS && strings.HasPrefix(url, "wss") {
 		url = "ws" + strings.TrimPrefix(c.URL, "wss")
 	}
+
+	url = url + "?websocket_feature=" + c.WebSocketAuthorizedFeature
+
 	c.cfg.Log.WithFields(log.Fields{
 		"prefix": "websocket.Client.connect",
 		"url":    url,
 	}).Debug("Dialing websocket")
 
+	fmt.Println(url)
 	conn, _, err := c.cfg.Dialer.Dial(url, header)
 	if err != nil {
 		c.cfg.Log.WithFields(log.Fields{
@@ -317,7 +325,7 @@ func (c *Client) writePump() {
 //
 
 // NewClient returns a new Client.
-func NewClient(url string, webSocketID string, cfg *Config) *Client {
+func NewClient(url string, webSocketID string, websocketAuthorizedFeature string, cfg *Config) *Client {
 	if cfg == nil {
 		cfg = &Config{}
 	}
@@ -347,11 +355,12 @@ func NewClient(url string, webSocketID string, cfg *Config) *Client {
 	}
 
 	return &Client{
-		URL:         url,
-		WebSocketID: webSocketID,
-		cfg:         cfg,
-		done:        make(chan struct{}),
-		send:        make(chan *OutgoingMessage),
+		URL:                        url,
+		WebSocketID:                webSocketID,
+		WebSocketAuthorizedFeature: websocketAuthorizedFeature,
+		cfg:                        cfg,
+		done:                       make(chan struct{}),
+		send:                       make(chan *OutgoingMessage),
 	}
 }
 

--- a/pkg/websocket/client_test.go
+++ b/pkg/websocket/client_test.go
@@ -24,6 +24,9 @@ func TestClientWebhookEventHandler(t *testing.T) {
 		assert.Equal(t, "websocket-random-id", r.Header.Get("Websocket-Id"))
 		c, err := upgrader.Upgrade(w, r, nil)
 		assert.Nil(t, err)
+
+		assert.Equal(t, "websocket_feature=webhook-payloads", r.URL.RawQuery)
+
 		defer c.Close()
 
 		evt := WebhookEvent{
@@ -49,6 +52,7 @@ func TestClientWebhookEventHandler(t *testing.T) {
 	client := NewClient(
 		url,
 		"websocket-random-id",
+		"webhook-payloads",
 		&Config{
 			EventHandler: EventHandlerFunc(func(msg IncomingMessage) {
 				rcvMsg = msg.WebhookEvent


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe  @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Now that we want to support listening for webhook events or request log events, we need to specify to the API what type of event a websocket connection is for. The type of feature should be specified as a parameter in the authorize request as well as in the subscribe request.

### Testing
Updated existing automated tests to include `websocket_feature`. Also tested manually to make sure authorization works for the appropriate feature specified.