### PR TITLE
Add instructions for what to do after generating completion files

### DIFF
--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"fmt"
+	"runtime"
+
 	"github.com/spf13/cobra"
 
+	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
@@ -10,6 +14,17 @@ type completionCmd struct {
 	cmd *cobra.Command
 
 	shell string
+}
+
+var installDirectory = map[string]map[string]string{
+	"darwin": map[string]string{
+		"zsh":  "/usr/local/share/zsh/site-functions",
+		"bash": "/usr/local/etc/bash_completion.d",
+	},
+	"linux": map[string]string{
+		"zsh":  "/usr/share/zsh/functions/Completion/Linux",
+		"bash": "/usr/share/bash-completion/completions",
+	},
 }
 
 func newCompletionCmd() *completionCmd {
@@ -20,10 +35,28 @@ func newCompletionCmd() *completionCmd {
 		Short: "Generate bash and zsh completion scripts",
 		Args:  validators.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if cc.shell == "zsh" {
-				return rootCmd.GenZshCompletionFile("stripe-completion.zsh")
+			userOS := runtime.GOOS
+			if userOS == "windows" {
+				fmt.Println("Warning: autocompletion for Windows is currently not supported and may not work.")
+				// Give them instructions for linux because Windows _might_ be using the linux fs under the hood
+				userOS = "linux"
 			}
-			return rootCmd.GenBashCompletionFile("stripe-completion.bash")
+
+			if cc.shell == "zsh" {
+				fileName := "stripe-completion.zsh"
+				fmt.Println(fmt.Sprintf("Generating zsh completion file in: %s", ansi.Bold(fileName)))
+				fmt.Println("You'll need to either source this file or move it to zsh's autocomplete folder.")
+				fmt.Println(fmt.Sprintf("To source, run: `source %s`", fileName))
+				fmt.Println(fmt.Sprintf("To load automatically, move to zsh's autocomplete directory: `mv %s %s`", fileName, installDirectory[userOS]["zsh"]))
+				return rootCmd.GenZshCompletionFile(fileName)
+			}
+
+			fileName := "stripe-completion.bash"
+			fmt.Println(fmt.Sprintf("Generating bash completion file in: %s", ansi.Bold(fileName)))
+			fmt.Println("You'll need to either source this file or move it to bash's autocomplete folder.")
+			fmt.Println(fmt.Sprintf("To source, run: `source %s`", fileName))
+			fmt.Println(fmt.Sprintf("To load automatically, move to bash's autocomplete directory: `mv %s %s`", fileName, installDirectory[userOS]["bash"]))
+			return rootCmd.GenBashCompletionFile(fileName)
 		},
 	}
 


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Add output/instructions for what to do with completion files:
```
» stripe-dev completion
Generating bash completion file in: stripe-completion.bash
You'll need to either source this file or move it to bash's autocomplete folder.
To source, run: `source stripe-completion.bash`
To load automatically, move to zsh's autocomplete directory: `mv stripe-completion.bash /usr/local/share/zsh/site-functions`