### PR TITLE
Add a validator for fixtures commands

### DIFF
--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/config"
 	gitpkg "github.com/stripe/stripe-cli/pkg/git"
 	"github.com/stripe/stripe-cli/pkg/samples"
+	"github.com/stripe/stripe-cli/pkg/validators"
 
 	"gopkg.in/src-d/go-git.v4"
 )
@@ -31,6 +32,7 @@ func NewCreateCmd(config *config.Config) *CreateCmd {
 	createCmd.Cmd = &cobra.Command{
 		Use:       "create",
 		ValidArgs: samples.Names(),
+		Args:      validators.MaximumNArgs(2),
 		Short:     "create a Stripe sample",
 		RunE:      createCmd.runCreateCmd,
 	}

--- a/pkg/cmd/samples/fixtures.go
+++ b/pkg/cmd/samples/fixtures.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/config"
 	s "github.com/stripe/stripe-cli/pkg/samples"
 	"github.com/stripe/stripe-cli/pkg/stripe"
+	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
 // FixturesCmd prints a list of all the available sample projects that users can
@@ -24,6 +25,7 @@ func NewFixturesCmd(cfg *config.Config) *FixturesCmd {
 
 	fixturesCmd.Cmd = &cobra.Command{
 		Use:   "fixtures",
+		Args:  validators.ExactArgs(1),
 		Short: "Run fixtures to populate your account with data",
 		Long:  `Run fixtures to populate your account with data`,
 		RunE:  fixturesCmd.runFixturesCmd,


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Fixtures was crashing when no arguments were given because it requires a file name. Adding a validator to prevent invoking the command without one.
