### PR TITLE
Forward custom headers

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -67,7 +67,7 @@ to your localhost:
 
 	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{"*"}, "A comma-separated list of which webhook events to listen for. For a list of all possible events, see: https://stripe.com/docs/api/events/types")
 	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward webhook events to")
-	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward.")
+	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward")
 	lc.cmd.Flags().StringSliceVar(&lc.forwardConnectHeaders, "connect-headers", []string{}, "A comma-separated list of custom headers to forward for connect.")
 	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect webhook events to (default: same as normal events)")
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -202,17 +202,17 @@ func buildEndpointRoutes(endpoints requests.WebhookEndpointList, forwardURL, for
 			// the path. We'll use this with `localhost` or with the `--forward-to` flag
 			if endpoint.Application == "" {
 				endpointRoutes = append(endpointRoutes, proxy.EndpointRoute{
-					URL:        buildForwardURL(forwardURL, u),
+					URL:        	buildForwardURL(forwardURL, u),
 					ForwardHeaders:	forwardHeaders,
-					Connect:    false,
-					EventTypes: endpoint.EnabledEvents,
+					Connect:    	false,
+					EventTypes: 	endpoint.EnabledEvents,
 				})
 			} else {
 				endpointRoutes = append(endpointRoutes, proxy.EndpointRoute{
-					URL:        buildForwardURL(forwardConnectURL, u),
-					ForwardHeaders: 	forwardConnectHeaders,
-					Connect:    true,
-					EventTypes: endpoint.EnabledEvents,
+					URL:        	buildForwardURL(forwardConnectURL, u),
+					ForwardHeaders: forwardConnectHeaders,
+					Connect:    	true,
+					EventTypes: 	endpoint.EnabledEvents,
 				})
 			}
 		}

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -68,7 +68,7 @@ to your localhost:
 	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{"*"}, "A comma-separated list of which webhook events to listen for. For a list of all possible events, see: https://stripe.com/docs/api/events/types")
 	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward webhook events to")
 	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward")
-	lc.cmd.Flags().StringSliceVar(&lc.forwardConnectHeaders, "connect-headers", []string{}, "A comma-separated list of custom headers to forward for connect.")
+	lc.cmd.Flags().StringSliceVar(&lc.forwardConnectHeaders, "connect-headers", []string{}, "A comma-separated list of custom headers to forward for Connect")
 	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect webhook events to (default: same as normal events)")
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
 	lc.cmd.Flags().BoolVar(&lc.livemode, "livemode", false, "Receive live mode events (default: test mode)")

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -67,8 +67,8 @@ to your localhost:
 
 	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{"*"}, "A comma-separated list of which webhook events to listen for. For a list of all possible events, see: https://stripe.com/docs/api/events/types")
 	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward webhook events to")
-	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "h", []string{}, "A comma-separated list of custom headers to forward.")
-	lc.cmd.Flags().StringSliceVarP(&lc.forwardConnectHeaders, "connect-headers", "", []string{}, "A comma-separated list of custom headers to forward for connect.")
+	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward.")
+	lc.cmd.Flags().StringSliceVar(&lc.forwardConnectHeaders, "connect-headers", []string{}, "A comma-separated list of custom headers to forward for connect.")
 	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect webhook events to (default: same as normal events)")
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
 	lc.cmd.Flags().BoolVar(&lc.livemode, "livemode", false, "Receive live mode events (default: test mode)")

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -90,8 +90,6 @@ to your localhost:
 // but since it's acting as the core functionality for the cmd above, I'm keeping it close.
 func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 
-	print("running listen command")
-
 	deviceName, err := Config.Profile.GetDeviceName()
 	if err != nil {
 		return err
@@ -189,8 +187,6 @@ func (lc *listenCmd) getEndpointsFromAPI(secretKey string) requests.WebhookEndpo
 	return examples.WebhookEndpointsList()
 }
 
