### PR TITLE
--help formatting

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -21,12 +21,13 @@ var rootCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Annotations: map[string]string{
-		"get":     "api",
-		"post":    "api",
-		"delete":  "api",
+		"get":     "http",
+		"post":    "http",
+		"delete":  "http",
 		"trigger": "webhooks",
 		"listen":  "webhooks",
-		"logs":    "logs",
+		"logs":    "api",
+		"status":  "api",
 	},
 	Version: version.Version,
 	Short:   "A CLI to help you integrate Stripe with your application",
@@ -61,13 +62,13 @@ func Execute() {
 %s
   {{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{if .Annotations}}
 
-%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "api")}}
+%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "http")}}
   {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
 
 %s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "webhooks")}}
   {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
 
-%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "logs")}}
+%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "api")}}
   {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
 
 %s{{range $index, $cmd := .Commands}}{{if (not (index $.Annotations $cmd.Name))}}
@@ -90,9 +91,9 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 		ansi.Bold("Usage:"),
 		ansi.Bold("Aliases:"),
 		ansi.Bold("Examples:"),
-		ansi.Bold("API commands:"),
+		ansi.Bold("HTTP commands:"),
 		ansi.Bold("Webhook commands:"),
-		ansi.Bold("Logs commands:"),
+		ansi.Bold("API commands:"),
 		ansi.Bold("Other commands:"),
 		ansi.Bold("Available commands:"),
 		ansi.Bold("Flags:"),

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -26,8 +26,8 @@ var rootCmd = &cobra.Command{
 		"delete":  "http",
 		"trigger": "webhooks",
 		"listen":  "webhooks",
-		"logs":    "api",
-		"status":  "api",
+		"logs":    "stripe",
+		"status":  "stripe",
 	},
 	Version: version.Version,
 	Short:   "A CLI to help you integrate Stripe with your application",
@@ -68,7 +68,7 @@ func Execute() {
 %s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "webhooks")}}
   {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
 
-%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "api")}}
+%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "stripe")}}
   {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
 
 %s{{range $index, $cmd := .Commands}}{{if (not (index $.Annotations $cmd.Name))}}
@@ -93,7 +93,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 		ansi.Bold("Examples:"),
 		ansi.Bold("HTTP commands:"),
 		ansi.Bold("Webhook commands:"),
-		ansi.Bold("API commands:"),
+		ansi.Bold("Stripe commands:"),
 		ansi.Bold("Other commands:"),
 		ansi.Bold("Available commands:"),
 		ansi.Bold("Flags:"),


### PR DESCRIPTION
### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
With the present organization, `stripe --help` returns information about the `GET`, `POST`, and `DELETE` commands in a section called `API commands`, and `logs` is in its own section and feels empty all alone.

This proposes a new format for the help section, where the existing `API commands` is renamed to `HTTP commands` and there is a new `Stripe commands` section which contains the `logs` command and the `status` command.

Here's what the new help section would look like.
<img width="676" alt="Screen Shot 2019-08-06 at 3 35 36 PM" src="https://user-images.githubusercontent.com/51489162/62582024-d9fab180-b85f-11e9-8215-dffdf872571d.png">

