### PR TITLE
Use `require.NoError` where applicable

### DIFF
--- a/pkg/cmd/resource/events_resend_test.go
+++ b/pkg/cmd/resource/events_resend_test.go
@@ -18,7 +18,7 @@ func TestRunEventsResendCmd(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		body, err := ioutil.ReadAll(r.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v1/events/evt_123/retry", r.URL.Path)
@@ -48,7 +48,7 @@ func TestRunEventsResendCmd_WithWebhookEndpoint(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		body, err := ioutil.ReadAll(r.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v1/events/evt_123/retry", r.URL.Path)

--- a/pkg/cmd/resource/operation_test.go
+++ b/pkg/cmd/resource/operation_test.go
@@ -34,7 +34,7 @@ func TestRunOperationCmd(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		body, err := ioutil.ReadAll(r.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v1/bars/bar_123", r.URL.Path)
@@ -75,7 +75,7 @@ func TestRunOperationCmd_ExtraParams(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		body, err := ioutil.ReadAll(r.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v1/bars/bar_123", r.URL.Path)

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -29,7 +29,7 @@ func TestGetPathNoXDG(t *testing.T) {
 	expected, err := homedir.Dir()
 	expected += "/.config/stripe"
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, actual, expected)
 }
 

--- a/pkg/login/interactive_login_test.go
+++ b/pkg/login/interactive_login_test.go
@@ -15,7 +15,7 @@ func TestAPIKeyInput(t *testing.T) {
 	actualKey, err := getConfigureAPIKey(keyInput)
 
 	require.Equal(t, expectedKey, actualKey)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestAPIKeyInputEmpty(t *testing.T) {

--- a/pkg/login/login_message_test.go
+++ b/pkg/login/login_message_test.go
@@ -18,7 +18,7 @@ func TestSuccessMessage(t *testing.T) {
 	account.Settings.Dashboard.DisplayName = testDisplayName
 
 	msg, err := SuccessMessage(account, "", "sk_test_123")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(
 		t,
 		"Done! The Stripe CLI is configured for test_disp_name with account id acct_123\n",
@@ -32,7 +32,7 @@ func TestSuccessMessageNoDisplayName(t *testing.T) {
 	}
 
 	msg, err := SuccessMessage(account, "", "sk_test_123")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(
 		t,
 		"Done! The Stripe CLI is configured for your account with account id acct_123\n",
@@ -43,7 +43,7 @@ func TestSuccessMessageNoDisplayName(t *testing.T) {
 func TestSuccessMessageBasicMessage(t *testing.T) {
 	account := &Account{}
 	msg, err := SuccessMessage(account, "", "sk_test_123")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(
 		t,
 		"Done! The Stripe CLI is configured\n",
@@ -67,7 +67,7 @@ func TestSuccessMessageGetAccount(t *testing.T) {
 	defer ts.Close()
 
 	msg, err := SuccessMessage(nil, ts.URL, "sk_test_123")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(
 		t,
 		"Done! The Stripe CLI is configured for test_disp_name with account id acct_123\n",
@@ -90,7 +90,7 @@ func TestSuccessMessageGetAccountNoDisplayName(t *testing.T) {
 	defer ts.Close()
 
 	msg, err := SuccessMessage(nil, ts.URL, "sk_test_123")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(
 		t,
 		"Done! The Stripe CLI is configured for your account with account id acct_123\n",

--- a/pkg/logtailing/tailer_test.go
+++ b/pkg/logtailing/tailer_test.go
@@ -20,7 +20,7 @@ func TestJsonifyFiltersAll(t *testing.T) {
 	}
 	expected := fmt.Sprintf(`{"filter_account":["my-account"],"filter_ip_address":["my-ip-address"],"filter_http_method":["my-http-method"],"filter_request_path":["my-request-path"],"filter_request_status":["my-request-status"],"filter_source":["my-source"],"filter_status_code":["my-status-code"],"filter_status_code_type":["my-status-code-type"]}`)
 	filtersStr, err := jsonifyFilters(filters)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, expected, filtersStr)
 }
 
@@ -31,7 +31,7 @@ func TestJsonifyFiltersSome(t *testing.T) {
 	}
 	expected := fmt.Sprintf(`{"filter_http_method":["my-http-method"],"filter_status_code":["my-status-code"]}`)
 	filtersStr, err := jsonifyFilters(filters)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, expected, filtersStr)
 }
 
@@ -47,7 +47,7 @@ func TestJsonifyFiltersEmpty(t *testing.T) {
 		FilterStatusCodeType: []string{},
 	}
 	filtersStr, err := jsonifyFilters(filters)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "{}", filtersStr)
 }
 

--- a/pkg/proxy/endpoint_test.go
+++ b/pkg/proxy/endpoint_test.go
@@ -19,7 +19,7 @@ func TestClientHandler(t *testing.T) {
 		w.Write([]byte("OK!"))
 
 		reqBody, err := ioutil.ReadAll(r.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "TestAgent/v1", r.UserAgent())
@@ -47,7 +47,7 @@ func TestClientHandler(t *testing.T) {
 		&EndpointConfig{
 			ResponseHandler: EndpointResponseHandlerFunc(func(evtCtx eventContext, forwardURL string, resp *http.Response) {
 				buf, err := ioutil.ReadAll(resp.Body)
-				require.Nil(t, err)
+				require.NoError(t, err)
 
 				rcvCtx = evtCtx
 				rcvBody = string(buf)
@@ -76,7 +76,7 @@ func TestClientHandler(t *testing.T) {
 
 	wg.Wait()
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "OK!", rcvBody)
 	require.Equal(t, ts.URL, rcvForwardURL)
 	require.Equal(t, "wh_123", rcvCtx.webhookID)

--- a/pkg/requests/base_test.go
+++ b/pkg/requests/base_test.go
@@ -86,7 +86,7 @@ func TestMakeRequest(t *testing.T) {
 		w.Write([]byte("OK!"))
 
 		reqBody, err := ioutil.ReadAll(r.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.MethodGet, r.Method)
 		require.Equal(t, "/foo/bar", r.URL.Path)
@@ -136,7 +136,7 @@ func TestGetUserConfirmationRequired(t *testing.T) {
 
 	confirmed, err := rb.getUserConfirmation(reader)
 	require.True(t, confirmed)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestGetUserConfirmationNotRequired(t *testing.T) {
@@ -148,7 +148,7 @@ func TestGetUserConfirmationNotRequired(t *testing.T) {
 
 	confirmed, err := rb.getUserConfirmation(reader)
 	require.True(t, confirmed)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestGetUserConfirmationAutoConfirm(t *testing.T) {
@@ -160,7 +160,7 @@ func TestGetUserConfirmationAutoConfirm(t *testing.T) {
 
 	confirmed, err := rb.getUserConfirmation(reader)
 	require.True(t, confirmed)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestGetUserConfirmationNoConfirm(t *testing.T) {
@@ -172,7 +172,7 @@ func TestGetUserConfirmationNoConfirm(t *testing.T) {
 
 	confirmed, err := rb.getUserConfirmation(reader)
 	require.False(t, confirmed)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestNormalizePath(t *testing.T) {

--- a/pkg/requests/examples_test.go
+++ b/pkg/requests/examples_test.go
@@ -25,7 +25,7 @@ func jsonBytes() []byte {
 func TestParseResponse(t *testing.T) {
 	bytes := jsonBytes()
 	resp, err := parseResponse(bytes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "test-id", resp["id"])
 }
 
@@ -46,7 +46,7 @@ func TestChargeCaptured(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := ioutil.ReadAll(r.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		// Because it's 2 calls to server for this
 		if count == 0 {
@@ -76,7 +76,7 @@ func TestChargeCaptured(t *testing.T) {
 func TestChargeFailed(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := ioutil.ReadAll(r.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, body)
 		require.EqualValues(t, "amount=2000&currency=usd&source=tok_chargeDeclined", string(body))
 
@@ -93,13 +93,13 @@ func TestChargeFailed(t *testing.T) {
 	}
 
 	err := ex.ChargeFailed()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestChargeSucceeded(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := ioutil.ReadAll(r.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, "amount=2000&currency=usd&source=tok_visa", string(body))
 
 		w.WriteHeader(http.StatusOK)
@@ -115,13 +115,13 @@ func TestChargeSucceeded(t *testing.T) {
 	}
 
 	err := ex.ChargeSucceeded()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestCustomerCreated(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := ioutil.ReadAll(r.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Empty(t, body)
 
 		w.WriteHeader(http.StatusOK)
@@ -137,7 +137,7 @@ func TestCustomerCreated(t *testing.T) {
 	}
 
 	err := ex.CustomerCreated()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestCustomerUpdated(t *testing.T) {
@@ -155,7 +155,7 @@ func TestCustomerUpdated(t *testing.T) {
 	}
 
 	err := ex.CustomerUpdated()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestCustomerSourceCreated(t *testing.T) {
@@ -173,7 +173,7 @@ func TestCustomerSourceCreated(t *testing.T) {
 	}
 
 	err := ex.CustomerSourceCreated()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestCustomerSourceUpdated(t *testing.T) {
@@ -191,7 +191,7 @@ func TestCustomerSourceUpdated(t *testing.T) {
 	}
 
 	err := ex.CustomerSourceUpdated()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestCustomerSubscriptionUpdated(t *testing.T) {
@@ -209,7 +209,7 @@ func TestCustomerSubscriptionUpdated(t *testing.T) {
 	}
 
 	err := ex.CustomerSubscriptionUpdated()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestInvoiceCreated(t *testing.T) {
@@ -227,7 +227,7 @@ func TestInvoiceCreated(t *testing.T) {
 	}
 
 	err := ex.InvoiceCreated()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestInvoiceFinalized(t *testing.T) {
@@ -245,7 +245,7 @@ func TestInvoiceFinalized(t *testing.T) {
 	}
 
 	err := ex.InvoiceFinalized()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestInvoicePaymentSucceeded(t *testing.T) {
@@ -263,7 +263,7 @@ func TestInvoicePaymentSucceeded(t *testing.T) {
 	}
 
 	err := ex.InvoicePaymentSucceeded()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestInvoiceUpdated(t *testing.T) {
@@ -281,7 +281,7 @@ func TestInvoiceUpdated(t *testing.T) {
 	}
 
 	err := ex.InvoiceUpdated()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestPaymentIntentCreated(t *testing.T) {
@@ -299,7 +299,7 @@ func TestPaymentIntentCreated(t *testing.T) {
 	}
 
 	err := ex.PaymentIntentCreated()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestPaymentIntentSucceeded(t *testing.T) {
@@ -317,7 +317,7 @@ func TestPaymentIntentSucceeded(t *testing.T) {
 	}
 
 	err := ex.PaymentIntentSucceeded()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestPaymentIntentCanceled(t *testing.T) {
@@ -335,7 +335,7 @@ func TestPaymentIntentCanceled(t *testing.T) {
 	}
 
 	err := ex.PaymentIntentCanceled()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestPaymentIntentFailed(t *testing.T) {
@@ -353,7 +353,7 @@ func TestPaymentIntentFailed(t *testing.T) {
 	}
 
 	err := ex.PaymentIntentFailed()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestPaymentMethodAttached(t *testing.T) {
@@ -371,7 +371,7 @@ func TestPaymentMethodAttached(t *testing.T) {
 	}
 
 	err := ex.PaymentMethodAttached()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestCheckoutSessionCompleted(t *testing.T) {
@@ -394,7 +394,7 @@ func TestCheckoutSessionCompleted(t *testing.T) {
 		case 2: // /v1/payment_methods
 			i++
 			body, err := ioutil.ReadAll(r.Body)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			require.NotEmpty(t, body)
 			require.EqualValues(t, "type=card&card[token]=tok_visa&billing_details[email]=stripe%40example.com", string(body))
@@ -409,7 +409,7 @@ func TestCheckoutSessionCompleted(t *testing.T) {
 			require.True(t, strings.Contains(path, "test-id"))
 
 			body, err := ioutil.ReadAll(r.Body)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			require.NotEmpty(t, body)
 			require.EqualValues(t, "payment_method=test-id", string(body))
@@ -432,5 +432,5 @@ func TestCheckoutSessionCompleted(t *testing.T) {
 
 	err := ex.CheckoutSessionCompleted()
 	t.Log(err)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/samples/fixtures_test.go
+++ b/pkg/samples/fixtures_test.go
@@ -119,10 +119,10 @@ func TestMakeRequest(t *testing.T) {
 	afero.WriteFile(fs, "test_fixture.json", []byte(testFixture), os.ModePerm)
 
 	fxt, err := NewFixture(fs, "sk_test_1234", ts.URL, "test_fixture.json")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = fxt.Execute()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.NotNil(t, fxt.responses["cust_bender"])
 	require.NotNil(t, fxt.responses["char_bender"])

--- a/pkg/samples/samples_test.go
+++ b/pkg/samples/samples_test.go
@@ -118,7 +118,7 @@ func TestFindServerFiles(t *testing.T) {
 		Fs: fs,
 	}
 	files, err := sample.findServerFiles("/user/bender/adding-sales-tax")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, expected, files)
 }
 
@@ -153,7 +153,7 @@ func TestPointToDotEnvWithOneIntegrationRb(t *testing.T) {
 		isIntegration: true,
 	}
 	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.rb")
 	expected := []byte(`ENV_PATH = '../.env'.freeze`)
@@ -175,7 +175,7 @@ func TestPointToDotEnvWithNoIntegrationRb(t *testing.T) {
 		isIntegration: false,
 	}
 	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.rb")
 	expected := []byte(`ENV_PATH = '../.env'.freeze`)
@@ -202,7 +202,7 @@ func TestPointToDotEnvWithMultipleIntegrationRb(t *testing.T) {
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.rb")
 	expected := []byte(`ENV_PATH = '../../.env'.freeze`)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, data)
 }
 
@@ -225,7 +225,7 @@ func TestPointToDotEnvWithMultipleIntegrationJava(t *testing.T) {
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.java")
 	expected := []byte(`String ENV_PATH = "../../";`)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, data)
 }
 
@@ -244,7 +244,7 @@ func TestPointToDotEnvWithMultipleIntegrationPhp(t *testing.T) {
 		isIntegration: true,
 	}
 	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.php")
 	expected := []byte(`$ENV_PATH = '../..';`)
@@ -267,7 +267,7 @@ func TestPointToDotEnvWithMultipleIntegrationJs(t *testing.T) {
 		isIntegration: true,
 	}
 	err := sample.PointToDotEnv("/user/bender/adding-sales-tax")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	data, _ := afero.ReadFile(fs, "/user/bender/adding-sales-tax/server/app.js")
 	expected := []byte(`const envPath = resolve(__dirname, "../../.env");`)

--- a/pkg/validators/validate_test.go
+++ b/pkg/validators/validate_test.go
@@ -29,22 +29,22 @@ func TestPublishableAPIKey(t *testing.T) {
 
 func TestLivemodeAPIKey(t *testing.T) {
 	err := APIKey("sk_live_12345")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestTestmodeAPIKey(t *testing.T) {
 	err := APIKey("sk_test_12345")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestTestmodeRestrictedAPIKey(t *testing.T) {
 	err := APIKey("rk_test_12345")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestHTTPMethod(t *testing.T) {
 	err := HTTPMethod("GET")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestHTTPMethodInvalid(t *testing.T) {
@@ -54,27 +54,27 @@ func TestHTTPMethodInvalid(t *testing.T) {
 
 func TestHTTPMethodLowercase(t *testing.T) {
 	err := HTTPMethod("post")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestRequestSourceAPI(t *testing.T) {
 	err := RequestSource("API")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestRequestSourceDashboard(t *testing.T) {
 	err := RequestSource("dashboard")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestRequestStatusSucceeded(t *testing.T) {
 	err := RequestStatus("succeeded")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestRequestStatusFailed(t *testing.T) {
 	err := RequestStatus("failed")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestRequestStatusInvalid(t *testing.T) {
@@ -89,7 +89,7 @@ func TestRequestSourceInvalid(t *testing.T) {
 
 func TestStatusCode(t *testing.T) {
 	err := StatusCode("200")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestStatusCodeUnusedInStripe(t *testing.T) {
@@ -99,7 +99,7 @@ func TestStatusCodeUnusedInStripe(t *testing.T) {
 
 func TestStatusCodeType(t *testing.T) {
 	err := StatusCodeType("2Xx")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestStatusCodeTypeUnusedInStripe(t *testing.T) {

--- a/pkg/websocket/client_test.go
+++ b/pkg/websocket/client_test.go
@@ -23,7 +23,7 @@ func TestClientWebhookEventHandler(t *testing.T) {
 		require.NotEmpty(t, r.Header.Get("X-Stripe-Client-User-Agent"))
 		require.Equal(t, "websocket-random-id", r.Header.Get("Websocket-Id"))
 		c, err := upgrader.Upgrade(w, r, nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, "websocket_feature=webhook-payloads", r.URL.RawQuery)
 
@@ -39,10 +39,10 @@ func TestClientWebhookEventHandler(t *testing.T) {
 		}
 
 		msg, err := json.Marshal(evt)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		err = c.WriteMessage(ws.TextMessage, msg)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}))
 
 	defer ts.Close()
@@ -95,7 +95,7 @@ func TestClientRequestLogEventHandler(t *testing.T) {
 		require.NotEmpty(t, r.Header.Get("X-Stripe-Client-User-Agent"))
 		require.Equal(t, "websocket-random-id", r.Header.Get("Websocket-Id"))
 		c, err := upgrader.Upgrade(w, r, nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, "websocket_feature=request-log-payloads", r.URL.RawQuery)
 
@@ -108,10 +108,10 @@ func TestClientRequestLogEventHandler(t *testing.T) {
 		}
 
 		msg, err := json.Marshal(evt)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		err = c.WriteMessage(ws.TextMessage, msg)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}))
 
 	defer ts.Close()


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
I don't think this changes much in practice, but it makes the test's intent clearer.