### PR TITLE
Fix config file permissions to not be world-readable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,6 +76,14 @@ func (c *Config) InitConfig() {
 		c.ProfilesFile = configFile
 		viper.SetConfigType("toml")
 		viper.SetConfigFile(configFile)
+		viper.SetConfigPermissions(os.FileMode(0600))
+
+		// Try to change permissions manually, because we used to create files
+		// with default permissions (0644)
+		err := os.Chmod(configFile, os.FileMode(0600))
+		if err != nil && !os.IsNotExist(err) {
+			log.Fatalf("%s", err)
+		}
 	}
 
 	// If a profiles file is found, read it in.


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe  @tomer-stripe @joek-stripe 
cc @stripe/dev-platform

 ### Summary
Use 0600 (`rw-------`) instead of the default 0644 (`rw-r--r--`) for the default configuration file. Since it stores API keys (and in the future may store _live_ API keys), it's important to keep it secure.

I used viper's `SetConfigPermissions` method, but that only applies to creating new files, so I also added a manual permissions change to fix existing files.

Not that this only applies to the default configuration file. If the user provides a custom file with `--config`, it's their responsibility to secure the file.
