### PR TITLE
Print login URL when failing to open browser

### DIFF
--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -50,9 +50,11 @@ func Login(baseURL string, config *config.Config, input io.Reader) error {
 
 	s := ansi.StartSpinner("Waiting for confirmation...", os.Stdout)
 
-	urlErr := openBrowser(links.BrowserURL)
-	if urlErr != nil {
-		return urlErr
+	err = openBrowser(links.BrowserURL)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to open browser, please go to %s manually.", links.BrowserURL)
+		ansi.StopSpinner(s, msg, os.Stdout)
+		s = ansi.StartSpinner("Waiting for confirmation...", os.Stdout)
 	}
 
 	//Call poll function


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
If we fail to open the browser automatically (for instance, because `xdg-open` is not available when running the CLI in a headless environment), then output the URL and proceed normally so users can still complete the login flow.

Fixes #158.
