### PR TITLE
Add -v flag for version

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -94,6 +94,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 		ansi.Bold("Global flags:"),
 		ansi.Bold("Additional help topics:"),
 	))
+	rootCmd.SetVersionTemplate(version.Template)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -110,6 +111,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&Config.Profile.ProfileName, "project-name", "default", "the project name to read from for config")
 	rootCmd.PersistentFlags().StringVar(&Config.Profile.DeviceName, "device-name", "", "device name")
+	rootCmd.Flags().BoolP("version", "v", false, "Get the version of the Stripe CLI")
 
 	viper.BindPFlag("secret_key", rootCmd.PersistentFlags().Lookup("api-key")) // #nosec G104
 

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/validators"
 	"github.com/stripe/stripe-cli/pkg/version"
 )
@@ -21,7 +20,7 @@ func newVersionCmd() *versionCmd {
 			Args:  validators.NoArgs,
 			Short: "Get the version of the Stripe CLI",
 			Run: func(cmd *cobra.Command, args []string) {
-				fmt.Println(fmt.Sprintf("stripe version "+version.Version+" %s", ansi.Bold("(beta)")))
+				fmt.Print(version.Template)
 			},
 		},
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,10 @@ import (
 	"github.com/stripe/stripe-cli/pkg/ansi"
 )
 
-// Version number of the CLI
+// Version of the CLI -- currently in beta
+// This is set to the actual version by GoReleaser, identify by the
+// git tag assigned to the release Versions built from source will
+// always show master.
 var Version = "master"
 
 var Template = fmt.Sprintf("stripe version %s %s\n", Version, ansi.Bold("(beta)"))

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,12 @@
 package version
 
+import (
+	"fmt"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+)
+
 // Version number of the CLI
 var Version = "master"
+
+var Template = fmt.Sprintf("stripe version %s %s\n", Version, ansi.Bold("(beta)"))


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @aarongreen-stripe @brandur-stripe 
cc @stripe/dev-platform
cc @fishcharlie

 ### Summary
Fixes #37, adds `-v` flag for version and cleans up version printing.
