### PR TITLE
Fix Docker image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
       - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
     binary: stripe
     env:
-      - CGO_ENABLED=1
+      - CGO_ENABLED=0
     main: ./cmd/stripe/main.go
     goos:
       - linux
@@ -67,6 +67,8 @@ changelog:
     - '^test:'
 nfpms:
   -
+    builds:
+    - stripe-linux-amd64
     vendor: Stripe
     homepage:  https://stripe.com
     maintainer: Stripe <support@stripe.com>
@@ -111,8 +113,20 @@ scoop:
   description: Stripe CLI utility
   license: Apache 2.0
 dockers:
-  - binaries:
+  - goos: linux
+    goarch: amd64
+    binaries:
     - stripe
+    builds:
+    - stripe-linux-amd64
     image_templates:
     - "stripe/stripe-cli:latest"
     - "stripe/stripe-cli:{{ .Tag }}"
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.name={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=repository=https://github.com/stripe/stripe-cli"
+    - "--label=homepage=https://stripe.com"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine
-RUN apk add ca-certificates
+RUN apk update && apk upgrade && \
+  apk add --no-cache ca-certificates
 COPY stripe /bin/stripe
 ENTRYPOINT ["/bin/stripe"]


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Fix Docker image.

My change from yesterday to enable cgo (#439) unfortunately broke the Docker image for the CLI, because the Alpine image does not have the required libraries that the cgo-enabled `stripe` binary expects.

I've fixed this by disabling cgo for Linux, and keeping it enabled for macOS and Windows, and verified that the Docker image works again (by building locally). The main reason we wanted cgo was to fix the DNS issue on macOS anyway.

If it turns out that using cgo for Linux is desirable for some reason, there are a few ways we can enable it:
- compile 2 different Linux binaries, one with cgo enabled and one with cgo disabled. Use the first one for distributing and the second one for the Docker image. (This will result in a much more complex `.goreleaser.yml file.)
- compile the Linux binary with cgo enabled, and update the Docker image to support it. (But this will result in a larger Docker image.)
