### PR TITLE
Fixes issue 449 - correct sub path for listen --load-from-webhooks-api

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -250,5 +250,11 @@ func buildForwardURL(forwardURL string, destination *url.URL) string {
 		log.Fatalf("Provided forward url cannot be parsed: %s", forwardURL)
 	}
 
-	return fmt.Sprintf("%s://%s%s", f.Scheme, f.Host, destination.Path)
+	return fmt.Sprintf(
+		"%s://%s%s%s",
+		f.Scheme,
+		f.Host,
+		strings.TrimSuffix(f.Path, "/"), // avoids having a double "//"
+		destination.Path,
+	)
 }

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -56,13 +56,20 @@ func TestBuildForwardURL(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "http://localhost/foo/bar.php", buildForwardURL("http://localhost/", f))
+	require.Equal(t, "http://localhost/foo/bar.php", buildForwardURL("http://localhost", f))
 	require.Equal(t, "https://localhost/foo/bar.php", buildForwardURL("https://localhost/", f))
 	require.Equal(t, "http://localhost:8000/foo/bar.php", buildForwardURL("http://localhost:8000", f))
+	require.Equal(t, "http://localhost:8000/foo/bar.php", buildForwardURL("http://localhost:8000/", f))
+	require.Equal(t, "http://localhost:8000/forward/sub/path/foo/bar.php", buildForwardURL("http://localhost:8000/forward/sub/path/", f))
+	require.Equal(t, "http://localhost:8000/forward/sub/path/foo/bar.php", buildForwardURL("http://localhost:8000/forward/sub/path", f))
 
 	f, err = url.Parse("http://example.com/bar/")
 	require.NoError(t, err)
 
 	require.Equal(t, "http://localhost/bar/", buildForwardURL("http://localhost/", f))
+	require.Equal(t, "http://localhost/bar/", buildForwardURL("http://localhost", f))
 	require.Equal(t, "https://localhost/bar/", buildForwardURL("https://localhost/", f))
+	require.Equal(t, "https://localhost/bar/", buildForwardURL("https://localhost", f))
 	require.Equal(t, "http://localhost:8000/bar/", buildForwardURL("http://localhost:8000", f))
+	require.Equal(t, "http://localhost:8000/bar/", buildForwardURL("http://localhost:8000/", f))
 }


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products 
cc @stripe/developer-products 

 ### Summary
Fixes https://github.com/stripe/stripe-cli/issues/449 

When building the forward URL from webhooks API endpoints, the `forwardURL.Path` was being ignored.
