### PR TITLE
Undo goreleaser config change for homebrew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,7 +81,7 @@ nfpms:
     - rpm
 brews:
   -
-    tap:
+    github:
       owner: stripe
       name: homebrew-stripe-cli
     commit_author:


### PR DESCRIPTION
 ### Reviewers
r? @pepin-stripe 
cc @stripe/developer-products

 ### Summary
We're using [`goreleaser-xcgo`](https://github.com/mailchain/goreleaser-xcgo) to run goreleaser in docker on Travis (due to previous issues. That docker image is running version [`0.127.0`](https://github.com/mailchain/goreleaser-xcgo/blob/master/Dockerfile#L5), which doesn't include the new syntax that I updated to in #502. I don't want to try to update the version on the docker image so I'm undoing this one syntax change for now.
