### PR TITLE
Revert "#401 Display API Version when running listen (#404)"

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -133,7 +133,7 @@ func (p *Proxy) Run() error {
 
 	select {
 	case <-p.webSocketClient.Connected():
-		ansi.StopSpinner(s, fmt.Sprintf("Ready! You are using Stripe API Version %s. Your webhook signing secret is %s (^C to quit)", session.APIVersion, ansi.Bold(session.Secret)), p.cfg.Log.Out)
+		ansi.StopSpinner(s, fmt.Sprintf("Ready! Your webhook signing secret is %s (^C to quit)", ansi.Bold(session.Secret)), p.cfg.Log.Out)
 	case <-p.ctx.Done():
 		ansi.StopSpinner(s, "", p.cfg.Log.Out)
 		p.cfg.Log.Fatalf("Aborting")

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -82,9 +82,7 @@ func (c *Client) Authorize(ctx context.Context, deviceName string, websocketFeat
 		return nil, err
 	}
 
-	session.APIVersion = resp.Header["Stripe-Version"]
 	c.cfg.Log.WithFields(log.Fields{
-		"api_version":                    session.APIVersion,
 		"prefix":                         "stripeauth.Client.Authorize",
 		"websocket_url":                  session.WebSocketURL,
 		"websocket_id":                   session.WebSocketID,

--- a/pkg/stripeauth/messages.go
+++ b/pkg/stripeauth/messages.go
@@ -3,7 +3,6 @@ package stripeauth
 // StripeCLISession is the API resource returned by Stripe when initiating
 // a new CLI session.
 type StripeCLISession struct {
-	APIVersion                  []string
 	DisplayConnectFilterWarning bool   `json:"display_connect_filter_warning"`
 	ReconnectDelay              int    `json:"reconnect_delay"`
 	Secret                      string `json:"secret"`

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -208,6 +208,7 @@ func (c *Client) connect() bool {
 
 	c.changeConnection(conn)
 	c.isConnected = true
+
 	c.wg = &sync.WaitGroup{}
 	c.wg.Add(2)
 
@@ -216,10 +217,7 @@ func (c *Client) connect() bool {
 	go c.writePump()
 
 	c.cfg.Log.WithFields(log.Fields{
-		"prefix":  "websocket.client.connect",
-		"headers": resp.Header,
-		"status":  resp.Status,
-		"config":  c.cfg,
+		"prefix": "websocket.client.connect",
 	}).Debug("Connected!")
 
 	return true


### PR DESCRIPTION
This reverts commit b0c4eec195ca4e8de04aff21426cf6e19754e4a2.

 ### Reviewers
r? @ob-stripe @mcavage-stripe 
cc @stripe/dev-platform

 ### Summary
Explained in the issue in #401 -- reverting so we can find a solution that will always be in sync with the webhook endpoint.