### PR TITLE
Don't check for latest version in `listen` if --print-secret is passed

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -93,7 +93,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if !lc.printJSON {
+	if !lc.printJSON && !lc.onlyPrintSecret {
 		version.CheckLatestVersion()
 	}
 


### PR DESCRIPTION
 ### Reviewers
r? @richardm-stripe 
cc @stripe/dev-platform

 ### Summary
Skip the check for latest version in `stripe listen` if `--print-secret` is passed. Issue reported at https://github.com/stripe/stripe-cli/pull/478#issuecomment-658415125.