### PR TITLE
Do not display or print filtered events

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -139,6 +139,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	p := proxy.New(&proxy.Config{
 		DeviceName:          deviceName,
 		Key:                 key,
+		Events:              lc.events,
 		EndpointRoutes:      endpointRoutes,
 		APIBaseURL:          lc.apiBaseURL,
 		WebSocketFeature:    webhooksWebSocketFeature,

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -139,7 +139,6 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	p := proxy.New(&proxy.Config{
 		DeviceName:          deviceName,
 		Key:                 key,
-		Events:              lc.events,
 		EndpointRoutes:      endpointRoutes,
 		APIBaseURL:          lc.apiBaseURL,
 		WebSocketFeature:    webhooksWebSocketFeature,
@@ -148,7 +147,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		SkipVerify:          lc.skipVerify,
 		Log:                 log.StandardLogger(),
 		NoWSS:               lc.noWSS,
-	})
+	}, lc.events)
 
 	err = p.Run()
 	if err != nil {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestFilterWebhookEvent(t *testing.T) {
-	proxyUseDefault := New(&Config{UseLatestAPIVersion: false})
-	proxyUseLatest := New(&Config{UseLatestAPIVersion: true})
+	proxyUseDefault := New(&Config{UseLatestAPIVersion: false}, []string{"*"})
+	proxyUseLatest := New(&Config{UseLatestAPIVersion: true}, []string{"*"})
 
 	evtDefault := &websocket.WebhookEvent{
 		Endpoint: websocket.WebhookEndpoint{


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Event filtering only filters events when POSTing requests, but it should also prevent them from being displayed at all. This PR handles that case by setting up a map to check against when processing the webhook event
