### PR TITLE
Add `--print-secret` flag to listen subcommand

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -33,6 +33,7 @@ type listenCmd struct {
 	loadFromWebhooksAPI   bool
 	printJSON             bool
 	skipVerify            bool
+	onlyPrintSecret       bool
 
 	apiBaseURL string
 	noWSS      bool
@@ -65,6 +66,7 @@ Stripe account.`,
 	lc.cmd.Flags().BoolVarP(&lc.printJSON, "print-json", "j", false, "Print full JSON objects to stdout")
 	lc.cmd.Flags().BoolVarP(&lc.loadFromWebhooksAPI, "load-from-webhooks-api", "a", false, "Load webhook endpoint configuration from the webhooks API")
 	lc.cmd.Flags().BoolVarP(&lc.skipVerify, "skip-verify", "", false, "Skip certificate verification when forwarding to HTTPS endpoints")
+	lc.cmd.Flags().BoolVar(&lc.onlyPrintSecret, "print-secret", false, "Only print the webhook signing secret and exit")
 
 	// Hidden configuration flags, useful for dev/debugging
 	lc.cmd.Flags().StringVar(&lc.apiBaseURL, "api-base", "", "Sets the API base URL")
@@ -163,6 +165,15 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		Log:                 log.StandardLogger(),
 		NoWSS:               lc.noWSS,
 	}, lc.events)
+
+	if lc.onlyPrintSecret {
+		secret, err := p.GetSessionSecret(context.Background())
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s", secret)
+		return nil
+	}
 
 	err = p.Run(context.Background())
 	if err != nil {

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -171,7 +171,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s", secret)
+		fmt.Printf("%s\n", secret)
 		return nil
 	}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -167,6 +167,15 @@ func (p *Proxy) Run(ctx context.Context) error {
 	return nil
 }
 
+// GetSessionSecret creates a session and returns the webhook signing secret.
+func (p *Proxy) GetSessionSecret(ctx context.Context) (string, error) {
+	session, err := p.createSession(ctx)
+	if err != nil {
+		p.cfg.Log.Fatalf("Error while authenticating with Stripe: %v", err)
+	}
+	return session.Secret, nil
+}
+
 func (p *Proxy) createSession(ctx context.Context) (*stripeauth.StripeCLISession, error) {
 	var session *stripeauth.StripeCLISession
 


### PR DESCRIPTION
 ### Reviewers
r? @bwang-stripe 
cc @stripe/dev-platform

 ### Summary
In response to #472, this adds the `--print-secret` flag proposed in #475 to the listen subcommand. This flag will cause `stripe listen --print-secret` to print the webhook signing secret and exit immediately. This can be used in scripts to more easily access the secret instead of parsing the output of `stripe listen.