### PR TITLE
#43: use uname syscall instead of shelling out

### DIFF
--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -1,0 +1,18 @@
+package useragent
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnameNotEmpty(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		u := getUname()
+		require.NotEmpty(t, u)
+		t.Log(u)
+	}
+
+	// Unfortunately we don't extract info from windows (GetSystemInfo) at this time
+}


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Our CLI was being flagged by AVG anti-malware tool, it was suspected this was because we were shelling out to `uname` to retrieve info. 

In my experience determining why a particular AV would choose to flag a golang binary is opaque, still though using the uname syscall is preferable here over shelling out.
