### PR TITLE
[wip] Document request parameters in operation `--help` invocations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365
 	github.com/joho/godotenv v1.3.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/kr/text v0.1.0
 	github.com/logrusorgru/aurora v0.0.0-20190803045625-94edacc10f9b
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/manifoldco/promptui v0.3.2

--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -2,14 +2,23 @@ package resource
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
 	"regexp"
+	"runtime"
+	"sort"
 	"strings"
 
+	"github.com/russross/blackfriday"
+
+	"github.com/kr/text"
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/spec"
 )
 
 //
@@ -46,6 +55,49 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 	return err
 }
 
+func (oc *OperationCmd) helpFunc(cmd *cobra.Command, args []string) {
+	err := pageString(oc.helpString(cmd), cmd.OutOrStdout())
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (oc *OperationCmd) helpString(cmd *cobra.Command) string {
+	var sb strings.Builder
+
+	stripeSpec, err := spec.LoadSpec("")
+	if err != nil {
+		panic(err)
+	}
+	opSpec := stripeSpec.Paths[spec.Path(oc.Path)][spec.HTTPVerb(strings.ToLower(oc.HTTPVerb))]
+
+	sb.WriteString(fmt.Sprintf(`%s
+
+%s
+
+%s
+
+%s
+
+%s
+`,
+		ansi.Bold("USAGE"),
+		text.Indent(cmd.CommandPath(), "    "),
+		ansi.Bold("DESCRIPTION"),
+		text.Indent(text.Wrap(opSpec.Description, 76), "    "),
+		ansi.Bold("PARAMETERS"),
+	))
+
+	paramsSchema := opSpec.RequestBody.Content["application/x-www-form-urlencoded"].Schema
+	for _, name := range sortedParamNames(paramsSchema) {
+		schema := paramsSchema.Properties[name]
+		sb.WriteString(paramHelpString(name, schema, "    "))
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
 //
 // Public functions
 //
@@ -53,7 +105,6 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 // NewOperationCmd returns a new OperationCmd.
 func NewOperationCmd(parentCmd *cobra.Command, name, path, httpVerb string, cfg *config.Config) *OperationCmd {
 	urlParams := extractURLParams(path)
-	httpVerb = strings.ToUpper(httpVerb)
 	operationCmd := &OperationCmd{
 		Base: &requests.Base{
 			Method:  httpVerb,
@@ -71,6 +122,7 @@ func NewOperationCmd(parentCmd *cobra.Command, name, path, httpVerb string, cfg 
 		Args:        cobra.MinimumNArgs(len(urlParams)),
 	}
 	cmd.SetUsageTemplate(operationUsageTemplate(urlParams))
+	cmd.SetHelpFunc(operationCmd.helpFunc)
 	cmd.DisableFlagsInUseLine = true
 	operationCmd.Cmd = cmd
 	operationCmd.InitFlags(false)
@@ -145,4 +197,58 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 		ansi.Bold("Global Flags:"),
 		ansi.Bold("Additional help topics:"),
 	)
+}
+
+func paramHelpString(name string, schema *spec.Schema, indent string) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("\n%so %s (%s)\n", indent, ansi.Bold(name), ansi.Italic(schema.Type)))
+
+	indent += "  "
+
+	if len(schema.Description) > 0 {
+		converted := string(blackfriday.Markdown([]byte(schema.Description), ansi.MarkdownTermRenderer(0), 0))
+		wrapped := text.Wrap(converted, 80-len(indent))
+		sb.WriteString(text.Indent(wrapped, indent))
+	}
+
+	for _, subName := range sortedParamNames(schema) {
+		subSchema := schema.Properties[subName]
+		sb.WriteString(paramHelpString(subName, subSchema, indent))
+	}
+
+	return sb.String()
+}
+
+func sortedParamNames(schema *spec.Schema) []string {
+	names := make([]string, 0, len(schema.Properties))
+	for name := range schema.Properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func pageString(s string, out io.Writer) error {
+	pagerExe := ""
+	switch {
+	case len(os.Getenv("PAGER")) > 0:
+		pagerExe = os.Getenv("PAGER")
+	case runtime.GOOS == "windows":
+		pagerExe = "more"
+	default:
+		pagerExe = "less"
+	}
+
+	pager := exec.Command(pagerExe)
+
+	pager.Stdin = strings.NewReader(s)
+	pager.Stdout = out
+
+	err := pager.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/cmd/resource/operation_test.go
+++ b/pkg/cmd/resource/operation_test.go
@@ -16,11 +16,11 @@ import (
 func TestNewOperationCmd(t *testing.T) {
 	parentCmd := &cobra.Command{Annotations: make(map[string]string)}
 
-	oc := NewOperationCmd(parentCmd, "foo", "/v1/bars/{id}", "get", &config.Config{})
+	oc := NewOperationCmd(parentCmd, "foo", "/v1/bars/{id}", http.MethodGet, &config.Config{})
 
 	require.Equal(t, "foo", oc.Name)
 	require.Equal(t, "/v1/bars/{id}", oc.Path)
-	require.Equal(t, "GET", oc.HTTPVerb)
+	require.Equal(t, http.MethodGet, oc.HTTPVerb)
 	require.Equal(t, []string{"{id}"}, oc.URLParams)
 	require.True(t, parentCmd.HasSubCommands())
 	val, ok := parentCmd.Annotations["foo"]
@@ -47,7 +47,7 @@ func TestRunOperationCmd(t *testing.T) {
 	profile := config.Profile{
 		APIKey: "sk_test_1234",
 	}
-	oc := NewOperationCmd(parentCmd, "foo", "/v1/bars/{id}", "post", &config.Config{
+	oc := NewOperationCmd(parentCmd, "foo", "/v1/bars/{id}", http.MethodPost, &config.Config{
 		Profile: profile,
 	})
 	oc.APIBaseURL = ts.URL
@@ -60,7 +60,7 @@ func TestRunOperationCmd(t *testing.T) {
 func TestRunOperationCmd_NoAPIKey(t *testing.T) {
 	viper.Reset()
 	parentCmd := &cobra.Command{Annotations: make(map[string]string)}
-	oc := NewOperationCmd(parentCmd, "foo", "/v1/bars/{id}", "post", &config.Config{})
+	oc := NewOperationCmd(parentCmd, "foo", "/v1/bars/{id}", http.MethodPost, &config.Config{})
 
 	err := oc.runOperationCmd(oc.Cmd, []string{"bar_123", "param1=value1", "param2=value2"})
 

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -113,16 +113,17 @@ type Schema struct {
 	// for anything right now.
 	AdditionalProperties interface{} `json:"additionalProperties,omitempty"`
 
-	AnyOf      []*Schema          `json:"anyOf,omitempty"`
-	Enum       []interface{}      `json:"enum,omitempty"`
-	Format     string             `json:"format,omitempty"`
-	Items      *Schema            `json:"items,omitempty"`
-	MaxLength  int                `json:"maxLength,omitempty"`
-	Nullable   bool               `json:"nullable,omitempty"`
-	Pattern    string             `json:"pattern,omitempty"`
-	Properties map[string]*Schema `json:"properties,omitempty"`
-	Required   []string           `json:"required,omitempty"`
-	Type       string             `json:"type,omitempty"`
+	AnyOf       []*Schema          `json:"anyOf,omitempty"`
+	Description string             `json:"description,omitempty"`
+	Enum        []interface{}      `json:"enum,omitempty"`
+	Format      string             `json:"format,omitempty"`
+	Items       *Schema            `json:"items,omitempty"`
+	MaxLength   int                `json:"maxLength,omitempty"`
+	Nullable    bool               `json:"nullable,omitempty"`
+	Pattern     string             `json:"pattern,omitempty"`
+	Properties  map[string]*Schema `json:"properties,omitempty"`
+	Required    []string           `json:"required,omitempty"`
+	Type        string             `json:"type,omitempty"`
 
 	// Ref is populated if this JSON Schema is actually a JSON reference, and
 	// it defines the location of the actual schema definition.


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/dev-platform

 ### Summary
When calling any operation command (e.g. `stripe subscriptions update`) with the `--help` flag, we should output a list of all possible request parameters.

This PR is a first attempt at this. It's far from ready, but you can test with:
```
$ go run cmd/stripe/main.go subscriptions update --help
```
(or any other operation command)

TODO:
- [x] ~re-embed the spec (I think it's fine to load the spec at runtime for this, and probably a lot easier than trying to do this via codegen)~ (done in #127)
- [x] use the correct pager (`$PAGER` if set, otherwise `less` on Unix/macOS or `more` on Windows)
- [ ] compute proper human-readable types, e.g. "array of strings", "array of objects", "integer OR string"...
- [ ] handle `anyOf` (polymorphic) params
- [ ] display the structure of element for array params
- [ ] handle `anyOf(object, empty string)` params (unsettable params)
- [ ] convert HTML to text/ANSI
- [ ] convert Markdown to text/ANSI
- and probably many other things
