### PR TITLE
Fix color support for Windows 10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,6 @@ require (
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect
-	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e // indirect
+	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e
 	golang.org/x/text v0.3.2 // indirect
 )

--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -84,7 +85,16 @@ func StartSpinner(msg string, w io.Writer) *spinner.Spinner {
 		return nil
 	}
 
-	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+	// See https://github.com/briandowns/spinner#available-character-sets for
+	// list of available charsets
+	charSetIdx := 11
+	if runtime.GOOS == "windows" {
+		// Less fancy, but uses ASCII characters so works with Windows default
+		// console.
+		charSetIdx = 8
+	}
+
+	s := spinner.New(spinner.CharSets[charSetIdx], 100*time.Millisecond)
 	s.Writer = w
 
 	if msg != "" {

--- a/pkg/ansi/init_windows.go
+++ b/pkg/ansi/init_windows.go
@@ -1,0 +1,23 @@
+// +build windows
+
+package ansi
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// enableAnsiColors enables support for ANSI color sequences in Windows
+// default console. Note that this only works with Windows 10.
+func enableAnsiColors() {
+	stdout := windows.Handle(os.Stdout.Fd())
+	var originalMode uint32
+
+	windows.GetConsoleMode(stdout, &originalMode)
+	windows.SetConsoleMode(stdout, originalMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+}
+
+func init() {
+	enableAnsiColors()
+}


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe @aarongreen-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
The Windows console does not support ANSI color codes, resulting in strange characters in the output (cf. #93). With Windows 10, the console _can_ support ANSI colors, but support must be explicitly enabled.

This PR does that by using some code adapted from this comment: https://github.com/sirupsen/logrus/issues/496#issue-210627761.

It also changes the [spinner charset](https://github.com/briandowns/spinner#available-character-sets) to use standard ASCII characters on Windows, since the default console font does not support the fancy characters.

Fixes #93 (to an extent).