### PR TITLE
Add device name and generated flag

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -46,6 +46,9 @@ var rootCmd = &cobra.Command{
 		getLogin(&fs, &Config),
 	),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// if the device name errors, don't fail running the command
+		deviceName, _ := Config.Profile.GetDeviceName()
+		stripe.GetTelemetryInstance().SetDeviceName(deviceName)
 		stripe.GetTelemetryInstance().SetCommandContext(cmd)
 	},
 }

--- a/pkg/stripe/telemetry.go
+++ b/pkg/stripe/telemetry.go
@@ -15,12 +15,28 @@ import (
 // CLITelemetry is the structure that holds telemetry data sent to Stripe in
 // API requests.
 type CLITelemetry struct {
-	CommandPath string `json:"command_path"`
+	CommandPath       string `json:"command_path"`
+	DeviceName        string `json:"device_name"`
+	GeneratedResource bool   `json:"generated_resource"`
 }
 
 // SetCommandContext sets the telemetry values for the command being executed.
 func (t *CLITelemetry) SetCommandContext(cmd *cobra.Command) {
 	t.CommandPath = cmd.CommandPath()
+	t.GeneratedResource = false
+
+	for _, value := range cmd.Annotations {
+		// Generated commands have an annotation called "operation", we can
+		// search for that to let us know it's generated
+		if value == "operation" {
+			t.GeneratedResource = true
+		}
+	}
+}
+
+// SetDeviceName puts the device name into telemetry
+func (t *CLITelemetry) SetDeviceName(deviceName string) {
+	t.DeviceName = deviceName
 }
 
 //


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
* Adds device name to telemetry
* Tags whether the command was a generated resource
