### PR TITLE
Create and publish Docker images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,3 +81,9 @@ scoop:
   homepage:  https://stripe.com
   description: Stripe CLI utility
   license: Apache 2.0
+dockers:
+  - binaries:
+    - stripe
+    image_templates:
+    - "stripe/stripe-cli:latest"
+    - "stripe/stripe-cli:{{ .Tag }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+COPY stripe /bin/stripe
+ENTRYPOINT ["/bin/stripe"]


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Create and publish Docker images for the CLI. This is useful for e.g. k8s or CI/CD deployments.

I've tested the creation part locally with `goreleaser --snapshot --skip-publish --rm-dist` and verified that the images work:
```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
stripe/stripe-cli   latest              6d33eb5410b1        33 minutes ago      15.7MB
stripe/stripe-cli   v0.4.0              6d33eb5410b1        33 minutes ago      15.7MB
alpine              latest              b7b28af77ffe        4 weeks ago         5.58MB
$ docker run --rm -it stripe/stripe-cli --version
stripe version v0.4.0-next (beta)
```

I'm less sure about the publishing part, I think we'll have to create a new release and see what happens on Travis.
