### PR TITLE
Help improvements

### DIFF
--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -17,7 +17,7 @@ func newCompletionCmd() *completionCmd {
 
 	cc.cmd = &cobra.Command{
 		Use:   "completion",
-		Short: "Generates bash and zsh completion scripts",
+		Short: "Generate bash and zsh completion scripts",
 		Args:  validators.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cc.shell == "zsh" {

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
@@ -21,9 +20,9 @@ func newDeleteCmd() *deleteCmd {
 	gc.reqs.Method = http.MethodDelete
 	gc.reqs.Profile = &Config.Profile
 	gc.reqs.Cmd = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete <path>",
 		Args:  validators.ExactArgs(1),
-		Short: "Make DELETE requests to the Stripe API using your test mode key.",
+		Short: "Make a DELETE request to the Stripe API",
 		Long: fmt.Sprintf(`%s
 
 Make DELETE requests to the Stripe API using your test mode key.
@@ -37,7 +36,7 @@ https://stripe.com/docs/api
 To delete a charge:
 
   $ stripe delete /customers/cus_FROPkgsHVRRspg`,
-			ansi.Italic("⚠️  The Stripe CLI is in beta! Have feedback? Let us know, run: 'stripe feedback'. ⚠️"),
+			getBanner(),
 		),
 		RunE: gc.reqs.RunRequestsCmd,
 	}

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
@@ -21,9 +20,9 @@ func newGetCmd() *getCmd {
 	gc.reqs.Method = http.MethodGet
 	gc.reqs.Profile = &Config.Profile
 	gc.reqs.Cmd = &cobra.Command{
-		Use:   "get",
+		Use:   "get <path>",
 		Args:  validators.ExactArgs(1),
-		Short: "Make GET requests to the Stripe API using your test mode key.",
+		Short: "Make a GET request to the Stripe API",
 		Long: fmt.Sprintf(`%s
 
 Make GET requests to the Stripe API using your test mode key.
@@ -41,7 +40,7 @@ To get a charge:
 To get 50 charges:
 
   $ stripe get --limit 50 /charges`,
-			ansi.Italic("⚠️  The Stripe CLI is in beta! Have feedback? Let us know, run: 'stripe feedback'. ⚠️"),
+			getBanner(),
 		),
 
 		RunE: gc.reqs.RunRequestsCmd,

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -11,7 +11,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/proxy"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
@@ -40,7 +39,7 @@ func newListenCmd() *listenCmd {
 	lc.cmd = &cobra.Command{
 		Use:   "listen",
 		Args:  validators.NoArgs,
-		Short: "Listens for webhook events sent from Stripe to help test your integration.",
+		Short: "Listen for webhook events",
 		Long: fmt.Sprintf(`%s
 
 The listen command lets you watch for and forward webhook events from Stripe.
@@ -57,7 +56,7 @@ Start listening for 'charge.created' and 'charge.updated' events and forward
 to your localhost:
 
   $ stripe listen --events charge.created,charge.updated --forward-to localhost:9000/events`,
-			ansi.Italic("⚠️  The Stripe CLI is in beta! Have feedback? Let us know, run: 'stripe feedback'. ⚠️"),
+			getBanner(),
 		),
 		RunE: lc.runListenCmd,
 	}

--- a/pkg/cmd/post.go
+++ b/pkg/cmd/post.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
@@ -21,9 +20,9 @@ func newPostCmd() *postCmd {
 	gc.reqs.Method = http.MethodPost
 	gc.reqs.Profile = &Config.Profile
 	gc.reqs.Cmd = &cobra.Command{
-		Use:   "post",
+		Use:   "post <path>",
 		Args:  validators.ExactArgs(1),
-		Short: "Make POST requests to the Stripe API using your test mode key.",
+		Short: "Make a POST request to the Stripe API",
 		Long: fmt.Sprintf(`%s
 
 Make POST requests to the Stripe API using your test mode key.
@@ -33,13 +32,14 @@ Currently, you can only POST data in test mode.
 
 For a full list of supported paths, see the API reference:
 https://stripe.com/docs/api
+`,
 
-Example:
-
-  $ stripe post /payment_intents -d amount=2000 -d currency=usd -d "payment_method_types[]=card"`,
-
-			ansi.Italic("⚠️  The Stripe CLI is in beta! Have feedback? Let us know, run: 'stripe feedback'. ⚠️"),
+			getBanner(),
 		),
+		Example: `stripe post /payment_intents \
+    -d amount=2000 \
+    -d currency=usd \
+    -d "payment_method_types[]=card"`,
 		RunE: gc.reqs.RunRequestsCmd,
 	}
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/version"
 )
@@ -45,61 +44,14 @@ If you're working on multiple projects, you can run the login command with the
 --project-name flag:
 
   $ stripe login --project-name rocket-rides`,
-		ansi.Italic("⚠️  The Stripe CLI is in beta! Have feedback? Let us know, run: 'stripe feedback'. ⚠️"),
+		getBanner(),
 	),
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	rootCmd.SetUsageTemplate(fmt.Sprintf(`%s{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
-
-%s
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
-
-%s
-  {{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{if .Annotations}}
-
-%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "http")}}
-  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
-
-%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "webhooks")}}
-  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
-
-%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "stripe")}}
-  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
-
-%s{{range $index, $cmd := .Commands}}{{if (not (index $.Annotations $cmd.Name))}}
-  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}{{else}}
-
-%s{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-
-%s
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
-
-%s
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
-
-%s{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
-`,
-		ansi.Bold("Usage:"),
-		ansi.Bold("Aliases:"),
-		ansi.Bold("Examples:"),
-		ansi.Bold("HTTP commands:"),
-		ansi.Bold("Webhook commands:"),
-		ansi.Bold("Stripe commands:"),
-		ansi.Bold("Other commands:"),
-		ansi.Bold("Available commands:"),
-		ansi.Bold("Flags:"),
-		ansi.Bold("Global flags:"),
-		ansi.Bold("Additional help topics:"),
-	))
+	rootCmd.SetUsageTemplate(getUsageTemplate())
 	rootCmd.SetVersionTemplate(version.Template)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/pkg/cmd/templates.go
+++ b/pkg/cmd/templates.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+)
+
+func init() {
+	cobra.AddTemplateFunc("wrappedInheritedFlagUsages", wrappedInheritedFlagUsages)
+	cobra.AddTemplateFunc("wrappedLocalFlagUsages", wrappedLocalFlagUsages)
+}
+
+func getBanner() string {
+	return ansi.Italic("⚠️  The Stripe CLI is in beta! Share your feedback with `stripe feedback` ⚠️")
+}
+
+func getUsageTemplate() string {
+	return fmt.Sprintf(`%s{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+%s
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+%s
+  {{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{if .Annotations}}
+
+%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "http")}}
+  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
+
+%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "webhooks")}}
+  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
+
+%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "stripe")}}
+  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
+
+%s{{range $index, $cmd := .Commands}}{{if (not (index $.Annotations $cmd.Name))}}
+  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}{{else}}
+
+%s{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+%s
+{{wrappedLocalFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+%s
+{{wrappedInheritedFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+%s{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`,
+		ansi.Bold("Usage:"),
+		ansi.Bold("Aliases:"),
+		ansi.Bold("Examples:"),
+		ansi.Bold("HTTP commands:"),
+		ansi.Bold("Webhook commands:"),
+		ansi.Bold("Stripe commands:"),
+		ansi.Bold("Other commands:"),
+		ansi.Bold("Available commands:"),
+		ansi.Bold("Flags:"),
+		ansi.Bold("Global flags:"),
+		ansi.Bold("Additional help topics:"),
+	)
+}
+
+func getTerminalWidth() int {
+	var width int
+	width, _, err := terminal.GetSize(0)
+	if err != nil {
+		width = 80
+	}
+	return width
+}
+
+func wrappedInheritedFlagUsages(cmd *cobra.Command) string {
+	return cmd.InheritedFlags().FlagUsagesWrapped(getTerminalWidth())
+}
+
+func wrappedLocalFlagUsages(cmd *cobra.Command) string {
+	return cmd.LocalFlags().FlagUsagesWrapped(getTerminalWidth())
+}

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -22,7 +22,7 @@ type triggerCmd struct {
 func newTriggerCmd() *triggerCmd {
 	tc := &triggerCmd{}
 	tc.cmd = &cobra.Command{
-		Use:  "trigger",
+		Use:  "trigger <event>",
 		Args: validators.ExactArgs(1),
 		ValidArgs: []string{
 			"charge.captured",
@@ -49,10 +49,6 @@ Cause a specific webhook event to be created and sent. Webhooks tested through
 the trigger command will also create all necessary side-effect events that are
 needed to create the triggered event.
 
-Trigger a payment_intent.created event:
-
-  $ stripe trigger payment_intent.created
-
 %s
   charge.captured
   charge.failed
@@ -70,10 +66,11 @@ Trigger a payment_intent.created event:
   payment_intent.payment_failed
   payment_intent.succeeded
   payment_method.attached`,
-			ansi.Italic("⚠️  The Stripe CLI is in beta! Have feedback? Let us know, run: 'stripe feedback'. ⚠️"),
+			getBanner(),
 			ansi.Bold("Supported events:"),
 		),
-		RunE: tc.runTriggerCmd,
+		Example: `stripe trigger payment_intent.created`,
+		RunE:    tc.runTriggerCmd,
 	}
 
 	// Hidden configuration flags, useful for dev/debugging


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
A bunch of improvements to help messages:
- wrap flag descriptions according to terminal width \o/
- make short messages shorter to ensure that command descriptions fit under 80 characters
- make short messages more consistent (don't use third person, don't add a trailing `.`)
- add required arguments to `delete`/`get`/`post` and `trigger`
- use the dedicated `Example` arg where applicable
