### PR TITLE
Add a terminal renderer for Markdown strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/pelletier/go-toml v1.4.0 // indirect
+	github.com/russross/blackfriday v1.5.2
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=

--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -120,6 +120,12 @@ func StopSpinner(s *spinner.Spinner, msg string, w io.Writer) {
 	s.Stop()
 }
 
+// StrikeThrough returns struck though text if the writer supports colors
+func StrikeThrough(text string) string {
+	color := Color(os.Stdout)
+	return color.Sprintf(color.StrikeThrough(text))
+}
+
 //
 // Private functions
 //

--- a/pkg/ansi/markdownterm.go
+++ b/pkg/ansi/markdownterm.go
@@ -1,0 +1,186 @@
+// nolint:golint
+package ansi
+
+import (
+	"bytes"
+
+	"github.com/russross/blackfriday"
+)
+
+// Markdown terminal renderer configuration options.
+const (
+	MDTERM_USE_ANSI = 1 << iota // use ANSI sequences
+)
+
+// MarkdownTerm is a type that implements the blackfriday.Renderer interface
+// for terminal output.
+//
+// Note that it only supports a small subset of Markdown features. It should
+// only be used for rendering documentation strings from Stripe's OpenAPI
+// specification file.
+//
+// Do not create this directly, instead use the MarkdownTermRenderer function.
+type MarkdownTerm struct {
+	flags int // MDTERM_* options
+}
+
+// MarkdownTermRenderer creates and configures a MarkdownTerm object, which
+// satisfies the Renderer interface.
+//
+// flags is a set of MDTERM_* options ORed together.
+func MarkdownTermRenderer(flags int) blackfriday.Renderer {
+	return &MarkdownTerm{flags: flags}
+}
+
+func (options *MarkdownTerm) GetFlags() int {
+	return options.flags
+}
+
+// Block-level callbacks
+
+func (options *MarkdownTerm) BlockCode(out *bytes.Buffer, text []byte, info string) {
+	out.Write(text)
+}
+
+func (options *MarkdownTerm) BlockQuote(out *bytes.Buffer, text []byte) {
+	out.Write(text)
+}
+
+func (options *MarkdownTerm) BlockHtml(out *bytes.Buffer, text []byte) {
+	out.Write(text)
+}
+
+func (options *MarkdownTerm) Header(out *bytes.Buffer, text func() bool, level int, id string) {
+	marker := out.Len()
+
+	if !text() {
+		out.Truncate(marker)
+		return
+	}
+	out.WriteString("\n")
+}
+
+func (options *MarkdownTerm) HRule(out *bytes.Buffer) {
+}
+
+func (options *MarkdownTerm) List(out *bytes.Buffer, text func() bool, flags int) {
+}
+
+func (options *MarkdownTerm) ListItem(out *bytes.Buffer, text []byte, flags int) {
+	out.WriteString("o ")
+	out.Write(text)
+}
+
+func (options *MarkdownTerm) Paragraph(out *bytes.Buffer, text func() bool) {
+	marker := out.Len()
+	out.WriteString("\n")
+	if !text() {
+		out.Truncate(marker)
+		return
+	}
+	out.WriteString("\n")
+}
+
+func (options *MarkdownTerm) Table(out *bytes.Buffer, header []byte, body []byte, columnData []int) {
+}
+
+func (options *MarkdownTerm) TableRow(out *bytes.Buffer, text []byte) {
+}
+
+func (options *MarkdownTerm) TableHeaderCell(out *bytes.Buffer, text []byte, align int) {
+}
+
+func (options *MarkdownTerm) TableCell(out *bytes.Buffer, text []byte, align int) {
+}
+
+func (options *MarkdownTerm) Footnotes(out *bytes.Buffer, text func() bool) {
+}
+
+func (options *MarkdownTerm) FootnoteItem(out *bytes.Buffer, name, text []byte, flags int) {
+}
+
+func (options *MarkdownTerm) TitleBlock(out *bytes.Buffer, text []byte) {
+	out.Write(text)
+}
+
+// Span-level callbacks
+
+func (options *MarkdownTerm) AutoLink(out *bytes.Buffer, link []byte, kind int) {
+	out.Write(link)
+}
+
+func (options *MarkdownTerm) CodeSpan(out *bytes.Buffer, text []byte) {
+	out.Write(text)
+}
+
+func (options *MarkdownTerm) DoubleEmphasis(out *bytes.Buffer, text []byte) {
+	if options.flags&MDTERM_USE_ANSI != 0 {
+		out.WriteString(Bold(string(text)))
+	} else {
+		out.Write(text)
+	}
+}
+
+func (options *MarkdownTerm) Emphasis(out *bytes.Buffer, text []byte) {
+	if options.flags&MDTERM_USE_ANSI != 0 {
+		out.WriteString(Italic(string(text)))
+	} else {
+		out.Write(text)
+	}
+}
+
+func (options *MarkdownTerm) Image(out *bytes.Buffer, link []byte, title []byte, alt []byte) {
+}
+
+func (options *MarkdownTerm) LineBreak(out *bytes.Buffer) {
+	out.WriteString("\n")
+}
+
+func (options *MarkdownTerm) Link(out *bytes.Buffer, link []byte, title []byte, content []byte) {
+	// We're not using Linkify here because pager programs like less don't
+	// support the hyperlink ANSI sequence.
+	out.Write(content)
+	out.WriteString(" [")
+	out.Write(link)
+	out.WriteString("]")
+}
+
+func (options *MarkdownTerm) RawHtmlTag(out *bytes.Buffer, tag []byte) {
+}
+
+func (options *MarkdownTerm) TripleEmphasis(out *bytes.Buffer, text []byte) {
+	if options.flags&MDTERM_USE_ANSI != 0 {
+		out.WriteString(Bold(Italic(string(text))))
+	} else {
+		out.Write(text)
+	}
+}
+
+func (options *MarkdownTerm) StrikeThrough(out *bytes.Buffer, text []byte) {
+	if options.flags&MDTERM_USE_ANSI != 0 {
+		out.WriteString(StrikeThrough(string(text)))
+	} else {
+		out.Write(text)
+	}
+}
+
+func (options *MarkdownTerm) FootnoteRef(out *bytes.Buffer, ref []byte, id int) {
+}
+
+// Low-level callbacks
+
+func (options *MarkdownTerm) Entity(out *bytes.Buffer, entity []byte) {
+	out.Write(entity)
+}
+
+func (options *MarkdownTerm) NormalText(out *bytes.Buffer, text []byte) {
+	out.Write(text)
+}
+
+// Header and footer
+
+func (options *MarkdownTerm) DocumentHeader(out *bytes.Buffer) {
+}
+
+func (options *MarkdownTerm) DocumentFooter(out *bytes.Buffer) {
+}

