### PR TITLE
give user success/failure feedback for `stripe trigger`

### DIFF
--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -117,5 +117,12 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(fmt.Sprintf("event %s is not supported.", event))
 	}
 	err = function.(func() error)()
+
+	if err == nil {
+		fmt.Println("Trigger succeeded! Check dashboard for event details.")
+	} else {
+		fmt.Println(fmt.Sprintf("Trigger failed: %s", err))
+	}
+
 	return err
 }


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
for https://jira.corp.stripe.com/browse/DX-4702: `stripe trigger` used to succeed/fail quietly, we now print a quick success message for good API requests and the error for requests that fail. original ticket suggested supplying the event ID but this is nontrivial as event IDs aren't returned in API responses.