### PR TITLE
Allow --forward-connect-to without --forward-to

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -132,6 +132,9 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 			Connect:        false,
 			EventTypes:     lc.events,
 		})
+	}
+
+	if len(lc.forwardConnectURL) > 0 {
 		endpointRoutes = append(endpointRoutes, proxy.EndpointRoute{
 			URL:            parseURL(lc.forwardConnectURL),
 			ForwardHeaders: lc.forwardConnectHeaders,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -100,11 +100,12 @@ func (p *Proxy) Run() error {
 	signal.Notify(p.interruptCh, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
+		<-p.interruptCh
+
 		log.WithFields(log.Fields{
 			"prefix": "proxy.Proxy.Run",
 		}).Debug("Ctrl+C received, cleaning up...")
 
-		<-p.interruptCh
 		cancel()
 	}()
 


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Allow `--forward-connect-to` to be used when `--forward-to` is not passed. In that case, only Connect events will be forwarded.

Fixes #242.
