### PR TITLE
Fix Racy Test

### DIFF
--- a/pkg/websocket/client_test.go
+++ b/pkg/websocket/client_test.go
@@ -2,7 +2,6 @@ package websocket
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -72,7 +71,6 @@ func TestClientWebhookEventHandler(t *testing.T) {
 		require.FailNow(t, "Timed out waiting for response from test server")
 	}
 
-	fmt.Println("assertions")
 	require.Equal(t, "TestAgent/v1", rcvMsg.HTTPHeaders["User-Agent"])
 	require.Equal(t, "t=123,v1=hunter2", rcvMsg.HTTPHeaders["Stripe-Signature"])
 	require.Equal(t, "{}", rcvMsg.EventPayload)


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @ianjabour-stripe (paired with me)

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
This test has been causing us much pain. Apparently the websocket client eventhandler can trigger multiple events. This changes the test to block only until the first event comes through and then just go with that, instead of assuming that only one event will ever happen.