### PR TITLE
More helpful usage errors

### DIFF
--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -49,3 +49,22 @@ func TestHelpFlag(t *testing.T) {
 	require.Contains(t, output, "Stripe commands:")
 	require.NoError(t, err)
 }
+
+func TestExampleCommands(t *testing.T) {
+	{
+		_, err := executeCommand(rootCmd, "foo")
+		require.Equal(t, err.Error(), "unknown command \"foo\" for \"stripe\"")
+	}
+	{
+		_, err := executeCommand(rootCmd, "listen", "foo")
+		require.Equal(t, err.Error(), "`stripe listen` does not take any positional arguments. See `stripe listen --help` for supported flags and usage")
+	}
+	{
+		_, err := executeCommand(rootCmd, "post")
+		require.Equal(t, err.Error(), "`stripe post` requires exactly 1 positional argument. See `stripe post --help` for supported flags and usage")
+	}
+	{
+		_, err := executeCommand(rootCmd, "samples", "create", "foo", "foo", "foo")
+		require.Equal(t, err.Error(), "`stripe samples create` accepts at maximum 2 positional arguments. See `stripe samples create --help` for supported flags and usage")
+	}
+}

--- a/pkg/validators/cmds.go
+++ b/pkg/validators/cmds.go
@@ -10,9 +10,9 @@ import (
 // NoArgs is a validator for commands to print an error when an argument is provided
 func NoArgs(cmd *cobra.Command, args []string) error {
 	errorMessage := fmt.Sprintf(
-		"%s does not take any arguments. See `stripe %s --help` for supported flags and usage",
-		cmd.Name(),
-		cmd.Name(),
+		"`%s` does not take any positional arguments. See `%s --help` for supported flags and usage",
+		cmd.CommandPath(),
+		cmd.CommandPath(),
 	)
 
 	if len(args) > 0 {
@@ -26,17 +26,17 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 // is different than the arguments passed in
 func ExactArgs(num int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		argument := "argument"
-		if num > 1 {
-			argument = "arguments"
+		argument := "positional argument"
+		if num != 1 {
+			argument = "positional arguments"
 		}
 
 		errorMessage := fmt.Sprintf(
-			"%s only takes %d %s. See `stripe %s --help` for supported flags and usage",
-			cmd.Name(),
+			"`%s` requires exactly %d %s. See `%s --help` for supported flags and usage",
+			cmd.CommandPath(),
 			num,
 			argument,
-			cmd.Name(),
+			cmd.CommandPath(),
 		)
 
 		if len(args) != num {
@@ -50,17 +50,17 @@ func ExactArgs(num int) cobra.PositionalArgs {
 // args are greater than the maximum amount
 func MaximumNArgs(num int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		argument := "argument"
+		argument := "positional argument"
 		if num > 1 {
-			argument = "arguments"
+			argument = "positional arguments"
 		}
 
 		errorMessage := fmt.Sprintf(
-			"%s only takes %d %s (or less). See `stripe %s --help` for supported flags and usage",
-			cmd.Name(),
+			"`%s` accepts at maximum %d %s. See `%s --help` for supported flags and usage",
+			cmd.CommandPath(),
 			num,
 			argument,
-			cmd.Name(),
+			cmd.CommandPath(),
 		)
 
 		if len(args) > num {

--- a/pkg/validators/cmds_test.go
+++ b/pkg/validators/cmds_test.go
@@ -20,7 +20,7 @@ func TestNoArgsWithArgs(t *testing.T) {
 	args := []string{"foo"}
 
 	result := NoArgs(c, args)
-	require.EqualError(t, result, "c does not take any arguments. See `stripe c --help` for supported flags and usage")
+	require.EqualError(t, result, "`c` does not take any positional arguments. See `c --help` for supported flags and usage")
 }
 
 func TestExactArgs(t *testing.T) {
@@ -36,7 +36,7 @@ func TestExactArgsTooMany(t *testing.T) {
 	args := []string{"foo", "bar"}
 
 	result := ExactArgs(1)(c, args)
-	require.EqualError(t, result, "c only takes 1 argument. See `stripe c --help` for supported flags and usage")
+	require.EqualError(t, result, "`c` requires exactly 1 positional argument. See `c --help` for supported flags and usage")
 }
 
 func TestExactArgsTooManyMoreThan1(t *testing.T) {
@@ -44,5 +44,5 @@ func TestExactArgsTooManyMoreThan1(t *testing.T) {
 	args := []string{"foo", "bar", "baz"}
 
 	result := ExactArgs(2)(c, args)
-	require.EqualError(t, result, "c only takes 2 arguments. See `stripe c --help` for supported flags and usage")
+	require.EqualError(t, result, "`c` requires exactly 2 positional arguments. See `c --help` for supported flags and usage")
 }


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 

 ### Summary
Fixes #372 

**Before:**
```shell
$ stripe logs tail foo
tail does not take any arguments. See `stripe tail --help` for supported flags and usage
```
**After:**
```shell
$ go run cmd/stripe/main.go logs tail foo
`stripe logs tail` does not take any positional arguments. See `stripe logs tail --help` for supported flags and usage
```

**Before:**
```shell
$ stripe samples create foo foo foo
create only takes 2 arguments (or less). See `stripe create --help` for supported flags and usage
```
**After:**
```shell
$ stripe samples create foo foo foo
`stripe samples create` accepts at maximum 2 positional arguments. See `stripe samples create --help` for supported flags and usage
```

**Before:**
```shell
$ stripe customers delete
delete only takes 1 argument. See `stripe delete --help` for supported flags and usage
```
**After:**
```shell
$ stripe customers delete
`stripe customers delete` requires exactly 1 positional argument. See `stripe customers delete --help` for supported flags and usage
```