### PR TITLE
Add trigger for 'payment_intent.canceled' event

### DIFF
--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -48,6 +48,7 @@ func newTriggerCmd() *triggerCmd {
 			"payment_intent.created",
 			"payment_intent.payment_failed",
 			"payment_intent.succeeded",
+			"payment_intent.canceled",
 			"payment_method.attached",
 		},
 		Short: "Trigger test webhook events to fire",
@@ -79,6 +80,7 @@ needed to create the triggered event.
   payment_intent.created
   payment_intent.payment_failed
   payment_intent.succeeded
+  payment_intent.canceled
   payment_method.attached
 
   You can also resend a past event using the --event flag:
@@ -146,6 +148,7 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 		"payment_intent.created":        examples.PaymentIntentCreated,
 		"payment_intent.payment_failed": examples.PaymentIntentFailed,
 		"payment_intent.succeeded":      examples.PaymentIntentSucceeded,
+		"payment_intent.canceled":       examples.PaymentIntentCanceled,
 		"payment_method.attached":       examples.PaymentMethodAttached,
 	}
 

--- a/pkg/requests/examples.go
+++ b/pkg/requests/examples.go
@@ -601,6 +601,26 @@ func (ex *Examples) PaymentIntentFailed() error {
 	return err
 }
 
+// PaymentIntentCanceled creates a canceled payment intent
+func (ex *Examples) PaymentIntentCanceled() error {
+	paymentIntent, err := ex.paymentIntentCreated([]string{
+		"amount=2000",
+		"currency=usd",
+	})
+
+	if err != nil {
+		return err
+	}
+
+	req, params := ex.buildRequest(http.MethodPost, []string{
+		"cancellation_reason=requested_by_customer",
+	})
+	reqURL := fmt.Sprintf("/v1/payment_intents/%v/cancel", paymentIntent["id"])
+	_, err = ex.performStripeRequest(req, reqURL, params)
+
+	return err
+}
+
 func (ex *Examples) paymentMethodCreated(card string) (map[string]interface{}, error) {
 	req, params := ex.buildRequest(http.MethodPost, []string{
 		"type=card",

--- a/pkg/requests/examples_test.go
+++ b/pkg/requests/examples_test.go
@@ -320,6 +320,24 @@ func TestPaymentIntentSucceeded(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestPaymentIntentCanceled(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		data := jsonBytes()
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	ex := Examples{
+		APIBaseURL: ts.URL,
+		APIVersion: "v1",
+		APIKey:     "secret-key",
+	}
+
+	err := ex.PaymentIntentCanceled()
+	require.Nil(t, err)
+}
+
 func TestPaymentIntentFailed(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/dev-platform

 ### Summary
Trigger for `payment_intent.canceled` has been added

Issue stripe/stripe-cli#228