### PR TITLE
Call resp.Body.Close everywhere

### DIFF
--- a/pkg/endpoint/client.go
+++ b/pkg/endpoint/client.go
@@ -79,6 +79,7 @@ func (c *Client) Post(webhookID string, body string, headers map[string]string) 
 		c.cfg.Log.Errorf("Failed to POST event to local endpoint, error = %v\n", err)
 		return err
 	}
+	defer resp.Body.Close()
 
 	c.cfg.ResponseHandler.ProcessResponse(webhookID, resp)
 

--- a/pkg/login/poll.go
+++ b/pkg/login/poll.go
@@ -16,10 +16,10 @@ const maxAttemptsDefault = 2 * 60
 const intervalDefault = 1 * time.Second
 
 type pollAPIKeyResponse struct {
-	Redeemed  bool   `json:"redeemed"`
-	AccountID string `json:"account_id"`
+	Redeemed           bool   `json:"redeemed"`
+	AccountID          string `json:"account_id"`
 	AccountDisplayName string `json:"account_display_name"`
-	APIKey    string `json:"testmode_key_secret"`
+	APIKey             string `json:"testmode_key_secret"`
 }
 
 // PollForKey polls Stripe at the specified interval until either the API key is available or we've reached the max attempts.
@@ -49,6 +49,7 @@ func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (string
 		if err != nil {
 			return "", nil, err
 		}
+		defer res.Body.Close()
 
 		bodyBytes, err := ioutil.ReadAll(res.Body)
 		if err != nil {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -38,6 +38,7 @@ func GetStatus() (Response, error) {
 	if err != nil {
 		return status, err
 	}
+	defer resp.Body.Close()
 
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -59,6 +59,7 @@ func (c *Client) Authorize(deviceName string, websocketFeature string) (*StripeC
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -161,7 +161,7 @@ func (c *Client) connect() bool {
 		"url":    url,
 	}).Debug("Dialing websocket")
 
-	conn, _, err := c.cfg.Dialer.Dial(url, header)
+	conn, resp, err := c.cfg.Dialer.Dial(url, header)
 	if err != nil {
 		c.cfg.Log.WithFields(log.Fields{
 			"prefix": "websocket.Client.connect",
@@ -169,6 +169,7 @@ func (c *Client) connect() bool {
 		}).Debug("Websocket connection error")
 		return false
 	}
+	defer resp.Body.Close()
 	c.changeConnection(conn)
 	c.isConnected = true
 


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Call `resp.Body.Close()` after all HTTP requests, as reported by https://github.com/timakin/bodyclose.