### PR TITLE
Add installation instructions to `stripe completion`

### DIFF
--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/validators"
+	"runtime"
 )
 
 type completionCmd struct {
@@ -33,6 +34,53 @@ func newCompletionCmd() *completionCmd {
 	return cc
 }
 
+var zsh_completion_instructions = `
+Suggested next steps:
+----------------------
+1. Move ` + "`stripe-completion.zsh`" + `to the correct location:
+    mkdir -p ~/.stripe
+    mv stripe-completion.zsh ~/.stripe
+
+2. Add the following lines to your ` + "`.zshrc`" + ` enabling shell completion for Stripe:
+    fpath=(~/.stripe $fpath)
+    autoload -Uz compinit && compinit -i
+
+3. Source your ` + "`.zshrc`" + `or open a new terminal session:
+    source ~/.zshrc
+`
+
+var bash_completion_instructions_mac = `
+1. (If you've never installed bash completion before) Install bash completion on your system.
+    brew install bash-completion
+
+2. (If you've never installed bash completion before) Follow the post-instructions that brew displays, and add a line like the following to your bash profile:
+    [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
+
+3. Move ` + "`stripe-completion.bash`" + `to the correct location:
+    mkdir -p ~/.stripe
+    mv stripe-completion.bash ~/.stripe
+
+4. Add the following line to your bash profile, so that Stripe autocompletion will be enabled every time you start a new terminal session.
+    source ~/.stripe/stripe-completion.bash
+
+5. And either restart your terminal, or run the following command in your current session, to enable immediately.
+    source ~/.stripe/stripe-completion.bash
+`
+
+var bash_completion_instructions_linux = `
+1. Make sure bash completion is installed on your system. Usually this means checking that a file such as ` + "`/etc/profile.d/bash_completion.sh`" + ` exists, and is sourced by your bash profile, but the location of this file varies across flavors of Linux.
+
+2. Move ` + "`stripe-completion.bash`" + `to the correct location:
+    mkdir -p ~/.stripe
+    mv stripe-completion.bash ~/.stripe
+
+3. Add the following line to your bash profile, so that Stripe autocompletion will be enabled every time you start a new terminal session.
+    source ~/.stripe/stripe-completion.bash
+
+4. And either restart your terminal, or run the following command in your current session, to enable immediately.
+    source ~/.stripe/stripe-completion.bash
+`
+
 func selectShell(shell string) error {
 	selected := shell
 	if selected == "" {
@@ -42,10 +90,22 @@ func selectShell(shell string) error {
 	switch {
 	case selected == "zsh":
 		fmt.Println("Detected `zsh`, generating zsh completion file: stripe-completion.zsh")
-		return rootCmd.GenZshCompletionFile("stripe-completion.zsh")
+                err := rootCmd.GenZshCompletionFile("stripe-completion.zsh")
+                if err == nil {
+                  fmt.Println(zsh_completion_instructions)
+                }
+                return err
 	case selected == "bash":
 		fmt.Println("Detected `bash`, generating bash completion file: stripe-completion.bash")
-		return rootCmd.GenBashCompletionFile("stripe-completion.bash")
+                err := rootCmd.GenBashCompletionFile("stripe-completion.bash")
+                if err == nil {
+                  if runtime.GOOS == "darwin" {
+                    fmt.Println(bash_completion_instructions_mac)
+                  } else if runtime.GOOS == "linux" {
+                    fmt.Println(bash_completion_instructions_linux)
+                  }
+                }
+                return err
 	default:
 		return fmt.Errorf("Could not automatically detect your shell. Please run the command with the `--shell` flag for either bash or zsh")
 	}

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/stripe/stripe-cli/pkg/validators"
 	"runtime"
+
+	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
 type completionCmd struct {
@@ -34,10 +35,13 @@ func newCompletionCmd() *completionCmd {
 	return cc
 }
 
-var zsh_completion_instructions = `
+const (
+	instructionsHeader = `
 Suggested next steps:
-----------------------
-1. Move ` + "`stripe-completion.zsh`" + `to the correct location:
+---------------------`
+
+	zshCompletionInstructions = `
+1. Move ` + "`stripe-completion.zsh`" + ` to the correct location:
     mkdir -p ~/.stripe
     mv stripe-completion.zsh ~/.stripe
 
@@ -45,41 +49,40 @@ Suggested next steps:
     fpath=(~/.stripe $fpath)
     autoload -Uz compinit && compinit -i
 
-3. Source your ` + "`.zshrc`" + `or open a new terminal session:
-    source ~/.zshrc
-`
+3. Source your ` + "`.zshrc`" + ` or open a new terminal session:
+    source ~/.zshrc`
 
-var bash_completion_instructions_mac = `
-1. (If you've never installed bash completion before) Install bash completion on your system.
-    brew install bash-completion
+	bashCompletionInstructionsMac = `
+Set up bash autocompletion on your system:
+1. Install the bash autocompletion package:
+     brew install bash-completion
+2. Follow the post-install instructions displayed by Homebrew; add a line like the following to your bash profile:
+     [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
 
-2. (If you've never installed bash completion before) Follow the post-instructions that brew displays, and add a line like the following to your bash profile:
-    [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
-
-3. Move ` + "`stripe-completion.bash`" + `to the correct location:
+Set up Stripe autocompletion:
+3. Move ` + "`stripe-completion.bash`" + ` to the correct location:
     mkdir -p ~/.stripe
     mv stripe-completion.bash ~/.stripe
 
-4. Add the following line to your bash profile, so that Stripe autocompletion will be enabled every time you start a new terminal session.
+4. Add the following line to your bash profile, so that Stripe autocompletion will be enabled every time you start a new terminal session:
     source ~/.stripe/stripe-completion.bash
 
-5. And either restart your terminal, or run the following command in your current session, to enable immediately.
-    source ~/.stripe/stripe-completion.bash
-`
+5. Either restart your terminal, or run the following command in your current session to enable immediately:
+    source ~/.stripe/stripe-completion.bash`
 
-var bash_completion_instructions_linux = `
-1. Make sure bash completion is installed on your system. Usually this means checking that a file such as ` + "`/etc/profile.d/bash_completion.sh`" + ` exists, and is sourced by your bash profile, but the location of this file varies across flavors of Linux.
+	bashCompletionInstructionsLinux = `
+1. Ensure bash autocompletion is installed on your system. Often, this means verifying that ` + "`/etc/profile.d/bash_completion.sh`" + ` exists, and is sourced by your bash profile; the location of this file varies across distributions of Linux.
 
-2. Move ` + "`stripe-completion.bash`" + `to the correct location:
+2. Move ` + "`stripe-completion.bash`" + ` to the correct location:
     mkdir -p ~/.stripe
     mv stripe-completion.bash ~/.stripe
 
-3. Add the following line to your bash profile, so that Stripe autocompletion will be enabled every time you start a new terminal session.
+3. Add the following line to your bash profile, so that Stripe autocompletion will be enabled every time you start a new terminal session:
     source ~/.stripe/stripe-completion.bash
 
-4. And either restart your terminal, or run the following command in your current session, to enable immediately.
-    source ~/.stripe/stripe-completion.bash
-`
+4. Either restart your terminal, or run the following command in your current session to enable immediately:
+    source ~/.stripe/stripe-completion.bash`
+)
 
 func selectShell(shell string) error {
 	selected := shell
@@ -90,22 +93,22 @@ func selectShell(shell string) error {
 	switch {
 	case selected == "zsh":
 		fmt.Println("Detected `zsh`, generating zsh completion file: stripe-completion.zsh")
-                err := rootCmd.GenZshCompletionFile("stripe-completion.zsh")
-                if err == nil {
-                  fmt.Println(zsh_completion_instructions)
-                }
-                return err
+		err := rootCmd.GenZshCompletionFile("stripe-completion.zsh")
+		if err == nil {
+			fmt.Printf("%s%s\n", instructionsHeader, zshCompletionInstructions)
+		}
+		return err
 	case selected == "bash":
 		fmt.Println("Detected `bash`, generating bash completion file: stripe-completion.bash")
-                err := rootCmd.GenBashCompletionFile("stripe-completion.bash")
-                if err == nil {
-                  if runtime.GOOS == "darwin" {
-                    fmt.Println(bash_completion_instructions_mac)
-                  } else if runtime.GOOS == "linux" {
-                    fmt.Println(bash_completion_instructions_linux)
-                  }
-                }
-                return err
+		err := rootCmd.GenBashCompletionFile("stripe-completion.bash")
+		if err == nil {
+			if runtime.GOOS == "darwin" {
+				fmt.Printf("%s%s\n", instructionsHeader, bashCompletionInstructionsMac)
+			} else if runtime.GOOS == "linux" {
+				fmt.Printf("%s%s\n", instructionsHeader, bashCompletionInstructionsLinux)
+			}
+		}
+		return err
 	default:
 		return fmt.Errorf("Could not automatically detect your shell. Please run the command with the `--shell` flag for either bash or zsh")
 	}


### PR DESCRIPTION
Paired with @ianjabour-stripe on this. Addresses https://github.com/stripe/stripe-cli/issues/446
### Reviewers
r? @tomer-stripe 
cc @auchenberg-stripe @ianjabour-stripe 

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Causes `stripe completion` to print instructions on how to install bash completion, after successfully generating the completion file.

The instructions are based off of instructions in the [new cli autocompletion docs](https://stripe.com/docs/stripe-cli/configure#autocompletion).

#### zsh
<img width="999" alt="00_zsh_instructions" src="https://user-images.githubusercontent.com/58703040/82385673-7c4ae680-99e7-11ea-9ab7-6d60cc94c2b5.png">


#### bash (Mac)
<img width="1006" alt="00_bash_mac_instructions" src="https://user-images.githubusercontent.com/58703040/82385662-7228e800-99e7-11ea-8003-a4ec326a9d81.png">


#### bash (Linux)
<img width="1679" alt="00_bash_linux_instructions" src="https://user-images.githubusercontent.com/58703040/82385640-6806e980-99e7-11ea-8650-af7ad443bc1c.png">



Side Note:
For Bash, we link to https://sourabhbajaj.com/mac-setup/BashCompletion/ from the CLI ref -- those instructions say to add
`[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion` but this didn't work for me -- instead, I had to do as brew instructed `[[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"`
