### PR TITLE
Fix int/string conversion in error message

### DIFF
--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -95,7 +95,7 @@ func NewFixture(fs afero.Fs, apiKey, stripeAccount, baseURL, file string) (*Fixt
 	}
 
 	if fxt.fixture.Meta.Version > SupportedVersions {
-		return nil, fmt.Errorf("Fixture version not supported: %s", string(fxt.fixture.Meta.Version))
+		return nil, fmt.Errorf("Fixture version not supported: %d", fxt.fixture.Meta.Version)
 	}
 
 	return &fxt, nil


### PR DESCRIPTION
In Go 1.14 this would do the wrong thing silently, but this will cause
tests to fail on Go 1.15.

 ### Reviewers
r? @
cc @stripe/dev-platform

 ### Summary

With the disclaimer that I didn't look at what this code is actually doing, I suspect we don't want a string of one rune that matches the version number. Instead, we likely want the integer version number as a string that represents that integer. In Go 1.14 this would do the wrong thing silently, but in Go 1.15 this will cause a test failure.