### PR TITLE
Return a better error if an api key is not configured

### DIFF
--- a/pkg/validators/validate.go
+++ b/pkg/validators/validate.go
@@ -41,8 +41,10 @@ func CallNonEmpty(validator ArgValidator, value string) error {
 
 // APIKey validates that a string looks like an API key.
 func APIKey(input string) error {
-	if len(input) < 12 {
-		return errors.New("API key is too short, must be at least 12 characters long")
+	if len(input) == 0 {
+		return errors.New("you have not configured API keys yet. To do so, run `stripe login` which will configure your API keys from Stripe")
+	} else if len(input) < 12 {
+		return errors.New("the API key provided is too short, it must be at least 12 characters long")
 	}
 
 	keyParts := strings.Split(input, "_")

--- a/pkg/validators/validate_test.go
+++ b/pkg/validators/validate_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNoKey(t *testing.T) {
+	err := APIKey("")
+	require.EqualError(t, err, "you have not configured API keys yet. To do so, run `stripe login` which will configure your API keys from Stripe")
+}
+
+func TestKeyTooShort(t *testing.T) {
+	err := APIKey("123")
+	require.EqualError(t, err, "the API key provided is too short, it must be at least 12 characters long")
+}
+
 func TestLegacyAPIKeys(t *testing.T) {
 	err := APIKey("sk_123457890abcdef")
 	require.EqualError(t, err, "you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Return a better error if an api key is not configured