### PR TITLE
serve cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/google/go-github/v28 v28.1.1
 	github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8 // indirect
+	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/websocket v1.4.1
 	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365
 	github.com/joho/godotenv v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf/go.mod h1:RpwtwJQFrIE
 github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8 h1:ehVe1P3MbhHjeN/Rn66N2fGLrP85XXO1uxpLhv0jtX8=
 github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
+github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
+github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -105,6 +105,7 @@ func init() {
 	rootCmd.AddCommand(newPostCmd().reqs.Cmd)
 	rootCmd.AddCommand(newResourcesCmd().cmd)
 	rootCmd.AddCommand(newSamplesCmd().cmd)
+	rootCmd.AddCommand(newServeCmd().cmd)
 	rootCmd.AddCommand(newStatusCmd().cmd)
 	rootCmd.AddCommand(newTriggerCmd().cmd)
 	rootCmd.AddCommand(newVersionCmd().cmd)

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/gorilla/handlers"
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+type serveCmd struct {
+	cmd *cobra.Command
+}
+
+func newServeCmd() *serveCmd {
+	var port string
+
+	sc := &serveCmd{}
+
+	sc.cmd = &cobra.Command{
+		Use:     "serve",
+		Short:   "Serve static files",
+		Args:    validators.MaximumNArgs(1),
+		Example: "stripe serve /path/to/directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := "."
+			if len(args) == 1 {
+				dir = args[0]
+			}
+
+			fmt.Println("Starting stripe server at address", fmt.Sprintf("http://localhost:%s", port))
+			http.Handle("/", http.FileServer(http.Dir(dir)))
+			err := http.ListenAndServe(fmt.Sprintf(":%s", port), handlers.LoggingHandler(os.Stdout, http.DefaultServeMux))
+
+			return err
+		},
+	}
+
+	sc.cmd.Flags().StringVar(&port, "port", "4242", "Provide a custom port to serve content from.")
+
+	return sc
+}

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -22,7 +22,8 @@ func newServeCmd() *serveCmd {
 
 	sc.cmd = &cobra.Command{
 		Use:     "serve",
-		Short:   "Serve static files",
+		Aliases: []string{"srv"},
+		Short:   "Serve static files locally",
 		Args:    validators.MaximumNArgs(1),
 		Example: "stripe serve /path/to/directory",
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe @adreyfus-stripe 
cc @stripe/dev-platform @suz-stripe @brandur-stripe 

 ### Summary
This adds a simple command to serve static files from the CLI. We'd like this for samples since a number of them have an `index.html` file and we've been suggested folks use the Python simple server, which may require installing the entire Python ecosystem.

The command is `stripe serve` (or `stripe srv`) which takes an optional argument that is a path to a directory. If not path is given, it serve the local folder: `'.'`.

The command has some basic logging available to it when requests are made:
```
➜ stripe-dev serve
Starting stripe server at address http://localhost:4242
::1 - - [28/Jan/2020:10:33:36 -0800] "GET / HTTP/1.1" 304 0
::1 - - [28/Jan/2020:10:33:41 -0800] "GET /.editorconfig HTTP/1.1" 200 233
^Csignal: interrupt
```

If an `index.html` file exists in the folder, the CLI will automatically render that. If not, it'll display a list of files in that specific directory.

The command itself will continue running (and block) until the user kills it with ctrl+c.