### PR TITLE
rename --load-from-webhooks-api to --use-configured-webhooks and keep…

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/stripe/stripe-cli/pkg/proxy"
 	"github.com/stripe/stripe-cli/pkg/requests"
@@ -30,7 +31,7 @@ type listenCmd struct {
 	events                []string
 	latestAPIVersion      bool
 	livemode              bool
-	loadFromWebhooksAPI   bool
+	useConfiguredWebhooks bool
 	printJSON             bool
 	skipVerify            bool
 	onlyPrintSecret       bool
@@ -64,7 +65,7 @@ Stripe account.`,
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
 	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test)")
 	lc.cmd.Flags().BoolVarP(&lc.printJSON, "print-json", "j", false, "Print full JSON objects to stdout")
-	lc.cmd.Flags().BoolVarP(&lc.loadFromWebhooksAPI, "load-from-webhooks-api", "a", false, "Load webhook endpoint configuration from the webhooks API")
+	lc.cmd.Flags().BoolVarP(&lc.useConfiguredWebhooks, "use-configured-webhooks", "a", false, "Load webhook endpoint configuration from the webhooks API/dashboard")
 	lc.cmd.Flags().BoolVarP(&lc.skipVerify, "skip-verify", "", false, "Skip certificate verification when forwarding to HTTPS endpoints")
 	lc.cmd.Flags().BoolVar(&lc.onlyPrintSecret, "print-secret", false, "Only print the webhook signing secret and exit")
 
@@ -74,6 +75,16 @@ Stripe account.`,
 
 	lc.cmd.Flags().BoolVar(&lc.noWSS, "no-wss", false, "Force unencrypted ws:// protocol instead of wss://")
 	lc.cmd.Flags().MarkHidden("no-wss") // #nosec G104
+
+	// renamed --load-from-webhooks-api to --use-configured-webhooks,  but want to keep backward compatibility
+	lc.cmd.Flags().SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		switch name {
+		case "load-from-webhooks-api":
+			name = "use-configured-webhooks"
+			break
+		}
+		return pflag.NormalizedName(name)
+	})
 
 	return lc
 }
@@ -134,7 +145,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	if lc.loadFromWebhooksAPI && len(lc.forwardURL) > 0 {
+	if lc.useConfiguredWebhooks && len(lc.forwardURL) > 0 {
 		if strings.HasPrefix(lc.forwardURL, "/") {
 			return errors.New("--forward-to cannot be a relative path when loading webhook endpoints from the API")
 		}
@@ -149,7 +160,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		endpointRoutes = buildEndpointRoutes(endpoints, parseURL(lc.forwardURL), parseURL(lc.forwardConnectURL), lc.forwardHeaders, lc.forwardConnectHeaders)
-	} else if lc.loadFromWebhooksAPI && len(lc.forwardURL) == 0 {
+	} else if lc.useConfiguredWebhooks && len(lc.forwardURL) == 0 {
 		return errors.New("--load-from-webhooks-api requires a location to forward to with --forward-to")
 	}
 

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -78,10 +78,8 @@ Stripe account.`,
 
 	// renamed --load-from-webhooks-api to --use-configured-webhooks,  but want to keep backward compatibility
 	lc.cmd.Flags().SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
-		switch name {
-		case "load-from-webhooks-api":
+		if name == "load-from-webhooks-api" {
 			name = "use-configured-webhooks"
-			break
 		}
 		return pflag.NormalizedName(name)
 	})


### PR DESCRIPTION
… backwards compatibility

 ### Reviewers
r? @richardm-stripe 
cc @stripe/developer-products

 ### Summary
--load-from-webhooks-api is a very confusing name. We are hoping that --use-configured-webhooks will be a bit more clear.
