### PR TITLE
Fix a panic crash if running open with no args

### DIFF
--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -108,7 +108,8 @@ func (oc *openCmd) runOpenCmd(cmd *cobra.Command, args []string) error {
 	if list || len(args) == 0 {
 
 		fmt.Println("open quickly opens Stripe pages. To use, run 'stripe open <shortcut>'.")
-		fmt.Println("open supports the following shortcuts:\n")
+		fmt.Println("open supports the following shortcuts:")
+		fmt.Println()
 		shortcuts := openNames()
 		sort.Strings(shortcuts)
 		longest := getLongestShortcut(shortcuts)

--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -105,11 +105,16 @@ func (oc *openCmd) runOpenCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if list {
+	if list || len(args) == 0 {
+
+		fmt.Println("open quickly opens Stripe pages. To use, run 'stripe open <shortcut>'.")
+		fmt.Println("open supports the following shortcuts:\n")
 		shortcuts := openNames()
 		sort.Strings(shortcuts)
 		longest := getLongestShortcut(shortcuts)
 
+		fmt.Println(fmt.Sprintf("%s%s", padName("shortcut", longest), "    url"))
+		fmt.Println(fmt.Sprintf("%s%s", padName("--------", longest), "    ---------"))
 		for _, shortcut := range shortcuts {
 			paddedName := padName(shortcut, longest)
 			fmt.Println(fmt.Sprintf("%s => %s", paddedName, nameURLmap[shortcut]))


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform @auchenberg-stripe 

 ### Summary
If no args are passed in, print out the supported shortcuts.

fixes #134 