### PR TITLE
Add shortcut for cliref in open command

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -23,7 +23,7 @@ func newConfigCmd() *configCmd {
 	cc.cmd = &cobra.Command{
 		Use:   "config",
 		Short: "Manually change the config values for the CLI",
-		Long: `config let's you set and unset specific configuration values for your profile if
+		Long: `config lets you set and unset specific configuration values for your profile if
 you need more granular control over the configuration.`,
 		Example: `stripe config --list
   stripe config --set color off

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -24,9 +24,6 @@ func newDeleteCmd() *deleteCmd {
 		Short: "Make a DELETE request to the Stripe API",
 		Long: `Make DELETE requests to the Stripe API using your test mode key.
 
-You can only delete data in test mode, the delete command does not work for
-live mode.
-
 For a full list of supported paths, see the API reference:
 https://stripe.com/docs/api
 

--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -14,6 +14,7 @@ import (
 var nameURLmap = map[string]string{
 	"api":                                "https://stripe.com/docs/api",
 	"apiref":                             "https://stripe.com/docs/api",
+	"cliref":                             "https://stripe.com/docs/cli",
 	"dashboard":                          "https://dashboard.stripe.com%s",
 	"dashboard/apikeys":                  "https://dashboard.stripe.com%s/apikeys",
 	"dashboard/atlas":                    "https://dashboard.stripe.com%s/atlas",

--- a/pkg/cmd/post.go
+++ b/pkg/cmd/post.go
@@ -25,7 +25,6 @@ func newPostCmd() *postCmd {
 		Long: `Make POST requests to the Stripe API using your test mode key.
 
 The post command supports API features like idempotency keys and expand flags.
-Currently, you can only POST data in test mode.
 
 For a full list of supported paths, see the API reference:
 https://stripe.com/docs/api


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe
cc @stripe/dev-platform

 ### Summary
![cliref_open](https://user-images.githubusercontent.com/58703040/80013082-2b48e080-8483-11ea-885c-8cc0548aed2a.gif)

**Primary change:** Add new listing for cliref in shortcuts used for `open` command.

**Secondary changes:**
- Remove lines which state `post` and `delete` can only be used in testmode.
- Fix small typo `let's -> lets`