### PR TITLE
Print options

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -138,6 +138,8 @@ func (p *Proxy) Run() error {
 		p.cfg.Log.Fatalf("Aborting")
 	}
 
+	p.printOptions()
+
 	// Block until context is done (i.e. Ctrl+C is pressed)
 	<-p.ctx.Done()
 
@@ -411,4 +413,29 @@ func truncate(str string, maxByteLength int, ellipsis bool) string {
 
 func isUTF8ContinuationByte(b byte) bool {
 	return (b & 0xC0) == 0x80
+}
+
+func (p *Proxy) printOptions() {
+	if !p.cfg.PrintJSON {
+		if p.cfg.UseLatestAPIVersion {
+			fmt.Println("Using Latest API Version")
+		} else {
+			fmt.Println("Using your account's default API version")
+		}
+
+		for i, endpoint := range p.cfg.EndpointRoutes {
+			fmt.Printf("Endpoint %d\n", i)
+
+			if endpoint.EventTypes[0] == "*" {
+				fmt.Printf("\tForwarding all events -> %s\n", endpoint.URL)
+			} else {
+				fmt.Printf("\tForwarding %s events -> %s\n", endpoint.EventTypes, endpoint.URL)
+			}
+
+			fmt.Printf("\tHeaders: %s\n", endpoint.ForwardHeaders)
+			fmt.Printf("\tConnect: %t\n", endpoint.Connect)
+		}
+
+		fmt.Println("--")
+	}
 }


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
When running listen with options, prints the options to console so user can see what events are being forwarded, URL they are forwarding to, etc.

Wondering if we should hide the output behind a -V verbose flag?
The current output looks like this:

<img width="1255" alt="Screen Shot 2019-09-20 at 1 43 02 PM" src="https://user-images.githubusercontent.com/55296083/65357739-b049df80-dbac-11e9-847e-59eab89f6ecf.png">
