### PR TITLE
Better synchronization for websocket commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,11 @@ export GO111MODULE := on
 export GOBIN := $(shell pwd)/bin
 export PATH := $(GOBIN):$(PATH)
 export GOPROXY := https://gocenter.io
+export GOLANGCI_LINT_VERSION := v1.21.0
 
 # Install all the build and lint dependencies
 setup:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s $(GOLANGCI_LINT_VERSION)
 	curl -L https://git.io/misspell | sh
 	go mod download
 .PHONY: setup

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -113,7 +114,7 @@ func getLinks(baseURL string, deviceName string) (*Links, error) {
 	data := url.Values{}
 	data.Set("device_name", deviceName)
 
-	res, err := client.PerformRequest(http.MethodPost, stripeCLIAuthPath, data.Encode(), nil)
+	res, err := client.PerformRequest(context.TODO(), http.MethodPost, stripeCLIAuthPath, data.Encode(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/login/login_message.go
+++ b/pkg/login/login_message.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -72,7 +73,7 @@ func getUserAccount(baseURL string, apiKey string) (*Account, error) {
 		APIKey:  apiKey,
 	}
 
-	resp, err := client.PerformRequest("GET", "/v1/account", "", nil)
+	resp, err := client.PerformRequest(context.TODO(), "GET", "/v1/account", "", nil)
 
 	if err != nil {
 		return nil, err

--- a/pkg/login/poll.go
+++ b/pkg/login/poll.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -51,7 +52,7 @@ func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (*PollA
 
 	var count = 0
 	for count < maxAttempts {
-		res, err := client.PerformRequest(http.MethodGet, parsedURL.Path, parsedURL.Query().Encode(), nil)
+		res, err := client.PerformRequest(context.TODO(), http.MethodGet, parsedURL.Path, parsedURL.Query().Encode(), nil)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -2,6 +2,7 @@ package requests
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -134,7 +135,7 @@ func (rb *Base) MakeRequest(apiKey, path string, params *RequestParameters, errO
 		rb.setVersionHeader(req, params)
 	}
 
-	resp, err := client.PerformRequest(rb.Method, path, data, configureReq)
+	resp, err := client.PerformRequest(context.TODO(), rb.Method, path, data, configureReq)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -1,6 +1,7 @@
 package samples
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -396,7 +397,7 @@ func (s *Samples) ConfigureDotEnv(sampleLocation string) error {
 
 	authClient := stripeauth.NewClient(apiKey, nil)
 
-	authSession, err := authClient.Authorize(deviceName, "webhooks", nil)
+	authSession, err := authClient.Authorize(context.TODO(), deviceName, "webhooks", nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -39,7 +39,7 @@ type Client struct {
 }
 
 // PerformRequest sends a request to Stripe and returns the response.
-func (c *Client) PerformRequest(method, path string, params string, configure func(*http.Request)) (*http.Response, error) {
+func (c *Client) PerformRequest(ctx context.Context, method, path string, params string, configure func(*http.Request)) (*http.Response, error) {
 	url, err := url.Parse(path)
 	if err != nil {
 		return nil, err
@@ -74,6 +74,10 @@ func (c *Client) PerformRequest(method, path string, params string, configure fu
 
 	if c.httpClient == nil {
 		c.httpClient = newHTTPClient(c.Verbose, os.Getenv("STRIPE_CLI_UNIX_SOCKET"))
+	}
+
+	if ctx != nil {
+		req = req.WithContext(ctx)
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/pkg/stripe/client_test.go
+++ b/pkg/stripe/client_test.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -30,7 +31,7 @@ func TestPerformRequest_ParamsEncoding_Delete(t *testing.T) {
 	params.Add("key_a", "value_a")
 	params.Add("key_b", "value_b")
 
-	resp, err := client.PerformRequest(http.MethodDelete, "/delete", params.Encode(), nil)
+	resp, err := client.PerformRequest(context.TODO(), http.MethodDelete, "/delete", params.Encode(), nil)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -56,7 +57,7 @@ func TestPerformRequest_ParamsEncoding_Get(t *testing.T) {
 	params.Add("key_a", "value_a")
 	params.Add("key_b", "value_b")
 
-	resp, err := client.PerformRequest(http.MethodGet, "/get", params.Encode(), nil)
+	resp, err := client.PerformRequest(context.TODO(), http.MethodGet, "/get", params.Encode(), nil)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -82,7 +83,7 @@ func TestPerformRequest_ParamsEncoding_Post(t *testing.T) {
 	params.Add("key_a", "value_a")
 	params.Add("key_b", "value_b")
 
-	resp, err := client.PerformRequest(http.MethodPost, "/post", params.Encode(), nil)
+	resp, err := client.PerformRequest(context.TODO(), http.MethodPost, "/post", params.Encode(), nil)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -100,7 +101,7 @@ func TestPerformRequest_ApiKey_Provided(t *testing.T) {
 		APIKey:  "sk_test_1234",
 	}
 
-	resp, err := client.PerformRequest(http.MethodGet, "/get", "", nil)
+	resp, err := client.PerformRequest(context.TODO(), http.MethodGet, "/get", "", nil)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -117,7 +118,7 @@ func TestPerformRequest_ApiKey_Omitted(t *testing.T) {
 		BaseURL: baseURL,
 	}
 
-	resp, err := client.PerformRequest(http.MethodGet, "/get", "", nil)
+	resp, err := client.PerformRequest(context.TODO(), http.MethodGet, "/get", "", nil)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -134,7 +135,7 @@ func TestPerformRequest_ConfigureFunc(t *testing.T) {
 		BaseURL: baseURL,
 	}
 
-	resp, err := client.PerformRequest(http.MethodGet, "/get", "", func(r *http.Request) {
+	resp, err := client.PerformRequest(context.TODO(), http.MethodGet, "/get", "", func(r *http.Request) {
 		r.Header.Add("Stripe-Version", "2019-07-10")
 	})
 	require.NoError(t, err)

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -1,6 +1,7 @@
 package stripeauth
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -36,7 +37,7 @@ type Client struct {
 }
 
 // Authorize sends a request to Stripe to initiate a new CLI session.
-func (c *Client) Authorize(deviceName string, websocketFeature string, filters *string) (*StripeCLISession, error) {
+func (c *Client) Authorize(ctx context.Context, deviceName string, websocketFeature string, filters *string) (*StripeCLISession, error) {
 	c.cfg.Log.WithFields(log.Fields{
 		"prefix": "stripeauth.client.Authorize",
 	}).Debug("Authenticating with Stripe...")
@@ -59,7 +60,7 @@ func (c *Client) Authorize(deviceName string, websocketFeature string, filters *
 		APIKey:  c.apiKey,
 	}
 
-	resp, err := client.PerformRequest(http.MethodPost, stripeCLISessionPath, form.Encode(), nil)
+	resp, err := client.PerformRequest(ctx, http.MethodPost, stripeCLISessionPath, form.Encode(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -1,6 +1,7 @@
 package stripeauth
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -36,7 +37,7 @@ func TestAuthorize(t *testing.T) {
 	client := NewClient("sk_test_123", &Config{
 		APIBaseURL: ts.URL,
 	})
-	session, err := client.Authorize("my-device", "webhooks", nil)
+	session, err := client.Authorize(context.TODO(), "my-device", "webhooks", nil)
 	require.NoError(t, err)
 	require.Equal(t, "some-id", session.WebSocketID)
 	require.Equal(t, "wss://example.com/subscribe/acct_123", session.WebSocketURL)
@@ -54,7 +55,7 @@ func TestUserAgent(t *testing.T) {
 	client := NewClient("sk_test_123", &Config{
 		APIBaseURL: ts.URL,
 	})
-	client.Authorize("my-device", "webhooks", nil)
+	client.Authorize(context.TODO(), "my-device", "webhooks", nil)
 }
 
 func TestStripeClientUserAgent(t *testing.T) {
@@ -77,5 +78,5 @@ func TestStripeClientUserAgent(t *testing.T) {
 	client := NewClient("sk_test_123", &Config{
 		APIBaseURL: ts.URL,
 	})
-	client.Authorize("my-device", "webhooks", nil)
+	client.Authorize(context.TODO(), "my-device", "webhooks", nil)
 }


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Improves the synchronization of all goroutines in websocket commands:
- create a cancelable [context](https://blog.golang.org/context)
- start a goroutine who will be blocked until Ctrl+C is pressed. When Ctrl+C is pressed, the goroutine cancels the context
- create a goroutine for the session creation request and pass the context to the HTTP client
- block until the goroutine returns
- if the session creation succeeds, pass the context to the websocket client
- block until either the context is canceled or the client is connected
- at this point only, display the success message (previously we would start the websocket client goroutine and immediately display the success message despite the fact that the websocket client was still connecting)

Fixes #156.

Future improvements:
- there's a lot of duplicated code between the proxy and logtailing packages, we should factorize it
- the websocket client still attempts to reconnect endlessly, even when the websocket ID is no longer valid
