### PR TITLE
Add feature to resend webhook based on event-id

### DIFF
--- a/pkg/requests/examples.go
+++ b/pkg/requests/examples.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/stripe/stripe-cli/pkg/config"
 )
@@ -453,4 +454,22 @@ func (ex *Examples) WebhookEndpointsList() WebhookEndpointList {
 	json.Unmarshal(resp, &data)
 
 	return data
+}
+
+// ResendEvent resends a webhook event using it's event-id "evt_<id>"
+func (ex *Examples) ResendEvent(id string) error {
+	pattern := `^evt_[A-Za-z0-9]{3,255}$`
+	match, err := regexp.MatchString(pattern, id)
+	if err != nil {
+		return err
+	}
+
+	if !match {
+		return fmt.Errorf("Invalid event-id provided, should be of the form '%s'", pattern)
+	}
+
+	req, params := ex.buildRequest(http.MethodPost, []string{})
+	reqURL := fmt.Sprintf("/v1/events/%s/retry", id)
+	_, err = ex.performStripeRequest(req, reqURL, params)
+	return err
 }

--- a/pkg/requests/examples_test.go
+++ b/pkg/requests/examples_test.go
@@ -352,3 +352,33 @@ func TestPaymentMethodAttached(t *testing.T) {
 	err := ex.PaymentMethodAttached()
 	require.Nil(t, err)
 }
+
+func TestResendEventThrowsErrorWithInvalidEventID(t *testing.T) {
+	ex := Examples{
+		APIBaseURL: "",
+		APIVersion: "v1",
+		APIKey:     "secret-key",
+	}
+
+	err := ex.ResendEvent("asdf")
+	require.NotNil(t, err)
+}
+
+func TestResendEventDoesNotErrorWithValidEventID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		data := jsonBytes()
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	ex := Examples{
+		APIBaseURL: ts.URL,
+		APIVersion: "v1",
+		APIKey:     "secret-key",
+	}
+
+	err := ex.ResendEvent("evt_123")
+	t.Log(err)
+	require.Nil(t, err)
+}

--- a/pkg/validators/cmds.go
+++ b/pkg/validators/cmds.go
@@ -44,3 +44,27 @@ func ExactArgs(num int) cobra.PositionalArgs {
 		return nil
 	}
 }
+
+// MaximumNArgs is a validator for commands to print an error when the provided
+// args are greater than the maximum amount
+func MaximumNArgs(num int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		argument := "argument"
+		if num > 1 {
+			argument = "arguments"
+		}
+
+		errorMessage := fmt.Sprintf(
+			"%s only takes %d %s (or less). See `stripe %s --help` for supported flags and usage",
+			cmd.Name(),
+			num,
+			argument,
+			cmd.Name(),
+		)
+
+		if len(args) > num {
+			return errors.New(errorMessage)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe
cc @stripe/dev-platform

 ### Summary
The CLI should be able to replay the exact webhook being sent to a user within a few minutes of receiving it.

e.g.
```
stripe trigger --event evt_123
```

DX-3594