### PR TITLE
Add support for forwarding Connect events to separate route

### DIFF
--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -22,17 +22,28 @@ func TestParseUrl(t *testing.T) {
 func TestBuildEndpointRoutes(t *testing.T) {
 	localURL := "http://localhost"
 
-	endpoint := requests.WebhookEndpoint{
+	endpointNormal := requests.WebhookEndpoint{
 		URL:           "https://planetexpress.com/hooks",
+		Application:   "",
+		EnabledEvents: []string{"*"},
+	}
+
+	endpointConnect := requests.WebhookEndpoint{
+		URL:           "https://planetexpress.com/connect-hooks",
+		Application:   "ca_123",
 		EnabledEvents: []string{"*"},
 	}
 
 	endpointList := requests.WebhookEndpointList{
-		Data: []requests.WebhookEndpoint{endpoint},
+		Data: []requests.WebhookEndpoint{endpointNormal, endpointConnect},
 	}
 
-	output := buildEndpointRoutes(endpointList, localURL)
-	assert.Equal(t, 1, len(output))
-	assert.Equal(t, output[0].URL, "http:/localhost/hooks")
-	assert.Equal(t, output[0].EventTypes, []string{"*"})
+	output := buildEndpointRoutes(endpointList, localURL, localURL)
+	assert.Equal(t, 2, len(output))
+	assert.Equal(t, "http:/localhost/hooks", output[0].URL)
+	assert.Equal(t, false, output[0].Connect)
+	assert.Equal(t, []string{"*"}, output[0].EventTypes)
+	assert.Equal(t, "http:/localhost/connect-hooks", output[1].URL)
+	assert.Equal(t, true, output[1].Connect)
+	assert.Equal(t, []string{"*"}, output[1].EventTypes)
 }

--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -43,6 +43,8 @@ type EndpointClient struct {
 	// URL the client sends POST requests to
 	URL string
 
+	connect bool
+
 	events map[string]bool
 
 	// Optional configuration parameters
@@ -51,7 +53,11 @@ type EndpointClient struct {
 
 // SupportsEventType takes an event of a webhook and compares it to the internal
 // list of supported events
-func (c *EndpointClient) SupportsEventType(eventType string) bool {
+func (c *EndpointClient) SupportsEventType(connect bool, eventType string) bool {
+	if connect != c.connect {
+		return false
+	}
+
 	// Endpoint supports all events, always return true
 	if c.events["*"] || c.events[eventType] {
 		return true
@@ -91,7 +97,7 @@ func (c *EndpointClient) Post(webhookID string, body string, headers map[string]
 //
 
 // NewEndpointClient returns a new EndpointClient.
-func NewEndpointClient(url string, events []string, cfg *EndpointConfig) *EndpointClient {
+func NewEndpointClient(url string, connect bool, events []string, cfg *EndpointConfig) *EndpointClient {
 	if cfg == nil {
 		cfg = &EndpointConfig{}
 	}
@@ -108,9 +114,10 @@ func NewEndpointClient(url string, events []string, cfg *EndpointConfig) *Endpoi
 	}
 
 	return &EndpointClient{
-		URL:    url,
-		events: convertToMap(events),
-		cfg:    cfg,
+		URL:     url,
+		connect: connect,
+		events:  convertToMap(events),
+		cfg:     cfg,
 	}
 }
 

--- a/pkg/proxy/endpoint_test.go
+++ b/pkg/proxy/endpoint_test.go
@@ -32,6 +32,7 @@ func TestClientHandler(t *testing.T) {
 	rcvWebhookID := ""
 	client := NewEndpointClient(
 		ts.URL,
+		false,
 		[]string{"*"},
 		&EndpointConfig{
 			ResponseHandler: EndpointResponseHandlerFunc(func(webhookID string, resp *http.Response) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -26,6 +26,9 @@ type EndpointRoute struct {
 	// URL is the endpoint's URL.
 	URL string
 
+	// Connect indicates whether the endpoint should receive normal (when false) or Connect (when true) events.
+	Connect bool
+
 	// EventTypes is the list of event types that should be sent to the endpoint.
 	EventTypes []string
 }
@@ -178,7 +181,7 @@ func (p *Proxy) processWebhookEvent(msg websocket.IncomingMessage) {
 	}
 
 	for _, endpoint := range p.endpointClients {
-		if endpoint.SupportsEventType(evt.Type) {
+		if endpoint.SupportsEventType(evt.isConnect(), evt.Type) {
 			go endpoint.Post(webhookEvent.WebhookID, webhookEvent.EventPayload, webhookEvent.HTTPHeaders)
 		}
 	}
@@ -236,6 +239,7 @@ func New(cfg *Config) *Proxy {
 		// append to endpointClients
 		p.endpointClients = append(p.endpointClients, NewEndpointClient(
 			route.URL,
+			route.Connect,
 			route.EventTypes,
 			&EndpointConfig{
 				Log:             p.cfg.Log,

--- a/pkg/requests/examples.go
+++ b/pkg/requests/examples.go
@@ -24,8 +24,9 @@ type WebhookEndpointList struct {
 
 // WebhookEndpoint contains the data for each webhook endpoint
 type WebhookEndpoint struct {
-	URL           string   `json:"url"`
+	Application   string   `json:"application"`
 	EnabledEvents []string `json:"enabled_events"`
+	URL           string   `json:"url"`
 }
 
 // Examples stores possible webhook test events to trigger for the CLI


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe @tomer-stripe @aarongreen-stripe 
cc @stripe/dev-platform

 ### Summary
Add support for forwarding Connect events to a separate endpoint, using a new `--forward-connect-to` flag. When the flag is omitted, Connect events are sent to the normal URL (i.e. same as current behavior).
