### PR TITLE
Add command to quickly open stripe pages

### DIFF
--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/stripe/stripe-cli/pkg/open"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+var nameURLmap = map[string]string{
+	"dashboard":                          "https://dashboard.stripe.com/",
+	"dashboard/payments":                 "https://dashboard.stripe.com/payments",
+	"dashboard/disputes":                 "https://dashboard.stripe.com/disputes",
+	"dashboard/balance":                  "https://dashboard.stripe.com/balance/overview",
+	"dashboard/payouts":                  "https://dashboard.stripe.com/payouts",
+	"dashboard/topups":                   "https://dashboard.stripe.com/topups",
+	"dashboard/transactions":             "https://dashboard.stripe.com/balance",
+	"dashboard/customers":                "https://dashboard.stripe.com/customers",
+	"dashboard/atlas":                    "https://dashboard.stripe.com/atlas",
+	"dashboard/radar":                    "https://dashboard.stripe.com/radar",
+	"dashboard/radar/reviews":            "https://dashboard.stripe.com/radar/reviews",
+	"dashboard/radar/list":               "https://dashboard.stripe.com/radar/list",
+	"dashboard/radar/rules":              "https://dashboard.stripe.com/radar/rules",
+	"dashboard/billing":                  "https://dashboard.stripe.com/billing",
+	"dashboard/invoices":                 "https://dashboard.stripe.com/invoices",
+	"dashboard/subscriptions":            "https://dashboard.stripe.com/subscriptions",
+	"dashboard/subscriptions/products":   "https://dashboard.stripe.com/subscriptions/products",
+	"dashboard/tax-rates":                "https://dashboard.stripe.com/tax-rates",
+	"dashboard/coupons":                  "https://dashboard.stripe.com/coupons",
+	"dashboard/connect":                  "https://dashboard.stripe.com/connect/overview",
+	"dashboard/connect/accounts":         "https://dashboard.stripe.com/connect/accounts/overview",
+	"dashboard/connect/transfers":        "https://dashboard.stripe.com/connect/transfers",
+	"dashboard/connect/collected-fees":   "https://dashboard.stripe.com/connect/application_fees",
+	"dashboard/orders":                   "https://dashboard.stripe.com/orders",
+	"dashboard/orders/products":          "https://dashboard.stripe.com/orders/products",
+	"dashboard/terminal":                 "https://dashboard.stripe.com/terminal",
+	"dashboard/terminal/locations":       "https://dashboard.stripe.com/terminal/locations",
+	"dashboard/terminal/hardware_orders": "https://dashboard.stripe.com/terminal/hardware_orders",
+	"dashboard/developers":               "https://dashboard.stripe.com/developers",
+	"dashboard/apikeys":                  "https://dashboard.stripe.com/apikeys",
+	"dashboard/webhooks":                 "https://dashboard.stripe.com/webhooks",
+	"dashboard/events":                   "https://dashboard.stripe.com/events",
+	"dashboard/logs":                     "https://dashboard.stripe.com/logs",
+	"dashboard/settings":                 "https://dashboard.stripe.com/settings",
+	"api":                                "https://stripe.com/docs/api",
+	"apiref":                             "https://stripe.com/docs/api",
+	"docs":                               "https://stripe.com/docs",
+}
+
+func openNames() []string {
+	keys := make([]string, 0, len(nameURLmap))
+	for k := range nameURLmap {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
+type openCmd struct {
+	cmd *cobra.Command
+}
+
+func newOpenCmd() *openCmd {
+	oc := &openCmd{}
+	oc.cmd = &cobra.Command{
+		Use:       "open",
+		Args:      validators.ExactArgs(1),
+		ValidArgs: openNames(),
+		Short:     "Quickly open Stripe pages",
+		RunE:      oc.runOpenCmd,
+	}
+
+	return oc
+}
+
+func (oc *openCmd) runOpenCmd(cmd *cobra.Command, args []string) error {
+	err := open.Browser(nameURLmap[args[0]])
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/stripe/stripe-cli/pkg/open"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -73,9 +75,13 @@ func newOpenCmd() *openCmd {
 }
 
 func (oc *openCmd) runOpenCmd(cmd *cobra.Command, args []string) error {
-	err := open.Browser(nameURLmap[args[0]])
-	if err != nil {
-		return err
+	if url, ok := nameURLmap[args[0]]; ok {
+		err := open.Browser(url)
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("Unsupported open command, given: %s", args[0])
 	}
 
 	return nil

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -90,6 +90,7 @@ func init() {
 	rootCmd.AddCommand(newVersionCmd().cmd)
 	rootCmd.AddCommand(newLogsCmd(&Config).Cmd)
 	rootCmd.AddCommand(newResourcesCmd().cmd)
+	rootCmd.AddCommand(newOpenCmd().cmd)
 
 	addAllResourcesCmds(rootCmd)
 }

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -8,16 +8,15 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
-	"runtime"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/open"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
-var execCommand = exec.Command
+var openBrowser = open.Browser
 
 const stripeCLIAuthPath = "/stripecli/auth"
 
@@ -79,27 +78,6 @@ func Login(baseURL string, config *config.Config, input io.Reader) error {
 	} else {
 		ansi.StopSpinner(s, message, os.Stdout)
 		fmt.Println(ansi.Italic("Please note: this key will expire after 90 days, at which point you'll need to re-authenticate."))
-	}
-
-	return nil
-}
-
-func openBrowser(url string) error {
-	var err error
-
-	switch runtime.GOOS {
-	case "linux":
-		err = execCommand("xdg-open", url).Start()
-	case "windows":
-		err = execCommand("rundll32", "url.dll,FileProtocolHandler", url).Start()
-	case "darwin":
-		err = execCommand("open", url).Start()
-	default:
-		err = fmt.Errorf("unsupported platform")
-	}
-
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/pkg/login/client_login_test.go
+++ b/pkg/login/client_login_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/open"
 )
 
 func TestLogin(t *testing.T) {
@@ -22,12 +22,10 @@ func TestLogin(t *testing.T) {
 		return
 	}
 
-	execCommand = func(string, ...string) *exec.Cmd {
-		cmd := exec.Command(os.Args[0], "-test.run=TestLogin")
-		cmd.Env = []string{"OPEN_URL=1"}
-		return cmd
+	openBrowser = func(string) error {
+		return nil
 	}
-	defer func() { execCommand = exec.Command }()
+	defer func() { openBrowser = open.Browser }()
 
 	profilesFile := filepath.Join(os.TempDir(), "stripe", "config.toml")
 

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -1,0 +1,31 @@
+package open
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+var execCommand = exec.Command
+
+// Browser takes a url and opens it using the default browser on the operating system
+func Browser(url string) error {
+	var err error
+
+	switch runtime.GOOS {
+	case "linux":
+		err = execCommand("xdg-open", url).Start()
+	case "windows":
+		err = execCommand("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		err = execCommand("open", url).Start()
+	default:
+		err = fmt.Errorf("unsupported platform")
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform @auchenberg-stripe @mg-stripe 

 ### Summary
Add a command to quickly open stripe pages.

I hard-coded this for the time being because I the dashboard does not consistently name paths, which would've made the more dynamic solution have a few tricky edge-cases. I think the long-term best solution is to probably generate some json file from our backend that we could easily parse.

The other benefit of this is that it also works with tab-completion since we list out all the paths specifically.

I didn't add search because I couldn't find a way to pre-search on /docs or the apiref through the url. We could do that as a follow up if we have a way to do this.
