### PR TITLE
Make sure we're using the same localhost url consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The `listen` command establishes a direct connection with Stripe, delivering web
 
 By default, `listen` accepts all webhook events displays them in your terminal. To forward events to your local app, use the `--forward-to` flag with the location:
 
-* `--forward-to localhost:9000`
+* `--forward-to localhost:3000`
 * `--forward-to https://example.com/hooks`
 
 Using `--forward-to` will return a [webhook signing secret](https://stripe.com/docs/webhooks/signatures), which you can add to your application's configuration:

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -57,7 +57,7 @@ Watch for all events sent from Stripe:
 Start listening for 'charge.created' and 'charge.updated' events and forward
 to your localhost:
 
-  $ stripe listen --events charge.created,charge.updated --forward-to localhost:9000/events`,
+  $ stripe listen --events charge.created,charge.updated --forward-to localhost:3000/events`,
 			getBanner(),
 		),
 		RunE: lc.runListenCmd,


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Small change, we were using `localhost:3000` and `localhost:9000` inconsistently. I've settled on the former.
