### PR TITLE
[WIP] Get samples from remote url

### DIFF
--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -14,7 +14,6 @@ import (
 	gitpkg "github.com/stripe/stripe-cli/pkg/git"
 	"github.com/stripe/stripe-cli/pkg/samples"
 	"github.com/stripe/stripe-cli/pkg/validators"
-	"github.com/stripe/stripe-cli/pkg/version"
 
 	"gopkg.in/src-d/go-git.v4"
 )
@@ -53,7 +52,6 @@ local configuration to let you get started faster.`,
 }
 
 func (cc *CreateCmd) runCreateCmd(cmd *cobra.Command, args []string) error {
-	version.CheckLatestVersion()
 	samples.InitSampleList()
 
 	if len(args) == 0 {

--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -54,6 +54,7 @@ local configuration to let you get started faster.`,
 
 func (cc *CreateCmd) runCreateCmd(cmd *cobra.Command, args []string) error {
 	version.CheckLatestVersion()
+	samples.InitSampleList()
 
 	if len(args) == 0 {
 		cmd.Help()

--- a/pkg/cmd/samples/list.go
+++ b/pkg/cmd/samples/list.go
@@ -2,12 +2,12 @@ package samples
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/samples"
 	"github.com/stripe/stripe-cli/pkg/validators"
-	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 // ListCmd prints a list of all the available sample projects that users can
@@ -32,15 +32,18 @@ the CLI.`,
 }
 
 func (lc *ListCmd) runListCmd(cmd *cobra.Command, args []string) {
-	version.CheckLatestVersion()
+	samples.InitSampleList()
 
 	fmt.Println("A list of available Stripe Samples:")
 	fmt.Println()
 
-	for _, sample := range samples.Get() {
-		fmt.Println(sample.BoldName())
-		fmt.Println(sample.Description)
-		fmt.Println(fmt.Sprintf("Repo: %s", sample.URL))
+	names := samples.Names()
+	sort.Strings(names)
+
+	for _, name := range names {
+		fmt.Println(samples.List[name].BoldName())
+		fmt.Println(samples.List[name].Description)
+		fmt.Println(fmt.Sprintf("Repo: %s", samples.List[name].URL))
 		fmt.Println()
 	}
 }

--- a/pkg/cmd/samples/list.go
+++ b/pkg/cmd/samples/list.go
@@ -2,7 +2,6 @@ package samples
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -38,13 +37,10 @@ func (lc *ListCmd) runListCmd(cmd *cobra.Command, args []string) {
 	fmt.Println("A list of available Stripe Samples:")
 	fmt.Println()
 
-	names := samples.Names()
-	sort.Strings(names)
-
-	for _, name := range names {
-		fmt.Println(samples.List[name].BoldName())
-		fmt.Println(samples.List[name].Description)
-		fmt.Println(fmt.Sprintf("Repo: %s", samples.List[name].URL))
+	for _, sample := range samples.Get() {
+		fmt.Println(sample.BoldName())
+		fmt.Println(sample.Description)
+		fmt.Println(fmt.Sprintf("Repo: %s", sample.URL))
 		fmt.Println()
 	}
 }

--- a/pkg/samples/list.go
+++ b/pkg/samples/list.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 )
@@ -21,20 +22,31 @@ type SampleList struct {
 }
 
 func getJson(url string, target interface{}) error {
+	spinner := ansi.StartSpinner("Loading...", os.Stdout)
 	r, err := http.Get(url)
 	if err != nil {
+		ansi.StopSpinner(spinner, "Error: Check your network connection and retry.", os.Stdout)
 		return err
 	}
 	defer r.Body.Close()
-
+	ansi.StopSpinner(spinner, "", os.Stdout)
 	return json.NewDecoder(r.Body).Decode(target)
 }
 
-func Get() []SampleData {
+func GetSamples() []SampleData {
 	// Fetch samples from gh-pages
 	sampleList := SampleList{}
 	getJson("https://thorsten-stripe.github.io/stripe-cli-gh-pages/samples.json", &sampleList)
 	return sampleList.Samples
+}
+
+var List = map[string]*SampleData{}
+
+func InitSampleList() map[string]*SampleData {
+	for _, sample := range GetSamples() {
+		List[sample.Name] = &sample
+	}
+	return List
 }
 
 // BoldName returns an ansi bold string for the name
@@ -47,160 +59,6 @@ func (sd *SampleData) BoldName() string {
 // CLI to some of their metadata
 func (sd *SampleData) GitRepo() string {
 	return fmt.Sprintf("%s.git", sd.URL)
-}
-
-// TODO refactor to use fetched data
-var addingSalesTax = &SampleData{
-	Name:        "adding-sales-tax",
-	Description: "Learn how to use PaymentIntents to build a simple checkout flow",
-	URL:         "https://github.com/stripe-samples/adding-sales-tax",
-}
-
-var checkoutSubscriptionAndAddOn = &SampleData{
-	Name:        "checkout-subscription-and-add-on",
-	Description: "Uses Stripe Checkout to create a payment page that starts a subscription for a new customer",
-	URL:         "https://github.com/stripe-samples/checkout-subscription-and-add-on",
-}
-
-var placingAHold = &SampleData{
-	Name:        "placing-a-hold",
-	Description: "Learn how to place a hold on a credit card (split auth / capture)",
-	URL:         "https://github.com/stripe-samples/placing-a-hold",
-}
-
-var paymentFormModal = &SampleData{
-	Name:        "payment-form-modal",
-	Description: "How to implement Stripe Elements within a modal dialog",
-	URL:         "https://github.com/stripe-samples/payment-form-modal",
-}
-
-var savingCardWithoutPayment = &SampleData{
-	Name:        "saving-card-without-payment",
-	Description: "How to build a form to save a credit card without taking a payment",
-	URL:         "https://github.com/stripe-samples/saving-card-without-payment",
-}
-
-var checkoutOneTimePayments = &SampleData{
-	Name:        "checkout-one-time-payments",
-	Description: "Use Checkout to quickly collect one-time payments",
-	URL:         "https://github.com/stripe-samples/checkout-one-time-payments",
-}
-
-var checkoutSingleSubscription = &SampleData{
-	Name:        "checkout-single-subscription",
-	Description: "Learn how to combine Checkout and Billing for fast subscription pages",
-	URL:         "https://github.com/stripe-samples/checkout-single-subscription",
-}
-
-var cardPayment = &SampleData{
-	Name:        "accept-a-card-payment",
-	Description: "Learn how to accept a basic card payment",
-	URL:         "https://github.com/stripe-samples/accept-a-card-payment",
-}
-
-var savingCardAfterPayment = &SampleData{
-	Name:        "saving-card-after-payment",
-	Description: "Learn how to save a card for later reuse after making a payment",
-	URL:         "https://github.com/stripe-samples/saving-card-after-payment",
-}
-
-var reactElementsCardPayment = &SampleData{
-	Name:        "react-elements-card-payment",
-	Description: "Learn how to build a checkout form with React",
-	URL:         "https://github.com/stripe-samples/react-elements-card-payment",
-}
-
-var cardPaymentCharges = &SampleData{
-	Name:        "card-payment-charges-api",
-	Description: "Learn how to accept a basic card payment with the Charges API",
-	URL:         "https://github.com/stripe-samples/card-payment-charges-api",
-}
-
-var multiPlanSubscriptions = &SampleData{
-	Name:        "multiple-plan-subscriptions",
-	Description: "Learn how to create a multi-plan subscription model",
-	URL:         "https://github.com/stripe-samples/charging-for-multiple-plan-subscriptions",
-}
-
-var singleSubscription = &SampleData{
-	Name:        "set-up-subscriptions",
-	Description: "Learn how to create a simple subscription with Stripe Billing",
-	URL:         "https://github.com/stripe-samples/set-up-subscriptions",
-}
-
-var oxxoPayment = &SampleData{
-	Name:        "oxxo-payment",
-	Description: "Build a payment form to collect OXXO and card payments",
-	URL:         "https://github.com/stripe-samples/oxxo-payment",
-}
-
-var auBecsPayment = &SampleData{
-	Name:        "au-becs-debit-payment",
-	Description: "Collecting AU BECS Direct Debit mandates and payments",
-	URL:         "https://github.com/stripe-samples/au-becs-debit-payment",
-}
-
-var sepaPayment = &SampleData{
-	Name:        "web-elements-sepa-debit-payment",
-	Description: "Accept SEPA Debit payments",
-	URL:         "https://github.com/stripe-samples/web-elements-sepa-debit-payment",
-}
-
-var idealPayment = &SampleData{
-	Name:        "web-elements-ideal-payment",
-	Description: "Build a payment form to collect iDEAL and card payments",
-	URL:         "https://github.com/stripe-samples/web-elements-ideal-payment",
-}
-
-var fpxPayment = &SampleData{
-	Name:        "web-elements-fpx-payment",
-	Description: "[Beta] Accept payments with FPX, a popular payment method in Malaysia",
-	URL:         "https://github.com/stripe-samples/web-elements-fpx-payment",
-}
-
-var chargingSavedCard = &SampleData{
-	Name:        "charging-a-saved-card",
-	Description: "Learn how to charge a saved card",
-	URL:         "https://github.com/stripe-samples/charging-a-saved-card",
-}
-
-var connectOnboardingStandard = &SampleData{
-	Name:        "connect-onboarding-for-standard",
-	Description: "Learn how to onboard users for Stripe Connect with Onboarding for Standard",
-	URL:         "https://github.com/stripe-samples/connect-onboarding-for-standard",
-}
-
-var developerOfficeHours = &SampleData{
-	Name:        "developer-office-hours",
-	Description: "Starter templates for following along with Developer Office Hours",
-	URL:         "https://github.com/stripe-samples/developer-office-hours",
-}
-
-// List contains a mapping of Stripe Samples that we want to be available in the
-// CLI to some of their metadata
-// TODO: what do we want to name these for it to be easier for users to select?
-var List = map[string]*SampleData{
-	"adding-sales-tax":                 addingSalesTax,
-	"checkout-subscription-and-add-on": checkoutSubscriptionAndAddOn,
-	"placing-a-hold":                   placingAHold,
-	"payment-form-modal":               paymentFormModal,
-	"saving-card-without-payment":      savingCardWithoutPayment,
-	"checkout-one-time-payments":       checkoutOneTimePayments,
-	"checkout-single-subscription":     checkoutSingleSubscription,
-	"accept-a-card-payment":            cardPayment,
-	"saving-card-after-payment":        savingCardAfterPayment,
-	"react-elements-card-payment":      reactElementsCardPayment,
-	"card-payment-charges-api":         cardPaymentCharges,
-	"multiple-plan-subscriptions":      multiPlanSubscriptions,
-	"set-up-subscriptions":             singleSubscription,
-	"au-becs-debit-payment":            auBecsPayment,
-	"web-elements-sepa-debit-payment":  sepaPayment,
-	"oxxo-payment":                     oxxoPayment,
-	"web-elements-ideal-payment":       idealPayment,
-	"web-elements-fpx-payment":         fpxPayment,
-	"charging-a-saved-card":            chargingSavedCard,
-	"connect-onboarding-for-standard":  connectOnboardingStandard,
-	"developer-office-hours":           developerOfficeHours,
 }
 
 // Names returns a list of all the sample's names

--- a/pkg/samples/list.go
+++ b/pkg/samples/list.go
@@ -17,11 +17,12 @@ type SampleData struct {
 	Description string `json:"description"`
 }
 
+// SampleList is used to unmarshal the samples array from the JSON response
 type SampleList struct {
 	Samples []SampleData `json:"samples"`
 }
 
-func getJson(url string, target interface{}) error {
+func getJSON(url string, target interface{}) error {
 	spinner := ansi.StartSpinner("Loading...", os.Stdout)
 	r, err := http.Get(url)
 	if err != nil {
@@ -33,17 +34,23 @@ func getJson(url string, target interface{}) error {
 	return json.NewDecoder(r.Body).Decode(target)
 }
 
-func GetSamples() []SampleData {
+func getSamples() []SampleData {
 	// Fetch samples from gh-pages
 	sampleList := SampleList{}
-	getJson("https://thorsten-stripe.github.io/stripe-cli-gh-pages/samples.json", &sampleList)
+	getJSON("https://thorsten-stripe.github.io/stripe-cli-gh-pages/samples.json", &sampleList)
 	return sampleList.Samples
 }
 
+// List contains a mapping of Stripe Samples that we want to be available in the
+// CLI to some of their metadata.
+// TODO: what do we want to name these for it to be easier for users to select?
+// TODO: should we group them by products for easier exploring?
 var List = map[string]*SampleData{}
 
+// InitSampleList fetches the samples from a remote JSON file and sets up the
+// List mapping.
 func InitSampleList() {
-	sampleList := GetSamples()
+	sampleList := getSamples()
 	for i, sample := range sampleList {
 		List[sample.Name] = &sampleList[i]
 	}

--- a/pkg/samples/list.go
+++ b/pkg/samples/list.go
@@ -55,8 +55,6 @@ func (sd *SampleData) BoldName() string {
 }
 
 // GitRepo returns a string of the repo with the .git prefix
-// List contains a mapping of Stripe Samples that we want to be available in the
-// CLI to some of their metadata
 func (sd *SampleData) GitRepo() string {
 	return fmt.Sprintf("%s.git", sd.URL)
 }

--- a/pkg/samples/list.go
+++ b/pkg/samples/list.go
@@ -1,7 +1,9 @@
 package samples
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 )
@@ -9,9 +11,30 @@ import (
 // SampleData stores the information needed for Stripe Samples to operate in
 // the CLI
 type SampleData struct {
-	Name        string
-	URL         string
-	Description string
+	Name        string `json:"name"`
+	URL         string `json:"URL"`
+	Description string `json:"description"`
+}
+
+type SampleList struct {
+	Samples []SampleData `json:"samples"`
+}
+
+func getJson(url string, target interface{}) error {
+	r, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	return json.NewDecoder(r.Body).Decode(target)
+}
+
+func Get() []SampleData {
+	// Fetch samples from gh-pages
+	sampleList := SampleList{}
+	getJson("https://thorsten-stripe.github.io/stripe-cli-gh-pages/samples.json", &sampleList)
+	return sampleList.Samples
 }
 
 // BoldName returns an ansi bold string for the name
@@ -20,10 +43,13 @@ func (sd *SampleData) BoldName() string {
 }
 
 // GitRepo returns a string of the repo with the .git prefix
+// List contains a mapping of Stripe Samples that we want to be available in the
+// CLI to some of their metadata
 func (sd *SampleData) GitRepo() string {
 	return fmt.Sprintf("%s.git", sd.URL)
 }
 
+// TODO refactor to use fetched data
 var addingSalesTax = &SampleData{
 	Name:        "adding-sales-tax",
 	Description: "Learn how to use PaymentIntents to build a simple checkout flow",

--- a/pkg/samples/list.go
+++ b/pkg/samples/list.go
@@ -42,11 +42,11 @@ func GetSamples() []SampleData {
 
 var List = map[string]*SampleData{}
 
-func InitSampleList() map[string]*SampleData {
-	for _, sample := range GetSamples() {
-		List[sample.Name] = &sample
+func InitSampleList() {
+	sampleList := GetSamples()
+	for i, sample := range sampleList {
+		List[sample.Name] = &sampleList[i]
 	}
-	return List
 }
 
 // BoldName returns an ansi bold string for the name


### PR DESCRIPTION
Closes #391 
Closes #392 

 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
@tomer-stripe @adreyfus-stripe POC for hosting a JSON list of the Stripe samples on GitHub.io and pull the list of samples from there instead of hardcoding them in the Stripe CLI.

In this POC I'm fetching from https://github.com/thorsten-stripe/stripe-cli-gh-pages/blob/gh-pages/samples.json but longer-term I'd propose moving that part to https://github.com/stripe/stripe.github.io and maintain the list of samples there. That way we don't have to release a new version of the CLI every time we add a sample.

Wdyt?