### PR TITLE
Don't follow redirects when POSTing webhook events

### DIFF
--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -74,7 +74,7 @@ func ColorizeStatus(status int) aurora.Value {
 	switch {
 	case status >= 500:
 		return color.Red(status).Bold()
-	case status >= 400:
+	case status >= 300:
 		return color.Yellow(status).Bold()
 	default:
 		return color.Green(status).Bold()

--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -136,6 +136,9 @@ func NewEndpointClient(url string, headers []string, connect bool, events []stri
 
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 			Timeout: defaultTimeout,
 		}
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -357,6 +357,9 @@ func New(cfg *Config, events []string) *Proxy {
 			route.EventTypes,
 			&EndpointConfig{
 				HTTPClient: &http.Client{
+					CheckRedirect: func(req *http.Request, via []*http.Request) error {
+						return http.ErrUseLastResponse
+					},
 					Timeout: defaultTimeout,
 					Transport: &http.Transport{
 						TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.SkipVerify},


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe @tomer-stripe 
cc @stripe/dev-platform @cjavilla-stripe 

 ### Summary
Do not follow redirects when POSTing webhook events to the local endpoint(s). This reproduces the behavior of real webhooks, where any status code >= 300 is considered a failure.

I suspect this was the real issue behind #114.
