### PR TITLE
[wip] Resource commands

### DIFF
--- a/pkg/cmd/resource/namespace.go
+++ b/pkg/cmd/resource/namespace.go
@@ -1,0 +1,86 @@
+package resource
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+)
+
+//
+// Public types
+//
+
+// NamespaceCmd represents namespace commands. Namespace commands are top-level
+// commands that are simply containers for resource commands.
+type NamespaceCmd struct {
+	Cmd *cobra.Command
+
+	Name string
+
+	ResourceCmds map[string]*ResourceCmd
+}
+
+//
+// Public functions
+//
+
+// NewNamespaceCmd returns a new NamespaceCmd.
+func NewNamespaceCmd(rootCmd *cobra.Command, namespaceName string) *NamespaceCmd {
+	cmd := &cobra.Command{
+		Use:         namespaceName,
+		Annotations: make(map[string]string),
+	}
+	cmd.SetUsageTemplate(namespaceUsageTemplate())
+
+	if namespaceName != "" {
+		rootCmd.AddCommand(cmd)
+		rootCmd.Annotations[namespaceName] = "namespace"
+	}
+
+	return &NamespaceCmd{
+		Cmd:          cmd,
+		Name:         namespaceName,
+		ResourceCmds: make(map[string]*ResourceCmd),
+	}
+}
+
+//
+// Private functions
+//
+
+func namespaceUsageTemplate() string {
+	return fmt.Sprintf(`%s{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} <resource> <operation> [parameters...]{{end}}{{if gt (len .Aliases) 0}}
+
+%s
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+%s
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+%s{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+%s
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+%s
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+%s{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`,
+		ansi.Bold("Usage:"),
+		ansi.Bold("Aliases:"),
+		ansi.Bold("Examples:"),
+		ansi.Bold("Available Resources:"),
+		ansi.Bold("Flags:"),
+		ansi.Bold("Global Flags:"),
+		ansi.Bold("Additional help topics:"),
+	)
+}

--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -1,0 +1,167 @@
+package resource
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/spec"
+)
+
+//
+// Public types
+//
+
+// OperationCmd represents operation commands. Operation commands are nested
+// under resource commands and represent a specific API operation for that
+// resource.
+type OperationCmd struct {
+	*requests.Base
+
+	Name      string
+	HTTPVerb  string
+	Path      string
+	URLParams []string
+}
+
+func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error {
+	secretKey, err := oc.Profile.GetSecretKey()
+	if err != nil {
+		return err
+	}
+
+	path := formatURL(oc.Path, args[:len(oc.URLParams)])
+
+	oc.Parameters.AppendData(args[len(oc.URLParams):])
+
+	_, err = oc.MakeRequest(secretKey, path, &oc.Parameters)
+
+	return err
+}
+
+//
+// Public functions
+//
+
+// NewOperationCmd returns a new OperationCmd.
+func NewOperationCmd(parentCmd *cobra.Command, op spec.StripeOperation, op2 spec.Operation) *OperationCmd {
+	urlParams := extractURLParams(op.Path)
+	httpVerb := strings.ToUpper(string(op.Operation))
+	operationCmd := &OperationCmd{
+		Base: &requests.Base{
+			Method: httpVerb,
+		},
+		Name:      op.MethodName,
+		HTTPVerb:  httpVerb,
+		Path:      op.Path,
+		URLParams: urlParams,
+	}
+	cmd := &cobra.Command{
+		Use:         op.MethodName,
+		Long:        op2.Description,
+		Annotations: make(map[string]string),
+		RunE:        operationCmd.runOperationCmd,
+		Args:        cobra.MinimumNArgs(len(urlParams)),
+	}
+	cmd.SetUsageTemplate(operationUsageTemplate(op2, urlParams))
+	cmd.DisableFlagsInUseLine = true
+	operationCmd.Cmd = cmd
+	operationCmd.InitFlags()
+
+	parentCmd.AddCommand(cmd)
+	parentCmd.Annotations[op.MethodName] = "operation"
+
+	return operationCmd
+}
+
+//
+// Private functions
+//
+
+func extractURLParams(path string) []string {
+	re := regexp.MustCompile(`{\w+}`)
+	return re.FindAllString(path, -1)
+}
+
+func formatURL(path string, urlParams []string) string {
+	s := make([]interface{}, len(urlParams))
+	for i, v := range urlParams {
+		s[i] = v
+	}
+	re := regexp.MustCompile(`{\w+}`)
+	format := re.ReplaceAllString(path, "%s")
+	return fmt.Sprintf(format, s...)
+}
+
+func operationUsageTemplate(op spec.Operation, urlParams []string) string {
+	params := strings.Map(func(r rune) rune {
+		switch r {
+		case '{':
+			return '<'
+		case '}':
+			return '>'
+		}
+		return r
+	}, strings.Join(urlParams, " "))
+	params += " [param1=value1] [param2=value2] ..."
+
+	return fmt.Sprintf(`%s{{if .Runnable}}
+  {{.UseLine}} %s{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+%s
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+%s
+{{.Example}}{{end}}%s{{if .HasAvailableSubCommands}}
+
+%s{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+%s
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+%s
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+%s{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`,
+		ansi.Bold("Usage:"),
+		params,
+		ansi.Bold("Aliases:"),
+		ansi.Bold("Examples:"),
+		parametersHelp(op),
+		ansi.Bold("Available Operations:"),
+		ansi.Bold("Flags:"),
+		ansi.Bold("Global Flags:"),
+		ansi.Bold("Additional help topics:"),
+	)
+}
+
+func parametersHelp(op spec.Operation) string {
+	t := template.Must(template.New("parameters").Parse(fmt.Sprintf(`
+
+%s{{with (index .RequestBody.Content "application/x-www-form-urlencoded").Schema }}{{ range $key, $value := .Properties }}
+  {{ $key }} ({{ $value.Type }}){{end}}{{end}}`,
+		ansi.Bold("Parameters:"),
+	)))
+
+	var out bytes.Buffer
+	if err := t.Execute(&out, op); err != nil {
+		// TODO better error handling
+		log.Fatal(err)
+		return ""
+	}
+
+	return out.String()
+}

