### PR TITLE
Use dashes instead of underscores in flag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ You can easily make API requests using the CLI:
 
 ```sh
 $ stripe charges retrieve ch_123
-$ stripe charges create amount=100 currency=usd source=tok_visa
+$ stripe charges create --amount=100 --currency=usd --source=tok_visa
+$ stripe charges update ch_123 -d "metadata[key]=value"
 ```
 
 For a full list of available resources, type `stripe resources` or the [wiki page](https://github.com/stripe/stripe-cli/wiki/resources:-available-commands#available-commands).

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -41,7 +41,7 @@ To delete a charge:
 		RunE: gc.reqs.RunRequestsCmd,
 	}
 
-	gc.reqs.InitFlags(true)
+	gc.reqs.InitFlags()
 
 	return gc
 }

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -46,7 +46,7 @@ To get 50 charges:
 		RunE: gc.reqs.RunRequestsCmd,
 	}
 
-	gc.reqs.InitFlags(true)
+	gc.reqs.InitFlags()
 
 	return gc
 }

--- a/pkg/cmd/post.go
+++ b/pkg/cmd/post.go
@@ -43,7 +43,7 @@ https://stripe.com/docs/api
 		RunE: gc.reqs.RunRequestsCmd,
 	}
 
-	gc.reqs.InitFlags(true)
+	gc.reqs.InitFlags()
 
 	return gc
 }

--- a/pkg/cmd/resource/operation_test.go
+++ b/pkg/cmd/resource/operation_test.go
@@ -41,8 +41,10 @@ func TestRunOperationCmd(t *testing.T) {
 		require.Equal(t, "Bearer sk_test_1234", r.Header.Get("Authorization"))
 		vals, err := url.ParseQuery(string(body))
 		require.NoError(t, err)
+		require.Equal(t, 3, len(vals))
 		require.Equal(t, vals["param1"][0], "value1")
 		require.Equal(t, vals["param2"][0], "value2")
+		require.Equal(t, vals["param_with_underscores"][0], "some_value")
 	}))
 	defer ts.Close()
 
@@ -52,8 +54,9 @@ func TestRunOperationCmd(t *testing.T) {
 		APIKey: "sk_test_1234",
 	}
 	oc := NewOperationCmd(parentCmd, "foo", "/v1/bars/{id}", http.MethodPost, map[string]string{
-		"param1": "string",
-		"param2": "string",
+		"param1":                 "string",
+		"param2":                 "string",
+		"param_with_underscores": "string",
 	}, &config.Config{
 		Profile: profile,
 	})
@@ -61,6 +64,7 @@ func TestRunOperationCmd(t *testing.T) {
 
 	oc.Cmd.Flags().Set("param1", "value1")
 	oc.Cmd.Flags().Set("param2", "value2")
+	oc.Cmd.Flags().Set("param-with-underscores", "some_value")
 	err := oc.runOperationCmd(oc.Cmd, []string{"bar_123"})
 
 	require.NoError(t, err)

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -87,13 +87,11 @@ func (rb *Base) RunRequestsCmd(cmd *cobra.Command, args []string) error {
 }
 
 // InitFlags initialize shared flags for all requests commands
-func (rb *Base) InitFlags(includeData bool) {
-	if includeData {
-		rb.Cmd.Flags().StringArrayVarP(&rb.Parameters.data, "data", "d", []string{}, "Data to pass for the API request")
-	}
+func (rb *Base) InitFlags() {
+	rb.Cmd.Flags().StringArrayVarP(&rb.Parameters.data, "data", "d", []string{}, "Data to pass for the API request")
 	rb.Cmd.Flags().StringArrayVarP(&rb.Parameters.expand, "expand", "e", []string{}, "Response attributes to expand inline. Available on all API requests, see the documentation for specific objects that support expansion")
 	rb.Cmd.Flags().StringVarP(&rb.Parameters.idempotency, "idempotency", "i", "", "Sets the idempotency key for your request, preventing replaying the same requests within a 24 hour period")
-	rb.Cmd.Flags().StringVarP(&rb.Parameters.version, "api-version", "v", "", "Set the Stripe API version to use for your request")
+	rb.Cmd.Flags().StringVarP(&rb.Parameters.version, "stripe-version", "v", "", "Set the Stripe API version to use for your request")
 	rb.Cmd.Flags().StringVar(&rb.Parameters.stripeAccount, "stripe-account", "", "Set a header identifying the connected account for which the request is being made")
 	rb.Cmd.Flags().BoolVarP(&rb.showHeaders, "show-headers", "s", false, "Show headers on responses to GET, POST, and DELETE requests")
 	rb.Cmd.Flags().BoolVarP(&rb.autoConfirm, "confirm", "c", false, "Automatically confirm the command being entered. WARNING: This will result in NOT being prompted for confirmation for certain commands")


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
Use dashes instead of underscores in flag names for request parameters (e.g. `--statement-descriptor` rather than `--statement_descriptor`).

I also had to rename the global `--api-version` flag to `--stripe-version`, because one of the requests does accept an `api_version` parameter, which is now rendered as an `--api-version` flag.
