### PR TITLE
Fix loading webhook endpoints from API and forwarding

### DIFF
--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -40,10 +40,10 @@ func TestBuildEndpointRoutes(t *testing.T) {
 
 	output := buildEndpointRoutes(endpointList, localURL, localURL)
 	assert.Equal(t, 2, len(output))
-	assert.Equal(t, "http:/localhost/hooks", output[0].URL)
+	assert.Equal(t, "http://localhost/hooks", output[0].URL)
 	assert.Equal(t, false, output[0].Connect)
 	assert.Equal(t, []string{"*"}, output[0].EventTypes)
-	assert.Equal(t, "http:/localhost/connect-hooks", output[1].URL)
+	assert.Equal(t, "http://localhost/connect-hooks", output[1].URL)
 	assert.Equal(t, true, output[1].Connect)
 	assert.Equal(t, []string{"*"}, output[1].EventTypes)
 }

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -84,7 +84,7 @@ Trigger a payment_intent.created event:
 }
 
 func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
-	secretKey, err := Config.Profile.GetAPIKey()
+	apiKey, err := Config.Profile.GetAPIKey()
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 		Profile:    Config.Profile,
 		APIBaseURL: tc.apiBaseURL,
 		APIVersion: apiVersion,
-		APIKey:     secretKey,
+		APIKey:     apiKey,
 	}
 
 	event := args[0]

--- a/pkg/requests/examples.go
+++ b/pkg/requests/examples.go
@@ -475,8 +475,9 @@ func (ex *Examples) WebhookEndpointsList() WebhookEndpointList {
 		Profile:        &ex.Profile,
 		Method:         http.MethodGet,
 		SuppressOutput: true,
+		APIBaseURL:     ex.APIBaseURL,
 	}
-	resp, _ := base.MakeRequest(ex.APIKey, "/webhook_endpoints", params)
+	resp, _ := base.MakeRequest(ex.APIKey, "/v1/webhook_endpoints", params)
 	data := WebhookEndpointList{}
 	json.Unmarshal(resp, &data)
 


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Base url was not being passed in to the webhooks endpoint load so it was always empty. I also discovered another issue in the process where `path.Join` removes all double forward slashes which caused issues when defining the scheme, fixed that too.

Fixes #88 