### PR TITLE
Clean up the help menus around resources

### DIFF
--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -19,7 +19,7 @@ func newResourcesCmd() *resourcesCmd {
 	rc.cmd = &cobra.Command{
 		Use:   "resources",
 		Args:  validators.NoArgs,
-		Short: "List namespace and resource subcommands",
+		Short: "List resource commands",
 	}
 	rc.cmd.SetHelpTemplate(getResourcesHelpTemplate())
 
@@ -30,16 +30,12 @@ func getResourcesHelpTemplate() string {
 	// This template uses `.Parent` to access subcommands on the root command.
 	return fmt.Sprintf(`%s
 
-%s{{range $index, $cmd := .Parent.Commands}}{{if (eq (index $.Parent.Annotations $cmd.Name) "namespace")}}
-  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
-
-%s{{range $index, $cmd := .Parent.Commands}}{{if (eq (index $.Parent.Annotations $cmd.Name) "resource")}}
+%s{{range $index, $cmd := .Parent.Commands}}{{if (or (eq (index $.Parent.Annotations $cmd.Name) "resource") (eq (index $.Parent.Annotations $cmd.Name) "namespace"))}}
   {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
 
 Use "stripe [command] --help" for more information about a command.
 `,
 		getBanner(),
-		ansi.Bold("Available Namespaces:"),
-		ansi.Bold("Available Resources:"),
+		ansi.Bold("Available commands:"),
 	)
 }

--- a/pkg/cmd/resources_test.go
+++ b/pkg/cmd/resources_test.go
@@ -11,7 +11,6 @@ func TestResources(t *testing.T) {
 
 	output, err := executeCommand(rootCmd, "resources")
 
-	require.Contains(t, output, "Available Namespaces:")
-	require.Contains(t, output, "Available Resources:")
+	require.Contains(t, output, "Available commands:")
 	require.NoError(t, err)
 }

--- a/pkg/cmd/templates.go
+++ b/pkg/cmd/templates.go
@@ -116,19 +116,23 @@ func getUsageTemplate() string {
   {{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{if .Annotations}}
 
 %s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "webhooks")}}
-  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
+  {{rpad $cmd.Name $cmd.NamePadding}} {{$cmd.Short}}{{end}}{{end}}
 
 %s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "stripe")}}
-  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
+  {{rpad $cmd.Name $cmd.NamePadding}} {{$cmd.Short}}{{end}}{{end}}
 
-%s{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "resources")}}
-  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
+%s
+  {{rpad "get" 29}} Quickly retrieve resources from Stripe
+  {{rpad "charges" 29}} Make requests (capture, create, list, etc) on charges
+  {{rpad "customers" 29}} Make requests (create, delete, list, etc) on customers
+  {{rpad "payment_intents" 29}} Make requests (cancel, capture, confirm, etc) on payment intents
+  {{rpad "..." 29}} %s
 
 %s{{range $index, $cmd := .Commands}}{{if (not (index $.Annotations $cmd.Name))}}
-  {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}{{else}}
+  {{rpad $cmd.Name $cmd.NamePadding}} {{$cmd.Short}}{{end}}{{end}}{{else}}
 
 %s{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+  {{rpad .Name .NamePadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 %s
 {{WrappedLocalFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
@@ -144,6 +148,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 		ansi.Bold("Webhook commands:"),
 		ansi.Bold("Stripe commands:"),
 		ansi.Bold("Resource commands:"),
+		ansi.Italic("To see more resource commands, run `stripe resources help`"),
 		ansi.Bold("Other commands:"),
 		ansi.Bold("Available commands:"),
 		ansi.Bold("Flags:"),


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Made a few clean-up changes to the help menu for resources:

<img width="662" alt="Screen Shot 2019-10-22 at 1 34 39 PM" src="https://user-images.githubusercontent.com/42354557/67330579-6fa5f480-f4d1-11e9-8100-47bcc3005181.png">
<img width="578" alt="Screen Shot 2019-10-22 at 1 34 25 PM" src="https://user-images.githubusercontent.com/42354557/67330580-6fa5f480-f4d1-11e9-8406-57a5aa9503d4.png">

