### PR TITLE
Merge endpoint package into proxy package

### DIFF
--- a/pkg/proxy/endpoint_test.go
+++ b/pkg/proxy/endpoint_test.go
@@ -1,4 +1,4 @@
-package endpoint
+package proxy
 
 import (
 	"io/ioutil"
@@ -30,11 +30,11 @@ func TestClientHandler(t *testing.T) {
 
 	rcvBody := ""
 	rcvWebhookID := ""
-	client := NewClient(
+	client := NewEndpointClient(
 		ts.URL,
 		[]string{"*"},
-		&Config{
-			ResponseHandler: ResponseHandlerFunc(func(webhookID string, resp *http.Response) {
+		&EndpointConfig{
+			ResponseHandler: EndpointResponseHandlerFunc(func(webhookID string, resp *http.Response) {
 				buf, err := ioutil.ReadAll(resp.Body)
 				assert.Nil(t, err)
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -13,7 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
-	"github.com/stripe/stripe-cli/pkg/endpoint"
 	"github.com/stripe/stripe-cli/pkg/stripeauth"
 	"github.com/stripe/stripe-cli/pkg/websocket"
 )
@@ -56,7 +55,7 @@ type Config struct {
 type Proxy struct {
 	cfg *Config
 
-	endpointClients  []*endpoint.Client
+	endpointClients  []*EndpointClient
 	stripeAuthClient *stripeauth.Client
 	webSocketClient  *websocket.Client
 
@@ -226,12 +225,12 @@ func New(cfg *Config) *Proxy {
 
 	for url, events := range cfg.EndpointsMap {
 		// append to endpointClients
-		p.endpointClients = append(p.endpointClients, endpoint.NewClient(
+		p.endpointClients = append(p.endpointClients, NewEndpointClient(
 			url,
 			events,
-			&endpoint.Config{
+			&EndpointConfig{
 				Log:             p.cfg.Log,
-				ResponseHandler: endpoint.ResponseHandlerFunc(p.processEndpointResponse),
+				ResponseHandler: EndpointResponseHandlerFunc(p.processEndpointResponse),
 			},
 		))
 	}


### PR DESCRIPTION
 ### Reviewers
r? @aarongreen-stripe @brandur-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Merge `endpoint` package into `proxy` package. Endpoint clients are fairly specific to the webhook proxy feature. I expect this refactor will make it easier to handle different routes for Connect events.