### PR TITLE
Remove a defer statement inside of a loop

### DIFF
--- a/pkg/login/poll.go
+++ b/pkg/login/poll.go
@@ -57,12 +57,12 @@ func PollForKey(pollURL string, interval time.Duration, maxAttempts int) (*PollA
 			return nil, nil, err
 		}
 
-		defer res.Body.Close()
-
 		bodyBytes, err := ioutil.ReadAll(res.Body)
 		if err != nil {
+			res.Body.Close()
 			return nil, nil, err
 		}
+		res.Body.Close()
 
 		if res.StatusCode != http.StatusOK {
 			return nil, nil, fmt.Errorf("unexpected http status code: %d %s", res.StatusCode, string(bodyBytes))


### PR DESCRIPTION
 ### Reviewers
cc @stripe/dev-platform

 ### Summary
I caught this with my [linter](https://github.com/gsquire/dll) while reviewing the code for learning purposes. I know retries may not happen frequently but if they did, they were leaking the previous connection's response body.
