### PR TITLE
Add 32-bit Windows build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ before:
     - go generate ./...
 project_name: stripe
 builds:
-  - id: stripe-darwin-amd64
+  - id: stripe-darwin
     ldflags:
       - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
     binary: stripe
@@ -19,7 +19,7 @@ builds:
       - darwin
     goarch:
       - amd64
-  - id: stripe-linux-amd64
+  - id: stripe-linux
     ldflags:
       - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
     binary: stripe
@@ -30,7 +30,7 @@ builds:
       - linux
     goarch:
       - amd64
-  - id: stripe-windows-amd64
+  - id: stripe-windows
     ldflags:
       - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
     binary: stripe
@@ -43,12 +43,14 @@ builds:
       - windows
     goarch:
       - amd64
+      - 386
 archives:
   -
     replacements:
       darwin: mac-os
       linux: linux
       windows: windows
+      386: i386
       amd64: x86_64
     format_overrides:
       - goos: windows


### PR DESCRIPTION
 ### Reviewers
r? @richardm-stripe 
cc @stripe/dev-platform

 ### Summary
Add 32-bit Windows build.

I've verified this works with:
```
$ docker run --privileged -v $PWD:/Users/ob/go/src/github.com/stripe/stripe-cli -v /var/run/docker.sock:/var/run/docker.sock -w /Users/ob/go/src/github.com/stripe/stripe-cli -it mailchain/goreleaser-xcgo --snapshot --skip-publish --rm-dist
```

This produces a `stripe_v1.4.1-next_windows_i386.zip` which includes a `stripe.exe` file:
```
$ file stripe.exe
stripe.exe: PE32 executable (console) Intel 80386 (stripped to external PDB), for MS Windows
```

(By contrast, the 64-bit version outputs this:
```
$ file stripe.exe
stripe.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
```
)

I don't have a 32-bit Windows VM to actually test the .exe, but there's no reason it shouldn't work.
