### PR TITLE
Live mode fixes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,7 @@ github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -32,7 +32,7 @@ type OperationCmd struct {
 }
 
 func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error {
-	apiKey, err := oc.Profile.GetAPIKey(false)
+	apiKey, err := oc.Profile.GetAPIKey(oc.Livemode)
 	if err != nil {
 		return err
 	}

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -66,6 +66,8 @@ func Login(baseURL string, config *config.Config, input io.Reader) error {
 		return validateErr
 	}
 
+	config.Profile.LiveModeAPIKey = response.LiveModeAPIKey
+	config.Profile.LiveModePublishableKey = response.LiveModePublishableKey
 	config.Profile.TestModeAPIKey = response.TestModeAPIKey
 	config.Profile.TestModePublishableKey = response.TestModePublishableKey
 	profileErr := config.Profile.CreateProfile()

--- a/pkg/login/interactive_login_test.go
+++ b/pkg/login/interactive_login_test.go
@@ -30,19 +30,6 @@ func TestAPIKeyInputEmpty(t *testing.T) {
 	require.EqualError(t, err, expectedErrorString)
 }
 
-func TestAPIKeyInputLivemode(t *testing.T) {
-	expectedKey := ""
-	livemodeKey := "sk_live_foo123"
-	expectedErrorString := "the CLI only supports using a test mode key"
-
-	keyInput := strings.NewReader(livemodeKey + "\n")
-	actualKey, err := getConfigureAPIKey(keyInput)
-
-	require.Equal(t, expectedKey, actualKey)
-	require.NotNil(t, err)
-	require.EqualError(t, err, expectedErrorString)
-}
-
 func TestDeviceNameInput(t *testing.T) {
 	expectedDeviceName := "Bender's Laptop"
 	deviceNameInput := strings.NewReader(expectedDeviceName)

--- a/pkg/login/poll.go
+++ b/pkg/login/poll.go
@@ -20,6 +20,8 @@ type PollAPIKeyResponse struct {
 	Redeemed               bool   `json:"redeemed"`
 	AccountID              string `json:"account_id"`
 	AccountDisplayName     string `json:"account_display_name"`
+	LiveModeAPIKey         string `json:"livemode_key_secret"`
+	LiveModePublishableKey string `json:"livemode_key_publishable"`
 	TestModeAPIKey         string `json:"testmode_key_secret"`
 	TestModePublishableKey string `json:"testmode_key_publishable"`
 }

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -47,10 +47,10 @@ type Base struct {
 
 	APIBaseURL string
 
+	Livemode bool
+
 	autoConfirm bool
 	showHeaders bool
-
-	livemode bool
 }
 
 var confirmationCommands = map[string]bool{http.MethodDelete: true}
@@ -69,7 +69,7 @@ func (rb *Base) RunRequestsCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	apiKey, err := rb.Profile.GetAPIKey(rb.livemode)
+	apiKey, err := rb.Profile.GetAPIKey(rb.Livemode)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (rb *Base) InitFlags(includeData bool) {
 	rb.Cmd.Flags().StringVar(&rb.Parameters.stripeAccount, "stripe-account", "", "Set a header identifying the connected account for which the request is being made")
 	rb.Cmd.Flags().BoolVarP(&rb.showHeaders, "show-headers", "s", false, "Show headers on responses to GET, POST, and DELETE requests")
 	rb.Cmd.Flags().BoolVarP(&rb.autoConfirm, "confirm", "c", false, "Automatically confirm the command being entered. WARNING: This will result in NOT being prompted for confirmation for certain commands")
-	rb.Cmd.Flags().BoolVar(&rb.livemode, "livemode", false, "Make a request against live mode instead of test mode")
+	rb.Cmd.Flags().BoolVar(&rb.Livemode, "livemode", false, "Make a request against live mode instead of test mode")
 
 	// Conditionally add flags for GET requests. I'm doing it here to keep `limit`, `start_after` and `ending_before` unexported
 	if rb.Method == http.MethodGet {

--- a/pkg/validators/validate.go
+++ b/pkg/validators/validate.go
@@ -54,10 +54,6 @@ func APIKey(input string) error {
 		return errors.New("the CLI only supports using a secret or restricted key")
 	}
 
-	if keyParts[1] != "test" {
-		return errors.New("the CLI only supports using a test mode key")
-	}
-
 	return nil
 }
 

--- a/pkg/validators/validate_test.go
+++ b/pkg/validators/validate_test.go
@@ -19,7 +19,7 @@ func TestPublishableAPIKey(t *testing.T) {
 
 func TestLivemodeAPIKey(t *testing.T) {
 	err := APIKey("sk_live_12345")
-	require.EqualError(t, err, "the CLI only supports using a test mode key")
+	require.Nil(t, err)
 }
 
 func TestTestmodeAPIKey(t *testing.T) {


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
A few fixes for live mode support:
- read and persist live keys in the login flow
- remove the live key check
- fix `--livemode` flag in operation commands
