### PR TITLE
Add log tailing to table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The main focus for this initial release is to improve the developer experience w
     * [listen](#listen)
     * [get, post, and delete](#get-post-and-delete)
     * [trigger](#trigger)
+    * [log tailing](#logs-tail)
     * [status](#status)
   * [Developing the Stripe CLI](#developing-the-stripe-cli)
     * [Installation](#installation-1)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The main focus for this initial release is to improve the developer experience w
     * [listen](#listen)
     * [get, post, and delete](#get-post-and-delete)
     * [trigger](#trigger)
-    * [log tailing](#logs-tail)
+    * [logs tail](#logs-tail)
     * [status](#status)
   * [Developing the Stripe CLI](#developing-the-stripe-cli)
     * [Installation](#installation-1)


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Whoops. I realized we forgot to add log tailing to the table of contents in the README. This fixes that.