### PR TITLE
Add retry to CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - make setup
 
 script:
-  - make ci
+  - travis_retry make ci
 
 deploy:
 - provider: script


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

This adds up to 3 retries when running `make ci`, as a stopgap to deal with flaky tests.
