### PR TITLE
Capitalize the language names in the selection prompt

### DIFF
--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -40,13 +40,7 @@ var languageDisplayNames = map[string]string{
 	"ruby":   "Ruby",
 }
 
-var displayNameLanguages = map[string]string{
-	"Java":   "java",
-	"Node":   "node",
-	"Python": "python",
-	"PHP":    "php",
-	"Ruby":   "ruby",
-}
+var displayNameLanguages = reverseStringMap(languageDisplayNames)
 
 func javaPath(path string) string {
 	return fmt.Sprintf(`String ENV_PATH = "%s/";`, path)
@@ -63,6 +57,16 @@ func phpPath(path string) string {
 
 func rbPath(path string) string {
 	return fmt.Sprintf(`ENV_PATH = '%s/.env'.freeze`, path)
+}
+
+func reverseStringMap(m map[string]string) map[string]string {
+	rm := make(map[string]string, len(m))
+
+	for key, value := range m {
+		rm[value] = key
+	}
+
+	return rm
 }
 
 // Samples stores the information for the selected sample in addition to the

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -32,6 +32,22 @@ var fileEnvTemplate = map[string]func(string) string{
 	".rb":   rbPath,
 }
 
+var languageDisplayNames = map[string]string{
+	"java":   "Java",
+	"node":   "Node",
+	"python": "Python",
+	"php":    "PHP",
+	"ruby":   "Ruby",
+}
+
+var displayNameLanguages = map[string]string{
+	"Java":   "java",
+	"Node":   "node",
+	"Python": "python",
+	"PHP":    "php",
+	"Ruby":   "ruby",
+}
+
 func javaPath(path string) string {
 	return fmt.Sprintf(`String ENV_PATH = "%s/";`, path)
 }
@@ -428,11 +444,29 @@ func selectOptions(label string, options []string) (string, error) {
 }
 
 func languageSelectPrompt(languages []string) (string, error) {
-	return selectOptions("What language would you like to use?", languages)
+	var displayLangs []string
+	for _, lang := range languages {
+		if val, ok := languageDisplayNames[lang]; ok {
+			displayLangs = append(displayLangs, val)
+		} else {
+			displayLangs = append(displayLangs, lang)
+		}
+	}
+
+	selected, err := selectOptions("What language would you like to use", displayLangs)
+	if err != nil {
+		return "", err
+	}
+
+	if val, ok := displayNameLanguages[selected]; ok {
+		return val, nil
+	}
+
+	return selected, nil
 }
 
 func integrationSelectPrompt(integrations []string) ([]string, error) {
-	selected, err := selectOptions("What type of integration would you like to use?", append(integrations, "all"))
+	selected, err := selectOptions("What type of integration would you like to use", append(integrations, "all"))
 	if err != nil {
 		return []string{}, err
 	}


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Request from @romain-stripe to properly capitalize the languages in the select prompt. I hardcode mappings from the folder name to the display name and vice versa to map the selections the user makes.
