### PR TITLE
Use golangci-lint for linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+run:
+  tests: false
+
+linters:
+  goimports:
+    local-prefixes: github.com/stripe/stripe-cli
+
+linters:
+  enable-all: true
+  disable:
+    - errcheck
+    - gochecknoglobals
+    - gochecknoinits
+    - gosec
+    - lll
+    - maligned
+    - unparam
+    - stylecheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
+dist: bionic
+
 language: go
 
-go:
-- 1.12.x
+go: '1.12.x'
 
 addons:
   apt:
     packages:
     - rpm
 
-env:
-  global:
-    - GO111MODULE=on
-    - GOBIN="${GOPATH}/bin"
-    - PATH="${GOBIN}:${PATH}"
+install:
+  - make setup
+
+script:
+  - make ci
 
 deploy:
 - provider: script

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,13 @@
     "editor.formatOnSave": false,
 
     "go.formatTool": "goimports",
+    "go.formatFlags": [
+        "-local", "github.com/stripe/stripe-cli",
+    ],
+    "go.lintTool": "golangci-lint",
+    "go.lintFlags": [
+        "--fast",
+    ],
     "[go]": {
         "editor.formatOnSave": true
     },

--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,80 @@
+SOURCE_FILES?=./...
+TEST_PATTERN?=.
+TEST_OPTIONS?=
+
 export GO111MODULE := on
 export GOBIN := $(shell pwd)/bin
 export PATH := $(GOBIN):$(PATH)
+export GOPROXY := https://gocenter.io
 
-all: test
+# Install all the build and lint dependencies
+setup:
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
+	curl -L https://git.io/misspell | sh
+	go mod download
+.PHONY: setup
 
-install-deps:
-	go get
-.PHONY: install-deps
+# Run all the tests
+test:
+	go test $(TEST_OPTIONS) -failfast -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=2m
+.PHONY: test
 
-update-deps:
-	go get -u
-.PHONY: update-deps
+# Run all the tests and opens the coverage report
+cover: test
+	go tool cover -html=coverage.txt
+.PHONY: cover
 
+# gofmt and goimports all go files
+fmt:
+	find . -name '*.go' | while read -r file; do gofmt -w -s "$$file"; goimports -w "$$file"; done
+.PHONY: fmt
+
+# Run all the linters
+lint:
+	# TODO: fix tests and disabled linter issues
+	./bin/golangci-lint run ./...
+	./bin/misspell -error **/*.go
+.PHONY: lint
+
+# Clean go.mod
+go-mod-tidy:
+	@go mod tidy -v
+	@git diff HEAD
+	@git diff-index --quiet HEAD
+.PHONY: go-mod-tidy
+
+# Run all the tests and code checks
+ci: build test lint go-mod-tidy
+.PHONY: ci
+
+# Build a beta version of stripe
+build:
+	go generate ./...
+	go build -o stripe cmd/stripe/main.go
+.PHONY: build
+
+# Show to-do items per file
+todo:
+	@grep \
+		--exclude-dir=vendor \
+		--exclude-dir=node_modules \
+		--exclude=Makefile \
+		--text \
+		--color \
+		-nRo -E ' TODO:.*|SkipNow' .
+.PHONY: todo
+
+# Updates the OpenAPI spec
 update-openapi-spec:
 	rm -f ./api/openapi-spec/spec3.sdk.json
 	wget https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.sdk.json -P ./api/openapi-spec
 .PHONY: update-openapi-spec
 
-lint:
-# In travis, we need to install golint explicitly. Don't do this in other
-# environments
-ifeq ($(ENVIRONMENT), travis)
-	go get golang.org/x/lint/golint
-	git checkout .
-endif
-	golint -set_exit_status ./...
-.PHONY: lint
-
-vet:
-	go vet $(shell go list ./... | grep -v /vendor/)
-.PHONY: vet
-
-test: install-deps lint vet
-	go test -race -cover -v ./...
-	@echo '\o/ yay, we did it!'
-.PHONY: test
-
-build:
-	go mod download
-	go generate ./...
-	go build -o stripe -ldflags "-s -w" cmd/stripe/main.go
-.PHONY: build
-
+# Releases a new version
+release:
 # This does not release anything from your local machine but creates a tag
 # for our CI to handle it
-release:
+
 	git pull origin master
 
 # Makefile's execute each line in its own subshell so variables don't
@@ -54,3 +84,5 @@ release:
 	git tag $$version
 	git push --tags
 .PHONY: release
+
+.DEFAULT_GOAL := build


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe  
cc @stripe/dev-platform

 ### Summary
Replace golang and govet with [GolangCI-Lint](https://github.com/golangci/golangci-lint), a pretty awesome metalinter tool.

This is basically the same setup as the one used by the GoReleaser project, except that I created a custom `.golangci.yml` configuration file to disable more linters because those would require larger changes. (I do think we should fix these issues and enable these linters, but we can do that later.)

The Makefile was updated to be very similar to GoReleaser's. Basically:
- run `make setup` to install (or update) the linter locally and download dependencies
- run `make build` (or just `make`) to compile the project and output a `stripe` executable
- run `make test` to run tests (and tests only)
- run `make cover` to run tests and open the coverage report
- run `make lint` to run the linter
- run `make go-mod-tidy` to ensure that that `go.mod` is up-to-date
- run `make ci` to run everything (compile the project, run tests, run the linter, check that `go.mod` is up-to-date`
- run `make todo` to display all TODOs in the source files

The existing make targets `update-openapi-spec` and `release` are unchanged.

I've also enabled GolangCI-Lint's VS Code integration, but in order for it to work, you need to install the tool globally with `brew install golangci/tap/golangci-lint`.
