### PR TITLE
Implement fixtures functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
+	github.com/thedevsaddam/gojsonq v2.2.2+incompatible
 	github.com/tidwall/gjson v1.3.2
 	github.com/tidwall/pretty v1.0.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/thedevsaddam/gojsonq v2.2.2+incompatible h1:IDBN1FNzhv9p83n8JEnuu0rrlXIVFlf8K9lWuXPJHfI=
+github.com/thedevsaddam/gojsonq v2.2.2+incompatible/go.mod h1:RBcQaITThgJAAYKH7FNp2onYodRz8URfsuEGpAch0NA=
 github.com/tidwall/gjson v1.3.2 h1:+7p3qQFaH3fOMXAJSrdZwGKcOO/lYdGS0HqGhPqDdTI=
 github.com/tidwall/gjson v1.3.2/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=

--- a/pkg/cmd/samples.go
+++ b/pkg/cmd/samples.go
@@ -21,6 +21,7 @@ func newSamplesCmd() *samplesCmd {
 	}
 
 	samplesCmd.cmd.AddCommand(samples.NewCreateCmd(&Config).Cmd)
+	samplesCmd.cmd.AddCommand(samples.NewFixturesCmd(&Config).Cmd)
 	samplesCmd.cmd.AddCommand(samples.NewListCmd().Cmd)
 
 	return samplesCmd

--- a/pkg/cmd/samples/fixtures.go
+++ b/pkg/cmd/samples/fixtures.go
@@ -38,13 +38,12 @@ func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fixture := s.Fixture{
-		Fs:      afero.NewOsFs(),
-		APIKey:  apiKey,
-		BaseURL: stripe.DefaultAPIBaseURL,
-	}
-
-	err = fixture.NewFixture(args[0])
+	fixture, err := s.NewFixture(
+		afero.NewOsFs(),
+		apiKey,
+		stripe.DefaultAPIBaseURL,
+		args[0],
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/samples/fixtures.go
+++ b/pkg/cmd/samples/fixtures.go
@@ -43,7 +43,21 @@ func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
 		APIKey:  apiKey,
 		BaseURL: stripe.DefaultAPIBaseURL,
 	}
-	fixture.NewFixture(args[0])
+
+	err = fixture.NewFixture(args[0])
+	if err != nil {
+		return err
+	}
+
+	err = fixture.Execute()
+	if err != nil {
+		return err
+	}
+
+	err = fixture.UpdateEnv()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/cmd/samples/fixtures.go
+++ b/pkg/cmd/samples/fixtures.go
@@ -1,0 +1,49 @@
+package samples
+
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	s "github.com/stripe/stripe-cli/pkg/samples"
+	"github.com/stripe/stripe-cli/pkg/stripe"
+)
+
+// FixturesCmd prints a list of all the available sample projects that users can
+// generate
+type FixturesCmd struct {
+	Cmd *cobra.Command
+	Cfg *config.Config
+}
+
+// NewFixturesCmd creates and returns a list command for samples
+func NewFixturesCmd(cfg *config.Config) *FixturesCmd {
+	fixturesCmd := &FixturesCmd{
+		Cfg: cfg,
+	}
+
+	fixturesCmd.Cmd = &cobra.Command{
+		Use:   "fixtures",
+		Short: "Run fixtures to populate your account with data",
+		Long:  `Run fixtures to populate your account with data`,
+		RunE:  fixturesCmd.runFixturesCmd,
+	}
+
+	return fixturesCmd
+}
+
+func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
+	apiKey, err := fc.Cfg.Profile.GetAPIKey(false)
+	if err != nil {
+		return err
+	}
+
+	fixture := s.Fixture{
+		Fs:      afero.NewOsFs(),
+		APIKey:  apiKey,
+		BaseURL: stripe.DefaultAPIBaseURL,
+	}
+	fixture.NewFixture(args[0])
+
+	return nil
+}