--- a/pkg/ansi/markdownterm_test.go
+++ b/pkg/ansi/markdownterm_test.go
@@ -1,0 +1,70 @@
+package ansi
+
+import (
+	"os"
+	"testing"
+
+	"github.com/russross/blackfriday"
+
+	"github.com/stretchr/testify/require"
+)
+
+func render(s string, useAnsi bool) string {
+	flags := 0
+	if useAnsi {
+		flags |= MDTERM_USE_ANSI
+	}
+	r := MarkdownTermRenderer(flags)
+	return string(blackfriday.Markdown([]byte(s), r, blackfriday.EXTENSION_STRIKETHROUGH))
+}
+
+func TestMain(m *testing.M) {
+	ForceColors = true
+	code := m.Run()
+	ForceColors = false
+	os.Exit(code)
+}
+
+func TestMarkdownTermRenderer(t *testing.T) {
+	r := MarkdownTermRenderer(MDTERM_USE_ANSI)
+	require.Equal(t, MDTERM_USE_ANSI, r.GetFlags())
+}
+
+func TestMarkdownTerm_Header(t *testing.T) {
+	require.Equal(t, "Foo\n", render("# Foo\n", true))
+	require.Equal(t, "Foo\n", render("# Foo\n", false))
+	require.Equal(t, "", render("", true))
+	require.Equal(t, "", render("", false))
+}
+
+func TestMarkdownTerm_Paragraph(t *testing.T) {
+	require.Equal(t, "\nFoo.\n\nBar.\n", render("Foo.\n\nBar.", true))
+	require.Equal(t, "\nFoo.\n\nBar.\n", render("Foo.\n\nBar.", false))
+	require.Equal(t, "", render("", true))
+	require.Equal(t, "", render("", false))
+}
+
+func TestMarkdownTerm_DoubleEmphasis(t *testing.T) {
+	require.Equal(t, "\n\x1b[1mfoo\x1b[0m\n", render("**foo**", true))
+	require.Equal(t, "\nfoo\n", render("**foo**", false))
+}
+
+func TestMarkdownTerm_Emphasis(t *testing.T) {
+	require.Equal(t, "\n\x1b[3mfoo\x1b[0m\n", render("*foo*", true))
+	require.Equal(t, "\nfoo\n", render("*foo*", false))
+}
+
+func TestMarkdownTerm_Link(t *testing.T) {
+	require.Equal(t, "\nfoo [https://example.com/foo]\n", render("[foo](https://example.com/foo)", true))
+	require.Equal(t, "\nfoo [https://example.com/foo]\n", render("[foo](https://example.com/foo)", false))
+}
+
+func TestMarkdownTerm_TripleEmphasis(t *testing.T) {
+	require.Equal(t, "\n\x1b[1m\x1b[3mfoo\x1b[0m\x1b[0m\n", render("***foo***", true))
+	require.Equal(t, "\nfoo\n", render("***foo***", false))
+}
+
+func TestMarkdownTerm_StrikeThrough(t *testing.T) {
+	require.Equal(t, "\n\x1b[9mfoo\x1b[0m\n", render("~~foo~~", true))
+	require.Equal(t, "\nfoo\n", render("~~foo~~", false))
+}


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Add a terminal renderer for Markdown strings, that can optionally use ANSI sequences.

The renderer is very basic and only supports a small subset of Markdown features, but it should be enough for rendering the documentation strings from the OpenAPI spec.

Markdown parsing is done by the [Blackfriday](https://github.com/russross/blackfriday) library.