### PR TITLE
Add Developer Office Hours Starter Sample

### DIFF
--- a/pkg/samples/list.go
+++ b/pkg/samples/list.go
@@ -138,6 +138,12 @@ var connectOnboardingStandard = &SampleData{
 	URL:         "https://github.com/stripe-samples/connect-onboarding-for-standard",
 }
 
+var developerOfficeHours = &SampleData{
+	Name:        "developer-office-hours",
+	Description: "Starter templates for following along with Developer Office Hours",
+	URL:         "https://github.com/stripe-samples/developer-office-hours",
+}
+
 // List contains a mapping of Stripe Samples that we want to be available in the
 // CLI to some of their metadata
 // TODO: what do we want to name these for it to be easier for users to select?
@@ -161,6 +167,7 @@ var List = map[string]*SampleData{
 	"web-elements-fpx-payment":         fpxPayment,
 	"charging-a-saved-card":            chargingSavedCard,
 	"connect-onboarding-for-standard":  connectOnboardingStandard,
+	"developer-office-hours":           developerOfficeHours,
 }
 
 // Names returns a list of all the sample's names


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @adreyfus-stripe 

 ### Summary
Adding link to stripe-sample for developer office hours. We're adding a mostly empty Stripe Sample that viewers can install with `stripe samples create developer-office-hours` which will serve as a standard starting point with boilerplate already populated so the user only needs to write the code to grasp the concept covered in the episode.
