### PR TITLE
Pass webhook conversation ID back to backend

### DIFF
--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -30,18 +30,18 @@ type EndpointConfig struct {
 
 // EndpointResponseHandler handles a response from the endpoint.
 type EndpointResponseHandler interface {
-	ProcessResponse(string, string, *http.Response)
+	ProcessResponse(string, string, string, *http.Response)
 }
 
 // EndpointResponseHandlerFunc is an adapter to allow the use of ordinary
 // functions as response handlers. If f is a function with the
 // appropriate signature, ResponseHandler(f) is a
 // ResponseHandler that calls f.
-type EndpointResponseHandlerFunc func(string, string, *http.Response)
+type EndpointResponseHandlerFunc func(string, string, string, *http.Response)
 
-// ProcessResponse calls f(webhookID, resp).
-func (f EndpointResponseHandlerFunc) ProcessResponse(webhookID, forwardURL string, resp *http.Response) {
-	f(webhookID, forwardURL, resp)
+// ProcessResponse calls f(webhookID, webhookConversationID, resp).
+func (f EndpointResponseHandlerFunc) ProcessResponse(webhookID, webhookConversationID, forwardURL string, resp *http.Response) {
+	f(webhookID, webhookConversationID, forwardURL, resp)
 }
 
 // EndpointClient is the client used to POST webhook requests to the local endpoint.
@@ -75,7 +75,7 @@ func (c *EndpointClient) SupportsEventType(connect bool, eventType string) bool 
 }
 
 // Post sends a message to the local endpoint.
-func (c *EndpointClient) Post(webhookID string, body string, headers map[string]string) error {
+func (c *EndpointClient) Post(webhookID, webhookConversationID, body string, headers map[string]string) error {
 	c.cfg.Log.WithFields(log.Fields{
 		"prefix": "proxy.EndpointClient.Post",
 	}).Debug("Forwarding event to local endpoint")
@@ -113,7 +113,7 @@ func (c *EndpointClient) Post(webhookID string, body string, headers map[string]
 	}
 	defer resp.Body.Close()
 
-	c.cfg.ResponseHandler.ProcessResponse(webhookID, c.URL, resp)
+	c.cfg.ResponseHandler.ProcessResponse(webhookID, webhookConversationID, c.URL, resp)
 
 	return nil
 }
@@ -136,7 +136,7 @@ func NewEndpointClient(url string, headers []string, connect bool, events []stri
 		}
 	}
 	if cfg.ResponseHandler == nil {
-		cfg.ResponseHandler = EndpointResponseHandlerFunc(func(string, string, *http.Response) {})
+		cfg.ResponseHandler = EndpointResponseHandlerFunc(func(string, string, string, *http.Response) {})
 	}
 
 	return &EndpointClient{

--- a/pkg/websocket/webhook_messages.go
+++ b/pkg/websocket/webhook_messages.go
@@ -8,34 +8,37 @@ type WebhookEndpoint struct {
 
 // WebhookEvent represents incoming webhook event messages sent by Stripe.
 type WebhookEvent struct {
-	Endpoint     WebhookEndpoint   `json:"endpoint"`
-	EventPayload string            `json:"event_payload"`
-	HTTPHeaders  map[string]string `json:"http_headers"`
-	Type         string            `json:"type"`
-	WebhookID    string            `json:"webhook_id"`
+	Endpoint              WebhookEndpoint   `json:"endpoint"`
+	EventPayload          string            `json:"event_payload"`
+	HTTPHeaders           map[string]string `json:"http_headers"`
+	Type                  string            `json:"type"`
+	WebhookConversationID string            `json:"webhook_conversation_id"`
+	WebhookID             string            `json:"webhook_id"`
 }
 
 // WebhookResponse represents outgoing webhook response messages sent to
 // Stripe.
 type WebhookResponse struct {
-	ForwardURL  string            `json:"forward_url"`
-	Status      int               `json:"status"`
-	HTTPHeaders map[string]string `json:"http_headers"`
-	Body        string            `json:"body"`
-	Type        string            `json:"type"`
-	WebhookID   string            `json:"webhook_id"`
+	ForwardURL            string            `json:"forward_url"`
+	Status                int               `json:"status"`
+	HTTPHeaders           map[string]string `json:"http_headers"`
+	Body                  string            `json:"body"`
+	Type                  string            `json:"type"`
+	WebhookConversationID string            `json:"webhook_conversation_id"`
+	WebhookID             string            `json:"webhook_id"`
 }
 
 // NewWebhookResponse returns a new webhookResponse message.
-func NewWebhookResponse(webhookID string, forwardURL string, status int, body string, headers map[string]string) *OutgoingMessage {
+func NewWebhookResponse(webhookID, webhookConversationID, forwardURL string, status int, body string, headers map[string]string) *OutgoingMessage {
 	return &OutgoingMessage{
 		WebhookResponse: &WebhookResponse{
-			WebhookID:   webhookID,
-			ForwardURL:  forwardURL,
-			Status:      status,
-			Body:        body,
-			HTTPHeaders: headers,
-			Type:        "webhook_response",
+			WebhookID:             webhookID,
+			WebhookConversationID: webhookConversationID,
+			ForwardURL:            forwardURL,
+			Status:                status,
+			Body:                  body,
+			HTTPHeaders:           headers,
+			Type:                  "webhook_response",
 		},
 	}
 }

--- a/pkg/websocket/webhook_messages_test.go
+++ b/pkg/websocket/webhook_messages_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestUnmarshalWebhookEvent(t *testing.T) {
-	var data = `{"type": "webhook_event", "event_payload": "foo", "http_headers": {"Request-Header": "bar"}, "webhook_id": "wh_123"}`
+	var data = `{"type": "webhook_event", "event_payload": "foo", "http_headers": {"Request-Header": "bar"}, "webhook_id": "wh_123", "webhook_conversation_id": "wc_123"}`
 
 	var msg IncomingMessage
 	err := json.Unmarshal([]byte(data), &msg)
@@ -22,11 +22,13 @@ func TestUnmarshalWebhookEvent(t *testing.T) {
 	require.Equal(t, "bar", msg.WebhookEvent.HTTPHeaders["Request-Header"])
 	require.Equal(t, "webhook_event", msg.WebhookEvent.Type)
 	require.Equal(t, "wh_123", msg.WebhookEvent.WebhookID)
+	require.Equal(t, "wc_123", msg.WebhookEvent.WebhookConversationID)
 }
 
 func TestMarshalWebhookResponse(t *testing.T) {
 	msg := NewWebhookResponse(
 		"wh_123",
+		"wc_123",
 		"http://localhost:5000/webhooks",
 		200,
 		"foo",
@@ -38,6 +40,7 @@ func TestMarshalWebhookResponse(t *testing.T) {
 
 	json := string(buf)
 	require.Equal(t, "wh_123", gjson.Get(json, "webhook_id").String())
+	require.Equal(t, "wc_123", gjson.Get(json, "webhook_conversation_id").String())
 	require.Equal(t, "http://localhost:5000/webhooks", gjson.Get(json, "forward_url").String())
 	require.Equal(t, 200, int(gjson.Get(json, "status").Num))
 	require.Equal(t, "foo", gjson.Get(json, "body").String())
@@ -47,6 +50,7 @@ func TestMarshalWebhookResponse(t *testing.T) {
 func TestNewWebhookResponse(t *testing.T) {
 	msg := NewWebhookResponse(
 		"wh_123",
+		"wc_123",
 		"http://localhost:5000/webhooks",
 		200,
 		"foo",
@@ -56,6 +60,7 @@ func TestNewWebhookResponse(t *testing.T) {
 	require.NotNil(t, msg.WebhookResponse)
 	require.Equal(t, "webhook_response", msg.Type)
 	require.Equal(t, "wh_123", msg.WebhookID)
+	require.Equal(t, "wc_123", msg.WebhookConversationID)
 	require.Equal(t, "http://localhost:5000/webhooks", msg.ForwardURL)
 	require.Equal(t, 200, msg.Status)
 	require.Equal(t, "foo", msg.Body)


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
The stripecli backend service now sends a `webhook_conversation_id` property in addition to `webhook_id` in webhook event messages. This PR updates the CLI to pass this ID back to the stripecli backend service when sending webhook responses, so we can link the webhook CLI response to the webhook conversation.
