### PR TITLE
add terminal quickstart feature (beta)

### DIFF
--- a/pkg/cmd/resource/terminal.go
+++ b/pkg/cmd/resource/terminal.go
@@ -1,0 +1,31 @@
+package resource
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+// AddTerminalSubCmds adds custom subcommands to the `terminal` command created
+// automatically as a resource command.
+func AddTerminalSubCmds(rootCmd *cobra.Command, cfg *config.Config) error {
+	found := false
+
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "terminal" {
+			found = true
+
+			NewQuickstartCmd(cmd, cfg)
+
+			break
+		}
+	}
+
+	if !found {
+		return errors.New("Could not find terminal command")
+	}
+
+	return nil
+}

--- a/pkg/cmd/resource/terminal_quickstart.go
+++ b/pkg/cmd/resource/terminal_quickstart.go
@@ -1,0 +1,55 @@
+package resource
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/terminal"
+	"github.com/stripe/stripe-cli/pkg/validators"
+	"github.com/stripe/stripe-cli/pkg/version"
+)
+
+// QuickstartCmd starts a prompt flow for connecting a Terminal reader to their Stripe account
+type QuickstartCmd struct {
+	cfg *config.Config
+	cmd *cobra.Command
+}
+
+// NewQuickstartCmd returns a new terminal quickstart command
+func NewQuickstartCmd(parentCmd *cobra.Command, config *config.Config) {
+	quickstartCmd := &QuickstartCmd{
+		cfg: config,
+	}
+
+	quickstartCmd.cmd = &cobra.Command{
+		Use:     "quickstart",
+		Args:    validators.MaximumNArgs(0),
+		Short:   "Set up a Terminal reader and take a test payment",
+		Example: `stripe terminal quickstart`,
+		RunE:    quickstartCmd.runQuickstartCmd,
+	}
+
+	parentCmd.AddCommand(quickstartCmd.cmd)
+}
+
+func (cc *QuickstartCmd) runQuickstartCmd(cmd *cobra.Command, args []string) error {
+	version.CheckLatestVersion()
+
+	readers := terminal.ReaderNames()
+	reader, err := terminal.ReaderTypeSelectPrompt(readers)
+
+	if err != nil {
+		return fmt.Errorf(err.Error())
+	}
+
+	if reader == terminal.ReaderList["verifone-p400"].Name {
+		err = terminal.QuickstartP400(cc.cfg)
+		if err != nil {
+			return fmt.Errorf(err.Error())
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/resource/terminal_quickstart.go
+++ b/pkg/cmd/resource/terminal_quickstart.go
@@ -27,7 +27,7 @@ func NewQuickstartCmd(parentCmd *cobra.Command, config *config.Config) {
 		Use:     "quickstart",
 		Args:    validators.MaximumNArgs(0),
 		Short:   "Set up a Terminal reader and take a test payment",
-		Example: `stripe terminal quickstart`,
+		Example: `stripe terminal quickstart --api-key sk_123`,
 		RunE:    quickstartCmd.runQuickstartCmd,
 	}
 
@@ -36,6 +36,18 @@ func NewQuickstartCmd(parentCmd *cobra.Command, config *config.Config) {
 
 func (cc *QuickstartCmd) runQuickstartCmd(cmd *cobra.Command, args []string) error {
 	version.CheckLatestVersion()
+
+	key, err := cc.cfg.Profile.GetAPIKey(false)
+
+	if err != nil {
+		return fmt.Errorf(err.Error())
+	}
+
+	err = validators.APIKeyNotRestricted(key)
+
+	if err != nil {
+		return fmt.Errorf(err.Error())
+	}
 
 	readers := terminal.ReaderNames()
 	reader, err := terminal.ReaderTypeSelectPrompt(readers)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -116,4 +116,9 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	err = resource.AddTerminalSubCmds(rootCmd, &Config)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -131,7 +131,7 @@ func (p *Profile) GetPublishableKey() string {
 	return ""
 }
 
-// GetTerminalPosDeviceID returns the device id from the config for Terminal quickstart to use
+// GetTerminalPOSDeviceID returns the device id from the config for Terminal quickstart to use
 func (p *Profile) GetTerminalPOSDeviceID() string {
 	if err := viper.ReadInConfig(); err == nil {
 		return viper.GetString(p.GetConfigField("terminal_pos_device_id"))

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -21,6 +21,7 @@ type Profile struct {
 	LiveModePublishableKey string
 	TestModeAPIKey         string
 	TestModePublishableKey string
+	TerminalPosDeviceID    string
 }
 
 // CreateProfile creates a profile when logging in
@@ -125,6 +126,15 @@ func (p *Profile) GetPublishableKey() string {
 		}
 
 		return viper.GetString(p.GetConfigField("test_mode_publishable_key"))
+	}
+
+	return ""
+}
+
+// GetTerminalPosDeviceID returns the device id from the config for Terminal quickstart to use
+func (p *Profile) GetTerminalPosDeviceID() string {
+	if err := viper.ReadInConfig(); err == nil {
+		return viper.GetString(p.GetConfigField("terminal_pos_device_id"))
 	}
 
 	return ""

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -21,7 +21,7 @@ type Profile struct {
 	LiveModePublishableKey string
 	TestModeAPIKey         string
 	TestModePublishableKey string
-	TerminalPosDeviceID    string
+	TerminalPOSDeviceID    string
 }
 
 // CreateProfile creates a profile when logging in
@@ -132,7 +132,7 @@ func (p *Profile) GetPublishableKey() string {
 }
 
 // GetTerminalPosDeviceID returns the device id from the config for Terminal quickstart to use
-func (p *Profile) GetTerminalPosDeviceID() string {
+func (p *Profile) GetTerminalPOSDeviceID() string {
 	if err := viper.ReadInConfig(); err == nil {
 		return viper.GetString(p.GetConfigField("terminal_pos_device_id"))
 	}

--- a/pkg/terminal/p400/diagnostics.go
+++ b/pkg/terminal/p400/diagnostics.go
@@ -1,0 +1,32 @@
+package p400
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptrace"
+)
+
+// Transport is used when we're tracing a Rabbit Service call, in order to surface DNS and connectivity related data / errors
+// it helps provide a more specific / succinct error to the user in order to be more helpful when they run into trouble
+type Transport struct {
+	DNSIPs []net.IPAddr
+	Err    error
+}
+
+// RoundTrip is a hook called from http client tracing to inspect for specific tcp dialing issues when calling Rabbit Service.
+// It allows for a less verbose error than what occurs further down the call stack, and attaches it to the Transport instance
+// It returns the response and any error unmodified in order to continue the completion of the http client's request work
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	res, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		t.Err = err
+	}
+
+	return res, err
+}
+
+// DNSDone is a hook called from http client tracing to extract any DNS service IP resolutions from the tcp dialing of Rabbit Service
+// it attaches this list of resolved IPs to the Transport instance so we can later check if any errors were due to DNS not resolving to a valid IP
+func (t *Transport) DNSDone(info httptrace.DNSDoneInfo) {
+	t.DNSIPs = info.Addrs
+}

--- a/pkg/terminal/p400/rabbit_service.go
+++ b/pkg/terminal/p400/rabbit_service.go
@@ -54,18 +54,23 @@ func encodeRPCContent(rpcContent interface{}) (string, error) {
 func CallRabbitService(tsCtx TerminalSessionContext, method string, methodContent interface{}, methodResponse interface{}, parentTraceID string) error {
 	encodedMethodContent, err := encodeRPCContent(methodContent)
 
-	var result RabbitServiceResponse
-
 	if err != nil {
 		return err
 	}
+
+	var result RabbitServiceResponse
 
 	payload := CreateRabbitServicePayload(method, encodedMethodContent, parentTraceID, tsCtx)
 	formattedIP := strings.Join(strings.Split(tsCtx.IPAddress, "."), "-")
 	t := &Transport{}
 
 	rabbitServiceURL := fmt.Sprintf(readerURL, formattedIP)
-	req, _ := http.NewRequest("POST", rabbitServiceURL, &payload)
+	req, err := http.NewRequest("POST", rabbitServiceURL, &payload)
+
+	if err != nil {
+		return ErrRabbitRequestCreationFailed
+	}
+
 	req.Header.Set("Content-Type", "application/json")
 
 	trace := &httptrace.ClientTrace{

--- a/pkg/terminal/p400/rabbit_service.go
+++ b/pkg/terminal/p400/rabbit_service.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 // RabbitServicePayload represents the JSON shape of all request bodies when calling Rabbit Service
@@ -98,8 +100,8 @@ func CreateRabbitServicePayload(method string, methodContent string, parentTrace
 		SessionToken: tsCtx.SessionToken,
 		RequestType:  "STANDARD",
 		VersionInfo: versionInfo{
-			ClientType:    "JS_SDK",
-			ClientVersion: "1.0.0",
+			ClientType:    "STRIPE_CLI",
+			ClientVersion: version.Version,
 		},
 		ParentTraceID: parentTraceID,
 		DeviceInfo:    tsCtx.DeviceInfo,

--- a/pkg/terminal/p400/rabbit_service.go
+++ b/pkg/terminal/p400/rabbit_service.go
@@ -89,9 +89,8 @@ func CallRabbitService(tsCtx TerminalSessionContext, method string, methodConten
 		return t.Err
 	}
 
+	defer res.Body.Close()
 	json.NewDecoder(res.Body).Decode(&result)
-
-	res.Body.Close()
 
 	if result.Content != "" {
 		decoded, err := base64.StdEncoding.DecodeString(result.Content)

--- a/pkg/terminal/p400/rabbit_service.go
+++ b/pkg/terminal/p400/rabbit_service.go
@@ -1,0 +1,114 @@
+package p400
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// RabbitServicePayload represents the JSON shape of all request bodies when calling Rabbit Service
+type RabbitServicePayload struct {
+	ID            int         `json:"id"`
+	Service       string      `json:"service"`
+	Method        string      `json:"method"`
+	Content       string      `json:"content"`
+	SessionToken  string      `json:"session_token"`
+	RequestType   string      `json:"request_type"`
+	VersionInfo   versionInfo `json:"version_info"`
+	ParentTraceID string      `json:"parent_trace_id"`
+	DeviceInfo    DeviceInfo  `json:"device_info"`
+}
+
+// RabbitServiceResponse is the response body from the Rabbit Service call
+type RabbitServiceResponse struct {
+	Content string `json:"content"`
+}
+
+type versionInfo struct {
+	ClientType    string `json:"client_type"`
+	ClientVersion string `json:"client_version"`
+}
+
+func encodeRPCContent(rpcContent interface{}) (string, error) {
+	jsonContent, err := json.Marshal(rpcContent)
+
+	if err != nil {
+		return "", err
+	}
+
+	contentBytes := []byte(string(jsonContent))
+	encodedContent := base64.StdEncoding.EncodeToString(contentBytes)
+
+	return encodedContent, nil
+}
+
+// CallRabbitService takes a TerminalSessionContext and method information and calls that Rabbit Service RPC method
+func CallRabbitService(tsCtx TerminalSessionContext, method string, methodContent interface{}, methodResponse interface{}, parentTraceID string) error {
+	encodedMethodContent, err := encodeRPCContent(methodContent)
+
+	var result RabbitServiceResponse
+
+	if err != nil {
+		return err
+	}
+
+	payload := CreateRabbitServicePayload(method, encodedMethodContent, parentTraceID, tsCtx)
+	formattedIP := strings.Join(strings.Split(tsCtx.IPAddress, "."), "-")
+
+	rabbitServiceURL := fmt.Sprintf(readerURL, formattedIP)
+	res, err := http.Post(rabbitServiceURL, "application/json", &payload)
+
+	if err != nil {
+		return err
+	}
+
+	json.NewDecoder(res.Body).Decode(&result)
+
+	res.Body.Close()
+
+	if result.Content != "" {
+		decoded, err := base64.StdEncoding.DecodeString(result.Content)
+
+		if err != nil {
+			return err
+		}
+
+		json.Unmarshal(decoded, methodResponse)
+	} else {
+		return errors.New("could not decode Rabbit Service response - no content")
+	}
+
+	return nil
+}
+
+// CreateRabbitServicePayload serializes the required information into a JSON payload used in calls to RabbitService
+func CreateRabbitServicePayload(method string, methodContent string, parentTraceID string, tsCtx TerminalSessionContext) bytes.Buffer {
+	sec := time.Now().Unix() * 1000
+
+	payload := &RabbitServicePayload{
+		ID:           int(sec),
+		Service:      "JackRabbitService",
+		Method:       method,
+		Content:      methodContent,
+		SessionToken: tsCtx.SessionToken,
+		RequestType:  "STANDARD",
+		VersionInfo: versionInfo{
+			ClientType:    "JS_SDK",
+			ClientVersion: "1.0.0",
+		},
+		ParentTraceID: parentTraceID,
+		DeviceInfo:    tsCtx.DeviceInfo,
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.Encode(payload)
+
+	return buf
+}

--- a/pkg/terminal/p400/rabbit_service_test.go
+++ b/pkg/terminal/p400/rabbit_service_test.go
@@ -12,9 +12,9 @@ func TestCreateRabbitServicePayload(t *testing.T) {
 		DeviceInfo: DeviceInfo{
 			DeviceClass:   "POS",
 			DeviceUUID:    "pos-1234",
-			HostOsVersion: "Mac OS",
+			HostOSVersion: "Mac OS",
 			HardwareModel: HardwareModel{
-				PosInfo: PosInfo{
+				POSInfo: POSInfo{
 					Description: "Mac OS:StripeCLI",
 				},
 			},

--- a/pkg/terminal/p400/rabbit_service_test.go
+++ b/pkg/terminal/p400/rabbit_service_test.go
@@ -1,0 +1,30 @@
+package p400
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateRabbitServicePayload(t *testing.T) {
+	tsCtx := TerminalSessionContext{
+		APIKey: "sk_123",
+		DeviceInfo: DeviceInfo{
+			DeviceClass:   "POS",
+			DeviceUUID:    "pos-1234",
+			HostOsVersion: "Mac OS",
+			HardwareModel: HardwareModel{
+				PosInfo: PosInfo{
+					Description: "Mac OS:StripeCLI",
+				},
+			},
+			AppModel: AppModel{
+				AppID:      "Stripe-CLI-Terminal-Quickstart",
+				AppVersion: "https://stripe.com/docs/stripe-cli",
+			},
+		},
+	}
+
+	payload := CreateRabbitServicePayload("clearReaderDisplay", "base64string=", "txn>23456", tsCtx)
+	require.NotEmpty(t, payload)
+}

--- a/pkg/terminal/p400/reader_constants.go
+++ b/pkg/terminal/p400/reader_constants.go
@@ -1,0 +1,11 @@
+package p400
+
+var (
+	readerURL                          = "https://%v.device.stripe-terminal-local-reader.net:4443/protojsonservice/JackRabbitService"
+	stripeTerminalReadersPath          = "/v1/terminal/readers?device_type=verifone_P400"
+	rpcSessionPath                     = "/v1/terminal/connection_tokens/generate_pos_rpc_session"
+	stripeTerminalConnectionTokensPath = "/v1/terminal/connection_tokens"
+	stripeTerminalRegisterPath         = "/v1/terminal/readers"
+	stripeCreatePaymentIntentPath      = "/v1/payment_intents"
+	stripeCapturePaymentIntentPath     = "/v1/payment_intents/%v/capture"
+)

--- a/pkg/terminal/p400/reader_errors.go
+++ b/pkg/terminal/p400/reader_errors.go
@@ -6,9 +6,9 @@ import (
 
 var (
 	// ErrActivateReaderFailed is for when a new RPC session could not be created for the reader
-	ErrActivateReaderFailed = errors.New("could not activate reader session")
+	ErrActivateReaderFailed = errors.New("Could not communicate with the Reader. Please make sure your reader is online and on the same network as your device.\nSee our troubleshooting docs here: https://stripe.com/docs/terminal/readers/verifone-p400#troubleshooting")
 	// ErrRegisterReaderFailed is for when adding the reader via the Stripe API could not be completed (likely bad reg code)
-	ErrRegisterReaderFailed = errors.New("could not register reader due to an invalid reader code")
+	ErrRegisterReaderFailed = errors.New("could not register the Reader due to an invalid reader code")
 	// ErrReaderSelectionFailed is for when the user quit the CLI at the reader choice prompt
 	ErrReaderSelectionFailed = errors.New("reader choice failed, no selection made")
 	// ErrDiscoverReadersFailed is for when the call to Stripe failed for listing the readers registered to user's account
@@ -24,9 +24,9 @@ var (
 	// ErrCapturePaymentIntentFailed is for when you need to manually collect the Payment Intent after a Payment Method is attached and it failed
 	ErrCapturePaymentIntentFailed = errors.New("could not capture the Payment Intent")
 	// ErrSetReaderDisplayFailed is for when the Rabbit call to update the reader display didn't work as planned
-	ErrSetReaderDisplayFailed = errors.New("could not set the reader's display")
+	ErrSetReaderDisplayFailed = errors.New("could not set the Reader's display")
 	// ErrClearReaderDisplayFailed is for when you're canceling a payment collection and need to reset the display back to default splash but it failed
-	ErrClearReaderDisplayFailed = errors.New("could not clear the reader's display")
+	ErrClearReaderDisplayFailed = errors.New("could not clear the Reader's display")
 	// ErrCollectPaymentFailed is for when the Rabbit call for the reader to go into collect payment state failed
 	ErrCollectPaymentFailed = errors.New("could not collect payment method")
 	// ErrCollectPaymentTimeout is for when the user didn't boop the card on the reader in a reasonable time
@@ -35,4 +35,6 @@ var (
 	ErrConfirmPaymentFailed = errors.New("could not confirm the payment")
 	// ErrQueryPaymentFailed is for when you're polling Rabbit to see if the user has booped their card on the reader yet but something went wrong
 	ErrQueryPaymentFailed = errors.New("could not query the payment")
+	// ErrDNSFailed is for when a reader's address could not be resolved by DNS while attempting to contact it via Rabbit Service
+	ErrDNSFailed = errors.New("Couldn't find your reader on the network. We think it's probably a DNS issue.\n See our troubleshooting docs here: https://stripe.com/docs/terminal/readers/verifone-p400#troubleshooting")
 )

--- a/pkg/terminal/p400/reader_errors.go
+++ b/pkg/terminal/p400/reader_errors.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// ErrActivateReaderFailed is for when a new RPC session could not be created for the reader
-	ErrActivateReaderFailed = errors.New("Could not communicate with the Reader. Please make sure your reader is online and on the same network as your device.\nSee our troubleshooting docs here: https://stripe.com/docs/terminal/readers/verifone-p400#troubleshooting")
+	ErrActivateReaderFailed = errors.New("couldn't communicate with the Reader. Please make sure your reader is online and on the same network as your device.\nSee our troubleshooting docs here: https://stripe.com/docs/terminal/readers/verifone-p400#troubleshooting")
 	// ErrRegisterReaderFailed is for when adding the reader via the Stripe API could not be completed (likely bad reg code)
 	ErrRegisterReaderFailed = errors.New("could not register the Reader due to an invalid reader code")
 	// ErrReaderSelectionFailed is for when the user quit the CLI at the reader choice prompt
@@ -20,7 +20,7 @@ var (
 	// ErrNewRPCSessionFailed is for when a new RPC Session (via the Stripe API not Rabbit) could not be created
 	ErrNewRPCSessionFailed = errors.New("could not create new Terminal session")
 	// ErrNewPaymentIntentFailed is for when calling Stripe for a new shiny Payment Intent failed
-	ErrNewPaymentIntentFailed = errors.New("Could not create new Payment Intent")
+	ErrNewPaymentIntentFailed = errors.New("could not create new Payment Intent")
 	// ErrCapturePaymentIntentFailed is for when you need to manually collect the Payment Intent after a Payment Method is attached and it failed
 	ErrCapturePaymentIntentFailed = errors.New("could not capture the Payment Intent")
 	// ErrSetReaderDisplayFailed is for when the Rabbit call to update the reader display didn't work as planned
@@ -36,5 +36,7 @@ var (
 	// ErrQueryPaymentFailed is for when you're polling Rabbit to see if the user has booped their card on the reader yet but something went wrong
 	ErrQueryPaymentFailed = errors.New("could not query the payment")
 	// ErrDNSFailed is for when a reader's address could not be resolved by DNS while attempting to contact it via Rabbit Service
-	ErrDNSFailed = errors.New("Couldn't find your reader on the network. We think it's probably a DNS issue.\n See our troubleshooting docs here: https://stripe.com/docs/terminal/readers/verifone-p400#troubleshooting")
+	ErrDNSFailed = errors.New("couldn't find your reader on the network. We think it's probably a DNS issue.\n See our troubleshooting docs here: https://stripe.com/docs/terminal/readers/verifone-p400#troubleshooting")
+	// ErrRabbitRequestCreationFailed is for when a Rabbit Service request is being rolled and the first stage of setting it up with the http client instance fails
+	ErrRabbitRequestCreationFailed = errors.New("could not prepare request for Reader")
 )

--- a/pkg/terminal/p400/reader_errors.go
+++ b/pkg/terminal/p400/reader_errors.go
@@ -1,0 +1,38 @@
+package p400
+
+import (
+	"errors"
+)
+
+var (
+	// ErrActivateReaderFailed is for when a new RPC session could not be created for the reader
+	ErrActivateReaderFailed = errors.New("could not activate reader session")
+	// ErrRegisterReaderFailed is for when adding the reader via the Stripe API could not be completed (likely bad reg code)
+	ErrRegisterReaderFailed = errors.New("could not register reader due to an invalid reader code")
+	// ErrReaderSelectionFailed is for when the user quit the CLI at the reader choice prompt
+	ErrReaderSelectionFailed = errors.New("reader choice failed, no selection made")
+	// ErrDiscoverReadersFailed is for when the call to Stripe failed for listing the readers registered to user's account
+	ErrDiscoverReadersFailed = errors.New("reader discovery was unable to list readers")
+	// ErrNoReadersRegistered is for when a user has elected to use a registered reader but the list for their account returns empty
+	ErrNoReadersRegistered = errors.New("no readers currently registered")
+	// ErrConnectionTokenFailed is for when the call to Stripe for a new Terminal connection token went wonky
+	ErrConnectionTokenFailed = errors.New("could not create new connection token")
+	// ErrNewRPCSessionFailed is for when a new RPC Session (via the Stripe API not Rabbit) could not be created
+	ErrNewRPCSessionFailed = errors.New("could not create new Terminal session")
+	// ErrNewPaymentIntentFailed is for when calling Stripe for a new shiny Payment Intent failed
+	ErrNewPaymentIntentFailed = errors.New("Could not create new Payment Intent")
+	// ErrCapturePaymentIntentFailed is for when you need to manually collect the Payment Intent after a Payment Method is attached and it failed
+	ErrCapturePaymentIntentFailed = errors.New("could not capture the Payment Intent")
+	// ErrSetReaderDisplayFailed is for when the Rabbit call to update the reader display didn't work as planned
+	ErrSetReaderDisplayFailed = errors.New("could not set the reader's display")
+	// ErrClearReaderDisplayFailed is for when you're canceling a payment collection and need to reset the display back to default splash but it failed
+	ErrClearReaderDisplayFailed = errors.New("could not clear the reader's display")
+	// ErrCollectPaymentFailed is for when the Rabbit call for the reader to go into collect payment state failed
+	ErrCollectPaymentFailed = errors.New("could not collect payment method")
+	// ErrCollectPaymentTimeout is for when the user didn't boop the card on the reader in a reasonable time
+	ErrCollectPaymentTimeout = errors.New("timed out waiting for payment to be presented")
+	// ErrConfirmPaymentFailed is for when the Rabbit call to confirm the payment method collected has failed
+	ErrConfirmPaymentFailed = errors.New("could not confirm the payment")
+	// ErrQueryPaymentFailed is for when you're polling Rabbit to see if the user has booped their card on the reader yet but something went wrong
+	ErrQueryPaymentFailed = errors.New("could not query the payment")
+)

--- a/pkg/terminal/p400/reader_errors.go
+++ b/pkg/terminal/p400/reader_errors.go
@@ -39,4 +39,8 @@ var (
 	ErrDNSFailed = errors.New("couldn't find your reader on the network. We think it's probably a DNS issue.\n See our troubleshooting docs here: https://stripe.com/docs/terminal/readers/verifone-p400#troubleshooting")
 	// ErrRabbitRequestCreationFailed is for when a Rabbit Service request is being rolled and the first stage of setting it up with the http client instance fails
 	ErrRabbitRequestCreationFailed = errors.New("could not prepare request for Reader")
+	// ErrStripeForbiddenResponse is for when a Stripe API call fails due to Terminal resource calls not supporting restricted keys
+	ErrStripeForbiddenResponse = errors.New("it seems that your Stripe API Key is either restricted or out of date. Are you using a valid Stripe Secret Key with the --api-key global flag for this command?")
+	// ErrStripeGenericResponse is for when any non status code happens for a Stripe call that isn't a 200 or a 403. This should be exceedingly rare (famous last words)
+	ErrStripeGenericResponse = errors.New("could not connect to Stripe, perhaps try again?")
 )

--- a/pkg/terminal/p400/reader_methods.go
+++ b/pkg/terminal/p400/reader_methods.go
@@ -239,7 +239,7 @@ func ActivateTerminalRPCSession(tsCtx TerminalSessionContext) (string, error) {
 		POSDeviceID:        tsCtx.DeviceInfo.DeviceUUID,
 		POSSoftwareInfo: POSSoftwareInfo{
 			POSType:    "pos-cli",
-			SdkVersion: "1.0.0",
+			SdkVersion: version.Version,
 		},
 	}
 

--- a/pkg/terminal/p400/reader_methods.go
+++ b/pkg/terminal/p400/reader_methods.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 // TerminalSessionContext is a type that contains important context most methods need to know to complete the quickstart flow
@@ -248,6 +250,10 @@ func ActivateTerminalRPCSession(tsCtx TerminalSessionContext) (string, error) {
 	err := CallRabbitService(tsCtx, rabbitMethods[activateTerminal], activateTermContent, &readerActivateResponse, activateTraceID)
 
 	if err != nil {
+		if err.Error() == ErrDNSFailed.Error() {
+			return "", err
+		}
+
 		return "", ErrActivateReaderFailed
 	}
 

--- a/pkg/terminal/p400/reader_methods.go
+++ b/pkg/terminal/p400/reader_methods.go
@@ -1,0 +1,391 @@
+package p400
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+	"strconv"
+	"time"
+)
+
+// TerminalSessionContext is a type that contains important context most methods need to know to complete the quickstart flow
+// one copy of this is passed around a lot and is mutable for whenever a property needs to change
+type TerminalSessionContext struct {
+	APIKey             string
+	IPAddress          string
+	LocationID         string
+	PstToken           string
+	SessionToken       string
+	TransactionID      int
+	MethodID           int
+	TransactionContext TransactionContext
+	DeviceInfo         DeviceInfo
+	PaymentIntentID    string
+	Amount             int
+	Currency           string
+}
+
+// DeviceInfo belongs to the Rabbit Service RPC call payload shape
+type DeviceInfo struct {
+	DeviceClass   string        `json:"device_class"`
+	DeviceUUID    string        `json:"device_uuid"`
+	HostOsVersion string        `json:"host_os_version"`
+	HardwareModel HardwareModel `json:"hardware_model"`
+	AppModel      AppModel      `json:"app_model"`
+}
+
+// HardwareModel belongs to the Rabbit Service RPC call payload shape
+type HardwareModel struct {
+	PosInfo PosInfo `json:"pos_info"`
+}
+
+// AppModel belongs to the Rabbit Service RPC call payload shape
+type AppModel struct {
+	AppID      string `json:"app_id"`
+	AppVersion string `json:"app_version"`
+}
+
+// PosInfo belongs to the Rabbit Service RPC call payload shape
+type PosInfo struct {
+	Description string `json:"description"`
+}
+
+// PosSoftwareInfo belongs to the Rabbit Service RPC call payload shape
+type PosSoftwareInfo struct {
+	PosType    string `json:"pos_type"`
+	SdkVersion string `json:"sdk_version"`
+}
+
+// PaymentMethod exists only so that you can pass a pointer reference of it to generate an actual empty payment method object when using JSON serialization and have it not be serialized as null
+type PaymentMethod struct {
+}
+
+// ReaderActivateContent represents the shape of the serialized protobuf sent to Rabbit Service for activating a terminal session
+type ReaderActivateContent struct {
+	PosActivationToken string          `json:"pos_activation_token"`
+	StoreName          string          `json:"store_name"`
+	PosDeviceID        string          `json:"pos_device_id"`
+	PosSoftwareInfo    PosSoftwareInfo `json:"pos_software_info"`
+}
+
+// ReaderActivateResponse is the RPC response from calling the activateTerminal method
+type ReaderActivateResponse struct {
+	SessionToken string `json:"session_token"`
+}
+
+// LineItem belongs to the Cart protobuf shape for updating the reader display via Rabbit Service
+type LineItem struct {
+	Description string `json:"description"`
+	Amount      int    `json:"amount"`
+	Quantity    int    `json:"quantity"`
+}
+
+// Cart belongs to the ReaderDisplayContent protobuf sent to Rabbit Service that updates the reader display
+type Cart struct {
+	LineItems []LineItem `json:"line_items"`
+	Tax       int        `json:"tax"`
+	Total     int        `json:"total"`
+	Currency  string     `json:"currency"`
+}
+
+// ReaderDisplayContent represents the shape of the serialized protobuf sent to Rabbit Service for updating the reader display
+type ReaderDisplayContent struct {
+	Type               string             `json:"type"`
+	Cart               Cart               `json:"cart"`
+	TransactionContext TransactionContext `json:"transaction_context"`
+}
+
+// ReaderDisplayClearContent represents the shape of the serialized protobuf sent to Rabbit Service for clearing the reader display
+type ReaderDisplayClearContent struct {
+	TransactionContext TransactionContext `json:"transaction_context"`
+}
+
+// ChargeAmount belongs to the ReaderCollectPaymentContent protobuf send to Rabbit Service for collecting a specific payment after the Payment Intent is created
+type ChargeAmount struct {
+	ChargeAmount   int    `json:"charge_amount"`
+	Currency       string `json:"currency"`
+	TipAmount      int    `json:"tip_amount"`
+	CashbackAmount int    `json:"cashback_amount"`
+}
+
+// ReaderCollectPaymentContent represents the shape of the serialized protobuf sent to Rabbit Service for collecting a payment for a specific Payment Intent
+type ReaderCollectPaymentContent struct {
+	ChargeAmount       ChargeAmount       `json:"charge_amount"`
+	TransactionContext TransactionContext `json:"transaction_context"`
+}
+
+// ReaderQueryPaymentContent represents the shape of the serialized protobuf sent to Rabbit Service for querying a payment for its collection state
+type ReaderQueryPaymentContent struct {
+	TransactionContext TransactionContext `json:"transaction_context"`
+}
+
+// ReaderQueryPaymentResponse is the decoded RPC response from calling the queryPaymentMethod reader method
+type ReaderQueryPaymentResponse struct {
+	PaymentMethod interface{} `json:"payment_method"`
+	PaymentStatus string      `json:"payment_status"`
+}
+
+// ReaderConfirmPaymentContent represents the shape of the serialized protobuf sent to Rabbit Service for confirming a payment after it is collectedf
+type ReaderConfirmPaymentContent struct {
+	PaymentIntentID    string             `json:"payment_intent_id"`
+	PaymentMethod      interface{}        `json:"payment_method"`
+	TransactionContext TransactionContext `json:"transaction_context"`
+}
+
+// ReaderConfirmPaymentResponse is the decoded RPC response from calling the processPayment reader method
+type ReaderConfirmPaymentResponse struct {
+	SystemContext          interface{}            `json:"system_context"`
+	RequestID              string                 `json:"request_id"`
+	ConfirmedPaymentIntent ConfirmedPaymentIntent `json:"confirmed_payment_intent"`
+}
+
+// ConfirmedPaymentIntent belongs to ReaderConfirmPaymentResponse
+type ConfirmedPaymentIntent struct {
+	PaymentMethod string `json:"payment_method"`
+}
+
+// TransactionContext belongs to each Rabbit Service protobuf payload and communicates the state and identity of the current transaction
+type TransactionContext struct {
+	TerminalID    string `json:"terminal_id"`
+	StartTime     int64  `json:"start_time"`
+	OperatorID    string `json:"operator_id"`
+	TransactionID string `json:"transaction_id"`
+}
+
+var rabbitMethods = []string{
+	"activateTerminal",
+	"setReaderDisplay",
+	"clearReaderDisplay",
+	"collectPaymentMethod",
+	"queryPaymentMethod",
+	"confirmPayment",
+}
+
+const (
+	activateTerminal = iota
+	setReaderDisplay
+	clearReaderDisplay
+	collectPaymentMethod
+	queryPaymentMethod
+	confirmPayment
+)
+
+// SetParentTraceID creates a string in a specific format for other methods to use for communicating which transaction a Rabbit Service call is concerning
+// it returns the created trace id string
+func SetParentTraceID(transactionID int, methodID int, methodName string) string {
+	return fmt.Sprintf("txn!%v>%s!%v", transactionID, methodName, methodID)
+}
+
+// GetOsString finds which operating system the user is running and creates the correct string name for it to report to Rabbit Service when making a call
+// this is mostly used by the TransactionContext properties
+func GetOsString() string {
+	var osString string
+
+	switch plat := runtime.GOOS; plat {
+	case "darwin":
+		osString = "Mac OS"
+	case "linux":
+		osString = "Linux"
+	case "windows":
+		osString = "Windows"
+	default:
+		osString = "Unknown"
+	}
+
+	return osString
+}
+
+// GeneratePosDeviceID creates a pseudorandom alpha string id for a point-of-sale quasi-unique identifier
+// mostly used for TransactionContext related tracking / tracing and is semi-persistent to a machine but not determinant
+func GeneratePosDeviceID(seed int64) string {
+	rand.Seed(seed)
+
+	idLength := 11
+	bytes := make([]byte, idLength)
+
+	for i := 0; i < idLength; i++ {
+		// pulling from ascii table a-z (97-122)
+		bytes[i] = byte(97 + rand.Intn(122-97))
+	}
+
+	id := fmt.Sprintf("pos-%v", string(bytes))
+
+	return id
+}
+
+// SetTransactionContext creates a new transaction context with a baked in start time and unique id
+func SetTransactionContext(tsCtx TerminalSessionContext) TransactionContext {
+	startTime := time.Now().Unix() * 1000
+	transactionID := int(rand.Float64() * 100000)
+
+	transactionContext := TransactionContext{
+		TerminalID:    tsCtx.DeviceInfo.DeviceUUID,
+		OperatorID:    tsCtx.DeviceInfo.DeviceUUID,
+		StartTime:     startTime,
+		TransactionID: strconv.Itoa(transactionID),
+	}
+
+	return transactionContext
+}
+
+// ActivateTerminalRPCSession calls Rabbit Service for a new reader session and returns the resulting session token
+func ActivateTerminalRPCSession(tsCtx TerminalSessionContext) (string, error) {
+	methodID := int(rand.Float64() * 100000)
+	activateTraceID := fmt.Sprintf("connectReader!%v", methodID)
+
+	activateTermContent := &ReaderActivateContent{
+		PosActivationToken: tsCtx.PstToken,
+		StoreName:          "empty",
+		PosDeviceID:        tsCtx.DeviceInfo.DeviceUUID,
+		PosSoftwareInfo: PosSoftwareInfo{
+			PosType:    "pos-cli",
+			SdkVersion: "1.0.0",
+		},
+	}
+
+	var readerActivateResponse ReaderActivateResponse
+
+	err := CallRabbitService(tsCtx, rabbitMethods[activateTerminal], activateTermContent, &readerActivateResponse, activateTraceID)
+
+	if err != nil {
+		return "", ErrActivateReaderFailed
+	}
+
+	newSessionToken := readerActivateResponse.SessionToken
+
+	return newSessionToken, nil
+}
+
+// SetReaderDisplay calls Rabbit Service to set a cart's contents on the reader display
+func SetReaderDisplay(tsCtx TerminalSessionContext, parentTraceID string) error {
+	setReaderDisplayContent := &ReaderDisplayContent{
+		Type: "cart",
+		Cart: Cart{
+			LineItems: []LineItem{{
+				Description: "Stripe CLI Test Payment",
+				Amount:      tsCtx.Amount,
+				Quantity:    1,
+			}},
+			Tax:      0,
+			Total:    tsCtx.Amount,
+			Currency: tsCtx.Currency,
+		},
+		TransactionContext: tsCtx.TransactionContext,
+	}
+
+	var setReaderDisplayResponse interface{}
+
+	err := CallRabbitService(tsCtx, rabbitMethods[setReaderDisplay], setReaderDisplayContent, &setReaderDisplayResponse, parentTraceID)
+
+	if err != nil {
+		return ErrSetReaderDisplayFailed
+	}
+
+	return nil
+}
+
+// CollectPaymentMethod calls Rabbit Service to put reader in payment collection state
+func CollectPaymentMethod(tsCtx TerminalSessionContext, parentTraceID string) error {
+	collectPaymentMethodContent := &ReaderCollectPaymentContent{
+		ChargeAmount: ChargeAmount{
+			ChargeAmount:   tsCtx.Amount,
+			Currency:       tsCtx.Currency,
+			CashbackAmount: 0,
+			TipAmount:      0,
+		},
+		TransactionContext: tsCtx.TransactionContext,
+	}
+
+	var collectPaymentResponse interface{}
+	err := CallRabbitService(tsCtx, rabbitMethods[collectPaymentMethod], collectPaymentMethodContent, &collectPaymentResponse, parentTraceID)
+
+	if err != nil {
+		return ErrCollectPaymentFailed
+	}
+
+	return nil
+}
+
+// ConfirmPayment calls Rabbit Service to confirm the payment that it collected, using Payment Intent and Payment Method to do so
+func ConfirmPayment(tsCtx TerminalSessionContext, paymentMethod interface{}, parentTraceID string) (string, error) {
+	confirmPaymentContent := &ReaderConfirmPaymentContent{
+		PaymentIntentID:    tsCtx.PaymentIntentID,
+		PaymentMethod:      &PaymentMethod{},
+		TransactionContext: tsCtx.TransactionContext,
+	}
+
+	var confirmPaymentResponse ReaderConfirmPaymentResponse
+	err := CallRabbitService(tsCtx, rabbitMethods[confirmPayment], confirmPaymentContent, &confirmPaymentResponse, parentTraceID)
+
+	if err != nil {
+		return "", ErrConfirmPaymentFailed
+	}
+
+	paymentMethodID := confirmPaymentResponse.ConfirmedPaymentIntent.PaymentMethod
+
+	return paymentMethodID, nil
+}
+
+// WaitForPaymentCollection is a recursive function that calls Rabbit Service to query the status of the payment that is waiting to be collected (ie. user booping card on the reader)
+// it exits if it either errors querying the payment, or the payment is successfully collected
+// it additionally times out with an error after querying for around 60 seconds
+// returns the payment method collected by the reader
+func WaitForPaymentCollection(tsCtx TerminalSessionContext, parentTraceID string, tries int) (interface{}, error) {
+	queryResult, err := QueryPaymentMethod(tsCtx, parentTraceID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if queryResult.PaymentStatus == "PAYMENT_PENDING" {
+		tries++
+		// below timeout is roughly 60 seconds
+		if tries > 120 {
+			err := ErrCollectPaymentTimeout
+			return nil, err
+		}
+	} else if queryResult.PaymentMethod != nil {
+		// payment method successfully collected
+		return queryResult.PaymentMethod, nil
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	return WaitForPaymentCollection(tsCtx, parentTraceID, tries)
+}
+
+// QueryPaymentMethod calls Rabbit Service to query the status of a payment currently being collected
+func QueryPaymentMethod(tsCtx TerminalSessionContext, parentTraceID string) (ReaderQueryPaymentResponse, error) {
+	queryPaymentMethodContent := &ReaderQueryPaymentContent{
+		TransactionContext: tsCtx.TransactionContext,
+	}
+
+	var queryPaymentResponse ReaderQueryPaymentResponse
+
+	err := CallRabbitService(tsCtx, rabbitMethods[queryPaymentMethod], queryPaymentMethodContent, &queryPaymentResponse, parentTraceID)
+
+	if err != nil {
+		return queryPaymentResponse, ErrQueryPaymentFailed
+	}
+
+	return queryPaymentResponse, nil
+}
+
+// ClearReaderDisplay calls Rabbit Service and sets the reader display back to the splash screen and ends any payment collection status
+func ClearReaderDisplay(tsCtx TerminalSessionContext) error {
+	parentTraceID := SetParentTraceID(tsCtx.TransactionID, tsCtx.MethodID, "disconnectReader")
+
+	clearReaderDisplayContent := &ReaderDisplayClearContent{
+		TransactionContext: tsCtx.TransactionContext,
+	}
+
+	var clearReaderDisplayResponse interface{}
+
+	err := CallRabbitService(tsCtx, rabbitMethods[clearReaderDisplay], clearReaderDisplayContent, &clearReaderDisplayResponse, parentTraceID)
+
+	if err != nil {
+		return ErrClearReaderDisplayFailed
+	}
+
+	return nil
+}

--- a/pkg/terminal/p400/reader_methods.go
+++ b/pkg/terminal/p400/reader_methods.go
@@ -50,8 +50,8 @@ type POSInfo struct {
 	Description string `json:"description"`
 }
 
-// PosSoftwareInfo belongs to the Rabbit Service RPC call payload shape
-type PosSoftwareInfo struct {
+// POSSoftwareInfo belongs to the Rabbit Service RPC call payload shape
+type POSSoftwareInfo struct {
 	POSType    string `json:"pos_type"`
 	SdkVersion string `json:"sdk_version"`
 }
@@ -65,7 +65,7 @@ type ReaderActivateContent struct {
 	POSActivationToken string          `json:"pos_activation_token"`
 	StoreName          string          `json:"store_name"`
 	POSDeviceID        string          `json:"pos_device_id"`
-	POSSoftwareInfo    PosSoftwareInfo `json:"pos_software_info"`
+	POSSoftwareInfo    POSSoftwareInfo `json:"pos_software_info"`
 }
 
 // ReaderActivateResponse is the RPC response from calling the activateTerminal method
@@ -237,7 +237,7 @@ func ActivateTerminalRPCSession(tsCtx TerminalSessionContext) (string, error) {
 		POSActivationToken: tsCtx.PstToken,
 		StoreName:          "empty",
 		POSDeviceID:        tsCtx.DeviceInfo.DeviceUUID,
-		POSSoftwareInfo: PosSoftwareInfo{
+		POSSoftwareInfo: POSSoftwareInfo{
 			POSType:    "pos-cli",
 			SdkVersion: "1.0.0",
 		},

--- a/pkg/terminal/p400/reader_methods.go
+++ b/pkg/terminal/p400/reader_methods.go
@@ -45,7 +45,7 @@ type AppModel struct {
 	AppVersion string `json:"app_version"`
 }
 
-// PosInfo belongs to the Rabbit Service RPC call payload shape
+// POSInfo belongs to the Rabbit Service RPC call payload shape
 type POSInfo struct {
 	Description string `json:"description"`
 }
@@ -176,7 +176,7 @@ func SetParentTraceID(transactionID int, methodID int, methodName string) string
 	return fmt.Sprintf("txn!%v>%s!%v", transactionID, methodName, methodID)
 }
 
-// GetOsString finds which operating system the user is running and creates the correct string name for it to report to Rabbit Service when making a call
+// GetOSString finds which operating system the user is running and creates the correct string name for it to report to Rabbit Service when making a call
 // this is mostly used by the TransactionContext properties
 func GetOSString() string {
 	var osString string
@@ -195,7 +195,7 @@ func GetOSString() string {
 	return osString
 }
 
-// GeneratePosDeviceID creates a pseudorandom alpha string id for a point-of-sale quasi-unique identifier
+// GeneratePOSDeviceID creates a pseudorandom alpha string id for a point-of-sale quasi-unique identifier
 // mostly used for TransactionContext related tracking / tracing and is semi-persistent to a machine but not determinant
 func GeneratePOSDeviceID(seed int64) string {
 	rand.Seed(seed)

--- a/pkg/terminal/p400/reader_methods.go
+++ b/pkg/terminal/p400/reader_methods.go
@@ -29,14 +29,14 @@ type TerminalSessionContext struct {
 type DeviceInfo struct {
 	DeviceClass   string        `json:"device_class"`
 	DeviceUUID    string        `json:"device_uuid"`
-	HostOsVersion string        `json:"host_os_version"`
+	HostOSVersion string        `json:"host_os_version"`
 	HardwareModel HardwareModel `json:"hardware_model"`
 	AppModel      AppModel      `json:"app_model"`
 }
 
 // HardwareModel belongs to the Rabbit Service RPC call payload shape
 type HardwareModel struct {
-	PosInfo PosInfo `json:"pos_info"`
+	POSInfo POSInfo `json:"pos_info"`
 }
 
 // AppModel belongs to the Rabbit Service RPC call payload shape
@@ -46,13 +46,13 @@ type AppModel struct {
 }
 
 // PosInfo belongs to the Rabbit Service RPC call payload shape
-type PosInfo struct {
+type POSInfo struct {
 	Description string `json:"description"`
 }
 
 // PosSoftwareInfo belongs to the Rabbit Service RPC call payload shape
 type PosSoftwareInfo struct {
-	PosType    string `json:"pos_type"`
+	POSType    string `json:"pos_type"`
 	SdkVersion string `json:"sdk_version"`
 }
 
@@ -62,10 +62,10 @@ type PaymentMethod struct {
 
 // ReaderActivateContent represents the shape of the serialized protobuf sent to Rabbit Service for activating a terminal session
 type ReaderActivateContent struct {
-	PosActivationToken string          `json:"pos_activation_token"`
+	POSActivationToken string          `json:"pos_activation_token"`
 	StoreName          string          `json:"store_name"`
-	PosDeviceID        string          `json:"pos_device_id"`
-	PosSoftwareInfo    PosSoftwareInfo `json:"pos_software_info"`
+	POSDeviceID        string          `json:"pos_device_id"`
+	POSSoftwareInfo    PosSoftwareInfo `json:"pos_software_info"`
 }
 
 // ReaderActivateResponse is the RPC response from calling the activateTerminal method
@@ -178,7 +178,7 @@ func SetParentTraceID(transactionID int, methodID int, methodName string) string
 
 // GetOsString finds which operating system the user is running and creates the correct string name for it to report to Rabbit Service when making a call
 // this is mostly used by the TransactionContext properties
-func GetOsString() string {
+func GetOSString() string {
 	var osString string
 
 	switch plat := runtime.GOOS; plat {
@@ -197,7 +197,7 @@ func GetOsString() string {
 
 // GeneratePosDeviceID creates a pseudorandom alpha string id for a point-of-sale quasi-unique identifier
 // mostly used for TransactionContext related tracking / tracing and is semi-persistent to a machine but not determinant
-func GeneratePosDeviceID(seed int64) string {
+func GeneratePOSDeviceID(seed int64) string {
 	rand.Seed(seed)
 
 	idLength := 11
@@ -234,11 +234,11 @@ func ActivateTerminalRPCSession(tsCtx TerminalSessionContext) (string, error) {
 	activateTraceID := fmt.Sprintf("connectReader!%v", methodID)
 
 	activateTermContent := &ReaderActivateContent{
-		PosActivationToken: tsCtx.PstToken,
+		POSActivationToken: tsCtx.PstToken,
 		StoreName:          "empty",
-		PosDeviceID:        tsCtx.DeviceInfo.DeviceUUID,
-		PosSoftwareInfo: PosSoftwareInfo{
-			PosType:    "pos-cli",
+		POSDeviceID:        tsCtx.DeviceInfo.DeviceUUID,
+		POSSoftwareInfo: PosSoftwareInfo{
+			POSType:    "pos-cli",
 			SdkVersion: "1.0.0",
 		},
 	}

--- a/pkg/terminal/p400/reader_methods_test.go
+++ b/pkg/terminal/p400/reader_methods_test.go
@@ -1,0 +1,37 @@
+package p400
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetParentTraceID(t *testing.T) {
+	expected := "txn!1234>activateTerminal!5678"
+	traceid := SetParentTraceID(1234, 5678, "activateTerminal")
+
+	require.Equal(t, expected, traceid, "they should be equal")
+}
+
+func TestGeneratePosDeviceID(t *testing.T) {
+	var seed int64 = 12345
+
+	expected := "pos-isjlqargbit"
+	posid := GeneratePosDeviceID(seed)
+
+	require.Equal(t, expected, posid, "they should be equal")
+}
+
+func TestSetTransactionContext(t *testing.T) {
+	tsCtx := TerminalSessionContext{
+		DeviceInfo: DeviceInfo{
+			DeviceUUID: "pos-isjlqargbit",
+		},
+	}
+	transCtx := SetTransactionContext(tsCtx)
+
+	require.NotNil(t, transCtx.TerminalID, "should have TerminalID field")
+	require.NotNil(t, transCtx.OperatorID, "should have OperatorID field")
+	require.NotNil(t, transCtx.StartTime, "should have StartTime field")
+	require.NotNil(t, transCtx.TransactionID, "should have TransactionID field")
+}

--- a/pkg/terminal/p400/reader_methods_test.go
+++ b/pkg/terminal/p400/reader_methods_test.go
@@ -17,7 +17,7 @@ func TestGeneratePosDeviceID(t *testing.T) {
 	var seed int64 = 12345
 
 	expected := "pos-isjlqargbit"
-	posid := GeneratePosDeviceID(seed)
+	posid := GeneratePOSDeviceID(seed)
 
 	require.Equal(t, expected, posid, "they should be equal")
 }

--- a/pkg/terminal/p400/reader_payment.go
+++ b/pkg/terminal/p400/reader_payment.go
@@ -94,11 +94,11 @@ func SummarizeQuickstartCompletion(tsCtx TerminalSessionContext) error {
 	exampleAppURL := color.Cyan("https://stripe.com/docs/terminal/example-applications")
 	paymentIntentURL := color.Cyan(fmt.Sprintf("https://dashboard.stripe.com/test/payments/%s", tsCtx.PaymentIntentID))
 	readerURL := color.Cyan(fmt.Sprintf("https://dashboard.stripe.com/test/terminal/locations/%s", tsCtx.LocationID))
+	successPrint := fmt.Sprintf("%s\n%s\n\n", successText, exampleAppURL)
+	fmt.Print(successPrint)
 
-	fmt.Println(fmt.Sprintf("%s\n%s\n", successText, exampleAppURL))
-
-	fmt.Println(fmt.Sprintf("View your test payment: %s", paymentIntentURL))
-	fmt.Println(fmt.Sprintf("View your registered reader: %s", readerURL))
+	fmt.Printf("View your test payment: %s\n", paymentIntentURL)
+	fmt.Printf("View your registered reader: %s\n", readerURL)
 
 	return nil
 }

--- a/pkg/terminal/p400/reader_payment.go
+++ b/pkg/terminal/p400/reader_payment.go
@@ -57,7 +57,7 @@ func CompleteTestPayment(tsCtx TerminalSessionContext) (TerminalSessionContext, 
 		return tsCtx, err
 	}
 
-	spinner := ansi.StartSpinner("Tap your Stripe Test Card against the reader...", os.Stdout)
+	spinner := ansi.StartSpinner("Tap, swipe or dip your Stripe Test Card in the reader...", os.Stdout)
 	paymentMethod, err := WaitForPaymentCollection(tsCtx, parentTraceID, 0)
 
 	if err != nil {

--- a/pkg/terminal/p400/reader_payment.go
+++ b/pkg/terminal/p400/reader_payment.go
@@ -1,0 +1,104 @@
+package p400
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+)
+
+// SetUpTestPayment asks the user for their payment amount / currency, then updates the reader display, then creates a new Payment Intent
+func SetUpTestPayment(tsCtx TerminalSessionContext) (TerminalSessionContext, error) {
+	var err error
+	tsCtx.Currency, err = ReaderChargeCurrencyPrompt()
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	tsCtx.Amount, err = ReaderChargeAmountPrompt()
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	spinner := ansi.StartSpinner("Setting reader display...", os.Stdout)
+	tsCtx.TransactionID = int(rand.Float64() * 100000)
+	tsCtx.MethodID = int(rand.Float64() * 100000)
+	parentTraceID := SetParentTraceID(tsCtx.TransactionID, tsCtx.MethodID, "setReaderDisplay")
+
+	err = SetReaderDisplay(tsCtx, parentTraceID)
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	ansi.StopSpinner(spinner, ansi.Faint("Reader display updated"), os.Stdout)
+	spinner = ansi.StartSpinner("Creating a new Payment Intent...", os.Stdout)
+
+	tsCtx.PaymentIntentID, err = CreatePaymentIntent(tsCtx)
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("Payment Intent created %s", tsCtx.PaymentIntentID)), os.Stdout)
+
+	return tsCtx, nil
+}
+
+// CompleteTestPayment sets the reader into collect payment mode, waits for the payment, confirms the payment, then finally captures the Payment Intent
+func CompleteTestPayment(tsCtx TerminalSessionContext) (TerminalSessionContext, error) {
+	parentTraceID := SetParentTraceID(tsCtx.TransactionID, tsCtx.MethodID, "processPayment")
+	err := CollectPaymentMethod(tsCtx, parentTraceID)
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	spinner := ansi.StartSpinner("Tap your Stripe Test Card against the reader...", os.Stdout)
+	paymentMethod, err := WaitForPaymentCollection(tsCtx, parentTraceID, 0)
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	ansi.StopSpinner(spinner, ansi.Faint("Payment Method collected"), os.Stdout)
+	spinner = ansi.StartSpinner("Confirming payment...", os.Stdout)
+	paymentMethodID, err := ConfirmPayment(tsCtx, paymentMethod, parentTraceID)
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("Payment confirmed %s", paymentMethodID)), os.Stdout)
+
+	// manually capturing payment intent as required by terminal flow
+	spinner = ansi.StartSpinner("Capturing Payment Intent...", os.Stdout)
+	err = CapturePaymentIntent(tsCtx)
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("Payment Intent manually captured %s", tsCtx.PaymentIntentID)), os.Stdout)
+
+	return tsCtx, nil
+}
+
+// SummarizeQuickstartCompletion is the success text that is output once the quickstart flow is completed. It lists the Payment Intent Dashboard URL, and the Terminal readers Dashboard URL
+func SummarizeQuickstartCompletion(tsCtx TerminalSessionContext) error {
+	color := ansi.Color(os.Stdout)
+	successText := color.Green("✔ Test payment complete! Here are some example applications from Stripe to continue with your integration.")
+	exampleAppURL := color.Cyan("https://stripe.com/docs/terminal/example-applications")
+	paymentIntentURL := color.Cyan(fmt.Sprintf("https://dashboard.stripe.com/test/payments/%s", tsCtx.PaymentIntentID))
+	readerURL := color.Cyan(fmt.Sprintf("https://dashboard.stripe.com/test/terminal/locations/%s", tsCtx.LocationID))
+
+	fmt.Println(fmt.Sprintf("%s\n%s\n", successText, exampleAppURL))
+
+	fmt.Println(fmt.Sprintf("View your test payment: %s", paymentIntentURL))
+	fmt.Println(fmt.Sprintf("View your registered reader: %s", readerURL))
+
+	return nil
+}

--- a/pkg/terminal/p400/reader_registration.go
+++ b/pkg/terminal/p400/reader_registration.go
@@ -38,7 +38,7 @@ func AttemptRegisterReader(tsCtx TerminalSessionContext, tries int) (string, err
 
 	if err != nil {
 		tries++
-		fmt.Println("Could not register reader - please try your code again.")
+		fmt.Println("Could not register the Reader - please try your code again.")
 
 		if tries < 3 {
 			return AttemptRegisterReader(tsCtx, tries)

--- a/pkg/terminal/p400/reader_registration.go
+++ b/pkg/terminal/p400/reader_registration.go
@@ -1,0 +1,116 @@
+package p400
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+)
+
+// ActivationTypeLabels defines the string values offered as options to the user to prompt them to choose a new or registered reader
+// We use these strings in a few places so defining them here cuts down on brittleness if they change
+var ActivationTypeLabels = []string{
+	"New",
+	"Already registered",
+}
+
+// this is a lookup for ActivationTypeLabels
+const (
+	NewReaderChoice = iota
+	RegisteredReaderChoice
+)
+
+// AttemptRegisterReader prompt the user for their p400 registration code, and tries to register the reader via Stripe API
+// it tries three times before returning an error
+// returns the registered reader's IP address if successful
+func AttemptRegisterReader(tsCtx TerminalSessionContext, tries int) (string, error) {
+	regcode, err := ReaderRegistrationCodePrompt()
+
+	if err != nil {
+		return "", err
+	}
+
+	spinner := ansi.StartSpinner("Registering your reader with Stripe...", os.Stdout)
+
+	IPAddress, err := RegisterReader(regcode, tsCtx)
+
+	ansi.StopSpinner(spinner, "", os.Stdout)
+
+	if err != nil {
+		tries++
+		fmt.Println("Could not register reader - please try your code again.")
+
+		if tries < 3 {
+			return AttemptRegisterReader(tsCtx, tries)
+		}
+
+		return "", ErrRegisterReaderFailed
+	}
+
+	return IPAddress, nil
+}
+
+// RegisterAndActivateReader prompts the user to either add a new reader or choose an existing reader on their account
+// it then calls the appropriate method to set them up and activate a reader session for them to take a test payment
+// it returns an updated TerminalSessionContext containing the session's connection token and rpc session token
+func RegisterAndActivateReader(tsCtx TerminalSessionContext) (TerminalSessionContext, error) {
+	var (
+		IPAddress      string
+		activationType string
+	)
+
+	// check if user has a reader already registered that they might want to use
+	readerList, err := DiscoverReaders(tsCtx)
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	// if user had at least one reader registered
+	if len(readerList) > 0 {
+		activationType, err = ReaderNewOrExistingPrompt()
+
+		if err != nil {
+			return tsCtx, err
+		}
+	}
+
+	if activationType == ActivationTypeLabels[RegisteredReaderChoice] {
+		IPAddress, err = RegisteredReaderChoicePrompt(readerList, tsCtx)
+
+		if err != nil {
+			return tsCtx, err
+		}
+	} else {
+		IPAddress, err = AttemptRegisterReader(tsCtx, 0)
+
+		if err != nil {
+			return tsCtx, err
+		}
+
+		fmt.Printf("> %s", ansi.Faint("Finished registering reader\n"))
+	}
+
+	tsCtx.IPAddress = IPAddress
+
+	spinner := ansi.StartSpinner("Requesting connection token...", os.Stdout)
+	tsCtx.PstToken, err = GetNewConnectionToken(tsCtx)
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	ansi.StopSpinner(spinner, ansi.Faint("Received new connection token"), os.Stdout)
+
+	spinner = ansi.StartSpinner("Connecting to Reader...", os.Stdout)
+	tsCtx.TransactionContext = SetTransactionContext(tsCtx)
+	tsCtx.SessionToken, err = ActivateTerminalRPCSession(tsCtx)
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	ansi.StopSpinner(spinner, ansi.Faint("Reader connected"), os.Stdout)
+
+	return tsCtx, nil
+}

--- a/pkg/terminal/p400/stripe_requests.go
+++ b/pkg/terminal/p400/stripe_requests.go
@@ -1,0 +1,273 @@
+package p400
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/stripe/stripe-cli/pkg/stripe"
+)
+
+// Metadata belongs to the Stripe P400 reader object
+// we don't currently make use of it directly for quickstart
+type Metadata struct{}
+
+// Reader represents the Stripe P400 reader object shape
+type Reader struct {
+	ID              string   `json:"id"`
+	Object          string   `json:"object"`
+	DeviceSwVersion string   `json:"device_software_version"`
+	DeviceType      string   `json:"device_type"`
+	IPAddress       string   `json:"ip_address"`
+	Label           string   `json:"label"`
+	Livemode        bool     `json:"livemode"`
+	Location        string   `json:"location"`
+	SerialNumber    string   `json:"serial_number"`
+	Status          string   `json:"status"`
+	Metadata        Metadata `json:"metadata"`
+}
+
+type readersResponse struct {
+	Error   string   `json:"error"`
+	Object  string   `json:"object"`
+	URL     string   `json:"url"`
+	HasMore bool     `json:"has_more"`
+	Data    []Reader `json:"data"`
+}
+
+type createPaymentIntentResponse struct {
+	ID string `json:"id"`
+}
+
+type startNewRPCSessionResponse struct {
+	SDKRPCSessionToken string `json:"sdk_rpc_session_token"`
+}
+
+type getConnectionTokenResponse struct {
+	Secret string `json:"secret"`
+}
+
+type registerReaderResponse struct {
+	IPAddress string `json:"ip_address"`
+}
+
+// DiscoverReaders calls the Stripe API to get a list of currently registered P400 readers on the account
+// it returns a map of Reader types
+func DiscoverReaders(tsCtx TerminalSessionContext) ([]Reader, error) {
+	parsedBaseURL, err := url.Parse(stripe.DefaultAPIBaseURL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var readersList []Reader
+
+	if err != nil {
+		return readersList, err
+	}
+
+	client := &stripe.Client{
+		BaseURL: parsedBaseURL,
+		APIKey:  tsCtx.APIKey,
+		Verbose: false,
+	}
+
+	res, err := client.PerformRequest(context.TODO(), http.MethodGet, stripeTerminalReadersPath, "", nil)
+
+	if err != nil || res.StatusCode != http.StatusOK {
+		return readersList, err
+	}
+
+	var result readersResponse
+
+	defer res.Body.Close()
+	json.NewDecoder(res.Body).Decode(&result)
+
+	readersList = result.Data
+
+	return readersList, nil
+}
+
+// StartNewRPCSession calls the Stripe API for a new RPC session token for interacting with a P400 reader
+// returns a session token when successful
+func StartNewRPCSession(tsCtx TerminalSessionContext) (string, error) {
+	httpclient := http.Client{}
+	parsedBaseURL, err := url.Parse(stripe.DefaultAPIBaseURL)
+
+	if err != nil {
+		return "", err
+	}
+
+	stripeTerminalRPCSessionURL := fmt.Sprintf("%s%s", parsedBaseURL, rpcSessionPath)
+
+	data := url.Values{}
+	data.Set("pos_device_info[device_class]", tsCtx.DeviceInfo.DeviceClass)
+	data.Set("pos_device_info[device_uuid]", tsCtx.DeviceInfo.DeviceUUID)
+	data.Set("pos_device_info[host_os_version]", tsCtx.DeviceInfo.HostOsVersion)
+	data.Set("pos_device_info[hardware_model][pos_info][description]", tsCtx.DeviceInfo.HardwareModel.PosInfo.Description)
+	data.Set("pos_device_info[app_model][app_id]", tsCtx.DeviceInfo.AppModel.AppID)
+	data.Set("pos_device_info[app_model][app_version]", tsCtx.DeviceInfo.AppModel.AppVersion)
+
+	encodedURLData := data.Encode()
+	urlDataBuffer := bytes.NewBuffer([]byte(encodedURLData))
+
+	request, err := http.NewRequest("POST", stripeTerminalRPCSessionURL, urlDataBuffer)
+
+	if err != nil {
+		return "", err
+	}
+
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %v", tsCtx.PstToken))
+
+	res, err := httpclient.Do(request)
+
+	if err != nil || res.StatusCode != http.StatusOK {
+		return "", err
+	}
+
+	var result startNewRPCSessionResponse
+
+	defer res.Body.Close()
+	json.NewDecoder(res.Body).Decode(&result)
+
+	sessionToken := result.SDKRPCSessionToken
+
+	return sessionToken, nil
+}
+
+// GetNewConnectionToken calls the Stripe API and requests a new connection token in order to start a new reader session
+// it returns the connection token when successful
+func GetNewConnectionToken(tsCtx TerminalSessionContext) (string, error) {
+	parsedBaseURL, err := url.Parse(stripe.DefaultAPIBaseURL)
+
+	if err != nil {
+		return "", err
+	}
+
+	client := &stripe.Client{
+		BaseURL: parsedBaseURL,
+		APIKey:  tsCtx.APIKey,
+		Verbose: false,
+	}
+
+	res, err := client.PerformRequest(context.TODO(), http.MethodPost, stripeTerminalConnectionTokensPath, "", nil)
+
+	if err != nil || res.StatusCode != http.StatusOK {
+		return "", err
+	}
+
+	var result getConnectionTokenResponse
+
+	defer res.Body.Close()
+	json.NewDecoder(res.Body).Decode(&result)
+
+	pstToken := result.Secret
+
+	return pstToken, nil
+}
+
+// CreatePaymentIntent calls the Stripe API to create a new Payment Intent in order to later attach a collected P400 payment to
+// it returns the Payment Intent Id
+func CreatePaymentIntent(tsCtx TerminalSessionContext) (string, error) {
+	parsedBaseURL, err := url.Parse(stripe.DefaultAPIBaseURL)
+
+	if err != nil {
+		return "", err
+	}
+
+	amountStr := strconv.Itoa(tsCtx.Amount)
+
+	client := &stripe.Client{
+		BaseURL: parsedBaseURL,
+		APIKey:  tsCtx.APIKey,
+		Verbose: false,
+	}
+
+	data := url.Values{}
+	data.Set("amount", amountStr)
+	data.Set("currency", tsCtx.Currency)
+	data.Set("payment_method_types[]", "card_present")
+	data.Set("capture_method", "manual")
+	data.Set("description", "Stripe CLI Test Payment")
+
+	res, err := client.PerformRequest(context.TODO(), http.MethodPost, stripeCreatePaymentIntentPath, data.Encode(), nil)
+
+	if err != nil || res.StatusCode != http.StatusOK {
+		return "", err
+	}
+
+	var result createPaymentIntentResponse
+
+	defer res.Body.Close()
+	json.NewDecoder(res.Body).Decode(&result)
+
+	paymentIntentID := result.ID
+
+	return paymentIntentID, nil
+}
+
+// CapturePaymentIntent manually captures the Payment Intent after a Payment Method is attached which is the required flow for collecting payments on the Terminal platform
+func CapturePaymentIntent(tsCtx TerminalSessionContext) error {
+	parsedBaseURL, err := url.Parse(stripe.DefaultAPIBaseURL)
+
+	if err != nil {
+		return err
+	}
+
+	stripeCapturePaymentIntentURL := fmt.Sprintf(stripeCapturePaymentIntentPath, tsCtx.PaymentIntentID)
+
+	client := &stripe.Client{
+		BaseURL: parsedBaseURL,
+		APIKey:  tsCtx.APIKey,
+		Verbose: false,
+	}
+
+	res, err := client.PerformRequest(context.TODO(), http.MethodPost, stripeCapturePaymentIntentURL, "", nil)
+
+	if err != nil || res.StatusCode != http.StatusOK {
+		return ErrCapturePaymentIntentFailed
+	}
+
+	res.Body.Close()
+
+	return nil
+}
+
+// RegisterReader calls the Stripe API to register a new P400 reader to an account
+// it returns the IP address of the reader if successful
+func RegisterReader(regcode string, tsCtx TerminalSessionContext) (string, error) {
+	parsedBaseURL, err := url.Parse(stripe.DefaultAPIBaseURL)
+
+	if err != nil {
+		return "", err
+	}
+
+	client := &stripe.Client{
+		BaseURL: parsedBaseURL,
+		APIKey:  tsCtx.APIKey,
+		Verbose: false,
+	}
+
+	data := url.Values{}
+	data.Set("registration_code", regcode)
+
+	res, err := client.PerformRequest(context.TODO(), http.MethodPost, stripeTerminalRegisterPath, data.Encode(), nil)
+
+	if err != nil || res.StatusCode != http.StatusOK {
+		return "", err
+	}
+
+	var result registerReaderResponse
+
+	defer res.Body.Close()
+	json.NewDecoder(res.Body).Decode(&result)
+
+	IPAddress := result.IPAddress
+
+	return IPAddress, nil
+}

--- a/pkg/terminal/p400/stripe_requests.go
+++ b/pkg/terminal/p400/stripe_requests.go
@@ -107,8 +107,8 @@ func StartNewRPCSession(tsCtx TerminalSessionContext) (string, error) {
 	data := url.Values{}
 	data.Set("pos_device_info[device_class]", tsCtx.DeviceInfo.DeviceClass)
 	data.Set("pos_device_info[device_uuid]", tsCtx.DeviceInfo.DeviceUUID)
-	data.Set("pos_device_info[host_os_version]", tsCtx.DeviceInfo.HostOsVersion)
-	data.Set("pos_device_info[hardware_model][pos_info][description]", tsCtx.DeviceInfo.HardwareModel.PosInfo.Description)
+	data.Set("pos_device_info[host_os_version]", tsCtx.DeviceInfo.HostOSVersion)
+	data.Set("pos_device_info[hardware_model][pos_info][description]", tsCtx.DeviceInfo.HardwareModel.POSInfo.Description)
 	data.Set("pos_device_info[app_model][app_id]", tsCtx.DeviceInfo.AppModel.AppID)
 	data.Set("pos_device_info[app_model][app_version]", tsCtx.DeviceInfo.AppModel.AppVersion)
 

--- a/pkg/terminal/p400/stripe_requests.go
+++ b/pkg/terminal/p400/stripe_requests.go
@@ -78,7 +78,19 @@ func DiscoverReaders(tsCtx TerminalSessionContext) ([]Reader, error) {
 
 	res, err := client.PerformRequest(context.TODO(), http.MethodGet, stripeTerminalReadersPath, "", nil)
 
-	if err != nil || res.StatusCode != http.StatusOK {
+	if err != nil {
+		return readersList, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		if res.StatusCode >= 400 && res.StatusCode < 500 {
+			err = ErrStripeForbiddenResponse
+		} else {
+			fmt.Println(res)
+			fmt.Println(res.StatusCode)
+			err = ErrStripeGenericResponse
+		}
+
 		return readersList, err
 	}
 
@@ -126,7 +138,17 @@ func StartNewRPCSession(tsCtx TerminalSessionContext) (string, error) {
 
 	res, err := httpclient.Do(request)
 
-	if err != nil || res.StatusCode != http.StatusOK {
+	if err != nil {
+		return "", err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		if res.StatusCode >= 400 && res.StatusCode < 500 {
+			err = ErrStripeForbiddenResponse
+		} else {
+			err = ErrStripeGenericResponse
+		}
+
 		return "", err
 	}
 
@@ -157,7 +179,17 @@ func GetNewConnectionToken(tsCtx TerminalSessionContext) (string, error) {
 
 	res, err := client.PerformRequest(context.TODO(), http.MethodPost, stripeTerminalConnectionTokensPath, "", nil)
 
-	if err != nil || res.StatusCode != http.StatusOK {
+	if err != nil {
+		return "", err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		if res.StatusCode >= 400 && res.StatusCode < 500 {
+			err = ErrStripeForbiddenResponse
+		} else {
+			err = ErrStripeGenericResponse
+		}
+
 		return "", err
 	}
 
@@ -197,7 +229,17 @@ func CreatePaymentIntent(tsCtx TerminalSessionContext) (string, error) {
 
 	res, err := client.PerformRequest(context.TODO(), http.MethodPost, stripeCreatePaymentIntentPath, data.Encode(), nil)
 
-	if err != nil || res.StatusCode != http.StatusOK {
+	if err != nil {
+		return "", err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		if res.StatusCode >= 400 && res.StatusCode < 500 {
+			err = ErrStripeForbiddenResponse
+		} else {
+			err = ErrStripeGenericResponse
+		}
+
 		return "", err
 	}
 
@@ -229,8 +271,18 @@ func CapturePaymentIntent(tsCtx TerminalSessionContext) error {
 
 	res, err := client.PerformRequest(context.TODO(), http.MethodPost, stripeCapturePaymentIntentURL, "", nil)
 
-	if err != nil || res.StatusCode != http.StatusOK {
+	if err != nil {
 		return ErrCapturePaymentIntentFailed
+	}
+
+	if res.StatusCode != http.StatusOK {
+		if res.StatusCode >= 400 && res.StatusCode < 500 {
+			err = ErrStripeForbiddenResponse
+		} else {
+			err = ErrStripeGenericResponse
+		}
+
+		return err
 	}
 
 	res.Body.Close()
@@ -258,7 +310,19 @@ func RegisterReader(regcode string, tsCtx TerminalSessionContext) (string, error
 
 	res, err := client.PerformRequest(context.TODO(), http.MethodPost, stripeTerminalRegisterPath, data.Encode(), nil)
 
-	if err != nil || res.StatusCode != http.StatusOK {
+	if err != nil {
+		return "", err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		if res.StatusCode >= 400 && res.StatusCode < 500 {
+			err = ErrStripeForbiddenResponse
+		} else {
+			fmt.Println(res)
+			fmt.Println(res.StatusCode)
+			err = ErrStripeGenericResponse
+		}
+
 		return "", err
 	}
 

--- a/pkg/terminal/p400/user_prompts.go
+++ b/pkg/terminal/p400/user_prompts.go
@@ -79,16 +79,16 @@ func ReaderNewOrExistingPrompt() (string, error) {
 // it returns the IP address of the chosen reader
 func RegisteredReaderChoicePrompt(readerList []Reader, tsCtx TerminalSessionContext) (string, error) {
 	templates := &promptui.SelectTemplates{
-		Label:    "{{ .Label }} ",
-		Active:   "▸ {{ .Label | underline }} ",
-		Inactive: "{{ .Label }} ",
+		Label:    "{{ .Label }} ({{ .Status }}) ",
+		Active:   "▸ {{ .Label | underline }} ({{ .Status }})",
+		Inactive: "{{ .Label }} ({{ .Status }})",
 		Selected: ansi.Faint(fmt.Sprintf("✔ Selected %s: {{ .Label | bold }} ", "reader")),
 	}
 
 	index, _, err := selectOptions(templates, "Select a reader:", readerList)
 
 	if err != nil {
-		return "", ErrDiscoverReadersFailed
+		return "", err
 	}
 
 	IPAddress := readerList[index].IPAddress

--- a/pkg/terminal/p400/user_prompts.go
+++ b/pkg/terminal/p400/user_prompts.go
@@ -52,6 +52,7 @@ func ReaderChargeCurrencyPrompt() (string, error) {
 		return "", err
 	}
 
+	// support any casing the user types but Stripe call needs lowercase
 	currency = strings.ToLower(currency)
 
 	return currency, nil

--- a/pkg/terminal/p400/user_prompts.go
+++ b/pkg/terminal/p400/user_prompts.go
@@ -1,0 +1,136 @@
+package p400
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+// ReaderRegistrationCodePrompt prompts the user to generate a new registration code on their P400 and asks them to enter it at the prompt
+// it returns the code that the user typed in
+func ReaderRegistrationCodePrompt() (string, error) {
+	fmt.Println("On your reader, enter the key sequence 0-7-1-3-9 to display a unique registration code.\nNow enter the registration code:")
+
+	result, err := textPrompt("Code", nil)
+
+	if err != nil {
+		return "", err
+	}
+
+	return result, nil
+}
+
+// ReaderChargeAmountPrompt prompts the user to enter a monetary amount to charge as a test payment
+// it converts the string the user entered into an integer and returns that
+func ReaderChargeAmountPrompt() (int, error) {
+	fmt.Println("Enter the amount you’d like to charge.")
+
+	result, err := textPrompt("Amount", validators.OneDollar)
+
+	if err != nil {
+		return 0, err
+	}
+
+	amountInt, err := strconv.Atoi(result)
+
+	return amountInt, err
+}
+
+// ReaderChargeCurrencyPrompt prompts the user for the currency they want to take a test payment in
+// it returns the currency code that the user entered
+func ReaderChargeCurrencyPrompt() (string, error) {
+	fmt.Println("Now let’s take a test payment. Enter the currency code for the payment.")
+
+	currency, err := textPrompt("Currency", nil)
+
+	if err != nil {
+		return "", err
+	}
+
+	currency = strings.ToLower(currency)
+
+	return currency, nil
+}
+
+// ReaderNewOrExistingPrompt prompts the user to choose to set up a new reader, or continue with an already registered reader
+// it returns their choice
+func ReaderNewOrExistingPrompt() (string, error) {
+	options := ActivationTypeLabels
+	templates := &promptui.SelectTemplates{
+		Label:    "{{ . }} ",
+		Selected: ansi.Faint(fmt.Sprintf("✔ Selected %s: {{ . | bold }} ", "setup type")),
+	}
+
+	_, selected, err := selectOptions(templates, "Is this reader new or already registered?", options)
+
+	if err != nil {
+		return "", err
+	}
+
+	return selected, nil
+}
+
+// RegisteredReaderChoicePrompt takes a list of registered p400 readers and prompts the reader to choose one to use
+// it returns the IP address of the chosen reader
+func RegisteredReaderChoicePrompt(readerList []Reader, tsCtx TerminalSessionContext) (string, error) {
+	templates := &promptui.SelectTemplates{
+		Label:    "{{ .Label }} ",
+		Active:   "▸ {{ .Label | underline }} ",
+		Inactive: "{{ .Label }} ",
+		Selected: ansi.Faint(fmt.Sprintf("✔ Selected %s: {{ .Label | bold }} ", "reader")),
+	}
+
+	index, _, err := selectOptions(templates, "Select a reader:", readerList)
+
+	if err != nil {
+		return "", ErrDiscoverReadersFailed
+	}
+
+	IPAddress := readerList[index].IPAddress
+
+	return IPAddress, nil
+}
+
+func textPrompt(label string, validator promptui.ValidateFunc) (string, error) {
+	templates := &promptui.PromptTemplates{
+		Prompt:  "▸ {{ . }}: ",
+		Valid:   "▸ {{ . }}: ",
+		Invalid: "▸ {{ . }}: ",
+		Success: "▸ {{ . }}: ",
+	}
+
+	prompt := promptui.Prompt{
+		Label:     label,
+		Templates: templates,
+		Validate:  validator,
+	}
+
+	result, err := prompt.Run()
+
+	if err != nil {
+		return "", err
+	}
+
+	return result, nil
+}
+
+func selectOptions(templates *promptui.SelectTemplates, label string, options interface{}) (int, string, error) {
+	prompt := promptui.Select{
+		Label:     label,
+		Items:     options,
+		Templates: templates,
+	}
+
+	index, result, err := prompt.Run()
+
+	if err != nil {
+		return 0, "", err
+	}
+
+	return index, result, nil
+}

--- a/pkg/terminal/quickstart_p400.go
+++ b/pkg/terminal/quickstart_p400.go
@@ -30,13 +30,13 @@ func QuickstartP400(cfg *config.Config) error {
 	if err != nil {
 		switch e := err.Error(); e {
 		case p400.ErrRegisterReaderFailed.Error():
-			return fmt.Errorf(err.Error())
+			fallthrough
 
 		case p400.ErrActivateReaderFailed.Error():
-			return fmt.Errorf(err.Error())
+			fallthrough
 
 		case p400.ErrConnectionTokenFailed.Error():
-			return fmt.Errorf(err.Error())
+			fallthrough
 
 		case p400.ErrNewRPCSessionFailed.Error():
 			return fmt.Errorf(err.Error())
@@ -52,11 +52,11 @@ func QuickstartP400(cfg *config.Config) error {
 
 	if err != nil {
 		switch e := err.Error(); e {
-		case p400.ErrSetReaderDisplayFailed.Error():
-			return fmt.Errorf(err.Error())
-
 		case p400.ErrNewPaymentIntentFailed.Error():
 			p400.ClearReaderDisplay(tsCtx)
+			fallthrough
+
+		case p400.ErrSetReaderDisplayFailed.Error():
 			return fmt.Errorf(err.Error())
 
 		default:
@@ -71,16 +71,16 @@ func QuickstartP400(cfg *config.Config) error {
 
 		switch e := err.Error(); e {
 		case p400.ErrCapturePaymentIntentFailed.Error():
-			return fmt.Errorf(err.Error())
+			fallthrough
 
 		case p400.ErrCollectPaymentFailed.Error():
-			return fmt.Errorf(err.Error())
+			fallthrough
 
 		case p400.ErrCollectPaymentTimeout.Error():
-			return fmt.Errorf(err.Error())
+			fallthrough
 
 		case p400.ErrConfirmPaymentFailed.Error():
-			return fmt.Errorf(err.Error())
+			fallthrough
 
 		case p400.ErrQueryPaymentFailed.Error():
 			return fmt.Errorf(err.Error())

--- a/pkg/terminal/quickstart_p400.go
+++ b/pkg/terminal/quickstart_p400.go
@@ -99,26 +99,26 @@ func QuickstartP400(cfg *config.Config) error {
 // it returns a TerminalSessionContext interface that is passed into most of the P400 reader related functions in the quickstart flow
 func SetTerminalSessionContext(cfg *config.Config) p400.TerminalSessionContext {
 	apiKey, _ := cfg.Profile.GetAPIKey(false)
-	posID := cfg.Profile.GetTerminalPosDeviceID()
+	posID := cfg.Profile.GetTerminalPOSDeviceID()
 
 	if posID == "" {
 		seed := time.Now().UnixNano()
-		posID = p400.GeneratePosDeviceID(seed)
+		posID = p400.GeneratePOSDeviceID(seed)
 		cfg.Profile.WriteConfigField("terminal_pos_device_id", posID)
 	}
 
-	hostOsVersion := p400.GetOsString()
-	posInfoDescription := fmt.Sprintf("%v:StripeCLI", hostOsVersion)
+	hostOSVersion := p400.GetOSString()
+	POSInfoDescription := fmt.Sprintf("%v:StripeCLI", hostOSVersion)
 
 	tsCtx := p400.TerminalSessionContext{
 		APIKey: apiKey,
 		DeviceInfo: p400.DeviceInfo{
 			DeviceClass:   "POS",
 			DeviceUUID:    posID,
-			HostOsVersion: hostOsVersion,
+			HostOSVersion: hostOSVersion,
 			HardwareModel: p400.HardwareModel{
-				PosInfo: p400.PosInfo{
-					Description: posInfoDescription,
+				POSInfo: p400.POSInfo{
+					Description: POSInfoDescription,
 				},
 			},
 			AppModel: p400.AppModel{

--- a/pkg/terminal/quickstart_p400.go
+++ b/pkg/terminal/quickstart_p400.go
@@ -1,0 +1,132 @@
+package terminal
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/terminal/p400"
+)
+
+// QuickstartP400 runs the quickstart interactive prompt sequence to walk the user through setting up a P400 reader
+func QuickstartP400(cfg *config.Config) error {
+	tsCtx := SetTerminalSessionContext(cfg)
+
+	// reset the reader's state on SIGINT
+	interruptChannel := make(chan os.Signal, 1)
+	signal.Notify(interruptChannel, os.Interrupt)
+
+	go func() {
+		// block unless SIGINT occurs
+		<-interruptChannel
+		p400.ClearReaderDisplay(tsCtx)
+		os.Exit(1)
+	}()
+
+	tsCtx, err := p400.RegisterAndActivateReader(tsCtx)
+
+	if err != nil {
+		switch e := err.Error(); e {
+		case p400.ErrRegisterReaderFailed.Error():
+			return fmt.Errorf(err.Error())
+
+		case p400.ErrActivateReaderFailed.Error():
+			return fmt.Errorf(err.Error())
+
+		case p400.ErrConnectionTokenFailed.Error():
+			return fmt.Errorf(err.Error())
+
+		case p400.ErrNewRPCSessionFailed.Error():
+			return fmt.Errorf(err.Error())
+
+		default:
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("Got it!")
+
+	tsCtx, err = p400.SetUpTestPayment(tsCtx)
+
+	if err != nil {
+		switch e := err.Error(); e {
+		case p400.ErrSetReaderDisplayFailed.Error():
+			return fmt.Errorf(err.Error())
+
+		case p400.ErrNewPaymentIntentFailed.Error():
+			p400.ClearReaderDisplay(tsCtx)
+			return fmt.Errorf(err.Error())
+
+		default:
+			os.Exit(1)
+		}
+	}
+
+	tsCtx, err = p400.CompleteTestPayment(tsCtx)
+
+	if err != nil {
+		p400.ClearReaderDisplay(tsCtx)
+
+		switch e := err.Error(); e {
+		case p400.ErrCapturePaymentIntentFailed.Error():
+			return fmt.Errorf(err.Error())
+
+		case p400.ErrCollectPaymentFailed.Error():
+			return fmt.Errorf(err.Error())
+
+		case p400.ErrCollectPaymentTimeout.Error():
+			return fmt.Errorf(err.Error())
+
+		case p400.ErrConfirmPaymentFailed.Error():
+			return fmt.Errorf(err.Error())
+
+		case p400.ErrQueryPaymentFailed.Error():
+			return fmt.Errorf(err.Error())
+
+		default:
+			os.Exit(1)
+		}
+	}
+
+	p400.SummarizeQuickstartCompletion(tsCtx)
+
+	return nil
+}
+
+// SetTerminalSessionContext creates a data struct that contains the context of the user's current quickstart session
+// it returns a TerminalSessionContext interface that is passed into most of the P400 reader related functions in the quickstart flow
+func SetTerminalSessionContext(cfg *config.Config) p400.TerminalSessionContext {
+	apiKey, _ := cfg.Profile.GetAPIKey(false)
+	posID := cfg.Profile.GetTerminalPosDeviceID()
+
+	if posID == "" {
+		seed := time.Now().UnixNano()
+		posID = p400.GeneratePosDeviceID(seed)
+		cfg.Profile.WriteConfigField("terminal_pos_device_id", posID)
+	}
+
+	hostOsVersion := p400.GetOsString()
+	posInfoDescription := fmt.Sprintf("%v:StripeCLI", hostOsVersion)
+
+	tsCtx := p400.TerminalSessionContext{
+		APIKey: apiKey,
+		DeviceInfo: p400.DeviceInfo{
+			DeviceClass:   "POS",
+			DeviceUUID:    posID,
+			HostOsVersion: hostOsVersion,
+			HardwareModel: p400.HardwareModel{
+				PosInfo: p400.PosInfo{
+					Description: posInfoDescription,
+				},
+			},
+			AppModel: p400.AppModel{
+				AppID:      "Stripe-CLI-Terminal-Quickstart",
+				AppVersion: "https://stripe.com/docs/stripe-cli",
+			},
+		},
+	}
+
+	return tsCtx
+}

--- a/pkg/terminal/reader_list.go
+++ b/pkg/terminal/reader_list.go
@@ -1,0 +1,30 @@
+package terminal
+
+// ReaderData contains information about a specific Stripe compatible reader. An example is the Verifone P400.
+type ReaderData struct {
+	Name        string
+	URL         string
+	Description string
+}
+
+var readerVerifoneP400 = &ReaderData{
+	Name:        "Verifone P400",
+	Description: "The Verifone P400 is a countertop reader for web-based Stripe Terminal apps. It connects to the Stripe Terminal SDK over the internet. This reader is compatible with JavaScript SDK.",
+	URL:         "https://www.verifone.com/sites/default/files/2018-01/p400_datasheet_ltr_013018.pdf",
+}
+
+// ReaderList is a map containing all of the Stripe compatible reader types that we support in the CLI.
+var ReaderList = map[string]*ReaderData{
+	"verifone-p400": readerVerifoneP400,
+}
+
+// ReaderNames is a function that uses ReaderList to extract the human friendly names of the CLI supported readers.
+// it returns a map of the human friendly reader names as strings
+func ReaderNames() []string {
+	names := make([]string, 0, len(ReaderList))
+	for index := range ReaderList {
+		names = append(names, ReaderList[index].Name)
+	}
+
+	return names
+}

--- a/pkg/terminal/user_prompts.go
+++ b/pkg/terminal/user_prompts.go
@@ -1,0 +1,40 @@
+package terminal
+
+import (
+	"fmt"
+
+	"github.com/manifoldco/promptui"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+)
+
+// ReaderTypeSelectPrompt prompts the user to choose which type of reader they want to set up
+// currently the only supported choice is the Verifone P400
+func ReaderTypeSelectPrompt(readers []string) (string, error) {
+	selected, err := selectOptions("reader type", "Select which type of reader you’d like to set up", readers)
+
+	if err != nil {
+		return "", err
+	}
+
+	return selected, nil
+}
+
+func selectOptions(template string, label string, options []string) (string, error) {
+	templates := &promptui.SelectTemplates{
+		Selected: ansi.Faint(fmt.Sprintf("✔ Selected %s: {{ . | bold }} ", template)),
+	}
+	prompt := promptui.Select{
+		Label:     label,
+		Items:     options,
+		Templates: templates,
+	}
+
+	_, result, err := prompt.Run()
+
+	if err != nil {
+		return "", err
+	}
+
+	return result, nil
+}

--- a/pkg/validators/validate.go
+++ b/pkg/validators/validate.go
@@ -59,6 +59,26 @@ func APIKey(input string) error {
 	return nil
 }
 
+// APIKeyNotRestricted validates that a string looks like a secret API key and is not a restricted key.
+func APIKeyNotRestricted(input string) error {
+	if len(input) == 0 {
+		return errors.New("you have not configured API keys yet. To do so, run `stripe login` which will configure your API keys from Stripe")
+	} else if len(input) < 12 {
+		return errors.New("the API key provided is too short, it must be at least 12 characters long")
+	}
+
+	keyParts := strings.Split(input, "_")
+	if len(keyParts) < 3 {
+		return errors.New("you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
+	}
+
+	if keyParts[0] != "sk" || keyParts[0] == "rk" {
+		return errors.New("this CLI command only supports using a secret key. Please re-run using the --api-key flag override with your secret API key")
+	}
+
+	return nil
+}
+
 // Account validates that a string is an acceptable account filter.
 func Account(account string) error {
 	accountUpper := strings.ToUpper(account)

--- a/pkg/validators/validate.go
+++ b/pkg/validators/validate.go
@@ -133,3 +133,17 @@ func StatusCodeType(code string) error {
 
 	return nil
 }
+
+// OneDollar validates that a provided number is at least 100 (ie. 1 dollar)
+func OneDollar(number string) error {
+	num, err := strconv.Atoi(number)
+	if err != nil {
+		return fmt.Errorf("Provided amount %v to charge should be an integer (eg. 100)", number)
+	}
+
+	if num >= 100 {
+		return nil
+	}
+
+	return fmt.Errorf("Provided amount %v to charge is not at least 100", number)
+}


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe @ob-stripe 
cc @stripe/dev-platform

 ### Summary

I built a “quickstart” experience for Stripe Terminal into the Stripe CLI, to allow developers to run a test payment on their new Verifone P400 Terminal reader in < 5 minutes.

The command to run (in test mode only) is `stripe terminal quickstart --api-key sk_test_123`

To see a GIF of what the flow generally looks like when using the command, expand the section below:

<details>
<summary>Expand for GIF</summary>
<img src="https://user-images.githubusercontent.com/54524269/74287842-c719db80-4cdf-11ea-83c1-aed97ab395ec.gif" alt="terminal animation showing the quickstart interactive prompt"/>
</details>

**Feedback**

All feedback is very welcome!

Would love nitpicky feedback about idiomatic Golang stuff because I'm so new to the language, especially around code duplication and type choices. I made some escape hatches in a few utility functions with interface types but would love guidance around this if you think it's going to be a concern.

Also - I'd love for volunteers to pull this down and build + play with it if you have a Verifone P400 reader 🙏

⚠️ this PR depends on some allow-listing work, so please don't merge just yet until it's all :ok: