### PR TITLE
Run listen command when starting stripe playback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,1 @@
-
-dist/
-bin/
 coverage.txt
-/stripe
-/stripe-darwin
-/stripe-linux
-/stripe-windows.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
+
+dist/
+bin/
 coverage.txt
+/stripe
+/stripe-darwin
+/stripe-linux
+/stripe-windows.exe
+default_cassette.yaml

--- a/pkg/cmd/playback.go
+++ b/pkg/cmd/playback.go
@@ -140,7 +140,7 @@ func (pc *playbackCmd) runPlaybackCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// --- Setup `stripe listen` and run it now if not in replay-only mode, else listen for changeModeChan.
+	// --- Setup `stripe listen` and run it now if not in replay-only mode, else listen for httpWrapper.ChangeModeChan.
 	lc := newListenCmd()
 	lc.forwardURL = addressString + "/playback/webhooks"
 	startListenCmd := func() {

--- a/pkg/cmd/playback.go
+++ b/pkg/cmd/playback.go
@@ -166,20 +166,6 @@ func (pc *playbackCmd) runPlaybackCmd(cmd *cobra.Command, args []string) error {
 			})
 		}
 		listenToModeSwitch()
-		// go func() {
-		// 	modeChan := make(chan string)
-		// 	httpWrapper.OnSwitchMode(modeChan)
-		// 	for {
-		// 		mode := <-modeChan
-		// 		switch strings.ToLower(mode) {
-		// 		case playback.Record, playback.Auto:
-		// 			close(modeChan)
-		// 			startListenCmd()
-		// 		default:
-		// 			continue
-		// 		}
-		// 	}
-		// }()
 	}
 
 	server := httpWrapper.InitializeServer(addressString)

--- a/pkg/cmd/playback.go
+++ b/pkg/cmd/playback.go
@@ -148,6 +148,15 @@ func (pc *playbackCmd) runPlaybackCmd(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}()
 
+	// --- Start up the listen server to proxy webhook endpoints to the playback server
+	lc := newListenCmd()
+	lc.forwardURL = addressString + "/playback/webhooks"
+	go func() {
+		err = lc.runListenCmd(lc.cmd, []string{})
+		fmt.Fprint(os.Stderr, err.Error())
+		os.Exit(1)
+	}()
+
 	// --- Print out post-startup summary on CLI
 	fmt.Println()
 	fmt.Println("------ Server Running ------")

