### PR TITLE
Return error on non-2xx status in trigger and fixtures

### DIFF
--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -41,7 +41,7 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 
 	oc.Parameters.AppendData(args[len(oc.URLParams):])
 
-	_, err = oc.MakeRequest(apiKey, path, &oc.Parameters)
+	_, err = oc.MakeRequest(apiKey, path, &oc.Parameters, false)
 
 	return err
 }

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -81,7 +81,7 @@ func (rb *Base) RunRequestsCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, err = rb.MakeRequest(apiKey, path, &rb.Parameters)
+	_, err = rb.MakeRequest(apiKey, path, &rb.Parameters, false)
 
 	return err
 }
@@ -113,7 +113,7 @@ func (rb *Base) InitFlags(includeData bool) {
 }
 
 // MakeRequest will make a request to the Stripe API with the specific variables given to it
-func (rb *Base) MakeRequest(apiKey, path string, params *RequestParameters) ([]byte, error) {
+func (rb *Base) MakeRequest(apiKey, path string, params *RequestParameters, errOnStatus bool) ([]byte, error) {
 	parsedBaseURL, err := url.Parse(rb.APIBaseURL)
 	if err != nil {
 		return []byte{}, err
@@ -142,6 +142,10 @@ func (rb *Base) MakeRequest(apiKey, path string, params *RequestParameters) ([]b
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
+
+	if errOnStatus && resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Request failed, status=%d, body=%s", resp.StatusCode, string(body))
+	}
 
 	if !rb.SuppressOutput {
 		if err != nil {

--- a/pkg/requests/examples.go
+++ b/pkg/requests/examples.go
@@ -63,7 +63,7 @@ func (ex *Examples) buildRequest(method string, data []string) (*Base, *RequestP
 }
 
 func (ex *Examples) performStripeRequest(req *Base, endpoint string, params *RequestParameters) (map[string]interface{}, error) {
-	resp, err := req.MakeRequest(ex.APIKey, endpoint, params)
+	resp, err := req.MakeRequest(ex.APIKey, endpoint, params, true)
 	if err != nil {
 		return nil, err
 	}
@@ -626,7 +626,7 @@ func (ex *Examples) WebhookEndpointsList() WebhookEndpointList {
 		SuppressOutput: true,
 		APIBaseURL:     ex.APIBaseURL,
 	}
-	resp, _ := base.MakeRequest(ex.APIKey, "/v1/webhook_endpoints", params)
+	resp, _ := base.MakeRequest(ex.APIKey, "/v1/webhook_endpoints", params, true)
 	data := WebhookEndpointList{}
 	json.Unmarshal(resp, &data)
 

--- a/pkg/samples/fixtures.go
+++ b/pkg/samples/fixtures.go
@@ -118,7 +118,7 @@ func (fxt *Fixture) makeRequest(data fixture) ([]byte, error) {
 
 	path := fxt.parsePath(data)
 
-	return req.MakeRequest(fxt.APIKey, path, fxt.createParams(data.Params))
+	return req.MakeRequest(fxt.APIKey, path, fxt.createParams(data.Params), true)
 }
 
 func (fxt *Fixture) parsePath(http fixture) string {


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
When an API request fails during a `trigger` or `fixtures` command, we want to error out immediately rather than proceed normally. This will result in better errors, especially if the API request that fails is not the last one, since in most cases we want to extract something from the API resource, which would fail with a non-obvious error if the "resource" that is returned is actually an error object (cf. https://github.com/stripe/stripe-cli/issues/151#issuecomment-536786023).
