### PR TITLE
Update golangci config file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,4 +26,5 @@ issues:
     - path: _test\.go
       linters:
         - dupl
+        - gomnd
   exclude-use-default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,18 +2,35 @@ run:
   tests: true
 
 linters:
-  enable-all: true
-  disable:
-    - errcheck
-    - gochecknoglobals
-    - gochecknoinits
-    - godox
-    - gosec
-    - lll
-    - maligned
-    - unparam
-    - stylecheck
-    - funlen
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - misspell
+    - nakedret
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unused
+    - varcheck
+    - whitespace
 
 linters-settings:
   goimports:
@@ -26,5 +43,4 @@ issues:
     - path: _test\.go
       linters:
         - dupl
-        - gomnd
   exclude-use-default: false

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export GO111MODULE := on
 export GOBIN := $(shell pwd)/bin
 export PATH := $(GOBIN):$(PATH)
 export GOPROXY := https://gocenter.io
-export GOLANGCI_LINT_VERSION := v1.21.0
+export GOLANGCI_LINT_VERSION := v1.23.3
 
 # Install all the build and lint dependencies
 setup:


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform @suz-stripe 

 ### Summary
I wanted to disable `gomnd` but I needed to update the golangci version. While doing that I noticed that `enable-all` is deprecated and going to be remove and the preferred pattern is now to use `disable-all` and opt-in: https://github.com/golangci/golangci-lint#config-file

`make lint` passes right now, hopefully I didn't miss anything big.
