### PR TITLE
Generate flags for polymorphic scalar types

### DIFF
--- a/pkg/cmd/resources_cmds.go
+++ b/pkg/cmd/resources_cmds.go
@@ -129,6 +129,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rAccountsCmd.Cmd, "delete", "/v1/accounts/{account}", http.MethodDelete, map[string]string{}, &Config)
 	resource.NewOperationCmd(rAccountsCmd.Cmd, "list", "/v1/accounts", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"starting_after": "string",
@@ -157,6 +158,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rApplePayDomainsCmd.Cmd, "retrieve", "/v1/apple_pay/domains/{domain}", http.MethodGet, map[string]string{}, &Config)
 	resource.NewOperationCmd(rApplicationFeesCmd.Cmd, "list", "/v1/application_fees", http.MethodGet, map[string]string{
 		"charge":         "string",
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"starting_after": "string",
@@ -164,6 +166,8 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rApplicationFeesCmd.Cmd, "retrieve", "/v1/application_fees/{id}", http.MethodGet, map[string]string{}, &Config)
 	resource.NewOperationCmd(rBalanceCmd.Cmd, "retrieve", "/v1/balance", http.MethodGet, map[string]string{}, &Config)
 	resource.NewOperationCmd(rBalanceTransactionsCmd.Cmd, "list", "/v1/balance_transactions", http.MethodGet, map[string]string{
+		"available_on":   "integer",
+		"created":        "integer",
 		"currency":       "string",
 		"ending_before":  "string",
 		"limit":          "integer",
@@ -232,6 +236,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"transfer_group":              "string",
 	}, &Config)
 	resource.NewOperationCmd(rChargesCmd.Cmd, "list", "/v1/charges", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"customer":       "string",
 		"ending_before":  "string",
 		"limit":          "integer",
@@ -265,6 +270,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rCouponsCmd.Cmd, "delete", "/v1/coupons/{coupon}", http.MethodDelete, map[string]string{}, &Config)
 	resource.NewOperationCmd(rCouponsCmd.Cmd, "list", "/v1/coupons", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"starting_after": "string",
@@ -353,6 +359,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rCustomersCmd.Cmd, "delete", "/v1/customers/{customer}", http.MethodDelete, map[string]string{}, &Config)
 	resource.NewOperationCmd(rCustomersCmd.Cmd, "delete_discount", "/v1/customers/{customer}/discount", http.MethodDelete, map[string]string{}, &Config)
 	resource.NewOperationCmd(rCustomersCmd.Cmd, "list", "/v1/customers", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"email":          "string",
 		"ending_before":  "string",
 		"limit":          "integer",
@@ -371,10 +378,12 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"phone":                 "string",
 		"source":                "string",
 		"tax_exempt":            "string",
+		"trial_end":             "string",
 	}, &Config)
 	resource.NewOperationCmd(rDisputesCmd.Cmd, "close", "/v1/disputes/{dispute}/close", http.MethodPost, map[string]string{}, &Config)
 	resource.NewOperationCmd(rDisputesCmd.Cmd, "list", "/v1/disputes", http.MethodGet, map[string]string{
 		"charge":         "string",
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"payment_intent": "string",
@@ -390,6 +399,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rEphemeralKeysCmd.Cmd, "delete", "/v1/ephemeral_keys/{key}", http.MethodDelete, map[string]string{}, &Config)
 	resource.NewOperationCmd(rEventsCmd.Cmd, "list", "/v1/events", http.MethodGet, map[string]string{
+		"created":          "integer",
 		"delivery_success": "boolean",
 		"ending_before":    "string",
 		"limit":            "integer",
@@ -443,6 +453,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"file":       "string",
 	}, &Config)
 	resource.NewOperationCmd(rFileLinksCmd.Cmd, "list", "/v1/file_links", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"ending_before":  "string",
 		"expired":        "boolean",
 		"file":           "string",
@@ -450,9 +461,12 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"starting_after": "string",
 	}, &Config)
 	resource.NewOperationCmd(rFileLinksCmd.Cmd, "retrieve", "/v1/file_links/{link}", http.MethodGet, map[string]string{}, &Config)
