### PR TITLE
Update docker container to allow https connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine
+RUN apk add ca-certificates
 COPY stripe /bin/stripe
 ENTRYPOINT ["/bin/stripe"]


### PR DESCRIPTION
Alpine is only provided with a restrained set of useful packages which didn't contains `ca-certificates` that handle certificate checking. Thus preventing stripe-cli to connect to stripe API.

 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
This PR adds `ca-certificates` package to alpine to allow stripe-cli to connect to stripe API over __HTTPS__.
