### PR TITLE
Newlines, newlines everywhere

### DIFF
--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -130,6 +130,7 @@ func StartSpinner(msg string, w io.Writer) *spinner.Spinner {
 	}
 
 	s.Start()
+
 	return s
 }
 

--- a/pkg/ansi/markdownterm.go
+++ b/pkg/ansi/markdownterm.go
@@ -57,6 +57,7 @@ func (options *MarkdownTerm) Header(out *bytes.Buffer, text func() bool, level i
 		out.Truncate(marker)
 		return
 	}
+
 	out.WriteString("\n")
 }
 
@@ -74,10 +75,12 @@ func (options *MarkdownTerm) ListItem(out *bytes.Buffer, text []byte, flags int)
 func (options *MarkdownTerm) Paragraph(out *bytes.Buffer, text func() bool) {
 	marker := out.Len()
 	out.WriteString("\n")
+
 	if !text() {
 		out.Truncate(marker)
 		return
 	}
+
 	out.WriteString("\n")
 }
 

--- a/pkg/ansi/markdownterm_test.go
+++ b/pkg/ansi/markdownterm_test.go
@@ -14,7 +14,9 @@ func render(s string, useAnsi bool) string {
 	if useAnsi {
 		flags |= MDTERM_USE_ANSI
 	}
+
 	r := MarkdownTermRenderer(flags)
+
 	return string(blackfriday.Markdown([]byte(s), r, blackfriday.EXTENSION_STRIKETHROUGH))
 }
 
@@ -22,6 +24,7 @@ func TestMain(m *testing.M) {
 	ForceColors = true
 	code := m.Run()
 	ForceColors = false
+
 	os.Exit(code)
 }
 

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -144,6 +144,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		if strings.HasPrefix(lc.forwardURL, "/") {
 			return errors.New("--forward-to cannot be a relative path when loading webhook endpoints from the API")
 		}
+
 		if strings.HasPrefix(lc.forwardConnectURL, "/") {
 			return errors.New("--forward-connect-to cannot be a relative path when loading webhook endpoints from the API")
 		}
@@ -191,11 +192,13 @@ func (lc *listenCmd) getEndpointsFromAPI(secretKey string) requests.WebhookEndpo
 		APIKey:     secretKey,
 		APIBaseURL: apiBaseURL,
 	}
+
 	return examples.WebhookEndpointsList()
 }
 
 func buildEndpointRoutes(endpoints requests.WebhookEndpointList, forwardURL, forwardConnectURL string, forwardHeaders []string, forwardConnectHeaders []string) []proxy.EndpointRoute {
 	endpointRoutes := make([]proxy.EndpointRoute, 0)
+
 	for _, endpoint := range endpoints.Data {
 		u, err := url.Parse(endpoint.URL)
 		// Silently skip over invalid paths
@@ -219,6 +222,7 @@ func buildEndpointRoutes(endpoints requests.WebhookEndpointList, forwardURL, for
 			}
 		}
 	}
+
 	return endpointRoutes
 }
 

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -39,5 +39,6 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 	if lc.interactive {
 		return login.InteractiveLogin(&Config)
 	}
+
 	return login.Login(lc.dashboardBaseURL, &Config, os.Stdin)
 }

