### PR TITLE
Make the resources command more prominent

### DIFF
--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -19,7 +19,7 @@ func newResourcesCmd() *resourcesCmd {
 	rc.cmd = &cobra.Command{
 		Use:   "resources",
 		Args:  validators.NoArgs,
-		Short: "list namespace and resource subcommands",
+		Short: "List namespace and resource subcommands",
 	}
 	rc.cmd.SetHelpTemplate(getResourcesHelpTemplate())
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -29,7 +29,7 @@ var rootCmd = &cobra.Command{
 		"listen":    "webhooks",
 		"logs":      "stripe",
 		"status":    "stripe",
-		"resources": "help",
+		"resources": "resources",
 	},
 	Version: version.Version,
 	Short:   "A CLI to help you integrate Stripe with your application",

--- a/pkg/cmd/templates.go
+++ b/pkg/cmd/templates.go
@@ -55,6 +55,9 @@ func getUsageTemplate() string {
 %s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "stripe")}}
   {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
 
+%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "resources")}}
+  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
+
 %s{{range $index, $cmd := .Commands}}{{if (not (index $.Annotations $cmd.Name))}}
   {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}{{else}}
 
@@ -65,10 +68,7 @@ func getUsageTemplate() string {
 {{WrappedLocalFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
 %s
-{{WrappedInheritedFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
-
-%s{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+{{WrappedInheritedFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableSubCommands}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `,
@@ -78,11 +78,11 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 		ansi.Bold("HTTP commands:"),
 		ansi.Bold("Webhook commands:"),
 		ansi.Bold("Stripe commands:"),
+		ansi.Bold("Resource commands:"),
 		ansi.Bold("Other commands:"),
 		ansi.Bold("Available commands:"),
 		ansi.Bold("Flags:"),
 		ansi.Bold("Global flags:"),
-		ansi.Bold("Additional help topics:"),
 	)
 }
 


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
I wanted to make the resources command call out more prominent, it felt like it was buried a bit. It now looks like:

<img width="568" alt="Screen Shot 2019-08-19 at 6 09 03 AM" src="https://user-images.githubusercontent.com/42354557/63267884-db58b080-c247-11e9-976a-90120e462de5.png">

