### PR TITLE
fix trailing null bytes issue in uname

### DIFF
--- a/pkg/useragent/uname_unix.go
+++ b/pkg/useragent/uname_unix.go
@@ -3,10 +3,15 @@
 package useragent
 
 import (
+	"bytes"
 	"fmt"
 
 	"golang.org/x/sys/unix"
 )
+
+func trimNulls(input []byte) []byte {
+	return bytes.Trim(input, "\x00")
+}
 
 func getUname() string {
 	u := new(unix.Utsname)
@@ -15,5 +20,5 @@ func getUname() string {
 		panic(err)
 	}
 
-	return fmt.Sprintf("%s %s %s %s %s", u.Sysname, u.Nodename, u.Release, u.Version, u.Machine)
+	return fmt.Sprintf("%s %s %s %s %s", trimNulls(u.Sysname[:]), trimNulls(u.Nodename[:]), trimNulls(u.Release[:]), trimNulls(u.Version[:]), trimNulls(u.Machine[:]))
 }

--- a/pkg/useragent/uname_unix_test.go
+++ b/pkg/useragent/uname_unix_test.go
@@ -3,6 +3,7 @@
 package useragent
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,5 +11,14 @@ import (
 
 func TestUnameNotEmpty(t *testing.T) {
 	u := getUname()
+	t.Log(fmt.Sprintf("%x", u)) // For NULL trim paranoia
 	require.NotEmpty(t, u)
+}
+
+func TestTrimNulls(t *testing.T) {
+	input := [256]byte{0xff}
+	t.Log(input)
+	output := trimNulls(input[:])
+	t.Log(output)
+	require.NotEqual(t, len(input), len(output))
 }


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
A previous fix to use uname syscall over shelling out to uname on Unixes introduces some null bytes into the user agent string, these are now removed.

See DX-4729 for more info

Fixes #182.