### PR TITLE
Manually check for env variables and disable the automatic ones

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -11,7 +11,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/stripe/stripe-cli/pkg/cmd/resource"
 	"github.com/stripe/stripe-cli/pkg/config"
@@ -91,9 +90,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&Config.LogLevel, "log-level", "info", "log level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().StringVarP(&Config.Profile.ProfileName, "project-name", "p", "default", "the project name to read from for config")
 	rootCmd.Flags().BoolP("version", "v", false, "Get the version of the Stripe CLI")
-
-	viper.SetEnvPrefix("stripe")
-	viper.AutomaticEnv() // read in environment variables that match
 
 	rootCmd.AddCommand(newCompletionCmd().cmd)
 	rootCmd.AddCommand(newConfigCmd().cmd)

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -55,6 +56,10 @@ func (p *Profile) GetColor() (string, error) {
 
 // GetDeviceName returns the configured device name
 func (p *Profile) GetDeviceName() (string, error) {
+	if os.Getenv("STRIPE_DEVICE_NAME") != "" {
+		return os.Getenv("STRIPE_DEVICE_NAME"), nil
+	}
+
 	if p.DeviceName != "" {
 		return p.DeviceName, nil
 	}
@@ -68,6 +73,10 @@ func (p *Profile) GetDeviceName() (string, error) {
 
 // GetAPIKey will return the existing key for the given profile
 func (p *Profile) GetAPIKey(livemode bool) (string, error) {
+	if os.Getenv("STRIPE_API_KEY") != "" {
+		return os.Getenv("STRIPE_API_KEY"), nil
+	}
+
 	if p.APIKey != "" {
 		err := validators.APIKey(p.APIKey)
 		if err != nil {

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -73,8 +73,14 @@ func (p *Profile) GetDeviceName() (string, error) {
 
 // GetAPIKey will return the existing key for the given profile
 func (p *Profile) GetAPIKey(livemode bool) (string, error) {
-	if os.Getenv("STRIPE_API_KEY") != "" {
-		return os.Getenv("STRIPE_API_KEY"), nil
+	envKey := os.Getenv("STRIPE_API_KEY")
+	if envKey != "" {
+		err := validators.APIKey(envKey)
+		if err != nil {
+			return "", err
+		}
+
+		return envKey, nil
 	}
 
 	if p.APIKey != "" {


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @brandur-stripe 
cc @stripe/dev-platform

 ### Summary
We're thinking that viper's automatic env wasn't playing well with how we setup user profiles. Since the two most likely cases of env variables are `device_name` and `api_key` this adds a quick check for those and uses that if found.