### PR TITLE
Fix create commands not working

### DIFF
--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -42,10 +42,6 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	if len(args) == 0 {
-		return nil
-	}
-
 	path := formatURL(oc.Path, args)
 
 	flagParams := make([]string, 0)

--- a/pkg/validators/cmds.go
+++ b/pkg/validators/cmds.go
@@ -26,11 +26,6 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 // is different than the arguments passed in
 func ExactArgs(num int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			cmd.Help()
-			return nil
-		}
-
 		argument := "argument"
 		if num > 1 {
 			argument = "arguments"


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
Realized that #323 introduced a small bug that prevented create commands from working since they don't usually have arguments. I removed that here for now. I also removed the help print from the validation error to be consistent with our other errors that return instead of print.