### PR TITLE
Don't require vfsgen to be installed

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -1,4 +1,4 @@
-//go:generate vfsgendev -source="github.com/stripe/stripe-cli/pkg/spec".FS
+//go:generate go run github.com/shurcooL/vfsgen/cmd/vfsgendev -source="github.com/stripe/stripe-cli/pkg/spec".FS
 
 package spec
 


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
According to [this comment](https://github.com/golang/go/issues/25922#issuecomment-451123151), this should let us run the `vfsgendev` without requiring it to be installed separately.