### PR TITLE
Add fix around regex pattern used for matching fixture queries

### DIFF
--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -42,6 +42,12 @@ type fixture struct {
 	Params interface{} `json:"params"`
 }
 
+type fixtureQuery struct {
+	Name         string
+	Query        string
+	DefaultValue string
+}
+
 // Fixture contains a mapping of an individual fixtures responses for querying
 type Fixture struct {
 	Fs            afero.Fs
@@ -144,7 +150,7 @@ func (fxt *Fixture) makeRequest(data fixture) ([]byte, error) {
 }
 
 func (fxt *Fixture) parsePath(http fixture) string {
-	if r, containsQuery := matchQuery(http.Path); containsQuery {
+	if r, containsQuery := matchFixtureQuery(http.Path); containsQuery {
 		var newPath []string
 
 		matches := r.FindAllStringSubmatch(http.Path, -1)
@@ -267,18 +273,17 @@ func (fxt *Fixture) parseArray(params []interface{}, parent string, index int) [
 }
 
 func (fxt *Fixture) parseQuery(value string) string {
-	if r, containsQuery := matchQuery(value); containsQuery {
-		nameAndQuery := r.FindStringSubmatch(value)
-		name := nameAndQuery[1]
+	if query, isQuery := toFixtureQuery(value); isQuery {
+		name := query.Name
 
 		// Check if there is a default value specified
-		if nameAndQuery[3] != "" {
-			value = nameAndQuery[3]
+		if query.DefaultValue != "" {
+			value = query.DefaultValue
 		}
 
 		// Catch and insert .env values
 		if name == ".env" {
-			key := nameAndQuery[2]
+			key := query.Query
 			// Check if env variable is present
 			envValue := os.Getenv(key)
 			if envValue == "" {
@@ -303,7 +308,7 @@ func (fxt *Fixture) parseQuery(value string) string {
 		// Reset just in case someone else called a query here
 		fxt.responses[name].Reset()
 
-		query := nameAndQuery[2]
+		query := query.Query
 		findResult, err := fxt.responses[name].FindR(query)
 		if err != nil {
 			return value
@@ -353,7 +358,28 @@ func (fxt *Fixture) updateEnv(env map[string]string) error {
 	return nil
 }
 
-func matchQuery(value string) (*regexp.Regexp, bool) {
+// toFixtureQuery will parse a string into a fixtureQuery struct, additionally
+// returning a bool indicating the value did contain a fixtureQuery.
+func toFixtureQuery(value string) (fixtureQuery, bool) {
+	// Queries to fill data will start with ${ and contain a : -- search for both
+	// to make sure that we're trying to parse a query.
+	// Additionally look for an optional default value: ${name:json_path|default_value}
+	var query fixtureQuery
+	isQuery := false
+
+	if r, didMatch := matchFixtureQuery(value); didMatch {
+		isQuery = true
+		match := r.FindStringSubmatch(value)
+		query = fixtureQuery{Name: match[1], Query: match[2], DefaultValue: match[3]}
+	}
+
+	return query, isQuery
+}
+
+// matchQuery will attempt to find matches for a fixture query pattern
+// returning a *Regexp which can be used to further parse and a boolean
+// indicating a match was found.
+func matchFixtureQuery(value string) (*regexp.Regexp, bool) {
 	// Queries to fill data will start with ${ and contain a : -- search for both
 	// to make sure that we're trying to parse a query.
 	// Additionally look for an optional default value: ${name:json_path|default_value}

--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -361,9 +361,6 @@ func (fxt *Fixture) updateEnv(env map[string]string) error {
 // toFixtureQuery will parse a string into a fixtureQuery struct, additionally
 // returning a bool indicating the value did contain a fixtureQuery.
 func toFixtureQuery(value string) (fixtureQuery, bool) {
-	// Queries to fill data will start with ${ and contain a : -- search for both
-	// to make sure that we're trying to parse a query.
-	// Additionally look for an optional default value: ${name:json_path|default_value}
 	var query fixtureQuery
 	isQuery := false
 
@@ -380,9 +377,10 @@ func toFixtureQuery(value string) (fixtureQuery, bool) {
 // returning a *Regexp which can be used to further parse and a boolean
 // indicating a match was found.
 func matchFixtureQuery(value string) (*regexp.Regexp, bool) {
-	// Queries to fill data will start with ${ and contain a : -- search for both
-	// to make sure that we're trying to parse a query.
-	// Additionally look for an optional default value: ${name:json_path|default_value}
+	// Queries will start with `${` and end with `}`. The `:` is a
+	// separator for `name:json_path`. Additionally, default value will
+	// be specified after the `|`.
+	// example: ${name:json_path|default_value}
 	r := regexp.MustCompile(`\${([^\|}]+):([^\|}]+)\|?([^/\n]+)?}`)
 	if r.Match([]byte(value)) {
 		return r, true

--- a/pkg/fixtures/fixtures_test.go
+++ b/pkg/fixtures/fixtures_test.go
@@ -133,7 +133,15 @@ func TestParseWithLocalEnv(t *testing.T) {
 	data := make(map[string]interface{})
 	data["phone"] = "${.env:PHONE_LOCAL|+1234567890}"
 
+	os.Setenv("CUST_ID", "cust_12345")
 	os.Setenv("PHONE_LOCAL", "+1234")
+
+	http := fixture{
+		Path: "/v1/customers/${.env:CUST_ID}",
+	}
+
+	path := fxt.parsePath(http)
+	assert.Equal(t, "/v1/customers/cust_12345", path)
 
 	output := (fxt.parseInterface(data))
 


### PR DESCRIPTION
### Reviewers
r? @thorsten-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
The root issue of env variables not working in the fixture `path` was that the
`parsePath` method was not using the same regex pattern that was used in
`parseParam`. This divergence caused the env variables to be supported as
params but not in a path.

After adding a test and creating a common util function to extract the
fixture query matches it was found that even the regex pattern that
seemed to work for both cases needed to be tweaked for the case where
multiple fixture queries are used in a row as with:
```
/v1/charges/${char_bender:id}/capture/${cust_bender:id}
```

The screenshots below show the matching issues with the previous patterns and the new pattern matching. 

### Old patterns
<img width="599" alt="Screen Shot 2020-04-27 at 6 15 13 PM" src="https://user-images.githubusercontent.com/58703040/80437365-3dc57e80-88b6-11ea-83a9-135db0685831.png">

<img width="653" alt="Screen Shot 2020-04-27 at 6 16 00 PM" src="https://user-images.githubusercontent.com/58703040/80437371-3ef6ab80-88b6-11ea-9ad9-e76c5038892e.png">


### New pattern
<img width="610" alt="Screen Shot 2020-04-27 at 6 21 52 PM" src="https://user-images.githubusercontent.com/58703040/80437070-8892c680-88b5-11ea-8deb-9f5cb8137959.png">