--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -73,8 +73,11 @@ func getLongestShortcut(shortcuts []string) int {
 
 func padName(name string, length int) string {
 	difference := length - len(name)
+
 	var b strings.Builder
+
 	fmt.Fprint(&b, name)
+
 	for i := 0; i < difference; i++ {
 		fmt.Fprint(&b, " ")
 	}
@@ -106,6 +109,7 @@ func (oc *openCmd) runOpenCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
 	livemode, err := cmd.Flags().GetBool("livemode")
 	if err != nil {
 		return err
@@ -115,12 +119,15 @@ func (oc *openCmd) runOpenCmd(cmd *cobra.Command, args []string) error {
 		fmt.Println("open quickly opens Stripe pages. To use, run 'stripe open <shortcut>'.")
 		fmt.Println("open supports the following shortcuts:")
 		fmt.Println()
+
 		shortcuts := openNames()
 		sort.Strings(shortcuts)
+
 		longest := getLongestShortcut(shortcuts)
 
 		fmt.Println(fmt.Sprintf("%s%s", padName("shortcut", longest), "    url"))
 		fmt.Println(fmt.Sprintf("%s%s", padName("--------", longest), "    ---------"))
+
 		for _, shortcut := range shortcuts {
 			maybeTestMode := ""
 			if !livemode {

--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -44,6 +44,7 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 	path := formatURL(oc.Path, args)
 
 	flagParams := make([]string, 0)
+
 	for stringProp, stringVal := range oc.stringFlags {
 		// only include fields explicitly set by the user to avoid conflicts between e.g. account_balance, balance
 		if oc.Cmd.Flags().Changed(stringProp) {
@@ -132,8 +133,10 @@ func formatURL(path string, urlParams []string) string {
 	for i, v := range urlParams {
 		s[i] = v
 	}
+
 	re := regexp.MustCompile(`{\w+}`)
 	format := re.ReplaceAllString(path, "%s")
+
 	return fmt.Sprintf(format, s...)
 }
 
@@ -150,6 +153,7 @@ func operationUsageTemplate(urlParams []string) string {
 	if args != "" {
 		args += " "
 	}
+
 	args += "[--param=value] [-d \"nested[param]=value\"]"
 
 	return fmt.Sprintf(`%s{{if .Runnable}}

--- a/pkg/cmd/resource/operation_test.go
+++ b/pkg/cmd/resource/operation_test.go
@@ -49,6 +49,7 @@ func TestRunOperationCmd(t *testing.T) {
 	defer ts.Close()
 
 	viper.Reset()
+
 	parentCmd := &cobra.Command{Annotations: make(map[string]string)}
 	profile := config.Profile{
 		APIKey: "sk_test_1234",
@@ -88,6 +89,7 @@ func TestRunOperationCmd_ExtraParams(t *testing.T) {
 	defer ts.Close()
 
 	viper.Reset()
+
 	parentCmd := &cobra.Command{Annotations: make(map[string]string)}
 	profile := config.Profile{
 		APIKey: "sk_test_1234",
@@ -109,6 +111,7 @@ func TestRunOperationCmd_ExtraParams(t *testing.T) {
 
 func TestRunOperationCmd_NoAPIKey(t *testing.T) {
 	viper.Reset()
+
 	parentCmd := &cobra.Command{Annotations: make(map[string]string)}
 	oc := NewOperationCmd(parentCmd, "foo", "/v1/bars/{id}", http.MethodPost, map[string]string{
 		"param1": "string",

--- a/pkg/cmd/resources_test.go
+++ b/pkg/cmd/resources_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestResources(t *testing.T) {
 	Execute()
+
 	output, err := executeCommand(rootCmd, "resources")
 
 	require.Contains(t, output, "Available Namespaces:")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -54,19 +54,23 @@ get started with pre-built samples (https://stripe.dev/samples).
 func Execute() {
 	rootCmd.SetUsageTemplate(getUsageTemplate())
 	rootCmd.SetVersionTemplate(version.Template)
+
 	if err := rootCmd.Execute(); err != nil {
 		if strings.Contains(err.Error(), "unknown command") {
-			suggestions := rootCmd.SuggestionsFor(os.Args[1])
 			suggStr := "\nS"
+
+			suggestions := rootCmd.SuggestionsFor(os.Args[1])
 			if len(suggestions) > 0 {
 				suggStr = fmt.Sprintf(" Did you mean \"%s\"?\nIf not, s", suggestions[0])
 			}
+
 			fmt.Println(fmt.Sprintf("Unknown command \"%s\" for \"%s\".%s"+
 				"ee \"stripe --help\" for a list of available commands.",
 				os.Args[1], rootCmd.CommandPath(), suggStr))
 		} else {
 			fmt.Println(err)
 		}
+
 		os.Exit(1)
 	}
 }

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -42,6 +42,7 @@ func TestGetPathXDG(t *testing.T) {
 
 func TestHelpFlag(t *testing.T) {
 	Execute()
+
 	output, err := executeCommand(rootCmd, "--help")
 
 	require.Contains(t, output, "Stripe commands:")

--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -96,6 +96,7 @@ To see supported samples, run 'stripe samples list'`, args[0])
 			return err
 		}
 	}
+
 	ansi.StopSpinner(spinner, "", os.Stdout)
 	fmt.Println(fmt.Sprintf("%s %s", color.Green("✔"), ansi.Faint("Finished downloading")))
 
@@ -133,10 +134,12 @@ To see supported samples, run 'stripe samples list'`, args[0])
 	if err != nil {
 		return err
 	}
+
 	ansi.StopSpinner(spinner, "", os.Stdout)
 	fmt.Println(fmt.Sprintf("%s %s", color.Green("✔"), ansi.Faint("Files copied")))
 
 	spinner = ansi.StartSpinner(fmt.Sprintf("Configuring your code... %s", selectedSample), os.Stdout)
+
 	err = sample.ConfigureDotEnv(targetPath)
 	if err != nil {
 		return err
@@ -146,6 +149,7 @@ To see supported samples, run 'stripe samples list'`, args[0])
 	if err != nil {
 		return err
 	}
+
 	ansi.StopSpinner(spinner, "", os.Stdout)
 	fmt.Println(fmt.Sprintf("%s %s", color.Green("✔"), ansi.Faint("Project configured")))
 	fmt.Println("You're all set. To get started: cd", selectedSample)

--- a/pkg/cmd/templates.go
+++ b/pkg/cmd/templates.go
@@ -153,10 +153,12 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 func getTerminalWidth() int {
 	var width int
+
 	width, _, err := terminal.GetSize(0)
 	if err != nil {
 		width = 80
 	}
+
 	return width
 }
 

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -119,6 +119,7 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		cmd.Usage()
+
 		return nil
 	}
 
@@ -147,12 +148,13 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 		"payment_intent.succeeded":      examples.PaymentIntentSucceeded,
 		"payment_method.attached":       examples.PaymentMethodAttached,
 	}
+
 	function, ok := supportedEvents[event]
 	if !ok {
 		return fmt.Errorf(fmt.Sprintf("event %s is not supported.", event))
 	}
-	err = function.(func() error)()
 
+	err = function.(func() error)()
 	if err == nil {
 		fmt.Println("Trigger succeeded! Check dashboard for event details.")
 	} else {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,7 @@ func (c *Config) GetConfigFolder(xdgPath string) string {
 			fmt.Println(err)
 			os.Exit(1)
 		}
+
 		configPath = filepath.Join(home, ".config")
 	}
 
@@ -90,6 +91,7 @@ func (c *Config) InitConfig() {
 		if err != nil {
 			deviceName = "unknown"
 		}
+
 		c.Profile.DeviceName = deviceName
 	}
 
@@ -97,6 +99,7 @@ func (c *Config) InitConfig() {
 	if err != nil {
 		log.Fatalf("%s", err)
 	}
+
 	switch color {
 	case ColorOn:
 		ansi.ForceColors = true
@@ -139,11 +142,13 @@ func (c *Config) EditConfig() error {
 		if editor == "" {
 			editor = "vi"
 		}
+
 		cmd := exec.Command(editor, c.ProfilesFile)
 		// Some editors detect whether they have control of stdin/out and will
 		// fail if they do not.
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
+
 		return cmd.Run()
 	case "windows":
 		// As far as I can tell, Windows doesn't have an easily accesible or
@@ -163,6 +168,7 @@ func (c *Config) PrintConfig() error {
 		if err != nil {
 			return err
 		}
+
 		fmt.Print(string(configFile))
 	} else {
 		configs := viper.GetStringMapString(c.Profile.ProfileName)
@@ -187,6 +193,7 @@ func removeKey(v *viper.Viper, key string) (*viper.Viper, error) {
 	delete(deepestMap, lastKey)
 
 	buf := new(bytes.Buffer)
+
 	encodeErr := toml.NewEncoder(buf).Encode(configMap)
 	if encodeErr != nil {
 		return nil, encodeErr
@@ -212,6 +219,7 @@ func makePath(path string) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -226,8 +234,10 @@ func deepSearch(m map[string]interface{}, path []string) map[string]interface{} 
 			m3 := make(map[string]interface{})
 			m[k] = m3
 			m = m3
+
 			continue
 		}
+
 		m3, ok := m2.(map[string]interface{})
 		if !ok {
 			// intermediate key is a value
@@ -235,8 +245,10 @@ func deepSearch(m map[string]interface{}, path []string) map[string]interface{} 
 			m3 = make(map[string]interface{})
 			m[k] = m3
 		}
+
 		// continue search from here
 		m = m3
 	}
+
 	return m
 }

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -73,6 +73,7 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		return p.APIKey, nil
 	}
 
@@ -89,10 +90,12 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 	// Try to fetch the API key from the configuration file
 	if err := viper.ReadInConfig(); err == nil {
 		key := viper.GetString(p.GetConfigField(livemodeKeyField(livemode)))
+
 		err := validators.APIKey(key)
 		if err != nil {
 			return "", err
 		}
+
 		return key, nil
 	}
 
@@ -135,6 +138,7 @@ func (p *Profile) DeleteConfigField(field string) error {
 	if err != nil {
 		return err
 	}
+
 	return p.writeProfile(v)
 }
 
@@ -149,15 +153,19 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 	if p.DeviceName != "" {
 		runtimeViper.Set(p.GetConfigField("device_name"), strings.TrimSpace(p.DeviceName))
 	}
+
 	if p.LiveModeAPIKey != "" {
 		runtimeViper.Set(p.GetConfigField("live_mode_api_key"), strings.TrimSpace(p.LiveModeAPIKey))
 	}
+
 	if p.LiveModePublishableKey != "" {
 		runtimeViper.Set(p.GetConfigField("live_mode_publishable_key"), strings.TrimSpace(p.LiveModePublishableKey))
 	}
+
 	if p.TestModeAPIKey != "" {
 		runtimeViper.Set(p.GetConfigField("test_mode_api_key"), strings.TrimSpace(p.TestModeAPIKey))
 	}
+
 	if p.TestModePublishableKey != "" {
 		runtimeViper.Set(p.GetConfigField("test_mode_publishable_key"), strings.TrimSpace(p.TestModePublishableKey))
 	}
@@ -169,6 +177,7 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 		runtimeViper = p.safeRemove(runtimeViper, "secret_key")
 		runtimeViper = p.safeRemove(runtimeViper, "api_key")
 	}
+
 	if p.TestModePublishableKey != "" {
 		runtimeViper = p.safeRemove(runtimeViper, "publishable_key")
 	}
@@ -177,6 +186,7 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 
 	// Ensure we preserve the config file type
 	runtimeViper.SetConfigType(filepath.Ext(profilesFile))
+
 	err = runtimeViper.WriteConfig()
 	if err != nil {
 		return err

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -30,6 +30,7 @@ func TestWriteProfile(t *testing.T) {
 	v := viper.New()
 
 	fmt.Println(profilesFile)
+
 	err := p.writeProfile(v)
 	require.NoError(t, err)
 
@@ -94,6 +95,7 @@ func helperLoadBytes(t *testing.T, name string) []byte {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	return bytes
 }
 

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -49,8 +49,10 @@ func Login(baseURL string, config *config.Config, input io.Reader) error {
 	fmt.Println(ansi.Faint("This pairing code verifies your authentication with Stripe."))
 
 	var s *spinner.Spinner
+
 	if isSSH() {
 		fmt.Println(fmt.Sprintf("To authenticate with Stripe, please go to: %s", links.BrowserURL))
+
 		s = ansi.StartSpinner("Waiting for confirmation...", os.Stdout)
 	} else {
 		fmt.Printf("Press Enter to open the browser (^C to quit)")
@@ -81,6 +83,7 @@ func Login(baseURL string, config *config.Config, input io.Reader) error {
 	config.Profile.LiveModePublishableKey = response.LiveModePublishableKey
 	config.Profile.TestModeAPIKey = response.TestModeAPIKey
 	config.Profile.TestModePublishableKey = response.TestModePublishableKey
+
 	profileErr := config.Profile.CreateProfile()
 	if profileErr != nil {
 		return profileErr
@@ -127,6 +130,7 @@ func getLinks(baseURL string, deviceName string) (*Links, error) {
 	}
 
 	var links Links
+
 	err = json.Unmarshal(bodyBytes, &links)
 	if err != nil {
 		return nil, err

--- a/pkg/login/client_login_test.go
+++ b/pkg/login/client_login_test.go
@@ -26,6 +26,7 @@ func TestLogin(t *testing.T) {
 	openBrowser = func(string) error {
 		return nil
 	}
+
 	defer func() { openBrowser = open.Browser }()
 
 	profilesFile := filepath.Join(os.TempDir(), "stripe", "config.toml")

--- a/pkg/login/interactive_login.go
+++ b/pkg/login/interactive_login.go
@@ -48,14 +48,17 @@ func InteractiveLogin(config *config.Config) error {
 
 func getConfigureAPIKey(input io.Reader) (string, error) {
 	fmt.Print("Enter your API key: ")
+
 	apiKey, err := securePrompt(input)
 	if err != nil {
 		return "", err
 	}
+
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
 		return "", errors.New("API key is required, please provide your API key")
 	}
+
 	err = validators.APIKey(apiKey)
 	if err != nil {
 		return "", err
@@ -113,10 +116,12 @@ func securePrompt(input io.Reader) (string, error) {
 		signal.Stop(signalChan)
 
 		fmt.Print("\n")
+
 		return string(buf), nil
 	}
 
 	reader := bufio.NewReader(input)
+
 	return reader.ReadString('\n')
 }
 
@@ -128,6 +133,7 @@ func protectTerminalState() (chan os.Signal, error) {
 
 	signalChan := make(chan os.Signal)
 	signal.Notify(signalChan, os.Interrupt)
+
 	go func() {
 		<-signalChan
 		terminal.Restore(int(syscall.Stdin), originalTerminalState) //nolint:unconvert

--- a/pkg/login/login_message.go
+++ b/pkg/login/login_message.go
@@ -34,6 +34,7 @@ func SuccessMessage(account *Account, baseURL string, apiKey string) (string, er
 		if err != nil {
 			return "", err
 		}
+
 		account = acc
 	}
 
@@ -80,6 +81,7 @@ func getUserAccount(baseURL string, apiKey string) (*Account, error) {
 	defer resp.Body.Close()
 
 	account := &Account{}
+
 	err = json.NewDecoder(resp.Body).Decode(account)
 	if err != nil {
 		return nil, err

--- a/pkg/login/poll.go
+++ b/pkg/login/poll.go
@@ -55,6 +55,7 @@ func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (*PollA
 		if err != nil {
 			return nil, nil, err
 		}
+
 		defer res.Body.Close()
 
 		bodyBytes, err := ioutil.ReadAll(res.Body)

--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -93,6 +93,7 @@ func New(cfg *Config) *Tailer {
 	if cfg.Log == nil {
 		cfg.Log = &log.Logger{Out: ioutil.Discard}
 	}
+
 	return &Tailer{
 		cfg: cfg,
 		stripeAuthClient: stripeauth.NewClient(cfg.Key, &stripeauth.Config{
@@ -205,6 +206,7 @@ func (tailer *Tailer) processRequestLogEvent(msg websocket.IncomingMessage) {
 
 	errorValues := reflect.ValueOf(&payload.Error).Elem()
 	errType := errorValues.Type()
+
 	for i := 0; i < errorValues.NumField(); i++ {
 		fieldValue := errorValues.Field(i).Interface()
 		if fieldValue != "" {
@@ -220,6 +222,7 @@ func jsonifyFilters(logFilters *LogFilters) (string, error) {
 	}
 
 	jsonStr := string(bytes)
+
 	return jsonStr, nil
 }
 

--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -84,6 +84,7 @@ func (c *EndpointClient) Post(webhookID, webhookConversationID, body string, hea
 	if err != nil {
 		return err
 	}
+
 	for k, v := range headers {
 		req.Header.Add(k, v)
 	}
@@ -111,6 +112,7 @@ func (c *EndpointClient) Post(webhookID, webhookConversationID, body string, hea
 
 		return err
 	}
+
 	defer resp.Body.Close()
 
 	c.cfg.ResponseHandler.ProcessResponse(webhookID, webhookConversationID, c.URL, resp)
@@ -127,14 +129,17 @@ func NewEndpointClient(url string, headers []string, connect bool, events []stri
 	if cfg == nil {
 		cfg = &EndpointConfig{}
 	}
+
 	if cfg.Log == nil {
 		cfg.Log = &log.Logger{Out: ioutil.Discard}
 	}
+
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = &http.Client{
 			Timeout: defaultTimeout,
 		}
 	}
+
 	if cfg.ResponseHandler == nil {
 		cfg.ResponseHandler = EndpointResponseHandlerFunc(func(string, string, string, *http.Response) {})
 	}
@@ -180,6 +185,7 @@ func convertToMapAndSanitize(headers []string) map[string]string {
 		splitHeader := strings.SplitN(header, ":", 2)
 		headerKey := strings.TrimSpace(splitHeader[0])
 		headerVal := strings.TrimSpace(splitHeader[1])
+
 		if headerKey != "" {
 			headerMap[headerKey] = headerVal
 		}

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -138,7 +138,9 @@ func (rb *Base) MakeRequest(apiKey, path string, params *RequestParameters, errO
 	if err != nil {
 		return []byte{}, err
 	}
+
 	defer resp.Body.Close()
+
 	body, err := ioutil.ReadAll(resp.Body)
 
 	if errOnStatus && resp.StatusCode >= 300 {
@@ -178,6 +180,7 @@ func (rb *Base) buildDataForRequest(params *RequestParameters) (string, error) {
 			keys = append(keys, splitDatum[0])
 			values = append(values, splitDatum[1])
 		}
+
 		for _, datum := range params.expand {
 			keys = append(keys, "expand[]")
 			values = append(values, datum)
@@ -189,10 +192,12 @@ func (rb *Base) buildDataForRequest(params *RequestParameters) (string, error) {
 			keys = append(keys, "limit")
 			values = append(values, params.limit)
 		}
+
 		if params.startingAfter != "" {
 			keys = append(keys, "starting_after")
 			values = append(values, params.startingAfter)
 		}
+
 		if params.endingBefore != "" {
 			keys = append(keys, "ending_before")
 			values = append(values, params.endingBefore)
@@ -205,6 +210,7 @@ func (rb *Base) buildDataForRequest(params *RequestParameters) (string, error) {
 // encode creates a url encoded string with the request parameters
 func encode(keys []string, values []string) string {
 	var buf strings.Builder
+
 	for i := range keys {
 		key := keys[i]
 		value := values[i]
@@ -220,16 +226,19 @@ func encode(keys []string, values []string) string {
 		if buf.Len() > 0 {
 			buf.WriteByte('&')
 		}
+
 		buf.WriteString(keyEscaped)
 		buf.WriteByte('=')
 		buf.WriteString(url.QueryEscape(value))
 	}
+
 	return buf.String()
 }
 
 func (rb *Base) setIdempotencyHeader(request *http.Request, params *RequestParameters) {
 	if params.idempotency != "" {
 		request.Header.Set("Idempotency-Key", params.idempotency)
+
 		if rb.Method == http.MethodGet || rb.Method == http.MethodDelete {
 			warning := fmt.Sprintf(
 				"Warning: sending an idempotency key with a %s request has no effect and should be avoided, as %s requests are idempotent by definition.",
@@ -278,6 +287,7 @@ func (rb *Base) getUserConfirmation(reader *bufio.Reader) (bool, error) {
 func createOrNormalizePath(arg string) (string, error) {
 	if idRegex.Match([]byte(arg)) {
 		matches := idRegex.FindStringSubmatch(arg)
+
 		if path, ok := idURLMap[matches[1]]; ok {
 			return path + arg, nil
 		}
@@ -292,11 +302,14 @@ func normalizePath(path string) string {
 	if strings.HasPrefix(path, "/v1/") {
 		return path
 	}
+
 	if strings.HasPrefix(path, "v1/") {
 		return "/" + path
 	}
+
 	if strings.HasPrefix(path, "/") {
 		return "/v1" + path
 	}
+
 	return "/v1/" + path
 }

--- a/pkg/requests/examples.go
+++ b/pkg/requests/examples.go
@@ -19,10 +19,12 @@ const (
 
 func parseResponse(response []byte) (map[string]interface{}, error) {
 	var result map[string]interface{}
+
 	err := json.Unmarshal(response, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return result, nil
 }
 
@@ -75,6 +77,7 @@ func (ex *Examples) chargeCreated(token string, data []string) (map[string]inter
 	paymentSource := fmt.Sprintf("source=%s", token)
 
 	req, params := ex.buildRequest(http.MethodPost, append(data, paymentSource))
+
 	return ex.performStripeRequest(req, "/v1/charges", params)
 }
 
@@ -95,6 +98,7 @@ func (ex *Examples) ChargeCaptured() error {
 	req, params := ex.buildRequest(http.MethodPost, []string{})
 	reqURL := fmt.Sprintf("/v1/charges/%s/capture", charge["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -104,6 +108,7 @@ func (ex *Examples) ChargeDisputed() error {
 		"amount=2000",
 		"currency=usd",
 	})
+
 	return err
 }
 
@@ -113,6 +118,7 @@ func (ex *Examples) ChargeFailed() error {
 		"amount=2000",
 		"currency=usd",
 	})
+
 	return err
 }
 
@@ -130,6 +136,7 @@ func (ex *Examples) ChargeRefunded() error {
 		fmt.Sprintf("charge=%s", charge["id"]),
 	})
 	_, err = ex.performStripeRequest(req, "/v1/refunds", params)
+
 	return err
 }
 
@@ -139,6 +146,7 @@ func (ex *Examples) ChargeSucceeded() error {
 		"amount=2000",
 		"currency=usd",
 	})
+
 	return err
 }
 
@@ -196,6 +204,7 @@ func (ex *Examples) CheckoutSessionCompleted() error {
 		fmt.Sprintf("payment_method=%s", pmID),
 	})
 	_, err = ex.performStripeRequest(req, fmt.Sprintf("/v1/payment_pages/%s/confirm", paymentPageID), params)
+
 	return err
 }
 
@@ -217,11 +226,14 @@ func (ex *Examples) CustomerUpdated() error {
 	if err != nil {
 		return err
 	}
+
 	req, params := ex.buildRequest(http.MethodPost, []string{
 		"metadata[foo]=bar",
 	})
+
 	reqURL := fmt.Sprintf("/v1/customers/%s", customer["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -231,9 +243,11 @@ func (ex *Examples) CustomerDeleted() error {
 	if err != nil {
 		return err
 	}
+
 	req, params := ex.buildRequest(http.MethodDelete, []string{})
 	reqURL := fmt.Sprintf("/v1/customers/%s", customer["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -251,6 +265,7 @@ func (ex *Examples) CustomerSourceCreated() error {
 
 	reqURL := fmt.Sprintf("/v1/customers/%s/sources", customer["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -267,6 +282,7 @@ func (ex *Examples) CustomerSourceUpdated() error {
 	})
 
 	reqURL := fmt.Sprintf("/v1/customers/%s/sources", customer["id"])
+
 	card, err := ex.performStripeRequest(req, reqURL, params)
 	if err != nil {
 		return err
@@ -277,6 +293,7 @@ func (ex *Examples) CustomerSourceUpdated() error {
 	})
 	reqURL = fmt.Sprintf("/v1/customers/%s/sources/%s", customer["id"], card["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -296,6 +313,7 @@ func (ex *Examples) CustomerSubscriptionUpdated() error {
 		"amount=2000",
 		"product[name]=myproduct",
 	})
+
 	plan, err := ex.performStripeRequest(req, "/v1/plans", params)
 	if err != nil {
 		return err
@@ -305,6 +323,7 @@ func (ex *Examples) CustomerSubscriptionUpdated() error {
 		fmt.Sprintf("items[0][plan]=%s", plan["id"]),
 		fmt.Sprintf("customer=%s", customer["id"]),
 	})
+
 	subscription, err := ex.performStripeRequest(req, "/v1/subscriptions", params)
 	if err != nil {
 		return err
@@ -313,8 +332,10 @@ func (ex *Examples) CustomerSubscriptionUpdated() error {
 	req, params = ex.buildRequest(http.MethodPost, []string{
 		"metadata[foo]=bar",
 	})
+
 	reqURL := fmt.Sprintf("/v1/subscriptions/%s", subscription["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -334,6 +355,7 @@ func (ex *Examples) CustomerSubscriptionDeleted() error {
 		"amount=2000",
 		"product[name]=myproduct",
 	})
+
 	plan, err := ex.performStripeRequest(req, "/v1/plans", params)
 	if err != nil {
 		return err
@@ -343,6 +365,7 @@ func (ex *Examples) CustomerSubscriptionDeleted() error {
 		fmt.Sprintf("items[0][plan]=%s", plan["id"]),
 		fmt.Sprintf("customer=%s", customer["id"]),
 	})
+
 	subscription, err := ex.performStripeRequest(req, "/v1/subscriptions", params)
 	if err != nil {
 		return err
@@ -351,6 +374,7 @@ func (ex *Examples) CustomerSubscriptionDeleted() error {
 	req, params = ex.buildRequest(http.MethodDelete, []string{})
 	reqURL := fmt.Sprintf("/v1/subscriptions/%s", subscription["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -418,6 +442,7 @@ func (ex *Examples) InvoiceFinalized() error {
 	req, params := ex.buildRequest(http.MethodPost, []string{})
 	reqURL := fmt.Sprintf("/v1/invoices/%s/finalize", invoice["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -450,6 +475,7 @@ func (ex *Examples) InvoicePaymentSucceeded() error {
 	req, params := ex.buildRequest(http.MethodPost, []string{})
 	reqURL := fmt.Sprintf("/v1/invoices/%s/pay", invoice["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -479,10 +505,10 @@ func (ex *Examples) InvoicePaymentFailed() error {
 		return err
 	}
 
-	fmt.Println("hello")
 	req, params := ex.buildRequest(http.MethodPost, []string{})
 	reqURL := fmt.Sprintf("/v1/invoices/%s/pay", invoice["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -516,6 +542,7 @@ func (ex *Examples) InvoiceUpdated() error {
 
 	reqURL := fmt.Sprintf("/v1/invoices/%s", invoice["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -532,6 +559,7 @@ func (ex *Examples) PaymentIntentCreated() error {
 		"currency=usd",
 		"payment_method_types[]=card",
 	})
+
 	return err
 }
 
@@ -541,6 +569,7 @@ func (ex *Examples) PaymentIntentSucceeded() error {
 	if err != nil {
 		return err
 	}
+
 	paymentMethodID := fmt.Sprintf("payment_method=%s", paymentMethod["id"])
 
 	_, err = ex.paymentIntentCreated([]string{
@@ -580,6 +609,7 @@ func (ex *Examples) paymentMethodCreated(card string) (map[string]interface{}, e
 		"card[exp_year]=2020",
 		"card[cvc]=123",
 	})
+
 	return ex.performStripeRequest(req, "/v1/payment_methods", params)
 }
 
@@ -589,6 +619,7 @@ func (ex *Examples) paymentMethodCreatedWithToken(token string) (map[string]inte
 		fmt.Sprintf("card[token]=%s", token),
 		"billing_details[email]=stripe@example.com",
 	})
+
 	return ex.performStripeRequest(req, "/v1/payment_methods", params)
 }
 
@@ -610,6 +641,7 @@ func (ex *Examples) PaymentMethodAttached() error {
 	})
 	reqURL := fmt.Sprintf("/v1/payment_methods/%s/attach", paymentMethod["id"])
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }
 
@@ -636,6 +668,7 @@ func (ex *Examples) WebhookEndpointsList() WebhookEndpointList {
 // ResendEvent resends a webhook event using it's event-id "evt_<id>"
 func (ex *Examples) ResendEvent(id string) error {
 	pattern := `^evt_[A-Za-z0-9]{3,255}$`
+
 	match, err := regexp.MatchString(pattern, id)
 	if err != nil {
 		return err
@@ -648,5 +681,6 @@ func (ex *Examples) ResendEvent(id string) error {
 	req, params := ex.buildRequest(http.MethodPost, []string{})
 	reqURL := fmt.Sprintf("/v1/events/%s/retry", id)
 	_, err = ex.performStripeRequest(req, reqURL, params)
+
 	return err
 }

--- a/pkg/requests/examples_test.go
+++ b/pkg/requests/examples_test.go
@@ -15,8 +15,10 @@ func jsonBytes() []byte {
 	type TestJSON struct {
 		ID string `json:"id"`
 	}
+
 	data := TestJSON{"test-id"}
 	bytes, _ := json.Marshal(data)
+
 	return bytes
 }
 
@@ -431,6 +433,7 @@ func TestCheckoutSessionCompleted(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		}
 	}))
+
 	defer ts.Close()
 
 	ex := Examples{

--- a/pkg/samples/fixtures.go
+++ b/pkg/samples/fixtures.go
@@ -103,6 +103,7 @@ func (fxt *Fixture) UpdateEnv() error {
 
 func (fxt *Fixture) makeRequest(data fixture) ([]byte, error) {
 	var rp requests.RequestParameters
+
 	if data.Method == "post" && !fxt.fixture.Meta.ExcludeMetadata {
 		now := time.Now().String()
 		metadata := fmt.Sprintf("metadata[_created_by_fixture]=%s", now)
@@ -131,6 +132,7 @@ func (fxt *Fixture) parsePath(http fixture) string {
 
 		for i, match := range matches {
 			value := fxt.parseQuery(match[0])
+
 			newPath = append(newPath, pathParts[i])
 			newPath = append(newPath, value)
 		}
@@ -154,6 +156,7 @@ func (fxt *Fixture) createParams(params interface{}) *requests.RequestParameters
 
 func (fxt *Fixture) parseInterface(params interface{}) []string {
 	var data []string
+
 	var cleanData []string
 
 	switch v := reflect.ValueOf(params); v.Kind() {
@@ -177,6 +180,7 @@ func (fxt *Fixture) parseInterface(params interface{}) []string {
 
 func (fxt *Fixture) parseMap(params map[string]interface{}, parent string) []string {
 	data := make([]string, len(params))
+
 	var keyname string
 
 	for key, value := range params {
@@ -193,12 +197,14 @@ func (fxt *Fixture) parseMap(params map[string]interface{}, parent string) []str
 			data = append(data, fmt.Sprintf("%s=%v", keyname, v.Int()))
 		case reflect.Map:
 			m := value.(map[string]interface{})
+
 			result := fxt.parseMap(m, keyname)
 			if len(result) > 0 {
 				data = append(data, result...)
 			}
 		case reflect.Array:
 			a := value.([]interface{})
+
 			result := fxt.parseArray(a, keyname)
 			if len(result) > 0 {
 				data = append(data, result...)
@@ -246,6 +252,7 @@ func (fxt *Fixture) parseQuery(value string) string {
 		fxt.responses[name].Reset()
 
 		query := nameAndQuery[2]
+
 		return fxt.responses[name].Find(query).(string)
 	}
 
@@ -259,6 +266,7 @@ func (fxt *Fixture) updateEnv(env map[string]string) error {
 	}
 
 	envFile := filepath.Join(dir, ".env")
+
 	exists, _ := afero.Exists(fxt.Fs, envFile)
 	if !exists {
 		// If there is no .env in the current directory, return and do nothing
@@ -283,6 +291,7 @@ func (fxt *Fixture) updateEnv(env map[string]string) error {
 	if err != nil {
 		return err
 	}
+
 	afero.WriteFile(fxt.Fs, envFile, []byte(content), os.ModePerm)
 
 	return nil

--- a/pkg/samples/fixtures_test.go
+++ b/pkg/samples/fixtures_test.go
@@ -113,6 +113,7 @@ func TestMakeRequest(t *testing.T) {
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
 	}))
+
 	defer func() { ts.Close() }()
 
 	afero.WriteFile(fs, "test_fixture.json", []byte(testFixture), os.ModePerm)

--- a/pkg/samples/os.go
+++ b/pkg/samples/os.go
@@ -58,8 +58,9 @@ func (s *Samples) MakeFolder(name string) (string, error) {
 
 // GetFolders returns a list of all folders for a given path
 func (s *Samples) GetFolders(path string) ([]string, error) {
-	files, err := afero.ReadDir(s.Fs, path)
 	var dir []string
+
+	files, err := afero.ReadDir(s.Fs, path)
 	if err != nil {
 		return []string{}, err
 	}
@@ -76,8 +77,9 @@ func (s *Samples) GetFolders(path string) ([]string, error) {
 
 // GetFiles returns a list of files for a given path
 func (s *Samples) GetFiles(path string) ([]string, error) {
-	files, err := afero.ReadDir(s.Fs, path)
 	var file []string
+
+	files, err := afero.ReadDir(s.Fs, path)
 	if err != nil {
 		return []string{}, err
 	}

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -167,10 +167,12 @@ func (s *Samples) checkForIntegrations() error {
 	if !folderSearch(folders, "server") {
 		s.integrations = folders
 		s.isIntegration = true
+
 		return nil
 	}
 
 	s.isIntegration = false
+
 	return nil
 }
 
@@ -250,6 +252,7 @@ func (s *Samples) Copy(target string) error {
 
 		serverSource := filepath.Join(s.repo, integration, "server", s.language)
 		clientSource := filepath.Join(s.repo, integration, "client")
+
 		filesSource, err := s.GetFiles(filepath.Join(s.repo, integration))
 		if err != nil {
 			return err
@@ -262,6 +265,7 @@ func (s *Samples) Copy(target string) error {
 		if err != nil {
 			return err
 		}
+
 		err = copy.Copy(clientSource, clientDestination)
 		if err != nil {
 			return err
@@ -285,6 +289,7 @@ func (s *Samples) Copy(target string) error {
 	if err != nil {
 		return err
 	}
+
 	for _, file := range filesSource {
 		err = copy.Copy(filepath.Join(s.repo, file), filepath.Join(target, file))
 		if err != nil {
@@ -297,13 +302,16 @@ func (s *Samples) Copy(target string) error {
 
 func (s *Samples) findServerFiles(target string) ([]string, error) {
 	var files []string
+
 	err := afero.Walk(s.Fs, target, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
+
 		if !info.IsDir() && strings.Contains(path, "server") {
 			files = append(files, path)
 		}
+
 		return nil
 	})
 
@@ -380,12 +388,14 @@ func (s *Samples) ConfigureDotEnv(sampleLocation string) error {
 	if err != nil {
 		return err
 	}
+
 	deviceName, err := s.Config.Profile.GetDeviceName()
 	if err != nil {
 		return err
 	}
 
 	authClient := stripeauth.NewClient(apiKey, nil)
+
 	authSession, err := authClient.Authorize(deviceName, "webhooks", nil)
 	if err != nil {
 		return err
@@ -397,6 +407,7 @@ func (s *Samples) ConfigureDotEnv(sampleLocation string) error {
 	dotenv["STATIC_DIR"] = "../client"
 
 	envFile := filepath.Join(sampleLocation, ".env")
+
 	err = godotenv.Write(dotenv, envFile)
 	if err != nil {
 		return err
@@ -454,6 +465,7 @@ func selectOptions(template, label string, options []string) (string, error) {
 
 func languageSelectPrompt(languages []string) (string, error) {
 	var displayLangs []string
+
 	for _, lang := range languages {
 		if val, ok := languageDisplayNames[lang]; ok {
 			displayLangs = append(displayLangs, val)

--- a/pkg/samples/samples_test.go
+++ b/pkg/samples/samples_test.go
@@ -153,10 +153,10 @@ func TestPointToDotEnvWithOneIntegrationRb(t *testing.T) {
 		isIntegration: true,
 	}
 	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
+	require.Nil(t, err)
 
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.rb")
 	expected := []byte(`ENV_PATH = '../.env'.freeze`)
-	require.Nil(t, err)
 	assert.Equal(t, string(expected), string(data))
 }
 
@@ -175,10 +175,11 @@ func TestPointToDotEnvWithNoIntegrationRb(t *testing.T) {
 		isIntegration: false,
 	}
 	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
+	require.Nil(t, err)
 
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.rb")
 	expected := []byte(`ENV_PATH = '../.env'.freeze`)
-	require.Nil(t, err)
+
 	assert.Equal(t, expected, data)
 }
 
@@ -200,6 +201,7 @@ func TestPointToDotEnvWithMultipleIntegrationRb(t *testing.T) {
 
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.rb")
 	expected := []byte(`ENV_PATH = '../../.env'.freeze`)
+
 	require.Nil(t, err)
 	assert.Equal(t, expected, data)
 }
@@ -222,6 +224,7 @@ func TestPointToDotEnvWithMultipleIntegrationJava(t *testing.T) {
 
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.java")
 	expected := []byte(`String ENV_PATH = "../../";`)
+
 	require.Nil(t, err)
 	assert.Equal(t, expected, data)
 }
@@ -241,10 +244,11 @@ func TestPointToDotEnvWithMultipleIntegrationPhp(t *testing.T) {
 		isIntegration: true,
 	}
 	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
+	require.Nil(t, err)
 
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.php")
 	expected := []byte(`$ENV_PATH = '../..';`)
-	require.Nil(t, err)
+
 	assert.Equal(t, expected, data)
 }
 
@@ -263,9 +267,10 @@ func TestPointToDotEnvWithMultipleIntegrationJs(t *testing.T) {
 		isIntegration: true,
 	}
 	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
+	require.Nil(t, err)
 
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.js")
 	expected := []byte(`const envPath = resolve(__dirname, "../../.env");`)
-	require.Nil(t, err)
+
 	assert.Equal(t, string(expected), string(data))
 }

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -139,6 +139,7 @@ func (s *Schema) String() string {
 	if err != nil {
 		panic(err)
 	}
+
 	return string(js)
 }
 
@@ -146,6 +147,7 @@ func (s *Schema) String() string {
 // provides better error messages instead of silently ignoring fields.
 func (s *Schema) UnmarshalJSON(data []byte) error {
 	var rawFields map[string]interface{}
+
 	err := json.Unmarshal(data, &rawFields)
 	if err != nil {
 		return err
@@ -154,6 +156,7 @@ func (s *Schema) UnmarshalJSON(data []byte) error {
 	for _, supportedField := range supportedSchemaFields {
 		delete(rawFields, supportedField)
 	}
+
 	for unsupportedField := range rawFields {
 		return fmt.Errorf(
 			"unsupported field in JSON schema: '%s'", unsupportedField)
@@ -164,11 +167,14 @@ func (s *Schema) UnmarshalJSON(data []byte) error {
 	// unmarshalling a Schema object instead of recursively calling this
 	// UnmarshalJSON function again.
 	type schemaAlias Schema
+
 	var inner schemaAlias
+
 	err = json.Unmarshal(data, &inner)
 	if err != nil {
 		return err
 	}
+
 	*s = Schema(inner)
 
 	return nil
@@ -244,6 +250,7 @@ func LoadSpec(specPath string) (*Spec, error) {
 	}
 
 	var stripeSpec Spec
+
 	err = json.Unmarshal(data, &stripeSpec)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding spec: %v", err)
@@ -265,5 +272,6 @@ func readSpecData(specPath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return ioutil.ReadAll(file)
 }

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -14,17 +14,19 @@ func TestLoadSpec(t *testing.T) {
 }
 
 func TestUnmarshal_Simple(t *testing.T) {
-	data := []byte(`{"type": "string"}`)
 	var schema Schema
+
+	data := []byte(`{"type": "string"}`)
 	err := json.Unmarshal(data, &schema)
 	require.NoError(t, err)
 	require.Equal(t, "string", schema.Type)
 }
 
 func TestUnmarshal_UnsupportedField(t *testing.T) {
+	var schema Schema
+
 	// We don't support 'const'
 	data := []byte(`{const: "hello"}`)
-	var schema Schema
 	err := json.Unmarshal(data, &schema)
 	require.Error(t, err)
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -39,6 +39,7 @@ func GetStatus() (Response, error) {
 	if err != nil {
 		return status, err
 	}
+
 	defer resp.Body.Close()
 
 	respBytes, err := ioutil.ReadAll(resp.Body)
@@ -47,6 +48,7 @@ func GetStatus() (Response, error) {
 	}
 
 	json.Unmarshal(respBytes, &status)
+
 	return status, nil
 }
 
@@ -74,6 +76,7 @@ func (r *Response) getMap(verbose bool) map[string]interface{} {
 // populated with extra data depending on verbosity
 func (r *Response) FormattedMessage(format string, verbose bool) (string, error) {
 	statusData := r.getMap(verbose)
+
 	if format == "json" {
 		data, err := json.MarshalIndent(statusData, "", "  ")
 		if err != nil {
@@ -102,7 +105,9 @@ As of: %s`,
 	if err != nil {
 		return "", err
 	}
+
 	var output bytes.Buffer
+
 	err = tmpl.Execute(&output, statusData)
 	if err != nil {
 		return "", nil
@@ -113,6 +118,7 @@ As of: %s`,
 
 func emojifiedStatus(status string) string {
 	color := ansi.Color(os.Stdout)
+
 	switch status {
 	case "up":
 		return color.Green("✔").String()

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -44,6 +44,7 @@ func (c *Client) PerformRequest(method, path string, params string, configure fu
 	if err != nil {
 		return nil, err
 	}
+
 	url = c.BaseURL.ResolveReference(url)
 
 	var body io.Reader
@@ -85,6 +86,7 @@ func (c *Client) PerformRequest(method, path string, params string, configure fu
 
 func newHTTPClient(verbose bool, unixSocket string) *http.Client {
 	var httpTransport *http.Transport
+
 	if unixSocket != "" {
 		dialFunc := func(network, addr string) (net.Conn, error) {
 			return net.Dial("unix", unixSocket)

--- a/pkg/stripe/client_test.go
+++ b/pkg/stripe/client_test.go
@@ -32,6 +32,7 @@ func TestPerformRequest_ParamsEncoding_Delete(t *testing.T) {
 
 	resp, err := client.PerformRequest(http.MethodDelete, "/delete", params.Encode(), nil)
 	require.NoError(t, err)
+
 	defer resp.Body.Close()
 }
 
@@ -57,6 +58,7 @@ func TestPerformRequest_ParamsEncoding_Get(t *testing.T) {
 
 	resp, err := client.PerformRequest(http.MethodGet, "/get", params.Encode(), nil)
 	require.NoError(t, err)
+
 	defer resp.Body.Close()
 }
 
@@ -82,6 +84,7 @@ func TestPerformRequest_ParamsEncoding_Post(t *testing.T) {
 
 	resp, err := client.PerformRequest(http.MethodPost, "/post", params.Encode(), nil)
 	require.NoError(t, err)
+
 	defer resp.Body.Close()
 }
 
@@ -99,6 +102,7 @@ func TestPerformRequest_ApiKey_Provided(t *testing.T) {
 
 	resp, err := client.PerformRequest(http.MethodGet, "/get", "", nil)
 	require.NoError(t, err)
+
 	defer resp.Body.Close()
 }
 
@@ -115,6 +119,7 @@ func TestPerformRequest_ApiKey_Omitted(t *testing.T) {
 
 	resp, err := client.PerformRequest(http.MethodGet, "/get", "", nil)
 	require.NoError(t, err)
+
 	defer resp.Body.Close()
 }
 
@@ -133,5 +138,6 @@ func TestPerformRequest_ConfigureFunc(t *testing.T) {
 		r.Header.Add("Stripe-Version", "2019-07-10")
 	})
 	require.NoError(t, err)
+
 	defer resp.Body.Close()
 }

--- a/pkg/stripe/verbosetransport.go
+++ b/pkg/stripe/verbosetransport.go
@@ -60,6 +60,7 @@ func (t *verboseTransport) dumpHeaders(header http.Header, indent string) {
 			if !strings.EqualFold(name, listed) {
 				continue
 			}
+
 			for _, v := range vv {
 				if v != "" {
 					r := regexp.MustCompile("(?i)^(basic|bearer) (.+)")

--- a/pkg/stripe/verbosetransport_test.go
+++ b/pkg/stripe/verbosetransport_test.go
@@ -19,6 +19,7 @@ func TestVerboseTransport_Verbose(t *testing.T) {
 	defer ts.Close()
 
 	var b bytes.Buffer
+
 	httpTransport := &http.Transport{}
 	tr := &verboseTransport{
 		Transport: httpTransport,
@@ -30,8 +31,10 @@ func TestVerboseTransport_Verbose(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer token")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 	resp, err := client.Do(req)
 	require.NoError(t, err)
+
 	defer resp.Body.Close()
 
 	out := b.String()

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -63,6 +63,7 @@ func (c *Client) Authorize(deviceName string, websocketFeature string, filters *
 	if err != nil {
 		return nil, err
 	}
+
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -97,9 +98,11 @@ func NewClient(key string, cfg *Config) *Client {
 	if cfg == nil {
 		cfg = &Config{}
 	}
+
 	if cfg.Log == nil {
 		cfg.Log = &log.Logger{Out: ioutil.Discard}
 	}
+
 	if cfg.APIBaseURL == "" {
 		cfg.APIBaseURL = stripe.DefaultAPIBaseURL
 	}

--- a/pkg/useragent/uname_unix.go
+++ b/pkg/useragent/uname_unix.go
@@ -15,6 +15,7 @@ func trimNulls(input []byte) []byte {
 
 func getUname() string {
 	u := new(unix.Utsname)
+
 	err := unix.Uname(u)
 	if err != nil {
 		panic(err)

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -69,5 +69,6 @@ func initUserAgent() {
 	if err != nil {
 		panic(err)
 	}
+
 	encodedStripeUserAgent = string(marshaled)
 }

--- a/pkg/validators/cmds.go
+++ b/pkg/validators/cmds.go
@@ -18,6 +18,7 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		return errors.New(errorMessage)
 	}
+
 	return nil
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,6 +27,7 @@ func CheckLatestVersion() {
 	if Version != "master" {
 		s := ansi.StartSpinner("Checking for new versions...", os.Stdout)
 		latest := getLatestVersion()
+
 		ansi.StopSpinner(s, "", os.Stdout)
 
 		if latest != "" && latest != Version {

--- a/pkg/websocket/client_test.go
+++ b/pkg/websocket/client_test.go
@@ -44,11 +44,13 @@ func TestClientWebhookEventHandler(t *testing.T) {
 		err = c.WriteMessage(ws.TextMessage, msg)
 		require.Nil(t, err)
 	}))
+
 	defer ts.Close()
 
 	url := "ws" + strings.TrimPrefix(ts.URL, "http")
 
 	var rcvMsg *WebhookEvent
+
 	client := NewClient(
 		url,
 		"websocket-random-id",
@@ -60,10 +62,13 @@ func TestClientWebhookEventHandler(t *testing.T) {
 			}),
 		},
 	)
+
 	go client.Run()
+
 	defer client.Stop()
 
 	done := make(chan struct{})
+
 	go func() {
 		wg.Wait()
 		close(done)
@@ -108,11 +113,13 @@ func TestClientRequestLogEventHandler(t *testing.T) {
 		err = c.WriteMessage(ws.TextMessage, msg)
 		require.Nil(t, err)
 	}))
+
 	defer ts.Close()
 
 	url := "ws" + strings.TrimPrefix(ts.URL, "http")
 
 	var rcvMsg *RequestLogEvent
+
 	client := NewClient(
 		url,
 		"websocket-random-id",
@@ -124,10 +131,13 @@ func TestClientRequestLogEventHandler(t *testing.T) {
 			}),
 		},
 	)
+
 	go client.Run()
+
 	defer client.Stop()
 
 	done := make(chan struct{})
+
 	go func() {
 		wg.Wait()
 		close(done)

--- a/pkg/websocket/messages.go
+++ b/pkg/websocket/messages.go
@@ -27,12 +27,14 @@ func (m *IncomingMessage) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(data, &evt); err != nil {
 			return err
 		}
+
 		m.WebhookEvent = &evt
 	case "request_log_event":
 		var evt RequestLogEvent
 		if err := json.Unmarshal(data, &evt); err != nil {
 			return err
 		}
+
 		m.RequestLogEvent = &evt
 	default:
 		return fmt.Errorf("Unexpected message type: %s", incomingMessageTypeOnly.Type)


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
The latest version of golangci-lint includes a new linter (https://github.com/bombsimon/wsl) that forces you to add empty lines. Because we enable all linters by default, this causes new CI builds to fail.

I'm a little ambivalent about it, but I think I like it overall. If you'd rather, we can just disable the linter though.
