### PR TITLE
default to vi on mac/linux for `config -e` if no EDITOR set

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,7 +135,11 @@ func (c *Config) EditConfig() error {
 
 	switch runtime.GOOS {
 	case "darwin", "linux":
-		cmd := exec.Command(os.Getenv("EDITOR"), c.ProfilesFile)
+		editor := os.Getenv("EDITOR")
+		if editor == "" {
+			editor = "vi"
+		}
+		cmd := exec.Command(editor, c.ProfilesFile)
 		// Some editors detect whether they have control of stdin/out and will
 		// fail if they do not.
 		cmd.Stdin = os.Stdin


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
`stripe config -e` broke if the EDITOR environment variable was empty on mac/linux, now defaults to vi (which we assume to be installed).