### PR TITLE
Simplify boolean logic

### DIFF
--- a/pkg/stripe/telemetry.go
+++ b/pkg/stripe/telemetry.go
@@ -63,9 +63,6 @@ func getTelemetryHeader() (string, error) {
 // false otherwise.
 func telemetryOptedOut(optoutVar string) bool {
 	optoutVar = strings.ToLower(optoutVar)
-	if optoutVar == "1" || optoutVar == "true" {
-		return true
-	}
 
-	return false
+	return optoutVar == "1" || optoutVar == "true"
 }


### PR DESCRIPTION
 ### Reviewers
cc @stripe/dev-platform

 ### Summary
This is a small patch to simplify the logic for the `telemetryOptedOut` function.
