### PR TITLE
Correctly read device name and profile for listen and http requests

### DIFF
--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -19,7 +19,7 @@ func newDeleteCmd() *deleteCmd {
 	gc := &deleteCmd{}
 
 	gc.reqs.Method = http.MethodDelete
-	gc.reqs.Profile = Config.Profile
+	gc.reqs.Profile = &Config.Profile
 	gc.reqs.Cmd = &cobra.Command{
 		Use:   "delete",
 		Args:  validators.ExactArgs(1),

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -19,7 +19,7 @@ func newGetCmd() *getCmd {
 	gc := &getCmd{}
 
 	gc.reqs.Method = http.MethodGet
-	gc.reqs.Profile = Config.Profile
+	gc.reqs.Profile = &Config.Profile
 	gc.reqs.Cmd = &cobra.Command{
 		Use:   "get",
 		Args:  validators.ExactArgs(1),

--- a/pkg/cmd/post.go
+++ b/pkg/cmd/post.go
@@ -19,7 +19,7 @@ func newPostCmd() *postCmd {
 	gc := &postCmd{}
 
 	gc.reqs.Method = http.MethodPost
-	gc.reqs.Profile = Config.Profile
+	gc.reqs.Profile = &Config.Profile
 	gc.reqs.Cmd = &cobra.Command{
 		Use:   "post",
 		Args:  validators.ExactArgs(1),

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -33,8 +33,13 @@ func (p *Profile) CreateProfile() error {
 
 // GetDeviceName returns the configured device name
 func (p *Profile) GetDeviceName() (string, error) {
+	deviceName := viper.GetString("device_name")
+	if deviceName != "" {
+		return deviceName, nil
+	}
+
 	if err := viper.ReadInConfig(); err == nil {
-		return viper.GetString("default.device_name"), nil
+		return viper.GetString(p.GetConfigField("device_name")), nil
 	}
 
 	return "", errors.New("your device name has not been configured. Use `stripe login` to set your device name")

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -33,7 +33,7 @@ type Base struct {
 	Cmd *cobra.Command
 
 	Method  string
-	Profile config.Profile
+	Profile *config.Profile
 
 	Parameters RequestParameters
 
@@ -50,6 +50,7 @@ var confirmationCommands = map[string]bool{http.MethodDelete: true}
 
 // RunRequestsCmd is the interface exposed for the CLI to run network requests through
 func (rb *Base) RunRequestsCmd(cmd *cobra.Command, args []string) error {
+	fmt.Print(rb.Profile.ProfileName)
 	if len(args) > 1 {
 		return fmt.Errorf("this command only supports one argument. Run with the --help flag to see usage and examples")
 	}

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -50,7 +50,6 @@ var confirmationCommands = map[string]bool{http.MethodDelete: true}
 
 // RunRequestsCmd is the interface exposed for the CLI to run network requests through
 func (rb *Base) RunRequestsCmd(cmd *cobra.Command, args []string) error {
-	fmt.Print(rb.Profile.ProfileName)
 	if len(args) > 1 {
 		return fmt.Errorf("this command only supports one argument. Run with the --help flag to see usage and examples")
 	}

--- a/pkg/requests/examples.go
+++ b/pkg/requests/examples.go
@@ -44,7 +44,7 @@ func (ex *Examples) buildRequest(method string, data []string) (*Base, *RequestP
 	}
 
 	base := &Base{
-		Profile:        ex.Profile,
+		Profile:        &ex.Profile,
 		Method:         method,
 		SuppressOutput: true,
 		APIBaseURL:     ex.APIBaseURL,
@@ -472,7 +472,7 @@ func (ex *Examples) WebhookEndpointsList() WebhookEndpointList {
 	}
 
 	base := &Base{
-		Profile:        ex.Profile,
+		Profile:        &ex.Profile,
 		Method:         http.MethodGet,
 		SuppressOutput: true,
 	}


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @aarongreen-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
* Fixes reading device name, this was hardcoded to `default` which caused issues for specific projects.
* Fixes profiles for http requests, this was always using `default` even if you passed in a project name.

Fixes #84 and fixes #85 