### PR TITLE
Add a dark color scheme for json colorize

### DIFF
--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -13,6 +13,15 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+var darkTerminalStyle = &pretty.Style{
+	Key:    [2]string{"\x1B[34m", "\x1B[0m"},
+	String: [2]string{"\x1B[30m", "\x1B[0m"},
+	Number: [2]string{"\x1B[94m", "\x1B[0m"},
+	True:   [2]string{"\x1B[35m", "\x1B[0m"},
+	False:  [2]string{"\x1B[35m", "\x1B[0m"},
+	Null:   [2]string{"\x1B[31m", "\x1B[0m"},
+}
+
 //
 // Public variables
 //
@@ -45,12 +54,17 @@ func Color(w io.Writer) aurora.Aurora {
 
 // ColorizeJSON returns a colorized version of the input JSON, if the writer
 // supports colors.
-func ColorizeJSON(json string, w io.Writer) string {
+func ColorizeJSON(json string, darkStyle bool, w io.Writer) string {
 	if !shouldUseColors(w) {
 		return json
 	}
 
-	return string(pretty.Color([]byte(json), nil))
+	style := (*pretty.Style)(nil)
+	if darkStyle {
+		style = darkTerminalStyle
+	}
+
+	return string(pretty.Color([]byte(json), style))
 }
 
 // ColorizeStatus returns a colorized number for HTTP status code

--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -171,7 +171,7 @@ func (tailer *Tailer) processRequestLogEvent(msg websocket.IncomingMessage) {
 	}
 
 	if tailer.cfg.OutputFormat == outputFormatJSON {
-		fmt.Println(ansi.ColorizeJSON(requestLogEvent.EventPayload, os.Stdout))
+		fmt.Println(ansi.ColorizeJSON(requestLogEvent.EventPayload, false, os.Stdout))
 		return
 	}
 

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -45,6 +45,8 @@ type Base struct {
 	// SuppressOutput is used by `trigger` to hide output
 	SuppressOutput bool
 
+	DarkStyle bool
+
 	APIBaseURL string
 
 	Livemode bool
@@ -93,6 +95,7 @@ func (rb *Base) InitFlags(includeData bool) {
 	rb.Cmd.Flags().BoolVarP(&rb.showHeaders, "show-headers", "s", false, "Show headers on responses to GET, POST, and DELETE requests")
 	rb.Cmd.Flags().BoolVarP(&rb.autoConfirm, "confirm", "c", false, "Automatically confirm the command being entered. WARNING: This will result in NOT being prompted for confirmation for certain commands")
 	rb.Cmd.Flags().BoolVar(&rb.Livemode, "livemode", false, "Make a request against live mode instead of test mode")
+	rb.Cmd.Flags().BoolVar(&rb.DarkStyle, "dark-style", false, "Use a darker color scheme better suited for lighter terminals")
 
 	// Conditionally add flags for GET requests. I'm doing it here to keep `limit`, `start_after` and `ending_before` unexported
 	if rb.Method == http.MethodGet {
@@ -142,7 +145,7 @@ func (rb *Base) MakeRequest(apiKey, path string, params *RequestParameters) ([]b
 			return []byte{}, err
 		}
 
-		result := ansi.ColorizeJSON(string(body), os.Stdout)
+		result := ansi.ColorizeJSON(string(body), rb.DarkStyle, os.Stdout)
 		fmt.Println(result)
 	}
 


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Adds a dark color scheme for terminals with lighter background colors:

<img width="488" alt="Screen Shot 2019-09-17 at 8 26 04 PM" src="https://user-images.githubusercontent.com/42354557/65105403-b01dca00-d989-11e9-992b-a47f221a0f7b.png">

A bit limited by what ansi colors are supported so it's not perfect, but it's a step up.