-// add custom host as arg
-// TODO: check if forward headers exist
 func buildEndpointRoutes(endpoints requests.WebhookEndpointList, forwardURL, forwardConnectURL string, forwardHeaders []string, forwardConnectHeaders []string) []proxy.EndpointRoute {
 	endpointRoutes := make([]proxy.EndpointRoute, 0)
 	for _, endpoint := range endpoints.Data {

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -22,16 +22,16 @@ const webhooksWebSocketFeature = "webhooks"
 type listenCmd struct {
 	cmd *cobra.Command
 
-	forwardURL          string
-	forwardHeaders		[]string
+	forwardURL            string
+	forwardHeaders        []string
 	forwardConnectHeaders []string
-	forwardConnectURL   string
-	events              []string
-	latestAPIVersion    bool
-	livemode            bool
-	loadFromWebhooksAPI bool
-	printJSON           bool
-	skipVerify          bool
+	forwardConnectURL     string
+	events                []string
+	latestAPIVersion      bool
+	livemode              bool
+	loadFromWebhooksAPI   bool
+	printJSON             bool
+	skipVerify            bool
 
 	apiBaseURL string
 	noWSS      bool
@@ -89,9 +89,9 @@ to your localhost:
 // Normally, this function would be listed alphabetically with the others declared in this file,
 // but since it's acting as the core functionality for the cmd above, I'm keeping it close.
 func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
-	
+
 	print("running listen command")
-	
+
 	deviceName, err := Config.Profile.GetDeviceName()
 	if err != nil {
 		return err
@@ -122,16 +122,16 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		// add custom headers to endpoint routes
 
 		endpointRoutes = append(endpointRoutes, proxy.EndpointRoute{
-			URL:        parseURL(lc.forwardURL),
-			ForwardHeaders:	lc.forwardHeaders,
-			Connect:    false,
-			EventTypes: lc.events,
+			URL:            parseURL(lc.forwardURL),
+			ForwardHeaders: lc.forwardHeaders,
+			Connect:        false,
+			EventTypes:     lc.events,
 		})
 		endpointRoutes = append(endpointRoutes, proxy.EndpointRoute{
-			URL:        parseURL(lc.forwardConnectURL),
-			ForwardHeaders:	lc.forwardConnectHeaders,
-			Connect:    true,
-			EventTypes: lc.events,
+			URL:            parseURL(lc.forwardConnectURL),
+			ForwardHeaders: lc.forwardConnectHeaders,
+			Connect:        true,
+			EventTypes:     lc.events,
 		})
 	}
 
@@ -148,7 +148,6 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 			return errors.New("You have not defined any webhook endpoints on your account. Go to the Stripe Dashboard to add some: https://dashboard.stripe.com/test/webhooks")
 		}
 
-		// pass in connect and non connect custom headers to build endpoint routes
 		endpointRoutes = buildEndpointRoutes(endpoints, parseURL(lc.forwardURL), parseURL(lc.forwardConnectURL), lc.forwardHeaders, lc.forwardConnectHeaders)
 	} else if lc.loadFromWebhooksAPI && len(lc.forwardURL) == 0 {
 		return errors.New("--load-from-webhooks-api requires a location to forward to with --forward-to")
@@ -202,17 +201,17 @@ func buildEndpointRoutes(endpoints requests.WebhookEndpointList, forwardURL, for
 			// the path. We'll use this with `localhost` or with the `--forward-to` flag
 			if endpoint.Application == "" {
 				endpointRoutes = append(endpointRoutes, proxy.EndpointRoute{
-					URL:        	buildForwardURL(forwardURL, u),
-					ForwardHeaders:	forwardHeaders,
-					Connect:    	false,
-					EventTypes: 	endpoint.EnabledEvents,
+					URL:            buildForwardURL(forwardURL, u),
+					ForwardHeaders: forwardHeaders,
+					Connect:        false,
+					EventTypes:     endpoint.EnabledEvents,
 				})
 			} else {
 				endpointRoutes = append(endpointRoutes, proxy.EndpointRoute{
-					URL:        	buildForwardURL(forwardConnectURL, u),
+					URL:            buildForwardURL(forwardConnectURL, u),
 					ForwardHeaders: forwardConnectHeaders,
-					Connect:    	true,
-					EventTypes: 	endpoint.EnabledEvents,
+					Connect:        true,
+					EventTypes:     endpoint.EnabledEvents,
 				})
 			}
 		}

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -38,12 +38,14 @@ func TestBuildEndpointRoutes(t *testing.T) {
 		Data: []requests.WebhookEndpoint{endpointNormal, endpointConnect},
 	}
 
-	output := buildEndpointRoutes(endpointList, localURL, localURL)
+	output := buildEndpointRoutes(endpointList, localURL, localURL, []string{"Host: hostname"}, []string{"Host: connecthostname"})
 	require.Equal(t, 2, len(output))
 	require.Equal(t, "http://localhost/hooks", output[0].URL)
+	require.Equal(t, []string{"Host: hostname"}, output[0].ForwardHeaders)
 	require.Equal(t, false, output[0].Connect)
 	require.Equal(t, []string{"*"}, output[0].EventTypes)
 	require.Equal(t, "http://localhost/connect-hooks", output[1].URL)
+	require.Equal(t, []string{"Host: connecthostname"}, output[1].ForwardHeaders)
 	require.Equal(t, true, output[1].Connect)
 	require.Equal(t, []string{"*"}, output[1].EventTypes)
 }

--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -6,9 +6,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"time"
-	"strings"
 	"regexp"
+	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -122,10 +122,9 @@ func (c *EndpointClient) Post(webhookID string, body string, headers map[string]
 // Public functions
 //
 
-
 // NewEndpointClient returns a new EndpointClient.
 func NewEndpointClient(url string, headers []string, connect bool, events []string, cfg *EndpointConfig) *EndpointClient {
-	
+
 	if cfg == nil {
 		cfg = &EndpointConfig{}
 	}
@@ -172,15 +171,9 @@ func convertToMap(events []string) map[string]bool {
 }
 
 func convertToMapAndSanitize(headers []string) map[string]string {
-	reg, err := regexp.Compile("[\x00-\x1f]+")
+	reg := regexp.MustCompile("[\x00-\x1f]+")
 
 	headerMap := make(map[string]string)
-
-	if err != nil {
-		// what to do if regex fails to compile?
-		fmt.Println("error with regex")
-		return headerMap
-	}
 
 	for _, header := range headers {
 

--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -186,7 +186,7 @@ func convertToMapAndSanitize(headers []string) map[string]string {
 
 		header = reg.ReplaceAllString(header, "")
 
-		splitHeader := strings.Split(header, ":")
+		splitHeader := strings.SplitN(header, ":", 2)
 		headerKey := strings.TrimSpace(splitHeader[0])
 		headerVal := strings.TrimSpace(splitHeader[1])
 		if headerKey != "" {

--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -88,6 +88,7 @@ func (c *EndpointClient) Post(webhookID string, body string, headers map[string]
 		req.Header.Add(k, v)
 	}
 
+	// add custom headers
 	for k, v := range c.headers {
 		if strings.ToLower(k) == "host" {
 			req.Host = v
@@ -140,39 +141,9 @@ func NewEndpointClient(url string, headers []string, connect bool, events []stri
 		cfg.ResponseHandler = EndpointResponseHandlerFunc(func(string, *http.Response) {})
 	}
 
-	// TODO: do sanitization here
-
-	reg, err := regexp.Compile("[\x00-\x1f]+")
-
-	headerMap := make(map[string]string)
-
-	if err != nil {
-		fmt.Println("error with regex")
-	}
-
-	for _, header := range headers {
-
-		// check for sub 0x20 ascii values
-		// cleanString := ""
-		// for _, runeValue := range header {
-		// 	if int(runeValue) >= 32 {
-		// 		cleanString += string(runeValue)
-		// 	}
-		// }
-
-		header = reg.ReplaceAllString(header, "")
-
-		splitHeader := strings.Split(header, ":")
-		headerKey := strings.TrimSpace(splitHeader[0])
-		headerVal := strings.TrimSpace(splitHeader[1])
-		if headerKey != "" {
-			headerMap[headerKey] = headerVal
-		}
-	}
-
 	return &EndpointClient{
 		URL:     url,
-		headers: headerMap,
+		headers: convertToMapAndSanitize(headers),
 		connect: connect,
 		events:  convertToMap(events),
 		cfg:     cfg,
@@ -198,4 +169,30 @@ func convertToMap(events []string) map[string]bool {
 	}
 
 	return eventsMap
+}
+
+func convertToMapAndSanitize(headers []string) map[string]string {
+	reg, err := regexp.Compile("[\x00-\x1f]+")
+
+	headerMap := make(map[string]string)
+
+	if err != nil {
+		// what to do if regex fails to compile?
+		fmt.Println("error with regex")
+		return headerMap
+	}
+
+	for _, header := range headers {
+
+		header = reg.ReplaceAllString(header, "")
+
+		splitHeader := strings.Split(header, ":")
+		headerKey := strings.TrimSpace(splitHeader[0])
+		headerVal := strings.TrimSpace(splitHeader[1])
+		if headerKey != "" {
+			headerMap[headerKey] = headerVal
+		}
+	}
+
+	return headerMap
 }

--- a/pkg/proxy/endpoint_test.go
+++ b/pkg/proxy/endpoint_test.go
@@ -32,6 +32,7 @@ func TestClientHandler(t *testing.T) {
 	rcvWebhookID := ""
 	client := NewEndpointClient(
 		ts.URL,
+		[]string{"Host: hostname"}, // custom headers
 		false,
 		[]string{"*"},
 		&EndpointConfig{

--- a/pkg/proxy/endpoint_test.go
+++ b/pkg/proxy/endpoint_test.go
@@ -24,6 +24,17 @@ func TestClientHandler(t *testing.T) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "TestAgent/v1", r.UserAgent())
 		require.Equal(t, "t=123,v1=hunter2", r.Header.Get("Stripe-Signature"))
+
+		// t.Error("!!!!!!!!!!!!!!!!!!!!")
+		// t.Error(r.Host)
+		
+		// test custom headers
+		require.Equal(t, "hostname", r.Host)
+		require.Equal(t, "customHeaderValue", r.Header.Get("customHeader"))
+		require.Equal(t, "customHeaderValue 2", r.Header.Get("customHeader2"))
+		require.Equal(t, "", r.Header.Get("emptyHeader"))
+		require.Equal(t, "tab", r.Header.Get("removeControlCharacters"))
+
 		require.Equal(t, "{}", string(reqBody))
 	}))
 	defer ts.Close()
@@ -32,7 +43,8 @@ func TestClientHandler(t *testing.T) {
 	rcvWebhookID := ""
 	client := NewEndpointClient(
 		ts.URL,
-		[]string{"Host: hostname"}, // custom headers
+		[]string{" Host:       hostname", "customHeader:customHeaderValue", "customHeader2:       customHeaderValue 2",
+			"emptyHeader:", ":", "::", "removeControlCharacters:	tab"}, // custom headers
 		false,
 		[]string{"*"},
 		&EndpointConfig{

--- a/pkg/proxy/endpoint_test.go
+++ b/pkg/proxy/endpoint_test.go
@@ -24,7 +24,7 @@ func TestClientHandler(t *testing.T) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "TestAgent/v1", r.UserAgent())
 		require.Equal(t, "t=123,v1=hunter2", r.Header.Get("Stripe-Signature"))
-		
+
 		require.Equal(t, "hostname", r.Host)
 		require.Equal(t, "customHeaderValue", r.Header.Get("customHeader"))
 		require.Equal(t, "customHeaderValue 2", r.Header.Get("customHeader2"))

--- a/pkg/proxy/endpoint_test.go
+++ b/pkg/proxy/endpoint_test.go
@@ -24,11 +24,7 @@ func TestClientHandler(t *testing.T) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "TestAgent/v1", r.UserAgent())
 		require.Equal(t, "t=123,v1=hunter2", r.Header.Get("Stripe-Signature"))
-
-		// t.Error("!!!!!!!!!!!!!!!!!!!!")
-		// t.Error(r.Host)
 		
-		// test custom headers
 		require.Equal(t, "hostname", r.Host)
 		require.Equal(t, "customHeaderValue", r.Header.Get("customHeader"))
 		require.Equal(t, "customHeaderValue 2", r.Header.Get("customHeader2"))

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -29,6 +29,9 @@ type EndpointRoute struct {
 	// URL is the endpoint's URL.
 	URL string
 
+	// Headers to forward to endpoints
+	ForwardHeaders []string
+
 	// Connect indicates whether the endpoint should receive normal (when false) or Connect (when true) events.
 	Connect bool
 
@@ -286,6 +289,7 @@ func New(cfg *Config, events []string) *Proxy {
 		// append to endpointClients
 		p.endpointClients = append(p.endpointClients, NewEndpointClient(
 			route.URL,
+			route.ForwardHeaders,
 			route.Connect,
 			route.EventTypes,
 			&EndpointConfig{


### PR DESCRIPTION
 ### Reviewers
r? @joek-stripe @joek
cc @stripe/dev-platform @ob-stripe @ob

 ### Summary
Allows users to add custom headers when running CLI "listen" command. Strips whitespace and sanitizes sub 0x20 ascii characters.

Fixes #129.