### PR TITLE
Fix global api key and device name flags

### DIFF
--- a/pkg/cmd/resource/operation_test.go
+++ b/pkg/cmd/resource/operation_test.go
@@ -43,9 +43,13 @@ func TestRunOperationCmd(t *testing.T) {
 	defer ts.Close()
 
 	viper.Reset()
-	viper.Set("api_key", "sk_test_1234")
 	parentCmd := &cobra.Command{Annotations: make(map[string]string)}
-	oc := NewOperationCmd(parentCmd, "foo", "/v1/bars/{id}", "post", &config.Config{})
+	profile := config.Profile{
+		APIKey: "sk_test_1234",
+	}
+	oc := NewOperationCmd(parentCmd, "foo", "/v1/bars/{id}", "post", &config.Config{
+		Profile: profile,
+	})
 	oc.APIBaseURL = ts.URL
 
 	err := oc.runOperationCmd(oc.Cmd, []string{"bar_123", "param1=value1", "param2=value2"})

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -65,13 +65,12 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(Config.InitConfig)
 
-	rootCmd.PersistentFlags().String("api-key", "", "Your test mode API secret key to use for the command")
+	rootCmd.PersistentFlags().StringVar(&Config.Profile.APIKey, "api-key", "", "Your test mode API secret key to use for the command")
 	rootCmd.PersistentFlags().StringVar(&Config.Color, "color", "", "turn on/off color output (on, off, auto)")
 	rootCmd.PersistentFlags().StringVar(&Config.ProfilesFile, "config", "", "config file (default is $HOME/.config/stripe/config.toml)")
-	rootCmd.PersistentFlags().StringVar(&Config.LogLevel, "log-level", "info", "log level (debug, info, warn, error)")
-
-	rootCmd.PersistentFlags().StringVar(&Config.Profile.ProfileName, "project-name", "default", "the project name to read from for config")
 	rootCmd.PersistentFlags().StringVar(&Config.Profile.DeviceName, "device-name", "", "device name")
+	rootCmd.PersistentFlags().StringVar(&Config.LogLevel, "log-level", "info", "log level (debug, info, warn, error)")
+	rootCmd.PersistentFlags().StringVar(&Config.Profile.ProfileName, "project-name", "default", "the project name to read from for config")
 	rootCmd.Flags().BoolP("version", "v", false, "Get the version of the Stripe CLI")
 
 	viper.SetEnvPrefix("stripe")

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -52,9 +52,8 @@ func (p *Profile) GetColor() (string, error) {
 
 // GetDeviceName returns the configured device name
 func (p *Profile) GetDeviceName() (string, error) {
-	deviceName := viper.GetString("device_name")
-	if deviceName != "" {
-		return deviceName, nil
+	if p.DeviceName != "" {
+		return p.DeviceName, nil
 	}
 
 	if err := viper.ReadInConfig(); err == nil {
@@ -66,19 +65,18 @@ func (p *Profile) GetDeviceName() (string, error) {
 
 // GetAPIKey will return the existing key for the given profile
 func (p *Profile) GetAPIKey() (string, error) {
+	if p.APIKey != "" {
+		err := validators.APIKey(p.APIKey)
+		if err != nil {
+			return "", err
+		}
+		return p.APIKey, nil
+	}
+
 	// If the user doesn't have an api_key field set, they might be using an
 	// old configuration so try to read from secret_key
 	if !viper.IsSet(p.GetConfigField("api_key")) {
 		p.RegisterAlias("api_key", "secret_key")
-	}
-
-	key := viper.GetString("api_key")
-	if key != "" {
-		err := validators.APIKey(key)
-		if err != nil {
-			return "", err
-		}
-		return key, nil
 	}
 
 	// Try to fetch the API key from the configuration file


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Fixes global flags. The old methods need to use `BindPFlags`, but that has a weird side-effect of writing empty fields in the config file. This sets the values inside of the config profile struct directly instead.
