### PR TITLE
Read from persisted color settings

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -111,7 +111,7 @@ func init() {
 	cobra.OnInitialize(Config.InitConfig)
 
 	rootCmd.PersistentFlags().String("api-key", "", "Your test mode API secret key to use for the command")
-	rootCmd.PersistentFlags().StringVar(&Config.Color, "color", "auto", "turn on/off color output (on, off, auto)")
+	rootCmd.PersistentFlags().StringVar(&Config.Color, "color", "", "turn on/off color output (on, off, auto)")
 	rootCmd.PersistentFlags().StringVar(&Config.ProfilesFile, "config", "", "config file (default is $HOME/.config/stripe/config.toml)")
 	rootCmd.PersistentFlags().StringVar(&Config.LogLevel, "log-level", "info", "log level (debug, info, warn, error)")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -117,14 +117,6 @@ func (c *Config) InitConfig() {
 	default:
 		log.Fatalf("Unrecognized log level value: %s. Expected one of debug, info, warn, error.", c.LogLevel)
 	}
-
-	if c.Profile.DeviceName == "" {
-		deviceName, err := os.Hostname()
-		if err != nil {
-			deviceName = "unknown"
-		}
-		c.Profile.DeviceName = deviceName
-	}
 }
 
 func (c *Config) EditConfig() error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,10 @@ import (
 	"github.com/stripe/stripe-cli/pkg/ansi"
 )
 
+const ColorOn = "on"
+const ColorOff = "off"
+const ColorAuto = "auto"
+
 // Config handles all overall configuration for the CLI
 type Config struct {
 	Color        string
@@ -90,13 +94,13 @@ func (c *Config) InitConfig() {
 		log.Fatalf("%s", err)
 	}
 	switch color {
-	case "on":
+	case ColorOn:
 		ansi.ForceColors = true
 		logFormatter.ForceColors = true
-	case "off":
+	case ColorOff:
 		ansi.DisableColors = true
 		logFormatter.DisableColors = true
-	case "auto":
+	case ColorAuto:
 		// Nothing to do
 	default:
 		log.Fatalf("Unrecognized color value: %s. Expected one of on, off, auto.", c.Color)

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -35,12 +35,12 @@ func (p *Profile) GetColor() (string, error) {
 
 	color = viper.GetString(p.GetConfigField("color"))
 	switch color {
-	case "", "auto":
-		return "auto", nil
-	case "on":
-		return "on", nil
-	case "off":
-		return "off", nil
+	case "", ColorAuto:
+		return ColorAuto, nil
+	case ColorOn:
+		return ColorOn, nil
+	case ColorOff:
+		return ColorOff, nil
 	default:
 		return "", fmt.Errorf("color value not supported: %s", color)
 	}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -24,6 +25,25 @@ func (p *Profile) CreateProfile() error {
 	}
 
 	return nil
+}
+
+func (p *Profile) GetColor() (string, error) {
+	color := viper.GetString("color")
+	if color != "" {
+		return color, nil
+	}
+
+	color = viper.GetString(p.GetConfigField("color"))
+	switch color {
+	case "", "auto":
+		return "auto", nil
+	case "on":
+		return "on", nil
+	case "off":
+		return "off", nil
+	default:
+		return "", fmt.Errorf("color value not supported: %s", color)
+	}
 }
 
 // GetDeviceName returns the configured device name


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @aarongreen-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
This lets the CLI read persisted color settings configured by users.

* I set the default color to `""` so that we know if someone is using the command line flag we should override the pre-defined configs
* I moved reading the profile config in to be a bit higher so that we can set the log colors sooner
* `GetColor` reads off the profile (like most other settings) and checks if color is provided first at a top level, then if it's set in the config file. If it's unset in the config file, it returns `""` and goes with auto.
