### PR TITLE
Check for ssh clients when logging in

### DIFF
--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/briandowns/spinner"
+
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/open"


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
This checks if the CLI is possibly running in an SSH client and if it is, prints the url instead of trying to open the browser (pulled from here: https://unix.stackexchange.com/questions/9605/how-can-i-detect-if-the-shell-is-controlled-from-ssh)

I tried to see if there was a good test to add here but since we're not catching stdout I wasn't sure of a decent way to validate this. Open to ideas!