-	resource.NewOperationCmd(rFileLinksCmd.Cmd, "update", "/v1/file_links/{link}", http.MethodPost, map[string]string{}, &Config)
+	resource.NewOperationCmd(rFileLinksCmd.Cmd, "update", "/v1/file_links/{link}", http.MethodPost, map[string]string{
+		"expires_at": "string",
+	}, &Config)
 	resource.NewOperationCmd(rFilesCmd.Cmd, "create", "/v1/files", http.MethodPost, map[string]string{}, &Config)
 	resource.NewOperationCmd(rFilesCmd.Cmd, "list", "/v1/files", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"purpose":        "string",
@@ -474,6 +488,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rInvoiceitemsCmd.Cmd, "delete", "/v1/invoiceitems/{invoiceitem}", http.MethodDelete, map[string]string{}, &Config)
 	resource.NewOperationCmd(rInvoiceitemsCmd.Cmd, "list", "/v1/invoiceitems", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"customer":       "string",
 		"ending_before":  "string",
 		"invoice":        "string",
@@ -512,7 +527,9 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rInvoicesCmd.Cmd, "list", "/v1/invoices", http.MethodGet, map[string]string{
 		"collection_method": "string",
+		"created":           "integer",
 		"customer":          "string",
+		"due_date":          "integer",
 		"ending_before":     "string",
 		"limit":             "integer",
 		"starting_after":    "string",
@@ -534,6 +551,8 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"customer":                          "string",
 		"schedule":                          "string",
 		"subscription":                      "string",
+		"subscription_billing_cycle_anchor": "string",
+		"subscription_cancel_at":            "integer",
 		"subscription_cancel_at_period_end": "boolean",
 		"subscription_cancel_now":           "boolean",
 		"subscription_prorate":              "boolean",
@@ -541,6 +560,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"subscription_proration_date":       "integer",
 		"subscription_start_date":           "integer",
 		"subscription_tax_percent":          "number",
+		"subscription_trial_end":            "string",
 		"subscription_trial_from_plan":      "boolean",
 	}, &Config)
 	resource.NewOperationCmd(rInvoicesCmd.Cmd, "upcomingLines", "/v1/invoices/upcoming/lines", http.MethodGet, map[string]string{
@@ -551,6 +571,8 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"schedule":                          "string",
 		"starting_after":                    "string",
 		"subscription":                      "string",
+		"subscription_billing_cycle_anchor": "string",
+		"subscription_cancel_at":            "integer",
 		"subscription_cancel_at_period_end": "boolean",
 		"subscription_cancel_now":           "boolean",
 		"subscription_prorate":              "boolean",
@@ -558,6 +580,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"subscription_proration_date":       "integer",
 		"subscription_start_date":           "integer",
 		"subscription_tax_percent":          "number",
+		"subscription_trial_end":            "string",
 		"subscription_trial_from_plan":      "boolean",
 	}, &Config)
 	resource.NewOperationCmd(rInvoicesCmd.Cmd, "update", "/v1/invoices/{invoice}", http.MethodPost, map[string]string{
@@ -571,6 +594,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"due_date":               "integer",
 		"footer":                 "string",
 		"statement_descriptor":   "string",
+		"tax_percent":            "number",
 	}, &Config)
 	resource.NewOperationCmd(rInvoicesCmd.Cmd, "void_invoice", "/v1/invoices/{invoice}/void", http.MethodPost, map[string]string{}, &Config)
 	resource.NewOperationCmd(rLineItemsCmd.Cmd, "list", "/v1/invoices/{invoice}/lines", http.MethodGet, map[string]string{
@@ -583,6 +607,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rMandatesCmd.Cmd, "retrieve", "/v1/mandates/{mandate}", http.MethodGet, map[string]string{}, &Config)
 	resource.NewOperationCmd(rOrderReturnsCmd.Cmd, "list", "/v1/order_returns", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"order":          "string",
@@ -596,6 +621,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"email":    "string",
 	}, &Config)
 	resource.NewOperationCmd(rOrdersCmd.Cmd, "list", "/v1/orders", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"customer":       "string",
 		"ending_before":  "string",
 		"limit":          "integer",
@@ -627,7 +653,9 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rPaymentIntentsCmd.Cmd, "confirm", "/v1/payment_intents/{intent}/confirm", http.MethodPost, map[string]string{
 		"error_on_requires_action": "boolean",
 		"mandate":                  "string",
+		"off_session":              "boolean",
 		"payment_method":           "string",
+		"receipt_email":            "string",
 		"return_url":               "string",
 		"save_payment_method":      "boolean",
 		"setup_future_usage":       "string",
@@ -645,6 +673,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"description":                 "string",
 		"error_on_requires_action":    "boolean",
 		"mandate":                     "string",
+		"off_session":                 "boolean",
 		"on_behalf_of":                "string",
 		"payment_method":              "string",
 		"receipt_email":               "string",
@@ -658,6 +687,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"use_stripe_sdk":              "boolean",
 	}, &Config)
 	resource.NewOperationCmd(rPaymentIntentsCmd.Cmd, "list", "/v1/payment_intents", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"customer":       "string",
 		"ending_before":  "string",
 		"limit":          "integer",
@@ -668,10 +698,12 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rPaymentIntentsCmd.Cmd, "update", "/v1/payment_intents/{intent}", http.MethodPost, map[string]string{
 		"amount":                      "integer",
+		"application_fee_amount":      "integer",
 		"currency":                    "string",
 		"customer":                    "string",
 		"description":                 "string",
 		"payment_method":              "string",
+		"receipt_email":               "string",
 		"save_payment_method":         "boolean",
 		"setup_future_usage":          "string",
 		"source":                      "string",
@@ -718,6 +750,8 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"statement_descriptor": "string",
 	}, &Config)
 	resource.NewOperationCmd(rPayoutsCmd.Cmd, "list", "/v1/payouts", http.MethodGet, map[string]string{
+		"arrival_date":   "integer",
+		"created":        "integer",
 		"destination":    "string",
 		"ending_before":  "string",
 		"limit":          "integer",
@@ -774,6 +808,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"interval":          "string",
 		"interval_count":    "integer",
 		"nickname":          "string",
+		"product":           "string",
 		"tiers_mode":        "string",
 		"trial_period_days": "integer",
 		"usage_type":        "string",
@@ -781,6 +816,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rPlansCmd.Cmd, "delete", "/v1/plans/{plan}", http.MethodDelete, map[string]string{}, &Config)
 	resource.NewOperationCmd(rPlansCmd.Cmd, "list", "/v1/plans", http.MethodGet, map[string]string{
 		"active":         "boolean",
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"product":        "string",
@@ -807,6 +843,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rPricesCmd.Cmd, "list", "/v1/prices", http.MethodGet, map[string]string{
 		"active":         "boolean",
+		"created":        "integer",
 		"currency":       "string",
 		"ending_before":  "string",
 		"limit":          "integer",
@@ -836,6 +873,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rProductsCmd.Cmd, "delete", "/v1/products/{id}", http.MethodDelete, map[string]string{}, &Config)
 	resource.NewOperationCmd(rProductsCmd.Cmd, "list", "/v1/products", http.MethodGet, map[string]string{
 		"active":         "boolean",
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"shippable":      "boolean",
@@ -864,6 +902,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rRefundsCmd.Cmd, "list", "/v1/refunds", http.MethodGet, map[string]string{
 		"charge":         "string",
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"payment_intent": "string",
@@ -873,6 +912,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rRefundsCmd.Cmd, "update", "/v1/refunds/{refund}", http.MethodPost, map[string]string{}, &Config)
 	resource.NewOperationCmd(rReviewsCmd.Cmd, "approve", "/v1/reviews/{review}/approve", http.MethodPost, map[string]string{}, &Config)
 	resource.NewOperationCmd(rReviewsCmd.Cmd, "list", "/v1/reviews", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"starting_after": "string",
@@ -901,6 +941,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"usage":          "string",
 	}, &Config)
 	resource.NewOperationCmd(rSetupIntentsCmd.Cmd, "list", "/v1/setup_intents", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"customer":       "string",
 		"ending_before":  "string",
 		"limit":          "integer",
@@ -1005,11 +1046,16 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"customer":          "string",
 		"end_behavior":      "string",
 		"from_subscription": "string",
+		"start_date":        "integer",
 	}, &Config)
 	resource.NewOperationCmd(rSubscriptionSchedulesCmd.Cmd, "list", "/v1/subscription_schedules", http.MethodGet, map[string]string{
+		"canceled_at":    "integer",
+		"completed_at":   "integer",
+		"created":        "integer",
 		"customer":       "string",
 		"ending_before":  "string",
 		"limit":          "integer",
+		"released_at":    "integer",
 		"scheduled":      "boolean",
 		"starting_after": "string",
 	}, &Config)
@@ -1039,24 +1085,30 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"payment_behavior":        "string",
 		"prorate":                 "boolean",
 		"proration_behavior":      "string",
+		"tax_percent":             "number",
+		"trial_end":               "string",
 		"trial_from_plan":         "boolean",
 		"trial_period_days":       "integer",
 	}, &Config)
 	resource.NewOperationCmd(rSubscriptionsCmd.Cmd, "delete_discount", "/v1/subscriptions/{subscription_exposed_id}/discount", http.MethodDelete, map[string]string{}, &Config)
 	resource.NewOperationCmd(rSubscriptionsCmd.Cmd, "list", "/v1/subscriptions", http.MethodGet, map[string]string{
-		"collection_method": "string",
-		"customer":          "string",
-		"ending_before":     "string",
-		"limit":             "integer",
-		"plan":              "string",
-		"price":             "string",
-		"starting_after":    "string",
-		"status":            "string",
+		"collection_method":    "string",
+		"created":              "integer",
+		"current_period_end":   "integer",
+		"current_period_start": "integer",
+		"customer":             "string",
+		"ending_before":        "string",
+		"limit":                "integer",
+		"plan":                 "string",
+		"price":                "string",
+		"starting_after":       "string",
+		"status":               "string",
 	}, &Config)
 	resource.NewOperationCmd(rSubscriptionsCmd.Cmd, "retrieve", "/v1/subscriptions/{subscription_exposed_id}", http.MethodGet, map[string]string{}, &Config)
 	resource.NewOperationCmd(rSubscriptionsCmd.Cmd, "update", "/v1/subscriptions/{subscription_exposed_id}", http.MethodPost, map[string]string{
 		"application_fee_percent": "number",
 		"billing_cycle_anchor":    "string",
+		"cancel_at":               "integer",
 		"cancel_at_period_end":    "boolean",
 		"collection_method":       "string",
 		"coupon":                  "string",
@@ -1068,6 +1120,8 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"prorate":                 "boolean",
 		"proration_behavior":      "string",
 		"proration_date":          "integer",
+		"tax_percent":             "number",
+		"trial_end":               "string",
 		"trial_from_plan":         "boolean",
 	}, &Config)
 	resource.NewOperationCmd(rTaxIdsCmd.Cmd, "create", "/v1/customers/{customer}/tax_ids", http.MethodPost, map[string]string{
@@ -1091,6 +1145,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rTaxRatesCmd.Cmd, "list", "/v1/tax_rates", http.MethodGet, map[string]string{
 		"active":         "boolean",
+		"created":        "integer",
 		"ending_before":  "string",
 		"inclusive":      "boolean",
 		"limit":          "integer",
@@ -1104,6 +1159,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"jurisdiction": "string",
 	}, &Config)
 	resource.NewOperationCmd(rTokensCmd.Cmd, "create", "/v1/tokens", http.MethodPost, map[string]string{
+		"card":     "string",
 		"customer": "string",
 	}, &Config)
 	resource.NewOperationCmd(rTokensCmd.Cmd, "retrieve", "/v1/tokens/{token}", http.MethodGet, map[string]string{}, &Config)
@@ -1117,6 +1173,8 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"transfer_group":       "string",
 	}, &Config)
 	resource.NewOperationCmd(rTopupsCmd.Cmd, "list", "/v1/topups", http.MethodGet, map[string]string{
+		"amount":         "integer",
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"starting_after": "string",
@@ -1148,6 +1206,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"transfer_group":     "string",
 	}, &Config)
 	resource.NewOperationCmd(rTransfersCmd.Cmd, "list", "/v1/transfers", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"destination":    "string",
 		"ending_before":  "string",
 		"limit":          "integer",
@@ -1216,6 +1275,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rIssuingAuthorizationsCmd.Cmd, "list", "/v1/issuing/authorizations", http.MethodGet, map[string]string{
 		"card":           "string",
 		"cardholder":     "string",
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"starting_after": "string",
@@ -1231,6 +1291,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"type":         "string",
 	}, &Config)
 	resource.NewOperationCmd(rIssuingCardholdersCmd.Cmd, "list", "/v1/issuing/cardholders", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"email":          "string",
 		"ending_before":  "string",
 		"limit":          "integer",
@@ -1255,6 +1316,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rIssuingCardsCmd.Cmd, "list", "/v1/issuing/cards", http.MethodGet, map[string]string{
 		"cardholder":     "string",
+		"created":        "integer",
 		"ending_before":  "string",
 		"exp_month":      "integer",
 		"exp_year":       "integer",
@@ -1280,6 +1342,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rIssuingTransactionsCmd.Cmd, "list", "/v1/issuing/transactions", http.MethodGet, map[string]string{
 		"card":           "string",
 		"cardholder":     "string",
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"starting_after": "string",
@@ -1299,6 +1362,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	}, &Config)
 	resource.NewOperationCmd(rRadarValueListItemsCmd.Cmd, "delete", "/v1/radar/value_list_items/{item}", http.MethodDelete, map[string]string{}, &Config)
 	resource.NewOperationCmd(rRadarValueListItemsCmd.Cmd, "list", "/v1/radar/value_list_items", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"starting_after": "string",
@@ -1315,6 +1379,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rRadarValueListsCmd.Cmd, "list", "/v1/radar/value_lists", http.MethodGet, map[string]string{
 		"alias":          "string",
 		"contains":       "string",
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"starting_after": "string",
@@ -1328,6 +1393,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"report_type": "string",
 	}, &Config)
 	resource.NewOperationCmd(rReportingReportRunsCmd.Cmd, "list", "/v1/reporting/report_runs", http.MethodGet, map[string]string{
+		"created":        "integer",
 		"ending_before":  "string",
 		"limit":          "integer",
 		"starting_after": "string",


### PR DESCRIPTION
 ### Reviewers
r? @brandur-stripe @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
Generate flags for polymorphic scalar types in resource commands, i.e. polymorphic types where at least one of the types is scalar.

For instance, the `product` parameter in plan creation requests can be a hash or a string. This PR will let users use the string form with `stripe plans create --product=prod_123`, rather than being forced to use the `-d` escape hatch `stripe plans create -d product=prod_123`.

Fixes #352.