### PR TITLE
Group request parameters flags separately in help messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
 	github.com/thedevsaddam/gojsonq v2.2.2+incompatible

--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -102,6 +102,7 @@ func NewOperationCmd(parentCmd *cobra.Command, name, path, httpVerb string, prop
 		// it's ok to treat all flags as string flags because we don't send any default flag values to the API
 		// i.e. "account_balance" default is "" not 0 but this is ok
 		operationCmd.stringFlags[prop] = cmd.Flags().String(prop, "", "")
+		cmd.Flags().SetAnnotation(prop, "request", []string{"true"})
 	}
 
 	// non-scalar fields handled in general '-d a=b' format
@@ -148,7 +149,10 @@ func operationUsageTemplate(urlParams []string) string {
 		}
 		return r
 	}, strings.Join(urlParams, " "))
-	args += " [param1=value1] [param2=value2] ..."
+	if args != "" {
+		args += " "
+	}
+	args += "[--param=value] [-d \"nested[param]=value\"]"
 
 	return fmt.Sprintf(`%s{{if .Runnable}}
   {{.UseLine}} %s{{end}}{{if .HasAvailableSubCommands}}
@@ -164,7 +168,10 @@ func operationUsageTemplate(urlParams []string) string {
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 %s
-{{WrappedLocalFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+{{WrappedRequestParamsFlagUsages . | trimTrailingWhitespaces}}
+
+%s
+{{WrappedNonRequestParamsFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
 %s
 {{WrappedInheritedFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
@@ -179,6 +186,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 		ansi.Bold("Aliases:"),
 		ansi.Bold("Examples:"),
 		ansi.Bold("Available Operations:"),
+		ansi.Bold("Request Parameters:"),
 		ansi.Bold("Flags:"),
 		ansi.Bold("Global Flags:"),
 		ansi.Bold("Additional help topics:"),

--- a/pkg/cmd/templates.go
+++ b/pkg/cmd/templates.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
@@ -29,6 +31,46 @@ func WrappedInheritedFlagUsages(cmd *cobra.Command) string {
 // terminal's width.
 func WrappedLocalFlagUsages(cmd *cobra.Command) string {
 	return cmd.LocalFlags().FlagUsagesWrapped(getTerminalWidth())
+}
+
+// WrappedRequestParamsFlagUsages returns a string containing the usage
+// information for all request parameters flags, i.e. flags used in operation
+// commands to set values for request parameters. The string is wrapped to the
+// terminal's width.
+func WrappedRequestParamsFlagUsages(cmd *cobra.Command) string {
+	var sb strings.Builder
+
+	// We're cheating a little bit in thie method: we're not actually wrapping
+	// anything, just printing out the flag names and assuming that no name
+	// will be long enough to go over the terminal's width.
+	// We do this instead of using pflag's `FlagUsagesWrapped` function because
+	// we don't want to print the types (all request parameters flags are
+	// defined as strings in the CLI, but it would be confusing to print that
+	// out as a lot of them are not strings in the API).
+	// If/when we do add help strings for request parameters flags, we'll have
+	// to do actual wrapping.
+	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+		if _, ok := flag.Annotations["request"]; ok {
+			sb.WriteString(fmt.Sprintf("      --%s\n", flag.Name))
+		}
+	})
+
+	return sb.String()
+}
+
+// WrappedNonRequestParamsFlagUsages returns a string containing the usage
+// information for all non-request parameters flags. The string is wrapped to
+// the terminal's width.
+func WrappedNonRequestParamsFlagUsages(cmd *cobra.Command) string {
+	nonRequestParamsFlags := pflag.NewFlagSet("request", pflag.ExitOnError)
+
+	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+		if _, ok := flag.Annotations["request"]; !ok {
+			nonRequestParamsFlags.AddFlag(flag)
+		}
+	})
+
+	return nonRequestParamsFlags.FlagUsagesWrapped(getTerminalWidth())
 }
 
 //
@@ -121,4 +163,6 @@ func getTerminalWidth() int {
 func init() {
 	cobra.AddTemplateFunc("WrappedInheritedFlagUsages", WrappedInheritedFlagUsages)
 	cobra.AddTemplateFunc("WrappedLocalFlagUsages", WrappedLocalFlagUsages)
+	cobra.AddTemplateFunc("WrappedRequestParamsFlagUsages", WrappedRequestParamsFlagUsages)
+	cobra.AddTemplateFunc("WrappedNonRequestParamsFlagUsages", WrappedNonRequestParamsFlagUsages)
 }


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Group request parameters flags separately from "normal" flags in help messages.

Couple of screen shots:

![image](https://user-images.githubusercontent.com/23086931/65990863-38e43d80-e441-11e9-93af-cbfdafccba28.png)

![image](https://user-images.githubusercontent.com/23086931/65990892-4e596780-e441-11e9-85f4-51dd3c528186.png)
