### PR TITLE
Disable function length

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - maligned
     - unparam
     - stylecheck
+    - funlen
 
 linters-settings:
   goimports:


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
New linter version automatically enabled function length linters, disable those