### PR TITLE
Show consistent help when error appears

### DIFF
--- a/pkg/cmd/fixtures.go
+++ b/pkg/cmd/fixtures.go
@@ -42,6 +42,10 @@ func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if len(args) == 0 {
+		return nil
+	}
+
 	fixture, err := fixtures.NewFixture(
 		afero.NewOsFs(),
 		apiKey,

--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
 //
@@ -39,6 +40,10 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 	apiKey, err := oc.Profile.GetAPIKey(oc.Livemode)
 	if err != nil {
 		return err
+	}
+
+	if len(args) == 0 {
+		return nil
 	}
 
 	path := formatURL(oc.Path, args)
@@ -97,7 +102,7 @@ func NewOperationCmd(parentCmd *cobra.Command, name, path, httpVerb string, prop
 		Use:         name,
 		Annotations: make(map[string]string),
 		RunE:        operationCmd.runOperationCmd,
-		Args:        cobra.ExactArgs(len(urlParams)),
+		Args:        validators.ExactArgs(len(urlParams)),
 	}
 
 	for prop := range propFlags {

--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -50,7 +50,8 @@ func (cc *CreateCmd) runCreateCmd(cmd *cobra.Command, args []string) error {
 	version.CheckLatestVersion()
 
 	if len(args) == 0 {
-		return fmt.Errorf("Creating a sample requires at least 1 argument, received 0")
+		cmd.Help()
+		return nil
 	}
 
 	if _, ok := samples.List[args[0]]; !ok {

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -58,7 +58,7 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) == 0 {
-		cmd.Usage()
+		cmd.Help()
 
 		return nil
 	}

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -64,6 +64,10 @@ func (rb *Base) RunRequestsCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("this command only supports one argument. Run with the --help flag to see usage and examples")
 	}
 
+	if len(args) == 0 {
+		return nil
+	}
+
 	confirmed, err := rb.confirmCommand()
 	if err != nil {
 		return err

--- a/pkg/validators/cmds.go
+++ b/pkg/validators/cmds.go
@@ -26,6 +26,11 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 // is different than the arguments passed in
 func ExactArgs(num int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			cmd.Help()
+			return nil
+		}
+
 		argument := "argument"
 		if num > 1 {
 			argument = "arguments"


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/dev-platform

 ### Summary
In regards of #308 , I tried to list the existing commands and make it show help instead of just the error message so that the user can get a clearer idea of what to do.
For the most of it, I only tried to check for the case of when the length of the arguments given are 0 (only `stripe <command>` since that should be the most frequent case of usage. The downside of this is the `err` that is going to be returned is becoming `nil` with the trade-off of showing a clean nice help message instead that should probably give the user a clearer guide.

- For all of the commands, I edited the package `validator` of `ExactArgs` to output `cmd.Help()` and `nil` `err` instead when the length of the arguments are 0.
- For `fixtures` and `create` subcommand of command `samples`, I edited the `err` to be `nil` when the arguments are 0 and add `cmd.Help()` for `create` subcommand.
- For the commands that use `request` package (`get`, `post`, `delete`), I edited the `err` to be `nil` when the arguments are 0 at `base.go`  
- For all of the resources and operations commands, I use the `ExactArgs` of `validator` package that has been edited before instead of the one from `cobra` lib, and set the `err` to be `nil` when the arguments are 0. 

I forgot and left the `ExactArgs` edit so I put it at the next commit.

Truly sorry if there's anything wrong. Looking forward to hearing your review :slightly_smiling_face: . 

Screenshots are attached below.
![image](https://user-images.githubusercontent.com/7043511/69796702-0a949b80-1201-11ea-9ef0-06db96bc8d5a.png)
![image](https://user-images.githubusercontent.com/7043511/69796730-18e2b780-1201-11ea-9058-c1cb05595c48.png)
