### PR TITLE
Add additional debuging

### DIFF
--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -271,13 +271,21 @@ func (c *Client) readPump() {
 				case !ws.IsCloseError(err):
 					// read errors do not prevent websocket reconnects in the CLI so we should
 					// only display this on debug-level logging
-					c.cfg.Log.Debug("read error: ", err)
+					c.cfg.Log.WithFields(log.Fields{
+						"prefix": "websocket.Client.Close",
+					}).Debug("read error: ", err)
 				case ws.IsUnexpectedCloseError(err, ws.CloseNormalClosure):
-					c.cfg.Log.Error("close error: ", err)
-					c.cfg.Log.Error("If you run into issues, please re-run with `--log-level debug` and share the output with the Stripe team on GitHub.")
+					c.cfg.Log.WithFields(log.Fields{
+						"prefix": "websocket.Client.Close",
+					}).Error("close error: ", err)
+					c.cfg.Log.WithFields(log.Fields{
+						"prefix": "stripecli.ADDITIONAL_INFO",
+					}).Error("If you run into issues, please re-run with `--log-level debug` and share the output with the Stripe team on GitHub.")
 				default:
 					c.cfg.Log.Error("other error: ", err)
-					c.cfg.Log.Error("If you run into issues, please re-run with `--log-level debug` and share the output with the Stripe team on GitHub.")
+					c.cfg.Log.WithFields(log.Fields{
+						"prefix": "stripecli.ADDITIONAL_INFO",
+					}).Error("If you run into issues, please re-run with `--log-level debug` and share the output with the Stripe team on GitHub.")
 				}
 				c.notifyClose <- err
 			}

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -267,10 +267,17 @@ func (c *Client) readPump() {
 					"prefix": "websocket.Client.readPump",
 				}).Debug("stopReadPump")
 			default:
-				if !ws.IsCloseError(err) {
-					c.cfg.Log.Error("read error: ", err)
-				} else if ws.IsUnexpectedCloseError(err, ws.CloseNormalClosure) {
-					c.cfg.Log.Error("read error: ", err)
+				switch {
+				case !ws.IsCloseError(err):
+					// read errors do not prevent websocket reconnects in the CLI so we should
+					// only display this on debug-level logging
+					c.cfg.Log.Debug("read error: ", err)
+				case ws.IsUnexpectedCloseError(err, ws.CloseNormalClosure):
+					c.cfg.Log.Error("close error: ", err)
+					c.cfg.Log.Error("If you run into issues, please re-run with `--log-level debug` and share the output with the Stripe team on GitHub.")
+				default:
+					c.cfg.Log.Error("other error: ", err)
+					c.cfg.Log.Error("If you run into issues, please re-run with `--log-level debug` and share the output with the Stripe team on GitHub.")
 				}
 				c.notifyClose <- err
 			}


### PR DESCRIPTION
 ### Reviewers
r? @ob-stripe 
cc @stripe/dev-platform

 ### Summary
* Changed the read error to debug-level instead of error, from testing it looks like this isn't causing the CLI to stop working
* Adding a default case to catch other possible errors that are coming up