### PR TITLE
small fixes to `stripe config` flags

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -46,6 +46,9 @@ func (cc *configCmd) runConfigCmd(cmd *cobra.Command, args []string) error {
 		return cc.config.PrintConfig()
 	case cc.edit:
 		return cc.config.EditConfig()
+	default:
+		// no flags set or unrecognized flags/args
+		return cc.cmd.Help()
 	}
 
 	return nil

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -12,7 +12,7 @@ type configCmd struct {
 
 	list  bool
 	edit  bool
-	unset bool
+	unset string
 }
 
 func newConfigCmd() *configCmd {
@@ -27,7 +27,7 @@ func newConfigCmd() *configCmd {
 
 	cc.cmd.Flags().BoolVar(&cc.list, "list", false, "list configs")
 	cc.cmd.Flags().BoolVarP(&cc.edit, "edit", "e", false, "open editor to the config file")
-	cc.cmd.Flags().BoolVar(&cc.unset, "unset", false, "unset a specific config field")
+	cc.cmd.Flags().StringVar(&cc.unset, "unset", "", "unset a specific config field")
 
 	return cc
 }
@@ -36,8 +36,8 @@ func (cc *configCmd) runConfigCmd(cmd *cobra.Command, args []string) error {
 	switch ok := true; ok {
 	case len(args) == 2:
 		return cc.config.Profile.WriteConfigField(args[0], args[1])
-	case len(args) == 1 && cc.unset:
-		return cc.config.Profile.DeleteConfigField(args[0])
+	case cc.unset != "":
+		return cc.config.Profile.DeleteConfigField(cc.unset)
 	case cc.list:
 		cc.config.PrintConfig()
 	case cc.edit:

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -13,7 +13,7 @@ type configCmd struct {
 	list  bool
 	edit  bool
 	unset string
-	set bool
+	set   bool
 }
 
 func newConfigCmd() *configCmd {
@@ -50,6 +50,4 @@ func (cc *configCmd) runConfigCmd(cmd *cobra.Command, args []string) error {
 		// no flags set or unrecognized flags/args
 		return cc.cmd.Help()
 	}
-
-	return nil
 }

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -13,6 +13,7 @@ type configCmd struct {
 	list  bool
 	edit  bool
 	unset string
+	set bool
 }
 
 func newConfigCmd() *configCmd {
@@ -28,18 +29,21 @@ func newConfigCmd() *configCmd {
 	cc.cmd.Flags().BoolVar(&cc.list, "list", false, "list configs")
 	cc.cmd.Flags().BoolVarP(&cc.edit, "edit", "e", false, "open editor to the config file")
 	cc.cmd.Flags().StringVar(&cc.unset, "unset", "", "unset a specific config field")
+	cc.cmd.Flags().BoolVar(&cc.set, "set string string", false, "set a config field to some value")
+
+	cc.cmd.Flags().SetInterspersed(false) // allow args to happen after flags to enable 2 arguments to --set
 
 	return cc
 }
 
 func (cc *configCmd) runConfigCmd(cmd *cobra.Command, args []string) error {
 	switch ok := true; ok {
-	case len(args) == 2:
+	case cc.set && len(args) == 2:
 		return cc.config.Profile.WriteConfigField(args[0], args[1])
 	case cc.unset != "":
 		return cc.config.Profile.DeleteConfigField(cc.unset)
 	case cc.list:
-		cc.config.PrintConfig()
+		return cc.config.PrintConfig()
 	case cc.edit:
 		return cc.config.EditConfig()
 	}


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
`stripe config` used to handle things with a confusing mix of boolean flags and unflagged args; now:
- `--unset field` is handled as a string flag vs a single arg + bool flag combination
- `--set field value` works vs just having fields set by unexplained args
- `stripe config` with no flags or unexpected flags/args defaults to showing the help page