### PR TITLE
add pre-commit hook to run linters

### DIFF
--- a/.pre-commit
+++ b/.pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# for this to work either manually copy to .git/hooks/pre-commit
+# or run `make githooks-init`
+
+# run linters before committing to give faster feedback to our developers 
+make lint

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ setup:
 	go mod download
 .PHONY: setup
 
+githooks-init:
+	cp .pre-commit .git/hooks/pre-commit
+.PHONY: githooks-init
+
 # Run all the tests
 test:
 	go test $(TEST_OPTIONS) -failfast -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=2m


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Added a file `.pre-commit` to our repo that can be manually added to your githooks or automatically via `make githooks-init`, so when you run `git commit` our `make lint` will be run to give you feedback more quickly 