### PR TITLE
update github actions to go 1.15.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
 ### Reviewers
r? @richardm-stripe 
cc @stripe/developer-products

 ### Summary
In go 1.15 (the actual dependency we build against), the URL package was updated with a new default field: https://golang.org/pkg/net/url/#URL

This breaks tests built between 1.14 vs 1.15 on another PR, so I'm actually putting everything on 1.15.
