### PR TITLE
Add events resend command

### DIFF
--- a/pkg/cmd/resource/events.go
+++ b/pkg/cmd/resource/events.go
@@ -1,0 +1,31 @@
+package resource
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+// AddEventsSubCmds adds custom subcommands to the `events` command created
+// automatically as a resource command.
+func AddEventsSubCmds(rootCmd *cobra.Command, cfg *config.Config) error {
+	found := false
+
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "events" {
+			found = true
+
+			NewEventsResendCmd(cmd, cfg)
+
+			break
+		}
+	}
+
+	if !found {
+		return errors.New("Could not find events command")
+	}
+
+	return nil
+}

--- a/pkg/cmd/resource/events_resend.go
+++ b/pkg/cmd/resource/events_resend.go
@@ -1,0 +1,40 @@
+package resource
+
+import (
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+// EventsResendCmd represents the event resend API operation command. This
+// command is manually defined because it has a custom behavior.
+type EventsResendCmd struct {
+	opCmd *OperationCmd
+}
+
+func (erc *EventsResendCmd) runEventsResendCmd(cmd *cobra.Command, args []string) error {
+	// If the `webhook-endpoint` flag was not passed, then add
+	// `for_stripecli=true` to the request so the event is replayed to the
+	// Stripe CLI.
+	if !erc.opCmd.Cmd.Flags().Changed("webhook-endpoint") {
+		erc.opCmd.Parameters.AppendData([]string{"for_stripecli=true"})
+	}
+
+	return erc.opCmd.runOperationCmd(cmd, args)
+}
+
+// NewEventsResendCmd returns a new EventsResendCmd.
+func NewEventsResendCmd(parentCmd *cobra.Command, cfg *config.Config) *EventsResendCmd {
+	eventsResendCmd := &EventsResendCmd{
+		opCmd: NewOperationCmd(parentCmd, "resend", "/v1/events/{event}/retry", http.MethodPost, map[string]string{
+			"account":          "string",
+			"webhook_endpoint": "string",
+		}, cfg),
+	}
+
+	eventsResendCmd.opCmd.Cmd.RunE = eventsResendCmd.runEventsResendCmd
+
+	return eventsResendCmd
+}

--- a/pkg/cmd/resource/events_resend_test.go
+++ b/pkg/cmd/resource/events_resend_test.go
@@ -1,0 +1,77 @@
+package resource
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+func TestRunEventsResendCmd(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		body, err := ioutil.ReadAll(r.Body)
+		require.Nil(t, err)
+
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/events/evt_123/retry", r.URL.Path)
+		require.Equal(t, "Bearer sk_test_1234", r.Header.Get("Authorization"))
+		vals, err := url.ParseQuery(string(body))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(vals))
+		require.Equal(t, vals["for_stripecli"][0], "true")
+	}))
+	defer ts.Close()
+
+	viper.Reset()
+
+	parentCmd := &cobra.Command{Annotations: make(map[string]string)}
+	profile := config.Profile{
+		APIKey: "sk_test_1234",
+	}
+	erc := NewEventsResendCmd(parentCmd, &config.Config{Profile: profile})
+	erc.opCmd.APIBaseURL = ts.URL
+
+	err := erc.runEventsResendCmd(erc.opCmd.Cmd, []string{"evt_123"})
+
+	require.NoError(t, err)
+}
+
+func TestRunEventsResendCmd_WithWebhookEndpoint(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		body, err := ioutil.ReadAll(r.Body)
+		require.Nil(t, err)
+
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/events/evt_123/retry", r.URL.Path)
+		require.Equal(t, "Bearer sk_test_1234", r.Header.Get("Authorization"))
+		vals, err := url.ParseQuery(string(body))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(vals))
+		require.Equal(t, vals["webhook_endpoint"][0], "we_123")
+	}))
+	defer ts.Close()
+
+	viper.Reset()
+
+	parentCmd := &cobra.Command{Annotations: make(map[string]string)}
+	profile := config.Profile{
+		APIKey: "sk_test_1234",
+	}
+	erc := NewEventsResendCmd(parentCmd, &config.Config{Profile: profile})
+	erc.opCmd.APIBaseURL = ts.URL
+
+	erc.opCmd.Cmd.Flags().Set("webhook-endpoint", "we_123")
+
+	err := erc.runEventsResendCmd(erc.opCmd.Cmd, []string{"evt_123"})
+
+	require.NoError(t, err)
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -8,10 +8,12 @@ import (
 	"os"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/stripe/stripe-cli/pkg/cmd/resource"
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/version"
 )
