### PR TITLE
Add support for passing request parameters as arguments

### DIFF
--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -42,7 +42,7 @@ To delete a charge:
 		RunE: gc.reqs.RunRequestsCmd,
 	}
 
-	gc.reqs.InitFlags()
+	gc.reqs.InitFlags(true)
 
 	return gc
 }

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -47,7 +47,7 @@ To get 50 charges:
 		RunE: gc.reqs.RunRequestsCmd,
 	}
 
-	gc.reqs.InitFlags()
+	gc.reqs.InitFlags(true)
 
 	return gc
 }

--- a/pkg/cmd/post.go
+++ b/pkg/cmd/post.go
@@ -43,7 +43,7 @@ Example:
 		RunE: gc.reqs.RunRequestsCmd,
 	}
 
-	gc.reqs.InitFlags()
+	gc.reqs.InitFlags(true)
 
 	return gc
 }

--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -38,6 +38,8 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 
 	path := formatURL(oc.Path, args[:len(oc.URLParams)])
 
+	oc.Parameters.AppendData(args[len(oc.URLParams):])
+
 	_, err = oc.MakeRequest(secretKey, path, &oc.Parameters)
 
 	return err
@@ -69,7 +71,7 @@ func NewOperationCmd(parentCmd *cobra.Command, name, path, httpVerb string) *Ope
 	cmd.SetUsageTemplate(operationUsageTemplate(urlParams))
 	cmd.DisableFlagsInUseLine = true
 	operationCmd.Cmd = cmd
-	operationCmd.InitFlags()
+	operationCmd.InitFlags(false)
 
 	parentCmd.AddCommand(cmd)
 	parentCmd.Annotations[name] = "operation"
@@ -106,6 +108,7 @@ func operationUsageTemplate(urlParams []string) string {
 		}
 		return r
 	}, strings.Join(urlParams, " "))
+	args += " [param1=value1] [param2=value2] ..."
 
 	return fmt.Sprintf(`%s{{if .Runnable}}
   {{.UseLine}} %s{{end}}{{if .HasAvailableSubCommands}}

--- a/pkg/cmd/resource/resource.go
+++ b/pkg/cmd/resource/resource.go
@@ -36,6 +36,8 @@ func GetResourceCmdName(name string) string {
 	case "balance":
 		// `balance` is a singleton resource and is not pluralized
 		return "balance"
+	case "capability":
+		return "capabilities"
 	case "three_d_secure":
 		return "3d_secure"
 	default:

--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -30,7 +30,7 @@ func addAllResourcesCmd(rootCmd *cobra.Command) {
 	rBankAccountsCmd := resource.NewResourceCmd(rootCmd, "bank_accounts")
 	rBitcoinReceiversCmd := resource.NewResourceCmd(rootCmd, "bitcoin_receivers")
 	rBitcoinTransactionsCmd := resource.NewResourceCmd(rootCmd, "bitcoin_transactions")
-	rCapabilitysCmd := resource.NewResourceCmd(rootCmd, "capabilitys")
+	rCapabilitiesCmd := resource.NewResourceCmd(rootCmd, "capabilities")
 	rCardsCmd := resource.NewResourceCmd(rootCmd, "cards")
 	rChargesCmd := resource.NewResourceCmd(rootCmd, "charges")
 	rCountrySpecsCmd := resource.NewResourceCmd(rootCmd, "country_specs")
@@ -135,9 +135,9 @@ func addAllResourcesCmd(rootCmd *cobra.Command) {
 
 	resource.NewOperationCmd(rBitcoinTransactionsCmd.Cmd, "list", "/v1/bitcoin/receivers/{receiver}/transactions", http.MethodGet)
 
-	resource.NewOperationCmd(rCapabilitysCmd.Cmd, "list", "/v1/accounts/{account}/capabilities", http.MethodGet)
-	resource.NewOperationCmd(rCapabilitysCmd.Cmd, "retrieve", "/v1/accounts/{account}/capabilities/{capability}", http.MethodGet)
-	resource.NewOperationCmd(rCapabilitysCmd.Cmd, "update", "/v1/accounts/{account}/capabilities/{capability}", http.MethodPost)
+	resource.NewOperationCmd(rCapabilitiesCmd.Cmd, "list", "/v1/accounts/{account}/capabilities", http.MethodGet)
+	resource.NewOperationCmd(rCapabilitiesCmd.Cmd, "retrieve", "/v1/accounts/{account}/capabilities/{capability}", http.MethodGet)
+	resource.NewOperationCmd(rCapabilitiesCmd.Cmd, "update", "/v1/accounts/{account}/capabilities/{capability}", http.MethodPost)
 
 	resource.NewOperationCmd(rCardsCmd.Cmd, "delete", "/v1/customers/{customer}/sources/{id}", http.MethodDelete)
 	resource.NewOperationCmd(rCardsCmd.Cmd, "update", "/v1/customers/{customer}/sources/{id}", http.MethodPost)

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -28,6 +28,10 @@ type RequestParameters struct {
 	stripeAccount string
 }
 
+func (r *RequestParameters) AppendData(data []string) {
+	r.data = append(r.data, data...)
+}
+
 // Base does stuff
 type Base struct {
 	Cmd *cobra.Command
@@ -75,8 +79,10 @@ func (rb *Base) RunRequestsCmd(cmd *cobra.Command, args []string) error {
 }
 
 // InitFlags initialize shared flags for all requests commands
-func (rb *Base) InitFlags() {
-	rb.Cmd.Flags().StringArrayVarP(&rb.Parameters.data, "data", "d", []string{}, "Data to pass for the API request")
+func (rb *Base) InitFlags(includeData bool) {
+	if includeData {
+		rb.Cmd.Flags().StringArrayVarP(&rb.Parameters.data, "data", "d", []string{}, "Data to pass for the API request")
+	}
 	rb.Cmd.Flags().StringArrayVarP(&rb.Parameters.expand, "expand", "e", []string{}, "Response attributes to expand inline. Available on all API requests, see the documentation for specific objects that support expansion")
 	rb.Cmd.Flags().StringVarP(&rb.Parameters.idempotency, "idempotency", "i", "", "Sets the idempotency key for your request, preventing replaying the same requests within a 24 hour period")
 	rb.Cmd.Flags().StringVarP(&rb.Parameters.version, "api-version", "v", "", "Set the Stripe API version to use for your request")


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Add support for passing request parameters as arguments instead of having to use the `-d` flag in resource commands.

Unfortunately the current state of the code makes it kind of difficult to write automated tests for this, I think we'd need to do some refactoring of the UI layer as well as the `requests` package (to inject the API key).

I did do some manual testing:
```sh
$ ./stripe charges update --help
Usage:
  stripe charges update <charge> [param1=value1] [param2=value2] ...

Flags:
  -v, --api-version string      Set the Stripe API version to use for your request
  -c, --confirm                 Automatically confirm the command being entered. WARNING: This will result in NOT being prompted for confirmation for certain commands
  -e, --expand stringArray      Response attributes to expand inline. Available on all API requests, see the documentation for specific objects that support expansion
  -h, --help                    help for update
  -i, --idempotency string      Sets the idempotency key for your request, preventing replaying the same requests within a 24 hour period
  -s, --show-headers            Show headers on responses to GET, POST, and DELETE requests
      --stripe-account string   Set a header identifying the connected account for which the request is being made

$./stripe charges update ch_123 "description=Foo bar baz" "metadata[key]=value"
{
  "id": "ch_123",
  "object": "charge",
  ...
  "description": "Foo bar baz",
  ...
  "metadata": {
    "key": "value"
  },
  ...
}
```
