### PR TITLE
Add support for creating a Checkout Session via the CLI

### DIFF
--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -31,7 +31,7 @@ func newTriggerCmd() *triggerCmd {
 			"charge.failed",
 			"charge.refunded",
 			"charge.succeeded",
-			"checkout.session.created",
+			"checkout.session.completed",
 			"customer.created",
 			"customer.deleted",
 			"customer.updated",
@@ -62,7 +62,7 @@ needed to create the triggered event.
   charge.failed
   charge.refunded
   charge.succeeded
-  checkout.session.created
+  checkout.session.completed
   customer.created
   customer.deleted
   customer.updated
@@ -126,7 +126,7 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 		"charge.failed":                 examples.ChargeFailed,
 		"charge.refunded":               examples.ChargeRefunded,
 		"charge.succeeded":              examples.ChargeSucceeded,
-		"checkout.session.created":      examples.SessionCreated,
+		"checkout.session.completed":    examples.CheckoutSessionCompleted,
 		"customer.created":              examples.CustomerCreated,
 		"customer.deleted":              examples.CustomerDeleted,
 		"customer.updated":              examples.CustomerUpdated,

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -31,6 +31,7 @@ func newTriggerCmd() *triggerCmd {
 			"charge.failed",
 			"charge.refunded",
 			"charge.succeeded",
+			"checkout.session.created",
 			"customer.created",
 			"customer.deleted",
 			"customer.updated",
@@ -61,6 +62,7 @@ needed to create the triggered event.
   charge.failed
   charge.refunded
   charge.succeeded
+  checkout.session.created
   customer.created
   customer.deleted
   customer.updated
@@ -124,6 +126,7 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 		"charge.failed":                 examples.ChargeFailed,
 		"charge.refunded":               examples.ChargeRefunded,
 		"charge.succeeded":              examples.ChargeSucceeded,
+		"checkout.session.created":      examples.SessionCreated,
 		"customer.created":              examples.CustomerCreated,
 		"customer.deleted":              examples.CustomerDeleted,
 		"customer.updated":              examples.CustomerUpdated,

--- a/pkg/requests/examples.go
+++ b/pkg/requests/examples.go
@@ -140,6 +140,24 @@ func (ex *Examples) ChargeSucceeded() error {
 	return err
 }
 
+// SessionCreated creates a checkout session
+// https://stripe.com/docs/api/checkout/sessions/create?lang=curl
+func (ex *Examples) SessionCreated() error {
+	req, params := ex.buildRequest(http.MethodPost, []string{
+		"success_url='https://httpbin.org/post'",
+		"cancel_url='https://httpbin.org/post'",
+		"payment_method_types[]=card",
+		"line_items[][name]=T-shirt",
+		"line_items[][description]=Comfortable cotton t-shirt",
+		"line_items[][amount]=1500",
+		"line_items[][currency]=usd",
+		"line_items[][quantity]=2",
+	})
+
+	_, err := ex.performStripeRequest(req, "/v1/checkout/sessions", params)
+	return err
+}
+
 func (ex *Examples) customerCreated(data []string) (map[string]interface{}, error) {
 	req, params := ex.buildRequest(http.MethodPost, data)
 	return ex.performStripeRequest(req, "/v1/customers", params)

--- a/pkg/requests/examples.go
+++ b/pkg/requests/examples.go
@@ -2,6 +2,7 @@ package requests
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -66,6 +67,7 @@ func (ex *Examples) performStripeRequest(req *Base, endpoint string, params *Req
 	if err != nil {
 		return nil, err
 	}
+
 	return parseResponse(resp)
 }
 
@@ -140,12 +142,12 @@ func (ex *Examples) ChargeSucceeded() error {
 	return err
 }
 
-// SessionCreated creates a checkout session
+// CheckoutSessionCompleted creates a checkout session
 // https://stripe.com/docs/api/checkout/sessions/create?lang=curl
-func (ex *Examples) SessionCreated() error {
+func (ex *Examples) CheckoutSessionCompleted() error {
 	req, params := ex.buildRequest(http.MethodPost, []string{
-		"success_url='https://httpbin.org/post'",
-		"cancel_url='https://httpbin.org/post'",
+		"success_url=https://httpbin.org/post",
+		"cancel_url=https://httpbin.org/post",
 		"payment_method_types[]=card",
 		"line_items[][name]=T-shirt",
 		"line_items[][description]=Comfortable cotton t-shirt",
@@ -154,7 +156,46 @@ func (ex *Examples) SessionCreated() error {
 		"line_items[][quantity]=2",
 	})
 
-	_, err := ex.performStripeRequest(req, "/v1/checkout/sessions", params)
+	paymentSession, err := ex.performStripeRequest(req, "/v1/checkout/sessions", params)
+	if err != nil {
+		return err
+	}
+
+	sessID, ok := paymentSession["id"]
+	if !ok {
+		return errors.New("Unable to retrieve PaymentSession ID")
+	}
+
+	// Undocumented API GET /v1/payment_pages
+	req, params = ex.buildRequest(http.MethodGet, []string{
+		fmt.Sprintf("session_id=%s", sessID),
+	})
+
+	paymentPage, err := ex.performStripeRequest(req, "/v1/payment_pages", params)
+	if err != nil {
+		return err
+	}
+
+	paymentPageID, ok := paymentPage["id"]
+	if !ok {
+		return errors.New("Unable to retrieve PaymentPage ID")
+	}
+
+	paymentMethod, err := ex.paymentMethodCreatedWithToken(validToken)
+	if err != nil {
+		return err
+	}
+
+	pmID, ok := paymentMethod["id"]
+	if !ok {
+		return errors.New("Unable to retrieve PaymentMethod ID")
+	}
+
+	// Undocumented API POST /v1/payment_pages/<ID>/confirm
+	req, params = ex.buildRequest(http.MethodPost, []string{
+		fmt.Sprintf("payment_method=%s", pmID),
+	})
+	_, err = ex.performStripeRequest(req, fmt.Sprintf("/v1/payment_pages/%s/confirm", paymentPageID), params)
 	return err
 }
 
@@ -538,6 +579,15 @@ func (ex *Examples) paymentMethodCreated(card string) (map[string]interface{}, e
 		"card[exp_month]=12",
 		"card[exp_year]=2020",
 		"card[cvc]=123",
+	})
+	return ex.performStripeRequest(req, "/v1/payment_methods", params)
+}
+
+func (ex *Examples) paymentMethodCreatedWithToken(token string) (map[string]interface{}, error) {
+	req, params := ex.buildRequest(http.MethodPost, []string{
+		"type=card",
+		fmt.Sprintf("card[token]=%s", token),
+		"billing_details[email]=stripe@example.com",
 	})
 	return ex.performStripeRequest(req, "/v1/payment_methods", params)
 }


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Added `stripe trigger checkout.session.created` which will exercise the new checkout session flow from the CLI

[dx-4745] closes #151 