### PR TITLE
Add missing comments for exported code

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,8 +20,13 @@ import (
 	"github.com/stripe/stripe-cli/pkg/ansi"
 )
 
+// ColorOn represnets the on-state for colors
 const ColorOn = "on"
+
+// ColorOff represents the off-state for colors
 const ColorOff = "off"
+
+// ColorAuto represents the auto-state for colors
 const ColorAuto = "auto"
 
 // Config handles all overall configuration for the CLI

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -28,6 +28,8 @@ func (p *Profile) CreateProfile() error {
 	return nil
 }
 
+// GetColor gets the color setting for the user based on the flag or the
+// persisted color stored in the config file
 func (p *Profile) GetColor() (string, error) {
 	color := viper.GetString("color")
 	if color != "" {


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Adds some missing comments to color configurations
