### PR TITLE
Add GitHub Action workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,11 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
+    # Windows throws false positives with linting because of CRLF / goimports incompat
+    - name: Set git to use LF
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run Setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.14.x]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run Setup
+      run: make setup
+    - name: Run Tests
+      run: make ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,4 @@ jobs:
       run: make setup
     - name: Run Tests
       run: make ci
+      shell: bash

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ bin/golangci-lint:
 	curl -fsSL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s $(GOLANGCI_LINT_VERSION)
 
 bin/misspell:
-	curl -fsSL https://git.io/misspell | sh
+	curl -fsSL https://git.io/misspell | bash
 
 # Clean go.mod
 go-mod-tidy:

--- a/Makefile
+++ b/Makefile
@@ -34,17 +34,13 @@ fmt:
 .PHONY: fmt
 
 # Run all the linters
-lint: bin/golangci-lint bin/misspell
+lint: bin/golangci-lint
 	# TODO: fix disabled linter issues
 	./bin/golangci-lint run ./...
-	./bin/misspell -error **/*.go
 .PHONY: lint
 
 bin/golangci-lint:
 	curl -fsSL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s $(GOLANGCI_LINT_VERSION)
-
-bin/misspell:
-	curl -fsSL https://git.io/misspell | bash
 
 # Clean go.mod
 go-mod-tidy:

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"path/filepath"
 	"testing"
 
 	"github.com/mitchellh/go-homedir"
@@ -27,7 +28,7 @@ func executeCommandC(root *cobra.Command, args ...string) (c *cobra.Command, out
 func TestGetPathNoXDG(t *testing.T) {
 	actual := Config.GetConfigFolder("")
 	expected, err := homedir.Dir()
-	expected += "/.config/stripe"
+	expected += filepath.Join("/", ".config", "stripe")
 
 	require.NoError(t, err)
 	require.Equal(t, actual, expected)
@@ -35,7 +36,7 @@ func TestGetPathNoXDG(t *testing.T) {
 
 func TestGetPathXDG(t *testing.T) {
 	actual := Config.GetConfigFolder("/some/xdg/path")
-	expected := "/some/xdg/path/stripe"
+	expected := filepath.Join("/", "some", "xdg", "path", "stripe")
 
 	require.Equal(t, actual, expected)
 }

--- a/pkg/login/client_login_test.go
+++ b/pkg/login/client_login_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -119,13 +120,21 @@ func TestGetLinksHTTPStatusError(t *testing.T) {
 }
 
 func TestGetLinksRequestError(t *testing.T) {
+	errorString := ""
+
+	if runtime.GOOS == "windows" {
+		errorString = "connectex: No connection could be made because the target machine actively refused it."
+	} else {
+		errorString = "connect: connection refused"
+	}
+
 	// Immediately close the HTTP server so that the request fails.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	ts.Close()
 
 	links, err := getLinks(ts.URL, "test")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "connect: connection refused")
+	require.Contains(t, err.Error(), errorString)
 	require.Empty(t, links)
 }
 


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/dev-platform

 ### Summary
+ Added a GitHub Action Workflow to run tests on Linux, Windows, and MacOS.
+ Fixed some issues in tests that failed within a Windows environment
+ Cleaned up Makefile to remove redundant separate install of `misspell` as it was failing to install on Windows. Looking at the `golinter-ci` config it appears that misspell is already installed and runs in this task with the other linters. Is this right?