--- a/pkg/cmd/resource/resource.go
+++ b/pkg/cmd/resource/resource.go
@@ -1,0 +1,101 @@
+package resource
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+)
+
+//
+// Public types
+//
+
+// ResourceCmd represents resource commands. Resource commands can be either
+// top-level commands or nested under namespace commands. Resource commands
+// are containers for operation commands.
+type ResourceCmd struct { //nolint:golint
+	Cmd *cobra.Command
+
+	Name string
+
+	OperationCmds map[string]*OperationCmd
+}
+
+//
+// Public functions
+//
+
+// GetResourceCmdName returns the name for the resource commands. This differs
+// from the resource name because we want to use the pluralized name in most
+// cases.
+func GetResourceCmdName(name string) string {
+	switch name {
+	case "balance":
+		// `balance` is a singleton resource and is not pluralized
+		return "balance"
+	case "three_d_secure":
+		// this name is just sad
+		return "3d_secure"
+	default:
+		return name + "s"
+	}
+}
+
+// NewResourceCmd returns a new ResourceCmd.
+func NewResourceCmd(parentCmd *cobra.Command, resourceName string) *ResourceCmd {
+	cmd := &cobra.Command{
+		Use:         resourceName,
+		Annotations: make(map[string]string),
+	}
+	cmd.SetUsageTemplate(resourceUsageTemplate())
+
+	parentCmd.AddCommand(cmd)
+	parentCmd.Annotations[resourceName] = "resource"
+
+	return &ResourceCmd{
+		Cmd:           cmd,
+		Name:          resourceName,
+		OperationCmds: make(map[string]*OperationCmd),
+	}
+}
+
+//
+// Private functions
+//
+
+func resourceUsageTemplate() string {
+	return fmt.Sprintf(`%s{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} <operation> [parameters...]{{end}}{{if gt (len .Aliases) 0}}
+
+%s
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+%s
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+%s{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+%s
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+%s
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+%s{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`,
+		ansi.Bold("Usage:"),
+		ansi.Bold("Aliases:"),
+		ansi.Bold("Examples:"),
+		ansi.Bold("Available Operations:"),
+		ansi.Bold("Flags:"),
+		ansi.Bold("Global Flags:"),
+		ansi.Bold("Additional help topics:"),
+	)
+}

