### PR TITLE
Add example to run Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ docker run --rm -it stripe/stripe-cli version
 stripe version x.y.z (beta)
 ```
 
+Please refer to the [wiki](../../wiki/Using-with-Docker) for detailed instructions on how to use the Docker container.
+
 ### Without package managers
 
 Instructions are also available for installing and using the CLI [without a package manager](https://github.com/stripe/stripe-cli/wiki/Installing-and-updating#without-a-package-manager).


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/dev-platform

 ### Summary
Docker containers cannot use `stripe-cli login` unless you use volumes to store the login data. Instead use the `--api-key` option to authenticate. I guess an additional example would help out to clarify that.
