### PR TITLE
Refine wording for `stripe serve`.

### DIFF
--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -32,7 +32,7 @@ func newServeCmd() *serveCmd {
 				dir = args[0]
 			}
 
-			fmt.Println("Starting stripe server at address", fmt.Sprintf("http://localhost:%s", port))
+			fmt.Println("Starting static file server at address", fmt.Sprintf("http://localhost:%s", port))
 			http.Handle("/", http.FileServer(http.Dir(dir)))
 			err := http.ListenAndServe(fmt.Sprintf(":%s", port), handlers.LoggingHandler(os.Stdout, http.DefaultServeMux))
 


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Updating the output of `stripe serve` to make it clear it's providing a static file server.