### PR TITLE
Fix json format casing specification

### DIFF
--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -144,7 +144,7 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 		Key:              key,
 		Log:              log.StandardLogger(),
 		NoWSS:            tailCmd.noWSS,
-		OutputFormat:     tailCmd.format,
+		OutputFormat:     strings.ToUpper(tailCmd.format),
 		WebSocketFeature: requestLogsWebSocketFeature,
 	})
 

--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/websocket"
 )
 
-const outputFormatJSON = "json"
+const outputFormatJSON = "JSON"
 
 // LogFilters contains all of the potential user-provided filters for log tailing
 type LogFilters struct {


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe @ob-stripe 
cc @stripe/dev-platform

 ### Summary
A user [reported](https://github.com/stripe/stripe-cli/issues/102) an issue with the `--format` argument for log tailing.

This converts the supplied argument to uppercase before doing the comparison, and fixes the issue reported by the user.