### PR TITLE
Remove go generate from goreleaser/travis build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,6 @@ env:
 before:
   hooks:
     - go mod download
-    - go generate ./...
 project_name: stripe
 builds:
   - main: ./cmd/stripe/main.go


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @aarongreen-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Removing the `go generate` command from the go-releaser script for now to unblock releases.
