### PR TITLE
Cleanup and make saveAndClose persist cassette to file in yaml

### DIFF
--- a/pkg/playback/http_playback.go
+++ b/pkg/playback/http_playback.go
@@ -24,6 +24,10 @@ func forwardRequest(wrappedRequest *httpRequest, destinationURL string) (resp *h
 
 	// Create a identical copy of the request
 	bodyBytes, err := json.Marshal(wrappedRequest.Body)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := http.NewRequest(wrappedRequest.Method, destinationURL, bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		return nil, err

--- a/pkg/playback/http_playback.go
+++ b/pkg/playback/http_playback.go
@@ -16,6 +16,21 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// errorJsonOuter and errorJSONInner are used to return `playback` error messages as JSON in HTTP response bodies to
+// mimic errors returned by the Stripe API. The intention is to make it easier for clients (which expect Stripe API errors)
+// using `stripe playback` to parse and display a useful error message when `stripe playback` emits errors.
+type errorJSONOuter struct {
+	Error errorJSONInner `json:"error"`
+}
+
+type errorJSONInner struct {
+	Code    string `json:"code"`
+	DocURL  string `json:"doc_url"`
+	Message string `json:"message"`
+	Param   string `json:"param"`
+	Type    string `json:"type"`
+}
+
 func forwardRequest(wrappedRequest *httpRequest, destinationURL string) (resp *http.Response, err error) {
 	client := &http.Client{
 		// set Timeout explicitly, otherwise the client will wait indefinitely for a response
@@ -41,21 +56,6 @@ func forwardRequest(wrappedRequest *httpRequest, destinationURL string) (resp *h
 		return nil, err
 	}
 	return res, nil
-}
-
-// errorJsonOuter and errorJSONInner are used to return `playback` error messages as JSON in HTTP response bodies to
-// mimic errors returned by the Stripe API. The intention is to make it easier for clients (which expect Stripe API errors)
-// using `stripe playback` to parse and display a useful error message when `stripe playback` emits errors.
-type errorJSONOuter struct {
-	Error errorJSONInner `json:"error"`
-}
-
-type errorJSONInner struct {
-	Code    string `json:"code"`
-	DocURL  string `json:"doc_url"`
-	Message string `json:"message"`
-	Param   string `json:"param"`
-	Type    string `json:"type"`
 }
 
 // Writes to the HTTP response using the given HTTP status code and error in the response body. Simultaneously, prints logs error text.

--- a/pkg/playback/http_recorder.go
+++ b/pkg/playback/http_recorder.go
@@ -43,11 +43,6 @@ func (httpRecorder *HTTPRecorder) insertCassette(writer io.Writer) error {
 	return nil
 }
 
-// Struct used to parse the event.Type from recorded webhook JSON bodies
-type stripeEvent struct {
-	Type string `json:"type"`
-}
-
 // Handler for the webhook endpoint that forwards incoming webhooks to the local application,
 // while recording the webhook and local app's response to the cassette.
 func (httpRecorder *HTTPRecorder) webhookHandler(w http.ResponseWriter, r *http.Request) {
@@ -97,6 +92,10 @@ func (httpRecorder *HTTPRecorder) webhookHandler(w http.ResponseWriter, r *http.
 	copyHTTPHeader(w.Header(), wrappedResp.Headers) // header map must be written before calling w.WriteHeader
 	w.WriteHeader(wrappedResp.StatusCode)
 	bodyBytes, err := json.Marshal(wrappedResp.Body)
+	if err != nil {
+		httpRecorder.log.Fatal(err)
+	}
+
 	_, err = io.Copy(w, bytes.NewBuffer(bodyBytes))
 
 	// Since at this point, we can't signal an error by writing the HTTP status code, and this is a significant failure - we log.Fatal
@@ -150,6 +149,10 @@ func (httpRecorder *HTTPRecorder) handler(w http.ResponseWriter, r *http.Request
 	copyHTTPHeader(w.Header(), wrappedResp.Headers) // header map must be written before calling w.WriteHeader
 	w.WriteHeader(wrappedResp.StatusCode)
 	bodyBytes, err := json.Marshal(wrappedResp.Body)
+	if err != nil {
+		httpRecorder.log.Fatal(err)
+	}
+
 	_, err = io.Copy(w, bytes.NewBuffer(bodyBytes))
 
 	// Since at this point, we can't signal an error by writing the HTTP status code, and this is a significant failure - we log.Fatal

--- a/pkg/playback/http_replayer.go
+++ b/pkg/playback/http_replayer.go
@@ -81,6 +81,10 @@ func (httpReplayer *HTTPReplayer) handler(w http.ResponseWriter, r *http.Request
 	copyHTTPHeader(w.Header(), wrappedResponse.Headers) // header map must be written before calling w.WriteHeader
 	w.WriteHeader(wrappedResponse.StatusCode)
 	bodyBytes, err := json.Marshal(wrappedResponse.Body)
+	if err != nil {
+		httpReplayer.log.Fatal(err)
+	}
+
 	_, err = io.Copy(w, bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		httpReplayer.log.Fatal(err)

--- a/pkg/playback/http_serializer.go
+++ b/pkg/playback/http_serializer.go
@@ -4,7 +4,6 @@ package playback
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -13,6 +12,19 @@ import (
 
 type serializer func(input interface{}) (bytes []byte, err error)
 type deserializer func(input *io.Reader) (value interface{}, err error)
+
+type httpRequest struct {
+	Method  string
+	Body    map[string]interface{}
+	Headers http.Header
+	URL     url.URL
+}
+
+type httpResponse struct {
+	Headers    http.Header
+	Body       map[string]interface{}
+	StatusCode int
+}
 
 func httpRequestToBytes(input interface{}) (data []byte, err error) {
 	return json.Marshal(input)
@@ -46,12 +58,6 @@ func httpResponsefromBytes(input *io.Reader) (val interface{}, err error) {
 	return output, err
 }
 
-type httpResponse struct {
-	Headers    http.Header
-	Body       map[string]interface{}
-	StatusCode int
-}
-
 func newHTTPResponse(resp *http.Response) (wrappedResponse httpResponse, err error) {
 	wrappedResponse = httpResponse{}
 
@@ -70,13 +76,6 @@ func newHTTPResponse(resp *http.Response) (wrappedResponse httpResponse, err err
 	return wrappedResponse, nil
 }
 
-type httpRequest struct {
-	Method  string
-	Body    map[string]interface{}
-	Headers http.Header
-	URL     url.URL
-}
-
 func newHTTPRequest(req *http.Request) (wrappedRequest httpRequest, err error) {
 	wrappedRequest = httpRequest{}
 
@@ -84,15 +83,9 @@ func newHTTPRequest(req *http.Request) (wrappedRequest httpRequest, err error) {
 	wrappedRequest.Headers = req.Header
 	wrappedRequest.URL = *req.URL
 
-	// var bodyBytes []byte
-	// bodyBytes, err = ioutil.ReadAll(req.Body)
-	// defer req.Body.Close()
-	// if err != nil {
-	// 	return wrappedRequest, err
-	// }
-	// wrappedRequest.Body = bodyBytes
-	json.NewDecoder(req.Body).Decode(&wrappedRequest.Body)
-	fmt.Println(wrappedRequest.Body["type"])
+	if req.Body != nil {
+		json.NewDecoder(req.Body).Decode(&wrappedRequest.Body)
+	}
 
 	return wrappedRequest, nil
 }

--- a/pkg/playback/http_serializer.go
+++ b/pkg/playback/http_serializer.go
@@ -4,6 +4,7 @@ package playback
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -47,7 +48,7 @@ func httpResponsefromBytes(input *io.Reader) (val interface{}, err error) {
 
 type httpResponse struct {
 	Headers    http.Header
-	Body       []byte
+	Body       map[string]interface{}
 	StatusCode int
 }
 
@@ -57,20 +58,21 @@ func newHTTPResponse(resp *http.Response) (wrappedResponse httpResponse, err err
 	wrappedResponse.Headers = resp.Header
 	wrappedResponse.StatusCode = resp.StatusCode
 
-	var bodyBytes []byte
-	bodyBytes, err = ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
-	if err != nil {
-		return wrappedResponse, err
-	}
-	wrappedResponse.Body = bodyBytes
+	// var bodyBytes []byte
+	// bodyBytes, err = ioutil.ReadAll(resp.Body)
+	// defer resp.Body.Close()
+	// if err != nil {
+	// 	return wrappedResponse, err
+	// }
+	// json.Unmarshal(bodyBytes, &wrappedResponse.Body)
+	json.NewDecoder(resp.Body).Decode(&wrappedResponse.Body)
 
 	return wrappedResponse, nil
 }
 
 type httpRequest struct {
 	Method  string
-	Body    []byte
+	Body    map[string]interface{}
 	Headers http.Header
 	URL     url.URL
 }
@@ -82,13 +84,15 @@ func newHTTPRequest(req *http.Request) (wrappedRequest httpRequest, err error) {
 	wrappedRequest.Headers = req.Header
 	wrappedRequest.URL = *req.URL
 
-	var bodyBytes []byte
-	bodyBytes, err = ioutil.ReadAll(req.Body)
-	defer req.Body.Close()
-	if err != nil {
-		return wrappedRequest, err
-	}
-	wrappedRequest.Body = bodyBytes
+	// var bodyBytes []byte
+	// bodyBytes, err = ioutil.ReadAll(req.Body)
+	// defer req.Body.Close()
+	// if err != nil {
+	// 	return wrappedRequest, err
+	// }
+	// wrappedRequest.Body = bodyBytes
+	json.NewDecoder(req.Body).Decode(&wrappedRequest.Body)
+	fmt.Println(wrappedRequest.Body["type"])
 
 	return wrappedRequest, nil
 }

--- a/pkg/playback/http_serializer_test.go
+++ b/pkg/playback/http_serializer_test.go
@@ -1,0 +1,35 @@
+package playback
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHTTPRequestReturnsWrappedRequest(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	wrappedRequest, err := newHTTPRequest(req)
+	check(t, err)
+	assert.Equal(t, wrappedRequest.Method, req.Method)
+
+	bodyBytes, _ := json.Marshal("some json body")
+	post, _ := http.NewRequest("POST", "example.com", bytes.NewBuffer(bodyBytes))
+	wrappedPost, err := newHTTPRequest(post)
+	check(t, err)
+	assert.Equal(t, &wrappedPost.URL, post.URL)
+}
+
+func TestNewHTTPResponseReturnsWrappedResponse(t *testing.T) {
+	res := http.Response{
+		Header:     http.Header{},
+		Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+		StatusCode: 200,
+	}
+	wrappedResponse, err := newHTTPResponse(&res)
+	check(t, err)
+	assert.Equal(t, wrappedResponse.StatusCode, res.StatusCode)
+}

--- a/pkg/playback/interactions.go
+++ b/pkg/playback/interactions.go
@@ -122,14 +122,14 @@ func (replayer *interactionReplayer) write(req interface{}) (resp *interface{}, 
 	var lastAccepted interface{}
 	acceptedIdx := -1
 
-	for idx, val := range replayer.cassette {
+	for idx, interaction := range replayer.cassette {
 		// var reader io.Reader = bytes.NewReader(val.Request)
 		// requestStruct, err := replayer.reqDeserializer(&reader)
 		// if err != nil {
 		// 	return nil, fmt.Errorf("error when deserializing cassette: %w", err)
 		// }
 
-		accept, shortCircuit := replayer.comparator(val.Request, req)
+		accept, shortCircuit := replayer.comparator(interaction.Request, req)
 
 		if accept {
 			// var reader io.Reader = bytes.NewReader(val.Response)
@@ -139,7 +139,7 @@ func (replayer *interactionReplayer) write(req interface{}) (resp *interface{}, 
 			// 	return nil, fmt.Errorf("error when deserializing cassette: %w", err)
 			// }
 
-			lastAccepted = val.Response
+			lastAccepted = interaction.Response
 			acceptedIdx = idx
 
 			if shortCircuit {
@@ -148,6 +148,7 @@ func (replayer *interactionReplayer) write(req interface{}) (resp *interface{}, 
 		}
 	}
 	if acceptedIdx != -1 {
+		// remove interactions that were accepted from tape
 		replayer.cassette = append(replayer.cassette[:acceptedIdx], replayer.cassette[acceptedIdx+1:]...)
 		return &lastAccepted, nil
 	}

--- a/pkg/playback/interactions_test.go
+++ b/pkg/playback/interactions_test.go
@@ -222,7 +222,8 @@ func TestSaveAndCloseToYaml(t *testing.T) {
 	// persist cassette to file
 	recorder.saveAndClose()
 
-	expectedYAML := `- type: 0
+	expectedYAML :=
+		`- type: 0
   request:
     method: POST
     body: {}
@@ -237,6 +238,7 @@ func TestSaveAndCloseToYaml(t *testing.T) {
       forcequery: false
       rawquery: ""
       fragment: ""
+      rawfragment: ""
   response:
     headers: {}
     body: {}


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
I wish I could cleanup more but at this point this is out of scope for now.

This cleanup starts deleting, renaming and moving a few things towards a simpler architecture that we'll hopefully get to early next year.