### PR TITLE
Hide the get, post, and delete commands

### DIFF
--- a/pkg/cmd/templates.go
+++ b/pkg/cmd/templates.go
@@ -73,9 +73,6 @@ func getUsageTemplate() string {
 %s
   {{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{if .Annotations}}
 
-%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "http")}}
-  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
-
 %s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "webhooks")}}
   {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
 
@@ -102,7 +99,6 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 		ansi.Bold("Usage:"),
 		ansi.Bold("Aliases:"),
 		ansi.Bold("Examples:"),
-		ansi.Bold("HTTP commands:"),
 		ansi.Bold("Webhook commands:"),
 		ansi.Bold("Stripe commands:"),
 		ansi.Bold("Resource commands:"),


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Hide the `get`, `post`, and `delete` commands in favor of people using the resource commands. We don't want to delete them so that people could still use them so we're opting to remove them from the main documentation.
