### PR TITLE
When setting up a sample, update the sample server to point to the correct file

### DIFF
--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -101,6 +101,10 @@ func (cc *CreateCmd) runCreateCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// TODO: setup .env
+	err = sample.PointToDotEnv(targetPath)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/samples/samples_test.go
+++ b/pkg/samples/samples_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockGit struct {
@@ -93,4 +94,178 @@ func TestDestinationPath(t *testing.T) {
 	}
 
 	assert.Equal(t, "planet-express/bender", sample.destinationPath("planet-express", "robots", "bender"))
+}
+
+func TestFindServerFiles(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	// Create a fake sample
+	fs.MkdirAll("/user/bender/adding-sales-tax/server", os.ModePerm)
+	fs.Create("/user/bender/adding-sales-tax/server/app.rb")
+	fs.Create("/user/bender/adding-sales-tax/server/README.md")
+	fs.MkdirAll("/user/bender/adding-sales-tax/client", os.ModePerm)
+	fs.Create("/user/bender/adding-sales-tax/client/README.md")
+	fs.Create("/user/bender/adding-sales-tax/client/frontend.js")
+
+	// Let's give bender some user files to make sure we don't do anything we're not supposed to
+	fs.MkdirAll("/user/bender/code/planex/server", os.ModePerm)
+	fs.Create("/user/bender/code/planex/server/app.py")
+	fs.MkdirAll("/user/bender/code/", os.ModePerm)
+
+	expected := []string{"/user/bender/adding-sales-tax/server/README.md", "/user/bender/adding-sales-tax/server/app.rb"}
+
+	sample := Samples{
+		Fs: fs,
+	}
+	files, err := sample.findServerFiles("/user/bender/adding-sales-tax")
+	require.Nil(t, err)
+	require.Equal(t, expected, files)
+}
+
+func TestFileWhiteList(t *testing.T) {
+	assert.True(t, fileWhitelist("/server/app.java"))
+	assert.True(t, fileWhitelist("/server/app.js"))
+	assert.True(t, fileWhitelist("/server/app.php"))
+	assert.True(t, fileWhitelist("/server/app.rb"))
+	assert.False(t, fileWhitelist("/server/app.py"))
+	assert.False(t, fileWhitelist("/server/.env"))
+	assert.False(t, fileWhitelist("/server/.htaccess"))
+	assert.False(t, fileWhitelist("/server/img.png"))
+	assert.False(t, fileWhitelist("/server/package.json"))
+	assert.False(t, fileWhitelist("/server/Gemfile"))
+	assert.False(t, fileWhitelist("/server/pom.xml"))
+	assert.False(t, fileWhitelist("/server/config.lock"))
+	assert.False(t, fileWhitelist("/server/requirements.txt"))
+}
+
+func TestPointToDotEnvWithOneIntegrationRb(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	file := []byte(`ENV_PATH = '/../../../.env'.freeze`)
+
+	// Create a fake sample
+	fs.MkdirAll("/user/bender/adding-sales-tax/server", os.ModePerm)
+	afero.WriteFile(fs, "/user/bender/adding-sales-tax/server/app.rb", file, os.ModePerm)
+
+	sample := Samples{
+		Fs:            fs,
+		integration:   []string{"planex"},
+		isIntegration: true,
+	}
+	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
+
+	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.rb")
+	expected := []byte(`ENV_PATH = '../.env'.freeze`)
+	require.Nil(t, err)
+	assert.Equal(t, string(expected), string(data))
+}
+
+func TestPointToDotEnvWithNoIntegrationRb(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	file := []byte(`ENV_PATH = '/../../../.env'.freeze`)
+
+	// Create a fake sample
+	fs.MkdirAll("/user/bender/adding-sales-tax/server", os.ModePerm)
+	afero.WriteFile(fs, "/user/bender/adding-sales-tax/server/app.rb", file, os.ModePerm)
+
+	sample := Samples{
+		Fs:            fs,
+		integration:   []string{},
+		isIntegration: false,
+	}
+	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
+
+	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.rb")
+	expected := []byte(`ENV_PATH = '../.env'.freeze`)
+	require.Nil(t, err)
+	assert.Equal(t, expected, data)
+}
+
+func TestPointToDotEnvWithMultipleIntegrationRb(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	file := []byte(`ENV_PATH = '/../../../.env'.freeze`)
+
+	// Create a fake sample
+	fs.MkdirAll("/user/bender/adding-sales-tax/server", os.ModePerm)
+	afero.WriteFile(fs, "/user/bender/adding-sales-tax/server/app.rb", file, os.ModePerm)
+
+	sample := Samples{
+		Fs:            fs,
+		integration:   []string{"planex", "planex2"},
+		isIntegration: true,
+	}
+	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
+
+	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.rb")
+	expected := []byte(`ENV_PATH = '../../.env'.freeze`)
+	require.Nil(t, err)
+	assert.Equal(t, expected, data)
+}
+
+func TestPointToDotEnvWithMultipleIntegrationJava(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	file := []byte(`String ENV_PATH = "../../..";`)
+
+	// Create a fake sample
+	fs.MkdirAll("/user/bender/adding-sales-tax/server", os.ModePerm)
+	afero.WriteFile(fs, "/user/bender/adding-sales-tax/server/app.java", file, os.ModePerm)
+
+	sample := Samples{
+		Fs:            fs,
+		integration:   []string{"planex", "planex2"},
+		isIntegration: true,
+	}
+	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
+
+	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.java")
+	expected := []byte(`String ENV_PATH = "../../";`)
+	require.Nil(t, err)
+	assert.Equal(t, expected, data)
+}
+
+func TestPointToDotEnvWithMultipleIntegrationPhp(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	file := []byte(`$ENV_PATH = '../../..';`)
+
+	// Create a fake sample
+	fs.MkdirAll("/user/bender/adding-sales-tax/server", os.ModePerm)
+	afero.WriteFile(fs, "/user/bender/adding-sales-tax/server/app.php", file, os.ModePerm)
+
+	sample := Samples{
+		Fs:            fs,
+		integration:   []string{"planex", "planex2"},
+		isIntegration: true,
+	}
+	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
+
+	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.php")
+	expected := []byte(`$ENV_PATH = '../..';`)
+	require.Nil(t, err)
+	assert.Equal(t, expected, data)
+}
+
+func TestPointToDotEnvWithMultipleIntegrationJs(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	file := []byte(`const envPath = resolve(__dirname, "../../../.env");`)
+
+	// Create a fake sample
+	fs.MkdirAll("/user/bender/adding-sales-tax/server", os.ModePerm)
+	afero.WriteFile(fs, "/user/bender/adding-sales-tax/server/app.js", file, os.ModePerm)
+
+	sample := Samples{
+		Fs:            fs,
+		integration:   []string{"planex", "planex2"},
+		isIntegration: true,
+	}
+	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
+
+	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.js")
+	expected := []byte(`const envPath = resolve(__dirname, "../../.env");`)
+	require.Nil(t, err)
+	assert.Equal(t, string(expected), string(data))
 }


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform @adreyfus-stripe @ctrudeau-stripe 

 ### Summary
After we setup a sample we need to modify the sample's server file to change the location that the .env points to. When we setup the sample we're removing 1-2 layers of folder hierarchy so it no longer points to the right location. We ended up doing this in the CLI as we believe it'll be the most cross-platform solution. We looked into symlinks but with them we're not for sure going to have perfect compatibility across platforms, we'd have to create >100 of them at the moment, and users might not fully understand what symlinks are doing.

This looks specifically for `java`, `rb`, `php`, and `js` files. Python is not needed because the dotenv library in Python is smart enough to recursively search upwards from the folder.

Each language sample has the same definition for env paths, so I explicitly search for that in the CLI. From there, once a match is found, the CLI reconstructs the definition with the correct path and replaces the existing definition.