### PR TITLE
Add version check to a number of commands

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 const webhooksWebSocketFeature = "webhooks"
@@ -99,6 +100,10 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	key, err := Config.Profile.GetAPIKey(lc.livemode)
 	if err != nil {
 		return err
+	}
+
+	if !lc.printJSON {
+		version.CheckLatestVersion()
 	}
 
 	for _, event := range lc.events {

--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/config"
 	logTailing "github.com/stripe/stripe-cli/pkg/logtailing"
 	"github.com/stripe/stripe-cli/pkg/validators"
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 const requestLogsWebSocketFeature = "request_logs"
@@ -144,6 +145,8 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	version.CheckLatestVersion()
 
 	tailer := logTailing.New(&logTailing.Config{
 		APIBaseURL:       tailCmd.apiBaseURL,

--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/open"
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 var nameURLmap = map[string]string{
@@ -137,6 +138,8 @@ func (oc *openCmd) runOpenCmd(cmd *cobra.Command, args []string) error {
 
 		return nil
 	}
+
+	version.CheckLatestVersion()
 
 	if url, ok := nameURLmap[args[0]]; ok {
 		livemode, err := cmd.Flags().GetBool("livemode")

--- a/pkg/cmd/samples.go
+++ b/pkg/cmd/samples.go
@@ -13,7 +13,6 @@ type samplesCmd struct {
 func newSamplesCmd() *samplesCmd {
 	samplesCmd := &samplesCmd{
 		cmd: &cobra.Command{
-			// TODO: fixtures subcommand
 			Use:   "samples",
 			Short: `Sample integrations built by Stripe`,
 			Long:  ``,

--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -13,6 +13,7 @@ import (
 	gitpkg "github.com/stripe/stripe-cli/pkg/git"
 	"github.com/stripe/stripe-cli/pkg/samples"
 	"github.com/stripe/stripe-cli/pkg/validators"
+	"github.com/stripe/stripe-cli/pkg/version"
 
 	"gopkg.in/src-d/go-git.v4"
 )
@@ -41,6 +42,8 @@ func NewCreateCmd(config *config.Config) *CreateCmd {
 }
 
 func (cc *CreateCmd) runCreateCmd(cmd *cobra.Command, args []string) error {
+	version.CheckLatestVersion()
+
 	if len(args) == 0 {
 		return fmt.Errorf("Creating a sample requires at least 1 argument, received 0")
 	}

--- a/pkg/cmd/samples/fixtures.go
+++ b/pkg/cmd/samples/fixtures.go
@@ -8,6 +8,7 @@ import (
 	s "github.com/stripe/stripe-cli/pkg/samples"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 // FixturesCmd prints a list of all the available sample projects that users can
@@ -35,6 +36,8 @@ func NewFixturesCmd(cfg *config.Config) *FixturesCmd {
 }
 
 func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
+	version.CheckLatestVersion()
+
 	apiKey, err := fc.Cfg.Profile.GetAPIKey(false)
 	if err != nil {
 		return err

--- a/pkg/cmd/samples/list.go
+++ b/pkg/cmd/samples/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/samples"
 	"github.com/stripe/stripe-cli/pkg/validators"
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 // ListCmd prints a list of all the available sample projects that users can
@@ -31,6 +32,8 @@ func NewListCmd() *ListCmd {
 }
 
 func (lc *ListCmd) runListCmd(cmd *cobra.Command, args []string) {
+	version.CheckLatestVersion()
+
 	fmt.Println("A list of available Stripe Sample integrations:")
 	fmt.Println()
 

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/status"
 	"github.com/stripe/stripe-cli/pkg/validators"
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 type statusCmd struct {
@@ -41,6 +42,10 @@ func newStatusCmd() *statusCmd {
 }
 
 func (sc *statusCmd) runStatusCmd(cmd *cobra.Command, args []string) error {
+	if sc.format != "json" {
+		version.CheckLatestVersion()
+	}
+
 	if sc.pollRate < 5 {
 		return fmt.Errorf("poll-rate must be at least 5 seconds, received %d", sc.pollRate)
 	}

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 const apiVersion = "2019-03-14"
@@ -98,6 +99,8 @@ needed to create the triggered event.
 }
 
 func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
+	version.CheckLatestVersion()
+
 	apiKey, err := Config.Profile.GetAPIKey(false)
 	if err != nil {
 		return err


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
This adds version checks to a number of CLI commands that would benefit from running on the latest version. Version checking fails silently so this will never prevent running any of the commands.
