### PR TITLE
Replace endpoints map with list of endpoint routes

### DIFF
--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -19,7 +19,7 @@ func TestParseUrl(t *testing.T) {
 	assert.Equal(t, "http://localhost:3000", parseURL("3000"))
 }
 
-func TestBuildEndpointsMap(t *testing.T) {
+func TestBuildEndpointRoutes(t *testing.T) {
 	localURL := "http://localhost"
 
 	endpoint := requests.WebhookEndpoint{
@@ -31,6 +31,8 @@ func TestBuildEndpointsMap(t *testing.T) {
 		Data: []requests.WebhookEndpoint{endpoint},
 	}
 
-	output := buildEndpointsMap(endpointList, localURL)
-	assert.Equal(t, output["http:/localhost/hooks"], []string{"*"})
+	output := buildEndpointRoutes(endpointList, localURL)
+	assert.Equal(t, 1, len(output))
+	assert.Equal(t, output[0].URL, "http:/localhost/hooks")
+	assert.Equal(t, output[0].EventTypes, []string{"*"})
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -21,7 +21,16 @@ import (
 // Public types
 //
 
-// Config provides the cfguration of a Proxy
+// EndpointRoute describes a local endpoint's routing configuration.
+type EndpointRoute struct {
+	// URL is the endpoint's URL.
+	URL string
+
+	// EventTypes is the list of event types that should be sent to the endpoint.
+	EventTypes []string
+}
+
+// Config provides the configuration of a Proxy
 type Config struct {
 	// DeviceName is the name of the device sent to Stripe to help identify the device
 	DeviceName string
@@ -30,7 +39,7 @@ type Config struct {
 	Key string
 
 	// EndpointsMap is a mapping of local webhook endpoint urls to the events they consume
-	EndpointsMap map[string][]string
+	EndpointRoutes []EndpointRoute
 
 	APIBaseURL string
 
@@ -223,11 +232,11 @@ func New(cfg *Config) *Proxy {
 		interruptCh: make(chan os.Signal, 1),
 	}
 
-	for url, events := range cfg.EndpointsMap {
+	for _, route := range cfg.EndpointRoutes {
 		// append to endpointClients
 		p.endpointClients = append(p.endpointClients, NewEndpointClient(
-			url,
-			events,
+			route.URL,
+			route.EventTypes,
 			&EndpointConfig{
 				Log:             p.cfg.Log,
 				ResponseHandler: EndpointResponseHandlerFunc(p.processEndpointResponse),


### PR DESCRIPTION
 ### Reviewers
r? @aarongreen-stripe @brandur-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
More refactoring. This replaces `EndpointsMap` (a map of URLs to event types) with `EndpointRoutes` (a list of `EndpointRoute` which is a struct containing a URL and a list of event types).

This allows for having more than one endpoint with the same URL, which will be needed for Connect support.
