### PR TITLE
Display error properties when tailing logs

### DIFF
--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -68,17 +68,17 @@ type Tailer struct {
 
 // EventPayload is the mapping for fields in event payloads from request log tailing
 type EventPayload struct {
-	CreatedAt int    `json:"created_at"`
-	Livemode  bool   `json:"livemode"`
-	Method    string `json:"method"`
-	RequestID string `json:"request_id"`
-	Status    int    `json:"status"`
-	URL       string `json:"url"`
-	Error     string `json:"error"`
+	CreatedAt int             `json:"created_at"`
+	Livemode  bool            `json:"livemode"`
+	Method    string          `json:"method"`
+	RequestID string          `json:"request_id"`
+	Status    int             `json:"status"`
+	URL       string          `json:"url"`
+	Error     RequestLogError `json:"error"`
 }
 
-// RedactedError is the mapping for fields in error from an EventPayload
-type RedactedError struct {
+// RequestLogError is the mapping for fields in error from an EventPayload
+type RequestLogError struct {
 	Type        string `json:"type"`
 	Charge      string `json:"charge"`
 	Code        string `json:"code"`
@@ -202,13 +202,8 @@ func (tailer *Tailer) processRequestLogEvent(msg websocket.IncomingMessage) {
 	outputStr := fmt.Sprintf("%s [%d] %s %s [%s]", color.Faint(localTime), coloredStatus, payload.Method, payload.URL, requestLink)
 	fmt.Println(outputStr)
 
-	var payloadError RedactedError
-	if err := json.Unmarshal([]byte(payload.Error), &payloadError); err != nil {
-		tailer.cfg.Log.Warn("Received malformed error from payload: ", err)
-	}
-
 	outputStr = fmt.Sprintf("Type: %s\nCharge: %s\nCode: %s\nDecline Code: %s\nMessage: %s\nParam: %s\n",
-		payloadError.Type, payloadError.Charge, payloadError.Code, payloadError.DeclineCode, payloadError.Message, payloadError.Param)
+		payload.Error.Type, payload.Error.Charge, payload.Error.Code, payload.Error.DeclineCode, payload.Error.Message, payload.Error.Param)
 	fmt.Println(outputStr)
 }
 

--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -69,12 +69,12 @@ type Tailer struct {
 
 // EventPayload is the mapping for fields in event payloads from request log tailing
 type EventPayload struct {
-	CreatedAt int    `json:"created_at"`
-	Livemode  bool   `json:"livemode"`
-	Method    string `json:"method"`
-	RequestID string `json:"request_id"`
-	Status    int    `json:"status"`
-	URL       string `json:"url"`
+	CreatedAt int           `json:"created_at"`
+	Livemode  bool          `json:"livemode"`
+	Method    string        `json:"method"`
+	RequestID string        `json:"request_id"`
+	Status    int           `json:"status"`
+	URL       string        `json:"url"`
 	Error     RedactedError `json:"error"`
 }
 


### PR DESCRIPTION
[wip] 

### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Changes to tailer to allow 'logs tail' to accept error info from request log events, and print to user.
