### PR TITLE
Send forward URL in webhook responses

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - errcheck
     - gochecknoglobals
     - gochecknoinits
+    - godox
     - gosec
     - lll
     - maligned

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -89,7 +89,6 @@ to your localhost:
 // Normally, this function would be listed alphabetically with the others declared in this file,
 // but since it's acting as the core functionality for the cmd above, I'm keeping it close.
 func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
-
 	deviceName, err := Config.Profile.GetDeviceName()
 	if err != nil {
 		return err
@@ -116,9 +115,6 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(lc.forwardURL) > 0 {
-
-		// add custom headers to endpoint routes
-
 		endpointRoutes = append(endpointRoutes, proxy.EndpointRoute{
 			URL:            parseURL(lc.forwardURL),
 			ForwardHeaders: lc.forwardHeaders,

--- a/pkg/login/interactive_login.go
+++ b/pkg/login/interactive_login.go
@@ -97,7 +97,6 @@ func redactAPIKey(apiKey string) string {
 
 func securePrompt(input io.Reader) (string, error) {
 	if input == os.Stdin {
-
 		// terminal.ReadPassword does not reset terminal state on ctrl-c interrupts,
 		// this results in the terminal input staying hidden after program exit.
 		// We need to manually catch the interrupt and restore terminal state before exiting.

--- a/pkg/login/login_message.go
+++ b/pkg/login/login_message.go
@@ -28,7 +28,6 @@ type Dashboard struct {
 
 // SuccessMessage returns the display message for a successfully authenticated user
 func SuccessMessage(account *Account, baseURL string, apiKey string) (string, error) {
-
 	// Account will be nil if user did interactive login
 	if account == nil {
 		acc, err := getUserAccount(baseURL, apiKey)

--- a/pkg/login/poll.go
+++ b/pkg/login/poll.go
@@ -83,7 +83,6 @@ func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (*PollA
 
 		count++
 		time.Sleep(interval)
-
 	}
 
 	return nil, nil, errors.New("exceeded max attempts")

--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -124,7 +124,6 @@ func (c *EndpointClient) Post(webhookID string, body string, headers map[string]
 
 // NewEndpointClient returns a new EndpointClient.
 func NewEndpointClient(url string, headers []string, connect bool, events []string, cfg *EndpointConfig) *EndpointClient {
-
 	if cfg == nil {
 		cfg = &EndpointConfig{}
 	}
@@ -176,7 +175,6 @@ func convertToMapAndSanitize(headers []string) map[string]string {
 	headerMap := make(map[string]string)
 
 	for _, header := range headers {
-
 		header = reg.ReplaceAllString(header, "")
 
 		splitHeader := strings.SplitN(header, ":", 2)

--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -30,18 +30,18 @@ type EndpointConfig struct {
 
 // EndpointResponseHandler handles a response from the endpoint.
 type EndpointResponseHandler interface {
-	ProcessResponse(string, *http.Response)
+	ProcessResponse(string, string, *http.Response)
 }
 
 // EndpointResponseHandlerFunc is an adapter to allow the use of ordinary
 // functions as response handlers. If f is a function with the
 // appropriate signature, ResponseHandler(f) is a
 // ResponseHandler that calls f.
-type EndpointResponseHandlerFunc func(string, *http.Response)
+type EndpointResponseHandlerFunc func(string, string, *http.Response)
 
 // ProcessResponse calls f(webhookID, resp).
-func (f EndpointResponseHandlerFunc) ProcessResponse(webhookID string, resp *http.Response) {
-	f(webhookID, resp)
+func (f EndpointResponseHandlerFunc) ProcessResponse(webhookID, forwardURL string, resp *http.Response) {
+	f(webhookID, forwardURL, resp)
 }
 
 // EndpointClient is the client used to POST webhook requests to the local endpoint.
@@ -113,7 +113,7 @@ func (c *EndpointClient) Post(webhookID string, body string, headers map[string]
 	}
 	defer resp.Body.Close()
 
-	c.cfg.ResponseHandler.ProcessResponse(webhookID, resp)
+	c.cfg.ResponseHandler.ProcessResponse(webhookID, c.URL, resp)
 
 	return nil
 }
@@ -137,7 +137,7 @@ func NewEndpointClient(url string, headers []string, connect bool, events []stri
 		}
 	}
 	if cfg.ResponseHandler == nil {
-		cfg.ResponseHandler = EndpointResponseHandlerFunc(func(string, *http.Response) {})
+		cfg.ResponseHandler = EndpointResponseHandlerFunc(func(string, string, *http.Response) {})
 	}
 
 	return &EndpointClient{

--- a/pkg/proxy/endpoint_test.go
+++ b/pkg/proxy/endpoint_test.go
@@ -36,6 +36,7 @@ func TestClientHandler(t *testing.T) {
 	defer ts.Close()
 
 	rcvBody := ""
+	rcvForwardURL := ""
 	rcvWebhookID := ""
 	client := NewEndpointClient(
 		ts.URL,
@@ -44,11 +45,12 @@ func TestClientHandler(t *testing.T) {
 		false,
 		[]string{"*"},
 		&EndpointConfig{
-			ResponseHandler: EndpointResponseHandlerFunc(func(webhookID string, resp *http.Response) {
+			ResponseHandler: EndpointResponseHandlerFunc(func(webhookID, forwardURL string, resp *http.Response) {
 				buf, err := ioutil.ReadAll(resp.Body)
 				require.Nil(t, err)
 
 				rcvBody = string(buf)
+				rcvForwardURL = forwardURL
 				rcvWebhookID = webhookID
 
 				wg.Done()
@@ -69,5 +71,6 @@ func TestClientHandler(t *testing.T) {
 
 	require.Nil(t, err)
 	require.Equal(t, "OK!", rcvBody)
+	require.Equal(t, ts.URL, rcvForwardURL)
 	require.Equal(t, "wh_123", rcvWebhookID)
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -222,7 +222,7 @@ func (p *Proxy) processWebhookEvent(msg websocket.IncomingMessage) {
 	// to pass back to Stripe
 }
 
-func (p *Proxy) processEndpointResponse(webhookID string, resp *http.Response) {
+func (p *Proxy) processEndpointResponse(webhookID, forwardURL string, resp *http.Response) {
 	localTime := time.Now().Format(timeLayout)
 
 	color := ansi.Color(os.Stdout)
@@ -258,7 +258,7 @@ func (p *Proxy) processEndpointResponse(webhookID string, resp *http.Response) {
 	}
 
 	if p.webSocketClient != nil {
-		msg := websocket.NewWebhookResponse(webhookID, resp.StatusCode, body, headers)
+		msg := websocket.NewWebhookResponse(webhookID, forwardURL, resp.StatusCode, body, headers)
 		p.webSocketClient.SendMessage(msg)
 	}
 }

--- a/pkg/websocket/messages_test.go
+++ b/pkg/websocket/messages_test.go
@@ -5,39 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/tidwall/gjson"
 )
-
-func TestUnmarshalWebhookEvent(t *testing.T) {
-	var data = `{"type": "webhook_event", "event_payload": "foo", "http_headers": {"Request-Header": "bar"}, "webhook_id": "wh_123"}`
-
-	var msg IncomingMessage
-	err := json.Unmarshal([]byte(data), &msg)
-	require.Nil(t, err)
-
-	require.NotNil(t, msg.WebhookEvent)
-	require.Nil(t, msg.RequestLogEvent)
-
-	require.Equal(t, "foo", msg.WebhookEvent.EventPayload)
-	require.Equal(t, "bar", msg.WebhookEvent.HTTPHeaders["Request-Header"])
-	require.Equal(t, "webhook_event", msg.WebhookEvent.Type)
-	require.Equal(t, "wh_123", msg.WebhookEvent.WebhookID)
-}
-
-func TestUnmarshalRequestLogEvent(t *testing.T) {
-	var data = `{"type": "request_log_event", "event_payload": "foo", "request_log_id": "resp_123"}`
-
-	var msg IncomingMessage
-	err := json.Unmarshal([]byte(data), &msg)
-	require.Nil(t, err)
-
-	require.NotNil(t, msg.RequestLogEvent)
-	require.Nil(t, msg.WebhookEvent)
-
-	require.Equal(t, "foo", msg.RequestLogEvent.EventPayload)
-	require.Equal(t, "resp_123", msg.RequestLogEvent.RequestLogID)
-	require.Equal(t, "request_log_event", msg.RequestLogEvent.Type)
-}
 
 func TestUnmarshalUnknownIncomingMsg(t *testing.T) {
 	var data = `{"type": "unknown_type", "foo": "bar"}`
@@ -45,17 +13,4 @@ func TestUnmarshalUnknownIncomingMsg(t *testing.T) {
 	var msg IncomingMessage
 	err := json.Unmarshal([]byte(data), &msg)
 	require.EqualError(t, err, "Unexpected message type: unknown_type")
-}
-
-func TestMarshalWebhookResponse(t *testing.T) {
-	msg := NewWebhookResponse("wh_123", 200, "foo", map[string]string{"Response-Header": "bar"})
-
-	buf, err := json.Marshal(msg)
-	require.Nil(t, err)
-
-	json := string(buf)
-	require.Equal(t, "wh_123", gjson.Get(json, "webhook_id").String())
-	require.Equal(t, 200, int(gjson.Get(json, "status").Num))
-	require.Equal(t, "foo", gjson.Get(json, "body").String())
-	require.Equal(t, "bar", gjson.Get(json, "http_headers.Response-Header").String())
 }

--- a/pkg/websocket/request_log_messages_test.go
+++ b/pkg/websocket/request_log_messages_test.go
@@ -1,0 +1,23 @@
+package websocket
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalRequestLogEvent(t *testing.T) {
+	var data = `{"type": "request_log_event", "event_payload": "foo", "request_log_id": "resp_123"}`
+
+	var msg IncomingMessage
+	err := json.Unmarshal([]byte(data), &msg)
+	require.NoError(t, err)
+
+	require.NotNil(t, msg.RequestLogEvent)
+	require.Nil(t, msg.WebhookEvent)
+
+	require.Equal(t, "foo", msg.RequestLogEvent.EventPayload)
+	require.Equal(t, "resp_123", msg.RequestLogEvent.RequestLogID)
+	require.Equal(t, "request_log_event", msg.RequestLogEvent.Type)
+}

--- a/pkg/websocket/webhook_messages.go
+++ b/pkg/websocket/webhook_messages.go
@@ -18,6 +18,7 @@ type WebhookEvent struct {
 // WebhookResponse represents outgoing webhook response messages sent to
 // Stripe.
 type WebhookResponse struct {
+	ForwardURL  string            `json:"forward_url"`
 	Status      int               `json:"status"`
 	HTTPHeaders map[string]string `json:"http_headers"`
 	Body        string            `json:"body"`
@@ -26,10 +27,11 @@ type WebhookResponse struct {
 }
 
 // NewWebhookResponse returns a new webhookResponse message.
-func NewWebhookResponse(webhookID string, status int, body string, headers map[string]string) *OutgoingMessage {
+func NewWebhookResponse(webhookID string, forwardURL string, status int, body string, headers map[string]string) *OutgoingMessage {
 	return &OutgoingMessage{
 		WebhookResponse: &WebhookResponse{
 			WebhookID:   webhookID,
+			ForwardURL:  forwardURL,
 			Status:      status,
 			Body:        body,
 			HTTPHeaders: headers,

--- a/pkg/websocket/webhook_messages_test.go
+++ b/pkg/websocket/webhook_messages_test.go
@@ -1,16 +1,62 @@
 package websocket
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
+func TestUnmarshalWebhookEvent(t *testing.T) {
+	var data = `{"type": "webhook_event", "event_payload": "foo", "http_headers": {"Request-Header": "bar"}, "webhook_id": "wh_123"}`
+
+	var msg IncomingMessage
+	err := json.Unmarshal([]byte(data), &msg)
+	require.NoError(t, err)
+
+	require.NotNil(t, msg.WebhookEvent)
+	require.Nil(t, msg.RequestLogEvent)
+
+	require.Equal(t, "foo", msg.WebhookEvent.EventPayload)
+	require.Equal(t, "bar", msg.WebhookEvent.HTTPHeaders["Request-Header"])
+	require.Equal(t, "webhook_event", msg.WebhookEvent.Type)
+	require.Equal(t, "wh_123", msg.WebhookEvent.WebhookID)
+}
+
+func TestMarshalWebhookResponse(t *testing.T) {
+	msg := NewWebhookResponse(
+		"wh_123",
+		"http://localhost:5000/webhooks",
+		200,
+		"foo",
+		map[string]string{"Response-Header": "bar"},
+	)
+
+	buf, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	json := string(buf)
+	require.Equal(t, "wh_123", gjson.Get(json, "webhook_id").String())
+	require.Equal(t, "http://localhost:5000/webhooks", gjson.Get(json, "forward_url").String())
+	require.Equal(t, 200, int(gjson.Get(json, "status").Num))
+	require.Equal(t, "foo", gjson.Get(json, "body").String())
+	require.Equal(t, "bar", gjson.Get(json, "http_headers.Response-Header").String())
+}
+
 func TestNewWebhookResponse(t *testing.T) {
-	msg := NewWebhookResponse("wh_123", 200, "foo", map[string]string{"Response-Header": "bar"})
+	msg := NewWebhookResponse(
+		"wh_123",
+		"http://localhost:5000/webhooks",
+		200,
+		"foo",
+		map[string]string{"Response-Header": "bar"},
+	)
+
 	require.NotNil(t, msg.WebhookResponse)
 	require.Equal(t, "webhook_response", msg.Type)
 	require.Equal(t, "wh_123", msg.WebhookID)
+	require.Equal(t, "http://localhost:5000/webhooks", msg.ForwardURL)
 	require.Equal(t, 200, msg.Status)
 	require.Equal(t, "foo", msg.Body)
 	require.Equal(t, "bar", msg.HTTPHeaders["Response-Header"])


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform @ballantyne-stripe @carolinem-stripe 

 ### Summary
Include the forward URL in webhook responses, so we can use it to display it in the dashboard.