--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/cmd/resource"
+	"github.com/stripe/stripe-cli/pkg/spec"
+)
+
+//
+// Private functions
+//
+
+func addAllResourceCmds(rootCmd *cobra.Command, stripeAPI *spec.Spec) {
+	namespaceCmds := make(map[string]*resource.NamespaceCmd)
+
+	for name, schema := range stripeAPI.Components.Schemas {
+		if schema.XStripeOperations == nil {
+			continue
+		}
+
+		namespaceName, resourceName := parseSchemaName(name)
+
+		for _, op := range *schema.XStripeOperations {
+			if op.MethodOn != "service" {
+				continue
+			}
+
+			// Create the namespace command if it doesn't already exist
+			if _, ok := namespaceCmds[namespaceName]; !ok {
+				namespaceCmds[namespaceName] = resource.NewNamespaceCmd(rootCmd, namespaceName)
+			}
+
+			// Create the resource command if it doesn't already exist
+			resourceCmdName := resource.GetResourceCmdName(resourceName)
+			if _, ok := namespaceCmds[namespaceName].ResourceCmds[resourceCmdName]; !ok {
+				var parentCmd *cobra.Command
+				if namespaceName == "" {
+					parentCmd = rootCmd
+				} else {
+					parentCmd = namespaceCmds[namespaceName].Cmd
+				}
+				namespaceCmds[namespaceName].ResourceCmds[resourceCmdName] = resource.NewResourceCmd(parentCmd, resourceCmdName)
+			}
+
+			// Create the operation command if it doesn't already exist
+			if _, ok := namespaceCmds[namespaceName].ResourceCmds[resourceCmdName].OperationCmds[op.MethodName]; !ok {
+				parentCmd := namespaceCmds[namespaceName].ResourceCmds[resourceCmdName].Cmd
+				op2 := *stripeAPI.Paths[spec.Path(op.Path)][op.Operation]
+				namespaceCmds[namespaceName].ResourceCmds[resourceCmdName].OperationCmds[op.MethodName] = resource.NewOperationCmd(parentCmd, op, op2)
+			}
+		}
+	}
+}
+
+func parseSchemaName(name string) (string, string) {
+	if strings.Contains(name, ".") {
+		components := strings.SplitN(name, ".", 2)
+		return components[0], components[1]
+	}
+	return "", name
+}

--- a/pkg/cmd/resources_test.go
+++ b/pkg/cmd/resources_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/spec"
+)
+
+func BenchmarkAddAllResourceCmds(b *testing.B) {
+	cmd := &cobra.Command{
+		Annotations: make(map[string]string),
+	}
+	stripeAPI, _ := spec.LoadSpec("")
+
+	for n := 0; n < b.N; n++ {
+		addAllResourceCmds(cmd, stripeAPI)
+	}
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/spec"
 	"github.com/stripe/stripe-cli/pkg/version"
 )
 
@@ -128,4 +129,11 @@ func init() {
 	rootCmd.AddCommand(newStatusCmd().cmd)
 	rootCmd.AddCommand(newTriggerCmd().cmd)
 	rootCmd.AddCommand(newVersionCmd().cmd)
+
+	stripeAPI, err := spec.LoadSpec("")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to parse OpenAPI spec")
+		os.Exit(1)
+	}
+	addAllResourceCmds(rootCmd, stripeAPI)
 }

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -28,6 +28,10 @@ type RequestParameters struct {
 	stripeAccount string
 }
 
+func (r *RequestParameters) AppendData(data []string) {
+	r.data = append(r.data, data...)
+}
+
 // Base does stuff
 type Base struct {
 	Cmd *cobra.Command

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func BenchmarkLoadSpec(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		LoadSpec("")
+	}
+}
+
 func TestLoadSpec(t *testing.T) {
 	data, err := LoadSpec("")
 	assert.NoError(t, err)


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/dev-platform

 ### Summary
This is very much a WIP, but it's (barely) functional, so opening a PR for early feedback.

This implements three new categories of commands:
- namespace commands: top-level, hold resource commands
- resource commands: either top-level (for core resources like charges, customers, etc.) or nested under a namespace command, hold operation commands
- operation commands: nested under a resource command, actually execute an API request

Operation commands are simply wrappers over the existing `post`/`get`/`delete` commands right now, so parameters are provided using the `-d` flag.

API parameters that require IDs (retrieve, update, custom operations like charge capture...) expect the ID as an argument. Nested resources need two IDs, the parent resource's and the nested resource's.

A few examples:
```
$ stripe charges create -d amount=123 -d currency=usd -d source=tok_visa
$ stripe charges retrieve ch_123
$ stripe issuing cards update ic_123 -d "metadata[key]=value"
$ stripe subscriptions cancel sub_123
```

TODO:
- [ ] Write tests
- [x] Use pluralized resource names (`charges` instead of `charge`).
  ~This is actually difficult because the spec doesn't have a field for that and it's not as simple as adding an "s" to the resource name (some resources like `balance` need to stay singular, other use words with non-trivial pluralization like `summary`). I'll need to extract the pluralized name from the URL, but that is itself not trivial because there's a not a single format that we can apply to all URLs (e.g. `/v1/invoices/upcoming`: is `upcoming` a method on the `invoices` resource, or is `upcoming` a resource in the `invoices` namespace?).~
  There really is no good way to get the pluralized name from the spec, so I just went with a simple whitelist.
- [ ] Strip out HTML from descriptions
- [ ] Figure out short descriptions for methods and parameters
  The descriptions in the spec are verbose (they're the same as the API reference). Not sure there's a good solution here unfortunately. Maybe just include links to the API reference?
- [ ] Figure out how to deal with request parameters: flags vs. args? Nested parameters? Array parameters?
- [ ] Probably many other things