--- a/pkg/samples/fixtures.go
+++ b/pkg/samples/fixtures.go
@@ -1,0 +1,183 @@
+package samples
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/spf13/afero"
+	"github.com/thedevsaddam/gojsonq"
+
+	"github.com/stripe/stripe-cli/pkg/requests"
+)
+
+// SupportedVersions is the version number of the fixture template the CLI supports
+const SupportedVersions = 0
+
+type metaFixture struct {
+	Version int `json:"_version"`
+}
+
+type fixtureFile struct {
+	Meta     metaFixture `json:"_meta"`
+	Fixtures []fixture   `json:"fixtures"`
+}
+
+type fixture struct {
+	Name string            `json:"name"`
+	HTTP map[string]string `json:"http"`
+	Data interface{}       `json:"data"`
+}
+
+// Fixture foo
+type Fixture struct {
+	Fs        afero.Fs
+	APIKey    string
+	BaseURL   string
+	responses map[string]*gojsonq.JSONQ
+}
+
+// NewFixture foo
+func (fxt *Fixture) NewFixture(file string) error {
+	var fixture fixtureFile
+	fxt.responses = make(map[string]*gojsonq.JSONQ)
+
+	filedata, err := afero.ReadFile(fxt.Fs, file)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(filedata, &fixture)
+	if err != nil {
+		return err
+	}
+
+	if fixture.Meta.Version > SupportedVersions {
+		return fmt.Errorf("Fixture version not supported: %s", string(fixture.Meta.Version))
+	}
+
+	for _, data := range fixture.Fixtures {
+		fmt.Println(fmt.Sprintf("Setting up fixture for: %s", data.Name))
+
+		resp, err := fxt.makeRequest(data)
+		if err != nil {
+			return err
+		}
+
+		fxt.responses[data.Name] = gojsonq.New().FromString(string(resp))
+	}
+
+	return nil
+}
+
+func (fxt *Fixture) makeRequest(data fixture) ([]byte, error) {
+	req := requests.Base{
+		Method:         strings.ToUpper(data.HTTP["method"]),
+		SuppressOutput: true,
+		APIBaseURL:     fxt.BaseURL,
+	}
+	return req.MakeRequest(fxt.APIKey, data.HTTP["path"], fxt.createParams(data.Data))
+}
+
+func (fxt *Fixture) createParams(params interface{}) *requests.RequestParameters {
+	requestParams := requests.RequestParameters{}
+	requestParams.AppendData(fxt.parseInterface(params))
+
+	return &requestParams
+}
+
+func (fxt *Fixture) parseInterface(params interface{}) []string {
+	var data []string
+	var cleanData []string
+
+	switch v := reflect.ValueOf(params); v.Kind() {
+	case reflect.Map:
+		m := params.(map[string]interface{})
+		data = append(data, fxt.parseMap(m, "")...)
+	case reflect.Array:
+		a := params.([]interface{})
+		data = append(data, fxt.parseArray(a, "")...)
+	default:
+	}
+
+	for _, d := range data {
+		if strings.TrimSpace(d) != "" {
+			cleanData = append(cleanData, strings.TrimSpace(d))
+		}
+	}
+
+	return cleanData
+}
+
+func (fxt *Fixture) parseMap(params map[string]interface{}, parent string) []string {
+	data := make([]string, len(params))
+	var keyname string
+
+	for key, value := range params {
+		if parent != "" {
+			keyname = fmt.Sprintf("%s[%s]", parent, key)
+		} else {
+			keyname = key
+		}
+
+		switch v := reflect.ValueOf(value); v.Kind() {
+		case reflect.String:
+			data = append(data, fmt.Sprintf("%s=%s", keyname, fxt.parseQuery(v.String())))
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			data = append(data, fmt.Sprintf("%s=%v", keyname, v.Int()))
+		case reflect.Map:
+			m := value.(map[string]interface{})
+			result := fxt.parseMap(m, keyname)
+			if len(result) > 0 {
+				data = append(data, result...)
+			}
+		case reflect.Array:
+			a := value.([]interface{})
+			result := fxt.parseArray(a, keyname)
+			if len(result) > 0 {
+				data = append(data, result...)
+			}
+		default:
+			continue
+		}
+	}
+
+	return data
+}
+
+func (fxt *Fixture) parseArray(params []interface{}, parent string) []string {
+	data := make([]string, len(params))
+
+	for _, value := range params {
+		switch v := reflect.ValueOf(value); v.Kind() {
+		case reflect.String:
+			data = append(data, fxt.parseQuery(v.String()))
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			data = append(data, string(v.Int()))
+		case reflect.Map:
+			m := value.(map[string]interface{})
+			data = append(data, fxt.parseMap(m, parent)...)
+		case reflect.Array:
+			a := value.([]interface{})
+			data = append(data, fxt.parseArray(a, parent)...)
+		default:
+			continue
+		}
+	}
+
+	return data
+}
+
+func (fxt *Fixture) parseQuery(value string) string {
+	// Queries to fill data will start with #$ and contain a : -- search for both
+	// to make sure that we're trying to parse a query
+	if strings.HasPrefix(value, "#$") && strings.Contains(value, ":") {
+		nameAndQuery := strings.SplitN(value, ":", 2)
+		name := strings.TrimLeft(nameAndQuery[0], "#$")
+		query := nameAndQuery[1]
+		return fxt.responses[name].Find(query).(string)
+	}
+
+	return value
+}

