### PR TITLE
Create .zip archive instead of .tar.gz for Windows binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,9 @@ archives:
       linux: linux
       windows: windows
       amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
     files:
     - none*
 checksum:


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Create `.zip` archive instead of `.tar.gz` for Windows binary.

Tested locally:
```
$ goreleaser --snapshot --skip-publish --rm-dist
$ ls dist/stripe_v0.8.2-next_*
dist/stripe_v0.8.2-next_linux_amd64.deb      dist/stripe_v0.8.2-next_mac-os_x86_64.tar.gz
dist/stripe_v0.8.2-next_linux_amd64.rpm      dist/stripe_v0.8.2-next_windows_x86_64.zip
dist/stripe_v0.8.2-next_linux_x86_64.tar.gz
```

Fixes #260.