--- a/pkg/playback/http_playback.go
+++ b/pkg/playback/http_playback.go
@@ -95,6 +95,8 @@ type Server struct {
 
 	log *log.Logger
 
+	SwitchModeChan chan string
+
 	// state machine state
 	mode                  string // the user specified state (auto, record, replay)
 	isRecordingInAutoMode bool   // internal state used when in auto mode to keep track of the state for the current cassette (either recording or replaying)
@@ -112,6 +114,7 @@ func NewServer(remoteURL string, webhookURL string, absCassetteDirectory string,
 	server.httpRecorder = newRecordServer(remoteURL, webhookURL)
 	server.httpReplayer = newReplayServer(webhookURL)
 	server.remoteURL = remoteURL
+	server.SwitchModeChan = make(chan string)
 
 	err = server.switchMode(mode)
 	if err != nil {
@@ -158,6 +161,7 @@ func (rr *Server) InitializeServer(address string) *http.Server {
 			return
 		}
 
+		rr.SwitchModeChan <- strings.ToLower(modeString)
 		rr.log.Info("/playback/mode: Set mode to ", strings.ToUpper(modeString))
 	})
 

--- a/pkg/playback/http_playback.go
+++ b/pkg/playback/http_playback.go
@@ -265,6 +265,7 @@ func (rr *Server) InitializeServer(address string) *http.Server {
 // Handles incoming Stripe API requests sent to the `playback` server.
 // Requests are handled differently depending on whether we are recording or replaying.
 func (rr *Server) handler(w http.ResponseWriter, r *http.Request) {
+	// TODO: Should we be automatically loading a cassette when none is loaded?
 	if !rr.cassetteLoaded {
 		err := errors.New("no cassette is loaded")
 		writeErrorToHTTPResponse(w, rr.log, err, 400)

--- a/pkg/playback/http_playback_test.go
+++ b/pkg/playback/http_playback_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -253,18 +252,9 @@ func TestPlaybackSingleRunCreateCustomerAndStandaloneCharge(t *testing.T) {
 	assert.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, 200, resp.StatusCode)
-
 	// --- END RECORD MODE
 
 	// --- Start interacting in REPLAY MODE
-	go func() {
-		select {
-		case <-httpWrapper.SwitchModeChan:
-			return
-		case <-time.After(1 * time.Second):
-			log.Fatal("Should have broadcast mode change to SwitchModeChan, did not.")
-		}
-	}()
 	resp, err = http.Post(fullAddressString+"/playback/mode/replay", "text/plain", nil)
 	assert.NoError(t, err)
 	defer resp.Body.Close()

--- a/pkg/playback/http_playback_test.go
+++ b/pkg/playback/http_playback_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -256,6 +257,14 @@ func TestPlaybackSingleRunCreateCustomerAndStandaloneCharge(t *testing.T) {
 	// --- END RECORD MODE
 
 	// --- Start interacting in REPLAY MODE
+	go func() {
+		select {
+		case <-httpWrapper.SwitchModeChan:
+			return
+		case <-time.After(1 * time.Second):
+			log.Fatal("Should have broadcast mode change to SwitchModeChan, did not.")
+		}
+	}()
 	resp, err = http.Post(fullAddressString+"/playback/mode/replay", "text/plain", nil)
 	assert.NoError(t, err)
 	defer resp.Body.Close()

--- a/pkg/playback/interactions.go
+++ b/pkg/playback/interactions.go
@@ -11,9 +11,10 @@ import (
 )
 
 // requestComparator compares 2 structs in the context of comparing a given request struct against
-// a request recorded in the request/
-// It then determines 1) whether that are equivalent 2) whether we should short-circuit
-// our search (return this one immediately, or keep scanning the cassette)
+// a request recorded in the cassette.
+// It then determines
+// 1) whether they are equivalent
+// 2) whether we should short-circuit our search (return this one immediately, or keep scanning the cassette)
 type requestComparator func(req1 interface{}, req2 interface{}) (accept bool, shortCircuitNow bool)
 
 // Contains binary data representing a generic request and response saved in a cassette.
@@ -32,7 +33,7 @@ type cassettePair struct {
 	Response []byte
 }
 
-// cassetteYaml is used store interaction data to be serialized a YAML file
+// cassetteYaml is used to store interaction data to be serialized to a YAML file
 type cassetteYaml struct {
 	Interactions []cassettePair
 }
@@ -47,13 +48,12 @@ type interactionRecorder struct {
 }
 
 func newInteractionRecorder(writer io.Writer, reqSerializer serializer, respSerializer serializer) (recorder *interactionRecorder, err error) {
-	recorder = &interactionRecorder{}
-
-	recorder.writer = writer
-	recorder.reqSerializer = reqSerializer
-	recorder.respSerializer = respSerializer
-
-	recorder.interactions = make([]cassettePair, 0)
+	recorder = &interactionRecorder{
+		writer:         writer,
+		reqSerializer:  reqSerializer,
+		respSerializer: respSerializer,
+		interactions:   make([]cassettePair, 0),
+	}
 
 	return recorder, nil
 }


### PR DESCRIPTION
 ### Reviewers
r? @richardm-stripe 
cc @stripe/developer-products @tomer-stripe 

 ### Summary
`stripe playback` needs to use `stripe listen` while in record mode so it can intercept webhook events from the stripe API and record them.

fixes DX-6101