### PR TITLE
Add `--stripe-account` flag to `trigger` and `fixtures`

### DIFF
--- a/pkg/cmd/fixtures.go
+++ b/pkg/cmd/fixtures.go
@@ -16,6 +16,8 @@ import (
 type FixturesCmd struct {
 	Cmd *cobra.Command
 	Cfg *config.Config
+
+	stripeAccount string
 }
 
 func newFixturesCmd(cfg *config.Config) *FixturesCmd {
@@ -30,6 +32,8 @@ func newFixturesCmd(cfg *config.Config) *FixturesCmd {
 		Long:  `Run fixtures to populate your account with data`,
 		RunE:  fixturesCmd.runFixturesCmd,
 	}
+
+	fixturesCmd.Cmd.Flags().StringVar(&fixturesCmd.stripeAccount, "stripe-account", "", "Set a header identifying the connected account")
 
 	return fixturesCmd
 }
@@ -50,6 +54,7 @@ func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
 		afero.NewOsFs(),
 		apiKey,
 		stripe.DefaultAPIBaseURL,
+		fc.stripeAccount,
 		args[0],
 	)
 	if err != nil {

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -16,8 +16,9 @@ import (
 type triggerCmd struct {
 	cmd *cobra.Command
 
-	fs         afero.Fs
-	apiBaseURL string
+	fs            afero.Fs
+	stripeAccount string
+	apiBaseURL    string
 }
 
 func newTriggerCmd() *triggerCmd {
@@ -41,6 +42,8 @@ needed to create the triggered event as well as the corresponding API objects.
 		Example: `stripe trigger payment_intent.created`,
 		RunE:    tc.runTriggerCmd,
 	}
+
+	tc.cmd.Flags().StringVar(&tc.stripeAccount, "stripe-account", "", "Set a header identifying the connected account")
 
 	// Hidden configuration flags, useful for dev/debugging
 	tc.cmd.Flags().StringVar(&tc.apiBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
@@ -67,7 +70,7 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 
 	var fixture *fixtures.Fixture
 	if file, ok := fixtures.Events[event]; ok {
-		fixture, err = fixtures.BuildFromFixture(tc.fs, apiKey, file)
+		fixture, err = fixtures.BuildFromFixture(tc.fs, apiKey, tc.stripeAccount, file)
 		if err != nil {
 			return err
 		}
@@ -77,7 +80,7 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf(fmt.Sprintf("event %s is not supported.", event))
 		}
 
-		fixture, err = fixtures.BuildFromFixture(tc.fs, apiKey, event)
+		fixture, err = fixtures.BuildFromFixture(tc.fs, apiKey, tc.stripeAccount, event)
 		if err != nil {
 			return err
 		}

--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -44,20 +44,22 @@ type fixture struct {
 
 // Fixture contains a mapping of an individual fixtures responses for querying
 type Fixture struct {
-	Fs        afero.Fs
-	APIKey    string
-	BaseURL   string
-	responses map[string]*gojsonq.JSONQ
-	fixture   fixtureFile
+	Fs            afero.Fs
+	APIKey        string
+	StripeAccount string
+	BaseURL       string
+	responses     map[string]*gojsonq.JSONQ
+	fixture       fixtureFile
 }
 
 // NewFixture creates a to later run steps for populating test data
-func NewFixture(fs afero.Fs, apiKey, baseURL, file string) (*Fixture, error) {
+func NewFixture(fs afero.Fs, apiKey, stripeAccount, baseURL, file string) (*Fixture, error) {
 	fxt := Fixture{
-		Fs:        fs,
-		APIKey:    apiKey,
-		BaseURL:   baseURL,
-		responses: make(map[string]*gojsonq.JSONQ),
+		Fs:            fs,
+		APIKey:        apiKey,
+		StripeAccount: stripeAccount,
+		BaseURL:       baseURL,
+		responses:     make(map[string]*gojsonq.JSONQ),
 	}
 
 	var filedata []byte
@@ -169,6 +171,8 @@ func (fxt *Fixture) parsePath(http fixture) string {
 func (fxt *Fixture) createParams(params interface{}) *requests.RequestParameters {
 	requestParams := requests.RequestParameters{}
 	requestParams.AppendData(fxt.parseInterface(params))
+
+	requestParams.SetStripeAccount(fxt.StripeAccount)
 
 	return &requestParams
 }

--- a/pkg/fixtures/fixtures_test.go
+++ b/pkg/fixtures/fixtures_test.go
@@ -118,7 +118,7 @@ func TestMakeRequest(t *testing.T) {
 
 	afero.WriteFile(fs, "test_fixture.json", []byte(testFixture), os.ModePerm)
 
-	fxt, err := NewFixture(fs, "sk_test_1234", ts.URL, "test_fixture.json")
+	fxt, err := NewFixture(fs, "sk_test_1234", "", ts.URL, "test_fixture.json")
 	require.NoError(t, err)
 
 	err = fxt.Execute()

--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -44,10 +44,11 @@ var Events = map[string]string{
 }
 
 // BuildFromFixture creates a new fixture struct for a file
-func BuildFromFixture(fs afero.Fs, apiKey, jsonFile string) (*Fixture, error) {
+func BuildFromFixture(fs afero.Fs, apiKey, stripeAccount, jsonFile string) (*Fixture, error) {
 	fixture, err := NewFixture(
 		fs,
 		apiKey,
+		stripeAccount,
 		stripe.DefaultAPIBaseURL,
 		jsonFile,
 	)

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -34,6 +34,11 @@ func (r *RequestParameters) AppendData(data []string) {
 	r.data = append(r.data, data...)
 }
 
+// SetStripeAccount sets the value for the `Stripe-Account` header.
+func (r *RequestParameters) SetStripeAccount(value string) {
+	r.stripeAccount = value
+}
+
 // Base encapsulates the required information needed to make requests to the API
 type Base struct {
 	Cmd *cobra.Command


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Add a `--stripe-account` flag to the `trigger` and `fixtures` commands to execute the fixture on a connected account.

Fixes #293.
