### PR TITLE
Hide login text if there's a config file

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -15,6 +16,8 @@ import (
 
 // Config is the cli configuration for the user
 var Config config.Config
+
+var fs = afero.NewOsFs()
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -38,16 +41,9 @@ var rootCmd = &cobra.Command{
 The Stripe CLI gives you tools to help build with Stripe. You can do things like
 connect to a Stripe webhook tunnel and test webhooks locally, make test mode
 requests to the API, and trigger certain webhook events.
-
-Before using the CLI, you'll need to login:
-
-  $ stripe login
-
-If you're working on multiple projects, you can run the login command with the
---project-name flag:
-
-  $ stripe login --project-name rocket-rides`,
+%s`,
 		getBanner(),
+		getLogin(&fs, &Config),
 	),
 }
 

--- a/pkg/cmd/templates.go
+++ b/pkg/cmd/templates.go
@@ -2,11 +2,15 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/config"
 )
 
 //
@@ -33,6 +37,29 @@ func WrappedLocalFlagUsages(cmd *cobra.Command) string {
 
 func getBanner() string {
 	return ansi.Italic("⚠️  The Stripe CLI is in beta! Share your feedback with `stripe feedback` ⚠️")
+}
+
+func getLogin(fs *afero.Fs, cfg *config.Config) string {
+	// We're checking against the path because we don't initialize the config
+	// at this point of execution.
+	path := cfg.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	file := filepath.Join(path, "config.toml")
+
+	exists, _ := afero.Exists(*fs, file)
+
+	if !exists {
+		return `
+Before using the CLI, you'll need to login:
+
+  $ stripe login
+
+If you're working on multiple projects, you can run the login command with the
+--project-name flag:
+
+  $ stripe login --project-name rocket-rides`
+	}
+
+	return ""
 }
 
 func getUsageTemplate() string {

--- a/pkg/cmd/templates_test.go
+++ b/pkg/cmd/templates_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+func TestGetLogin(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := config.Config{}
+	expected := `
+Before using the CLI, you'll need to login:
+
+  $ stripe login
+
+If you're working on multiple projects, you can run the login command with the
+--project-name flag:
+
+  $ stripe login --project-name rocket-rides`
+	output := getLogin(&fs, &cfg)
+
+	assert.Equal(t, expected, output)
+}
+
+func TestGetLoginEmpty(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := config.Config{}
+
+	file := filepath.Join(cfg.GetConfigFolder(os.Getenv("XDG_CONFIG")), "config.toml")
+
+	afero.WriteFile(fs, file, []byte{}, os.ModePerm)
+
+	output := getLogin(&fs, &cfg)
+
+	assert.Equal(t, "", output)
+}

--- a/pkg/cmd/templates_test.go
+++ b/pkg/cmd/templates_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/stripe/stripe-cli/pkg/config"
 )
 


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
We don't need to render the login text all the time so hide this if there's a config file. We also have existing behavior that'll raise an error for users if they try to run a command that requires an API key but one isn't set.
