### PR TITLE
Add --no-listen flag to prevent listen command to be ran by playback

### DIFF
--- a/pkg/cmd/playback.go
+++ b/pkg/cmd/playback.go
@@ -153,21 +153,23 @@ func (pc *playbackCmd) runPlaybackCmd(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	if pc.mode != playback.Replay {
-		go startListenCmd()
-	} else {
-		var listenToModeSwitch func()
-		listenToModeSwitch = func() {
-			httpWrapper.OnSwitchMode(func(mode string) {
-				switch strings.ToLower(mode) {
-				case playback.Record, playback.Auto:
-					go startListenCmd()
-				default:
-					listenToModeSwitch()
-				}
-			})
+	if !pc.noListen {
+		if pc.mode != playback.Replay {
+			go startListenCmd()
+		} else {
+			var listenToModeSwitch func()
+			listenToModeSwitch = func() {
+				httpWrapper.OnSwitchMode(func(mode string) {
+					switch strings.ToLower(mode) {
+					case playback.Record, playback.Auto:
+						go startListenCmd()
+					default:
+						listenToModeSwitch()
+					}
+				})
+			}
+			listenToModeSwitch()
 		}
-		listenToModeSwitch()
 	}
 
 	server := httpWrapper.InitializeServer(addressString)

--- a/pkg/cmd/playback.go
+++ b/pkg/cmd/playback.go
@@ -43,6 +43,7 @@ type playbackCmd struct {
 	cassetteDir string
 	address     string
 	webhookURL  string
+	noListen    bool
 }
 
 func newPlaybackCmd() *playbackCmd {
@@ -83,6 +84,7 @@ Currently, stripe playback only supports serving over HTTP.
 	pc.cmd.Flags().StringVar(&pc.webhookURL, "forward-to", fmt.Sprintf("http://localhost:%d", defaultWebhookPort), "URL to forward webhooks to")
 	pc.cmd.Flags().StringVar(&pc.filepath, "cassette", "default_cassette.yaml", "The cassette file to use")
 	pc.cmd.Flags().StringVar(&pc.cassetteDir, "cassette-root-dir", "./", "Directory to store all cassettes in. Relative cassette paths are considered relative to this directory.")
+	pc.cmd.Flags().BoolVar(&pc.noListen, "no-listen", false, "Do not automatically proxy and record webhook events to the cassette.")
 
 	// // Hidden configuration flags, useful for dev/debugging
 	pc.cmd.Flags().StringVar(&pc.apiBaseURL, "api-base", "https://api.stripe.com", "The API base URL")


### PR DESCRIPTION
 ### Reviewers
r? @richardm-stripe 
cc @stripe/developer-products

 ### Summary
Add --no-listen flag to prevent listen command to be ran by playback
solves DX-6102