@@ -106,4 +108,9 @@ func init() {
 	rootCmd.AddCommand(newVersionCmd().cmd)
 
 	addAllResourcesCmds(rootCmd)
+
+	err := resource.AddEventsSubCmds(rootCmd, &Config)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -18,7 +18,6 @@ type triggerCmd struct {
 	cmd *cobra.Command
 
 	apiBaseURL string
-	eventID    string
 }
 
 func newTriggerCmd() *triggerCmd {
@@ -82,9 +81,7 @@ needed to create the triggered event.
   payment_intent.succeeded
   payment_intent.canceled
   payment_method.attached
-
-  You can also resend a past event using the --event flag:
-  e.g. stripe trigger --event evt_123`,
+`,
 			getBanner(),
 			ansi.Bold("Supported events:"),
 		),
@@ -95,7 +92,6 @@ needed to create the triggered event.
 	// Hidden configuration flags, useful for dev/debugging
 	tc.cmd.Flags().StringVar(&tc.apiBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
 	tc.cmd.Flags().MarkHidden("api-base") // #nosec G104
-	tc.cmd.Flags().StringVar(&tc.eventID, "event", "", "ID of the event to resend")
 
 	return tc
 }
@@ -116,10 +112,6 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) == 0 {
-		if tc.eventID != "" {
-			return examples.ResendEvent(tc.eventID)
-		}
-
 		cmd.Usage()
 
 		return nil

--- a/pkg/requests/examples.go
+++ b/pkg/requests/examples.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"regexp"
 
 	"github.com/stripe/stripe-cli/pkg/config"
 )
@@ -683,24 +682,4 @@ func (ex *Examples) WebhookEndpointsList() WebhookEndpointList {
 	json.Unmarshal(resp, &data)
 
 	return data
-}
-
-// ResendEvent resends a webhook event using it's event-id "evt_<id>"
-func (ex *Examples) ResendEvent(id string) error {
-	pattern := `^evt_[A-Za-z0-9]{3,255}$`
-
-	match, err := regexp.MatchString(pattern, id)
-	if err != nil {
-		return err
-	}
-
-	if !match {
-		return fmt.Errorf("Invalid event-id provided, should be of the form '%s'", pattern)
-	}
-
-	req, params := ex.buildRequest(http.MethodPost, []string{})
-	reqURL := fmt.Sprintf("/v1/events/%s/retry", id)
-	_, err = ex.performStripeRequest(req, reqURL, params)
-
-	return err
 }

--- a/pkg/requests/examples_test.go
+++ b/pkg/requests/examples_test.go
@@ -374,36 +374,6 @@ func TestPaymentMethodAttached(t *testing.T) {
 	require.Nil(t, err)
 }
 
-func TestResendEventThrowsErrorWithInvalidEventID(t *testing.T) {
-	ex := Examples{
-		APIBaseURL: "",
-		APIVersion: "v1",
-		APIKey:     "secret-key",
-	}
-
-	err := ex.ResendEvent("asdf")
-	require.NotNil(t, err)
-}
-
-func TestResendEventDoesNotErrorWithValidEventID(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		data := jsonBytes()
-		w.Write(data)
-	}))
-	defer ts.Close()
-
-	ex := Examples{
-		APIBaseURL: ts.URL,
-		APIVersion: "v1",
-		APIKey:     "secret-key",
-	}
-
-	err := ex.ResendEvent("evt_123")
-	t.Log(err)
-	require.Nil(t, err)
-}
-
 func TestCheckoutSessionCompleted(t *testing.T) {
 	i := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform @rattrayalex-stripe 

 ### Summary
- Removes the `--event` flag in the `trigger` command (`trigger` is now exclusively used to trigger new test events, not replay existing ones)
- Add a new `events resend` subcommand (`events` already has `retrieve` and `list` subcommands which are regular API operation commands). The command expects one argument (the event ID) and accepts two optional flags: `--webhook-endpoint` to replay the event on a specific endpoint and `--account` to replay an event from a connected account. If `--webhook-endpoint` is omitted, then the CLI will send `for_stripecli=true` in the request to instruct the API to replay the event to the CLI endpoints.

Because the new command inherits all the standard API operation command infrastructure, it supports the `--livemode` flag.
