### PR TITLE
Add explicit --shell flag to completion comand in brew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,7 +62,7 @@ brews:
     install: |
       bin.install "stripe"
       rm Dir["#{bin}/{stripe-completion.bash,stripe-completion.zsh}"]
-      system bin/"stripe", "completion"
+      system bin/"stripe", "completion", "--shell", "bash"
       system bin/"stripe", "completion", "--shell", "zsh"
       bash_completion.install "stripe-completion.bash"
       zsh_completion.install "stripe-completion.zsh"


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Add explicit `--shell` flag to `completion` command in the brew install script.

Fixes #279.