--- a/pkg/samples/fixtures.go
+++ b/pkg/samples/fixtures.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/spf13/afero"
@@ -88,10 +89,18 @@ func (fxt *Fixture) NewFixture(file string) error {
 }
 
 func (fxt *Fixture) makeRequest(data fixture) ([]byte, error) {
+	var rp requests.RequestParameters
+	if data.HTTP.Method == "post" {
+		now := time.Now().String()
+		metadata := fmt.Sprintf("metadata[_created_by_fixture]=%s", now)
+		rp.AppendData([]string{metadata})
+	}
+
 	req := requests.Base{
 		Method:         strings.ToUpper(data.HTTP.Method),
 		SuppressOutput: true,
 		APIBaseURL:     fxt.BaseURL,
+		Parameters:     rp,
 	}
 
 	path := fxt.parsePath(data.HTTP)

--- a/pkg/samples/fixtures_test.go
+++ b/pkg/samples/fixtures_test.go
@@ -126,6 +126,9 @@ func TestMakeRequest(t *testing.T) {
 	err := fxt.NewFixture("test_fixture.json")
 	require.Nil(t, err)
 
+	err = fxt.Execute()
+	require.Nil(t, err)
+
 	require.NotNil(t, fxt.responses["cust_bender"])
 	require.NotNil(t, fxt.responses["char_bender"])
 	require.NotNil(t, fxt.responses["capt_bender"])

--- a/pkg/samples/fixtures_test.go
+++ b/pkg/samples/fixtures_test.go
@@ -18,7 +18,7 @@ import (
 const testFixture = `
 {
 	"_meta": {
-		"template_version": "0"
+		"template_version": 0
 	},
 	"fixtures": [
 		{
@@ -117,13 +117,7 @@ func TestMakeRequest(t *testing.T) {
 
 	afero.WriteFile(fs, "test_fixture.json", []byte(testFixture), os.ModePerm)
 
-	fxt := Fixture{
-		Fs:      fs,
-		BaseURL: ts.URL,
-		APIKey:  "sk_test_1234",
-	}
-
-	err := fxt.NewFixture("test_fixture.json")
+	fxt, err := NewFixture(fs, "sk_test_1234", ts.URL, "test_fixture.json")
 	require.Nil(t, err)
 
 	err = fxt.Execute()

--- a/pkg/samples/fixtures_test.go
+++ b/pkg/samples/fixtures_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/thedevsaddam/gojsonq"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +45,18 @@ const testFixture = `
 				"customer": "#$cust_bender:id",
 				"source": "tok_visa",
 				"amount": "100",
-				"currency": "usd"
+				"currency": "usd",
+				"capture": false
+			}
+		},
+		{
+			"name": "capt_bender",
+			"http": {
+				"path": "/v1/charges/:charge/capture",
+				"method": "post",
+				"params": {
+					":charge": "#$char_bender:id"
+				}
 			}
 		}
 	]
