### PR TITLE
Use mailchain/goreleaser-xcgo Docker image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,17 +6,43 @@ before:
     - go generate ./...
 project_name: stripe
 builds:
-  - main: ./cmd/stripe/main.go
+  - id: stripe-darwin-amd64
+    ldflags:
+      - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
+    binary: stripe
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
+    main: ./cmd/stripe/main.go
     goos:
       - darwin
+    goarch:
+      - amd64
+  - id: stripe-linux-amd64
+    ldflags:
+      - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
+    binary: stripe
+    env:
+      - CGO_ENABLED=1
+    main: ./cmd/stripe/main.go
+    goos:
       - linux
+    goarch:
+      - amd64
+  - id: stripe-windows-amd64
+    ldflags:
+      - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
+    binary: stripe
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    main: ./cmd/stripe/main.go
+    goos:
       - windows
     goarch:
       - amd64
-    ldflags:
-      - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
 archives:
   -
     replacements:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,14 @@ install:
 script:
   - make ci
 
-after_success:
-  - test -n "$TRAVIS_TAG" && docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-
 deploy:
 - provider: script
   skip_cleanup: true
-  script: curl -sL https://git.io/goreleaser | bash -s -- --rm-dist
+  # We're running GoReleaser using the mailchain/goreleaser-xcgo Docker image
+  # so we can use cgo when building the binaries for all platforms.
+  # See https://github.com/stripe/stripe-cli/pull/439 and
+  # https://github.com/goreleaser/goreleaser/issues/708#issuecomment-488779914
+  script: docker run -e DOCKER_USERNAME=$DOCKER_USERNAME -e DOCKER_PASSWORD=$DOCKER_PASSWORD -e GITHUB_TOKEN=$GITHUB_TOKEN --rm --privileged -v $TRAVIS_BUILD_DIR:/go/src/github.com/stripe/stripe-cli -v /var/run/docker.sock:/var/run/docker.sock -w /go/src/github.com/stripe/stripe-cli mailchain/goreleaser-xcgo --rm-dist
   verbose: true
   on:
     tags: true


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
This PR enables the use of cgo for all binaries, which should fix the DNS issue on macOS that some users have been observing, caused by a known upstream issue in Go itself (https://github.com/golang/go/issues/12524).

Instead of running GoReleaser directly in Travis, it's now run in a Docker image that is set up specifically to be able to use cgo when compiling binaries for macOS and Windows: https://github.com/mailchain/goreleaser-xcgo.

The Docker image is fairly simple: it's based on the official `dockercore/golang-cross` image, and simply adds GoReleaser and Docker to the container (we need Docker inside the Docker container itself, because GoReleaser needs to be able to push the Docker image it creates to the central repository).

I've tested this as best I could, by running the image locally:
```
# This works
$ docker run --privileged -v $PWD:/Users/ob/go/src/github.com/stripe/stripe-cli -v /var/run/docker.sock:/var/run/docker.sock -w /Users/ob/go/src/github.com/stripe/stripe-cli mailchain/goreleaser-xcgo --snapshot --rm-dist --skip-publish

# Log into the Docker container
$ docker run --privileged -v $PWD:/Users/ob/go/src/github.com/stripe/stripe-cli -v /var/run/docker.sock:/var/run/docker.sock -w /Users/ob/go/src/github.com/stripe/stripe-cli -it --entrypoint /bin/bash mailchain/goreleaser-xcgo

# Inside the Docker container
$ goreleaser --snapshot --skip-publish

# On the host machine, get the macOS binary
$ docker cp bd0aec3fdf03:/Users/ob/go/src/github.com/stripe/stripe-cli/dist/stripe-darwin-amd64_darwin_amd64/stripe .

# Run the binary
$ GODEBUG=netdns=cgo+1 ./stripe listen
go package net: using cgo DNS resolver

# In contrast, brew-installed binary
$ GODEBUG=netdns=cgo+1 stripe listen
go package net: built with netgo build tag; using Go's DNS resolver
```
