### PR TITLE
Add clean make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,4 +97,11 @@ release:
 	git push --tags
 .PHONY: release
 
+clean:
+	go clean ./...
+	rm -f stripe stripe-darwin stripe-linux stripe-windows.exe
+	rm -f coverage.txt
+	rm -rf dist/
+.PHONY: clean
+
 .DEFAULT_GOAL := build


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Add a `clean` target to the Makefile to clear out files generated by the build.
