### PR TITLE
use api-base flag when running trigger command

### DIFF
--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -70,7 +70,7 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 
 	var fixture *fixtures.Fixture
 	if file, ok := fixtures.Events[event]; ok {
-		fixture, err = fixtures.BuildFromFixture(tc.fs, apiKey, tc.stripeAccount, file)
+		fixture, err = fixtures.BuildFromFixture(tc.fs, apiKey, tc.stripeAccount, tc.apiBaseURL, file)
 		if err != nil {
 			return err
 		}
@@ -80,7 +80,7 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf(fmt.Sprintf("event %s is not supported.", event))
 		}
 
-		fixture, err = fixtures.BuildFromFixture(tc.fs, apiKey, tc.stripeAccount, event)
+		fixture, err = fixtures.BuildFromFixture(tc.fs, apiKey, tc.stripeAccount, tc.apiBaseURL, event)
 		if err != nil {
 			return err
 		}

--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -5,8 +5,6 @@ import (
 	"sort"
 
 	"github.com/spf13/afero"
-
-	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 // Events is a mapping of pre-built trigger events and the corresponding json file
@@ -54,12 +52,12 @@ var Events = map[string]string{
 }
 
 // BuildFromFixture creates a new fixture struct for a file
-func BuildFromFixture(fs afero.Fs, apiKey, stripeAccount, jsonFile string) (*Fixture, error) {
+func BuildFromFixture(fs afero.Fs, apiKey, stripeAccount, apiBaseURL, jsonFile string) (*Fixture, error) {
 	fixture, err := NewFixture(
 		fs,
 		apiKey,
 		stripeAccount,
-		stripe.DefaultAPIBaseURL,
+		apiBaseURL,
 		jsonFile,
 	)
 	if err != nil {


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Fixes a bug where the `api-base` flag was ignored when running the `trigger` command.
