### PR TITLE
Remove `go generate` command from build step

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,6 @@ env:
 before:
   hooks:
     - go mod download
-    - go generate ./...
 project_name: stripe
 builds:
   - main: ./cmd/stripe/main.go

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ test: install-deps lint vet
 
 build:
 	go mod download
-	go generate ./...
 	go build -o stripe -ldflags "-s -w" cmd/stripe/main.go
 .PHONY: build
 


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @aarongreen-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Running `go generate ./...` changes the `go.mod` and `go.sum` files, which prevents goreleaser from releasing new versions. I'm removing this for now since it looks like @ob-stripe added it in #49 and I don't think we need it for any existing functionality.