@@ -98,10 +110,15 @@ func TestParseWithQuery(t *testing.T) {
 func TestMakeRequest(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		if req.URL.String() == "/v1/customers" {
+		switch url := req.URL.String(); url {
+		case "/v1/customers":
 			res.Write([]byte(`{"id": "cust_12345", "foo": "bar"}`))
-		} else if req.URL.String() == "/v1/charges" {
-			res.Write([]byte(`{"charge": true}`))
+		case "/v1/charges":
+			res.Write([]byte(`{"charge": true, "id": "char_12345"}`))
+		case "/v1/charges/char_12345/capture":
+			// Do nothing, we just want to verify this request came in
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
 	}))
 	defer func() { ts.Close() }()
@@ -117,12 +134,80 @@ func TestMakeRequest(t *testing.T) {
 	err := fxt.NewFixture("test_fixture.json")
 	require.Nil(t, err)
 
+	require.NotNil(t, fxt.responses["cust_bender"])
+	require.NotNil(t, fxt.responses["char_bender"])
+	require.NotNil(t, fxt.responses["capt_bender"])
+
 	// After you make a `Find` request you need `Reset` the gojsonq object
 	fxt.responses["cust_bender"].Reset()
-	fxt.responses["char_bender"].Reset()
-
-	require.NotNil(t, fxt.responses["cust_bender"])
 	require.Equal(t, "cust_12345", fxt.responses["cust_bender"].Find("id"))
-	require.NotNil(t, fxt.responses["char_bender"])
+
+	fxt.responses["char_bender"].Reset()
+	require.Equal(t, "char_12345", fxt.responses["char_bender"].Find("id"))
+
+	fxt.responses["char_bender"].Reset()
 	require.True(t, fxt.responses["char_bender"].Find("charge").(bool))
+}
+
+func TestParsePathDoNothing(t *testing.T) {
+	fxt := Fixture{}
+	http := fixtureHTTP{
+		Path: "/v1/charges",
+	}
+
+	path := fxt.parsePath(http)
+	assert.Equal(t, http.Path, path)
+}
+
+func TestParseOneParam(t *testing.T) {
+	fxt := Fixture{
+		responses: map[string]*gojsonq.JSONQ{
+			"char_bender": gojsonq.New().FromString(`{"id": "cust_12345"}`),
+		},
+	}
+	http := fixtureHTTP{
+		Path: "/v1/charges/:charge",
+		Params: map[string]string{
+			":charge": "#$char_bender:id",
+		},
+	}
+
+	path := fxt.parsePath(http)
+	assert.Equal(t, "/v1/charges/cust_12345", path)
+}
+
+func TestParseOneParamWithTrailing(t *testing.T) {
+	fxt := Fixture{
+		responses: map[string]*gojsonq.JSONQ{
+			"char_bender": gojsonq.New().FromString(`{"id": "char_12345"}`),
+		},
+	}
+	http := fixtureHTTP{
+		Path: "/v1/charges/:charge/capture",
+		Params: map[string]string{
+			":charge": "#$char_bender:id",
+		},
+	}
+
+	path := fxt.parsePath(http)
+	assert.Equal(t, "/v1/charges/char_12345/capture", path)
+}
+
+func TestParseTwoParam(t *testing.T) {
+	fxt := Fixture{
+		responses: map[string]*gojsonq.JSONQ{
+			"char_bender": gojsonq.New().FromString(`{"id": "char_12345"}`),
+			"cust_bender": gojsonq.New().FromString(`{"id": "cust_12345"}`),
+		},
+	}
+	http := fixtureHTTP{
+		Path: "/v1/charges/:charge/capture/:cust",
+		Params: map[string]string{
+			":charge": "#$char_bender:id",
+			":cust":   "#$cust_bender:id",
+		},
+	}
+
+	path := fxt.parsePath(http)
+	assert.Equal(t, "/v1/charges/char_12345/capture/cust_12345", path)
 }

--- a/pkg/samples/fixtures_test.go
+++ b/pkg/samples/fixtures_test.go
@@ -1,0 +1,128 @@
+package samples
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/thedevsaddam/gojsonq"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testFixture = `
+{
+	"_meta": {
+		"template_version": "0"
+	},
+	"fixtures": [
+		{
+			"name": "cust_bender",
+			"http": {
+				"path": "/v1/customers",
+				"method": "post"
+			},
+			"data": {
+				"name": "Bender Bending Rodriguez",
+				"email": "bender@planex.com",
+				"address": {
+					"line1": "1 Planet Express St",
+					"city": "New New York"
+				}
+			}
+		},
+		{
+			"name": "char_bender",
+			"http": {
+				"path": "/v1/charges",
+				"method": "post"
+			},
+			"data": {
+				"customer": "#$cust_bender:id",
+				"source": "tok_visa",
+				"amount": "100",
+				"currency": "usd"
+			}
+		}
+	]
+}`
+
+func TestParseInterface(t *testing.T) {
+	address := make(map[string]interface{})
+	address["line1"] = "1 Planet Express St"
+	address["city"] = "New New York"
+
+	data := make(map[string]interface{})
+	data["name"] = "Bender Bending Rodriguez"
+	data["email"] = "bender@planex.com"
+	data["address"] = address
+
+	fxt := Fixture{}
+
+	output := (fxt.parseInterface(data))
+	sort.Strings(output)
+
+	require.Equal(t, len(output), 4)
+	require.Equal(t, output[0], "address[city]=New New York")
+	require.Equal(t, output[1], "address[line1]=1 Planet Express St")
+	require.Equal(t, output[2], "email=bender@planex.com")
+	require.Equal(t, output[3], "name=Bender Bending Rodriguez")
+}
+
+func TestParseWithQuery(t *testing.T) {
+	jsonData := gojsonq.New().JSONString(`{"id": "cust_bend123456789"}`)
+
+	fxt := Fixture{}
+	fxt.responses = make(map[string]*gojsonq.JSONQ)
+	fxt.responses["cust_bender"] = jsonData
+
+	data := make(map[string]interface{})
+	data["customer"] = "#$cust_bender:id"
+	data["source"] = "tok_visa"
+	data["amount"] = "100"
+	data["currency"] = "usd"
+
+	output := (fxt.parseInterface(data))
+	sort.Strings(output)
+
+	require.Equal(t, len(output), 4)
+	require.Equal(t, output[0], "amount=100")
+	require.Equal(t, output[1], "currency=usd")
+	require.Equal(t, output[2], "customer=cust_bend123456789")
+	require.Equal(t, output[3], "source=tok_visa")
+}
+
+func TestMakeRequest(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.URL.String() == "/v1/customers" {
+			res.Write([]byte(`{"id": "cust_12345", "foo": "bar"}`))
+		} else if req.URL.String() == "/v1/charges" {
+			res.Write([]byte(`{"charge": true}`))
+		}
+	}))
+	defer func() { ts.Close() }()
+
+	afero.WriteFile(fs, "test_fixture.json", []byte(testFixture), os.ModePerm)
+
+	fxt := Fixture{
+		Fs:      fs,
+		BaseURL: ts.URL,
+		APIKey:  "sk_test_1234",
+	}
+
+	err := fxt.NewFixture("test_fixture.json")
+	require.Nil(t, err)
+
+	// After you make a `Find` request you need `Reset` the gojsonq object
+	fxt.responses["cust_bender"].Reset()
+	fxt.responses["char_bender"].Reset()
+
+	require.NotNil(t, fxt.responses["cust_bender"])
+	require.Equal(t, "cust_12345", fxt.responses["cust_bender"].Find("id"))
+	require.NotNil(t, fxt.responses["char_bender"])
+	require.True(t, fxt.responses["char_bender"].Find("charge").(bool))
+}


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform @adreyfus-stripe @ctrudeau-stripe 

 ### Summary
_I copied this PR over from #125 since that PR got a bit weird with a bunch of rebasing on the parent_

This implements a relatively simple `fixtures` command that takes a json file of a specific structure and makes requests to the API. The JSON files looks like:
```
{
	"_meta": {
		"template_version": "0"
	},
	"fixtures": [
		{
			"name": "cust_bender",
			"path": "/v1/customers",
			"method": "post",
			"params": {
				"name": "Bender Bending Rodriguez",
				"email": "bender@planex.com",
				"address": {
					"line1": "1 Planet Express St",
					"city": "New New York"
				}
			}
		},
		{
			"name": "char_bender",
			"path": "/v1/charges",
			"method": "post",
			"params": {
				"customer": "${cust_bender:id}",
				"source": "tok_visa",
				"amount": "100",
				"currency": "usd",
				"capture": false
			}
		},
		{
			"name": "capt_bender",
			"path": "/v1/charges/${char_bender:id}/capture",
			"method": "post"
		}
	]
}
```

Where:
* `_meta` contains some information about the fixture, like the template version for the CLI to know if the fixture is compatible
* `fixtures` which contains a lists of API requests to make
* `fixtures[].name` identifies the request
* `fixtures[].path` stores the path for the request to be made
* `fixtures[].params` is a map of key/value pairs to put into the request
* `env` is a map of local .env values to overwrite (optional)

For making the requests, I'm using the pre-exiting requests package we built.

The way this works is by recursively parsing the data object and building the appropriate params (as well as correctly nesting fields for things like `address[city]`). This uses reflect to determine if the data is a string, int, map, or array. While the data is being parsed, anytime a string value comes up I try to parse it for a query, which is indicated by `${...}`.

The `${...}` queries are structured as: `${<NAME>:<JSON PATH>}`, where the json path is defined from the `gojsonq` library: https://github.com/thedevsaddam/gojsonq/wiki/Queries#findpath

URLs can also contain data from past queries by adding the query into the path`/v1/charges/${...}` in between slashes.
