### PR TITLE
Refactor the serialization system to correctly save human-readable yaml to file

### DIFF
--- a/pkg/playback/http_playback.go
+++ b/pkg/playback/http_playback.go
@@ -24,6 +24,10 @@ func forwardRequest(wrappedRequest *httpRequest, destinationURL string) (resp *h
 
 	// Create a identical copy of the request
 	bodyBytes, err := json.Marshal(wrappedRequest.Body)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := http.NewRequest(wrappedRequest.Method, destinationURL, bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		return nil, err

--- a/pkg/playback/http_playback.go
+++ b/pkg/playback/http_playback.go
@@ -16,6 +16,21 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// errorJsonOuter and errorJSONInner are used to return `playback` error messages as JSON in HTTP response bodies to
+// mimic errors returned by the Stripe API. The intention is to make it easier for clients (which expect Stripe API errors)
+// using `stripe playback` to parse and display a useful error message when `stripe playback` emits errors.
+type errorJSONOuter struct {
+	Error errorJSONInner `json:"error"`
+}
+
+type errorJSONInner struct {
+	Code    string `json:"code"`
+	DocURL  string `json:"doc_url"`
+	Message string `json:"message"`
+	Param   string `json:"param"`
+	Type    string `json:"type"`
+}
+
 func forwardRequest(wrappedRequest *httpRequest, destinationURL string) (resp *http.Response, err error) {
 	client := &http.Client{
 		// set Timeout explicitly, otherwise the client will wait indefinitely for a response
@@ -41,21 +56,6 @@ func forwardRequest(wrappedRequest *httpRequest, destinationURL string) (resp *h
 		return nil, err
 	}
 	return res, nil
-}
-
-// errorJsonOuter and errorJSONInner are used to return `playback` error messages as JSON in HTTP response bodies to
-// mimic errors returned by the Stripe API. The intention is to make it easier for clients (which expect Stripe API errors)
-// using `stripe playback` to parse and display a useful error message when `stripe playback` emits errors.
-type errorJSONOuter struct {
-	Error errorJSONInner `json:"error"`
-}
-
-type errorJSONInner struct {
-	Code    string `json:"code"`
-	DocURL  string `json:"doc_url"`
-	Message string `json:"message"`
-	Param   string `json:"param"`
-	Type    string `json:"type"`
 }
 
 // Writes to the HTTP response using the given HTTP status code and error in the response body. Simultaneously, prints logs error text.

--- a/pkg/playback/http_playback.go
+++ b/pkg/playback/http_playback.go
@@ -38,12 +38,7 @@ func forwardRequest(wrappedRequest *httpRequest, destinationURL string) (resp *h
 	}
 
 	// Create a identical copy of the request
-	bodyBytes, err := json.Marshal(wrappedRequest.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest(wrappedRequest.Method, destinationURL, bytes.NewBuffer(bodyBytes))
+	req, err := http.NewRequest(wrappedRequest.Method, destinationURL, bytes.NewBuffer(wrappedRequest.Body))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/playback/http_playback_test.go
+++ b/pkg/playback/http_playback_test.go
@@ -167,12 +167,12 @@ func TestSimpleRecordReplayServerSeparately(t *testing.T) {
 
 	// Also sanity check that the mock server is responding with the expected responses
 	assert.Equal(t, "testHeaderValue", res1.Header.Get("testHeader"))
-	bodyBytes, err := ioutil.ReadAll(res1.Body)
-	check(t, err)
-	assert.Equal(t, mockResponse1.Body, bodyBytes)
+	bodyBytes1, err := ioutil.ReadAll(res1.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, mockResponse1.Body, bodyBytes1)
 
 	bodyBytes2, err := ioutil.ReadAll(res2.Body)
-	check(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, mockResponse2.Body, bodyBytes2)
 
 	// Shutdown replay server
@@ -274,11 +274,11 @@ func TestPlaybackSingleRunCreateCustomerAndStandaloneCharge(t *testing.T) {
 	// Also sanity check that the mock server is responding with the expected responses
 	assert.Equal(t, "testHeaderValue", res1.Header.Get("testHeader"))
 	bodyBytes1, err := ioutil.ReadAll(res1.Body)
-	check(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, mockResponse1.Body, bodyBytes1)
 
 	bodyBytes2, err := ioutil.ReadAll(res2.Body)
-	check(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, mockResponse2.Body, bodyBytes2)
 
 	// --- END REPLAY MODE

--- a/pkg/playback/http_recorder.go
+++ b/pkg/playback/http_recorder.go
@@ -43,11 +43,6 @@ func (httpRecorder *HTTPRecorder) insertCassette(writer io.Writer) error {
 	return nil
 }
 
-// Struct used to parse the event.Type from recorded webhook JSON bodies
-type stripeEvent struct {
-	Type string `json:"type"`
-}
-
 // Handler for the webhook endpoint that forwards incoming webhooks to the local application,
 // while recording the webhook and local app's response to the cassette.
 func (httpRecorder *HTTPRecorder) webhookHandler(w http.ResponseWriter, r *http.Request) {
@@ -97,6 +92,10 @@ func (httpRecorder *HTTPRecorder) webhookHandler(w http.ResponseWriter, r *http.
 	copyHTTPHeader(w.Header(), wrappedResp.Headers) // header map must be written before calling w.WriteHeader
 	w.WriteHeader(wrappedResp.StatusCode)
 	bodyBytes, err := json.Marshal(wrappedResp.Body)
+	if err != nil {
+		httpRecorder.log.Fatal(err)
+	}
+
 	_, err = io.Copy(w, bytes.NewBuffer(bodyBytes))
 
 	// Since at this point, we can't signal an error by writing the HTTP status code, and this is a significant failure - we log.Fatal
@@ -150,6 +149,10 @@ func (httpRecorder *HTTPRecorder) handler(w http.ResponseWriter, r *http.Request
 	copyHTTPHeader(w.Header(), wrappedResp.Headers) // header map must be written before calling w.WriteHeader
 	w.WriteHeader(wrappedResp.StatusCode)
 	bodyBytes, err := json.Marshal(wrappedResp.Body)
+	if err != nil {
+		httpRecorder.log.Fatal(err)
+	}
+
 	_, err = io.Copy(w, bytes.NewBuffer(bodyBytes))
 
 	// Since at this point, we can't signal an error by writing the HTTP status code, and this is a significant failure - we log.Fatal

--- a/pkg/playback/http_recorder.go
+++ b/pkg/playback/http_recorder.go
@@ -39,7 +39,7 @@ func newHTTPRecorder(remoteURL string, webhookURL string) (httpRecorder HTTPReco
 
 // Prepare the recorder to start recording to a new cassette.
 func (httpRecorder *HTTPRecorder) insertCassette(writer io.Writer) error {
-	recorder, err := newInteractionRecorder(writer, httpRequestToBytes, httpResponseToBytes)
+	recorder, err := newInteractionRecorder(writer, YAMLSerializer{})
 	if err != nil {
 		return err
 	}

--- a/pkg/playback/http_replayer.go
+++ b/pkg/playback/http_replayer.go
@@ -141,7 +141,6 @@ func (httpReplayer *HTTPReplayer) getNextRecordedCassetteResponse(request *httpR
 		return &httpResponse{}, err
 	}
 
-	fmt.Println(*uncastResponse)
 	wrappedResponse := (*uncastResponse).(httpResponse)
 
 	return &wrappedResponse, err

--- a/pkg/playback/http_replayer.go
+++ b/pkg/playback/http_replayer.go
@@ -171,25 +171,25 @@ func (httpReplayer *HTTPReplayer) readAnyPendingWebhookRecordingsFromCassette() 
 	// --- Deserialize the bytes into HTTP request & response pairs
 	webhookRequests = make([]*httpRequest, 0)
 	webhookResponses = make([]*httpResponse, 0)
-	for _, interaction := range interactions {
-		// var reqReader io.Reader = bytes.NewReader(rawWebhookBytes.Request)
-		// rawWhReq, err := httpRequestfromBytes(&reqReader)
-		// if err != nil {
-		// 	return nil, nil, fmt.Errorf("error when deserializing cassette to replay webhooks: %w", err)
-		// }
-		// whReq := rawWhReq.(httpRequest)
+	// for _, interaction := range interactions {
+	// 	// var reqReader io.Reader = bytes.NewReader(rawWebhookBytes.Request)
+	// 	// rawWhReq, err := httpRequestfromBytes(&reqReader)
+	// 	// if err != nil {
+	// 	// 	return nil, nil, fmt.Errorf("error when deserializing cassette to replay webhooks: %w", err)
+	// 	// }
+	// 	// whReq := rawWhReq.(httpRequest)
 
-		webhookRequests = append(webhookRequests, &interaction.Request)
+	// 	webhookRequests = append(webhookRequests, &interaction.Request)
 
-		// var respReader io.Reader = bytes.NewReader(rawWebhookBytes.Response)
-		// rawWhResp, err := httpResponsefromBytes(&respReader)
-		// if err != nil {
-		// 	return nil, nil, fmt.Errorf("error when deserializing cassette to replay webhooks: %w", err)
-		// }
-		// whResp := rawWhResp.(httpResponse)
+	// 	// var respReader io.Reader = bytes.NewReader(rawWebhookBytes.Response)
+	// 	// rawWhResp, err := httpResponsefromBytes(&respReader)
+	// 	// if err != nil {
+	// 	// 	return nil, nil, fmt.Errorf("error when deserializing cassette to replay webhooks: %w", err)
+	// 	// }
+	// 	// whResp := rawWhResp.(httpResponse)
 
-		webhookResponses = append(webhookResponses, &interaction.Response)
-	}
+	// 	webhookResponses = append(webhookResponses, &interaction.Response)
+	// }
 
 	return webhookRequests, webhookResponses, nil
 }

--- a/pkg/playback/http_replayer.go
+++ b/pkg/playback/http_replayer.go
@@ -39,7 +39,7 @@ func (httpReplayer *HTTPReplayer) readCassette(reader io.Reader) error {
 		return true, true
 	}
 
-	replayer, err := newInteractionReplayer(reader, YAMLSerializer{}, sequentialComparator)
+	replayer, err := newInteractionReplayer(reader, httpRequestfromBytes, httpResponsefromBytes, YAMLSerializer{}, sequentialComparator)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,6 @@ func (httpReplayer *HTTPReplayer) handler(w http.ResponseWriter, r *http.Request
 
 	// --- Read matching response from cassette
 	var wrappedResponse *httpResponse
-	fmt.Println("HELLO")
 	wrappedResponse, err = httpReplayer.getNextRecordedCassetteResponse(&wrappedRequest)
 	if err != nil {
 		writeErrorToHTTPResponse(w, httpReplayer.log, err, 500)

--- a/pkg/playback/http_replayer.go
+++ b/pkg/playback/http_replayer.go
@@ -5,7 +5,6 @@ package playback
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"sync"
@@ -148,25 +147,25 @@ func (httpReplayer *HTTPReplayer) getNextRecordedCassetteResponse(request *httpR
 
 // Reads any contiguous set of webhook recordings from the start of the cassette
 func (httpReplayer *HTTPReplayer) readAnyPendingWebhookRecordingsFromCassette() (webhookRequests []*httpRequest, webhookResponses []*httpResponse, err error) {
-	interactions := make([]interaction, 0)
+	// interactions := make([]interaction, 0)
 
-	// --- Read the pending webhook interactions (stored as raw bytes) from the cassette
-	for httpReplayer.replayer.interactionsRemaining() > 0 {
-		interaction, err := httpReplayer.replayer.peekFront()
-		if err != nil {
-			return nil, nil, fmt.Errorf("error when checking webhooks: %w", err)
-		}
+	// // --- Read the pending webhook interactions (stored as raw bytes) from the cassette
+	// for httpReplayer.replayer.interactionsRemaining() > 0 {
+	// 	interaction, err := httpReplayer.replayer.peekFront()
+	// 	if err != nil {
+	// 		return nil, nil, fmt.Errorf("error when checking webhooks: %w", err)
+	// 	}
 
-		if interaction.Type == incomingInteraction {
-			interactions = append(interactions, interaction)
-			_, err = httpReplayer.replayer.popFront()
-			if err != nil {
-				return nil, nil, fmt.Errorf("unexpectedly reached end of cassette when checking for pending webhooks: %w", err)
-			}
-		} else {
-			break
-		}
-	}
+	// 	if interaction.Type == incomingInteraction {
+	// 		interactions = append(interactions, interaction)
+	// 		_, err = httpReplayer.replayer.popFront()
+	// 		if err != nil {
+	// 			return nil, nil, fmt.Errorf("unexpectedly reached end of cassette when checking for pending webhooks: %w", err)
+	// 		}
+	// 	} else {
+	// 		break
+	// 	}
+	// }
 
 	// --- Deserialize the bytes into HTTP request & response pairs
 	webhookRequests = make([]*httpRequest, 0)

--- a/pkg/playback/http_replayer.go
+++ b/pkg/playback/http_replayer.go
@@ -150,7 +150,7 @@ func (httpReplayer *HTTPReplayer) getNextRecordedCassetteResponse(request *httpR
 func (httpReplayer *HTTPReplayer) readAnyPendingWebhookRecordingsFromCassette() (webhookRequests []*httpRequest, webhookResponses []*httpResponse, err error) {
 	interactions := make([]interaction, 0)
 
-	// // --- Read the pending webhook interactions (stored as raw bytes) from the cassette
+	// --- Read the pending webhook interactions (stored as raw bytes) from the cassette
 	for httpReplayer.replayer.interactionsRemaining() > 0 {
 		interaction, err := httpReplayer.replayer.peekFront()
 		if err != nil {

--- a/pkg/playback/http_replayer.go
+++ b/pkg/playback/http_replayer.go
@@ -81,6 +81,10 @@ func (httpReplayer *HTTPReplayer) handler(w http.ResponseWriter, r *http.Request
 	copyHTTPHeader(w.Header(), wrappedResponse.Headers) // header map must be written before calling w.WriteHeader
 	w.WriteHeader(wrappedResponse.StatusCode)
 	bodyBytes, err := json.Marshal(wrappedResponse.Body)
+	if err != nil {
+		httpReplayer.log.Fatal(err)
+	}
+
 	_, err = io.Copy(w, bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		httpReplayer.log.Fatal(err)

--- a/pkg/playback/http_serializer.go
+++ b/pkg/playback/http_serializer.go
@@ -14,7 +14,7 @@ type serializer interface {
 	serializeReq(interface{}) ([]byte, error)
 	serializeResp(interface{}) ([]byte, error)
 	newInteraction(interactionType, httpRequest, httpResponse) interaction
-	encodeCassetteToBytes(cassette) ([]byte, error)
+	encodeCassette(cassette) ([]byte, error)
 }
 
 // type serializer func(input interface{}) (bytes []byte, err error)
@@ -63,7 +63,8 @@ func newHTTPResponse(resp *http.Response) (wrappedResponse httpResponse, err err
 	wrappedResponse.Headers = resp.Header
 	wrappedResponse.StatusCode = resp.StatusCode
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	var bodyBytes []byte
+	bodyBytes, err = ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return wrappedResponse, err
@@ -80,7 +81,8 @@ func newHTTPRequest(req *http.Request) (wrappedRequest httpRequest, err error) {
 	wrappedRequest.Headers = req.Header
 	wrappedRequest.URL = *req.URL
 
-	bodyBytes, err := ioutil.ReadAll(req.Body)
+	var bodyBytes []byte
+	bodyBytes, err = ioutil.ReadAll(req.Body)
 	defer req.Body.Close()
 	if err != nil {
 		return wrappedRequest, err

--- a/pkg/playback/http_serializer.go
+++ b/pkg/playback/http_serializer.go
@@ -4,6 +4,7 @@ package playback
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -64,13 +65,6 @@ func newHTTPResponse(resp *http.Response) (wrappedResponse httpResponse, err err
 	wrappedResponse.Headers = resp.Header
 	wrappedResponse.StatusCode = resp.StatusCode
 
-	// var bodyBytes []byte
-	// bodyBytes, err = ioutil.ReadAll(resp.Body)
-	// defer resp.Body.Close()
-	// if err != nil {
-	// 	return wrappedResponse, err
-	// }
-	// json.Unmarshal(bodyBytes, &wrappedResponse.Body)
 	json.NewDecoder(resp.Body).Decode(&wrappedResponse.Body)
 
 	return wrappedResponse, nil
@@ -83,9 +77,13 @@ func newHTTPRequest(req *http.Request) (wrappedRequest httpRequest, err error) {
 	wrappedRequest.Headers = req.Header
 	wrappedRequest.URL = *req.URL
 
-	if req.Body != nil {
-		json.NewDecoder(req.Body).Decode(&wrappedRequest.Body)
-	}
+	json.NewDecoder(req.Body).Decode(&wrappedRequest.Body)
+
+	fmt.Println(req.Body)
+	bodyBytes, _ := ioutil.ReadAll(req.Body)
+	fmt.Println(string(bodyBytes))
+	fmt.Println(wrappedRequest.Body)
+	fmt.Println(wrappedRequest)
 
 	return wrappedRequest, nil
 }

--- a/pkg/playback/http_serializer.go
+++ b/pkg/playback/http_serializer.go
@@ -3,22 +3,17 @@
 package playback
 
 import (
-	"encoding/json"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 )
 
 type serializer interface {
-	serializeReq(interface{}) ([]byte, error)
-	serializeResp(interface{}) ([]byte, error)
-	newInteraction(interactionType, httpRequest, httpResponse) interaction
-	encodeCassette(cassette) ([]byte, error)
+	serializeReq(httpRequest) (interface{}, error)
+	serializeResp(httpResponse) (interface{}, error)
+	EncodeCassette(Cassette) ([]byte, error)
+	DecodeCassette([]byte) (Cassette, error)
 }
-
-// type serializer func(input interface{}) (bytes []byte, err error)
-type deserializer func(input *io.Reader) (value interface{}, err error)
 
 type httpRequest struct {
 	Method  string
@@ -31,30 +26,6 @@ type httpResponse struct {
 	Headers    http.Header
 	Body       []byte
 	StatusCode int
-}
-
-func httpRequestfromBytes(input *io.Reader) (val interface{}, err error) {
-	output := httpRequest{}
-
-	inputBytes, err := ioutil.ReadAll(*input)
-	if err != nil {
-		return output, err
-	}
-
-	err = json.Unmarshal(inputBytes, &output)
-	return output, err
-}
-
-func httpResponsefromBytes(input *io.Reader) (val interface{}, err error) {
-	output := httpResponse{}
-
-	inputBytes, err := ioutil.ReadAll(*input)
-	if err != nil {
-		return output, err
-	}
-
-	err = json.Unmarshal(inputBytes, &output)
-	return output, err
 }
 
 func newHTTPResponse(resp *http.Response) (wrappedResponse httpResponse, err error) {

--- a/pkg/playback/http_serializer.go
+++ b/pkg/playback/http_serializer.go
@@ -4,7 +4,6 @@ package playback
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -13,6 +12,19 @@ import (
 
 type serializer func(input interface{}) (bytes []byte, err error)
 type deserializer func(input *io.Reader) (value interface{}, err error)
+
+type httpRequest struct {
+	Method  string
+	Body    map[string]interface{}
+	Headers http.Header
+	URL     url.URL
+}
+
+type httpResponse struct {
+	Headers    http.Header
+	Body       map[string]interface{}
+	StatusCode int
+}
 
 func httpRequestToBytes(input interface{}) (data []byte, err error) {
 	return json.Marshal(input)
@@ -46,12 +58,6 @@ func httpResponsefromBytes(input *io.Reader) (val interface{}, err error) {
 	return output, err
 }
 
-type httpResponse struct {
-	Headers    http.Header
-	Body       map[string]interface{}
-	StatusCode int
-}
-
 func newHTTPResponse(resp *http.Response) (wrappedResponse httpResponse, err error) {
 	wrappedResponse = httpResponse{}
 
@@ -70,13 +76,6 @@ func newHTTPResponse(resp *http.Response) (wrappedResponse httpResponse, err err
 	return wrappedResponse, nil
 }
 
-type httpRequest struct {
-	Method  string
-	Body    map[string]interface{}
-	Headers http.Header
-	URL     url.URL
-}
-
 func newHTTPRequest(req *http.Request) (wrappedRequest httpRequest, err error) {
 	wrappedRequest = httpRequest{}
 
@@ -84,15 +83,9 @@ func newHTTPRequest(req *http.Request) (wrappedRequest httpRequest, err error) {
 	wrappedRequest.Headers = req.Header
 	wrappedRequest.URL = *req.URL
 
-	// var bodyBytes []byte
-	// bodyBytes, err = ioutil.ReadAll(req.Body)
-	// defer req.Body.Close()
-	// if err != nil {
-	// 	return wrappedRequest, err
-	// }
-	// wrappedRequest.Body = bodyBytes
-	json.NewDecoder(req.Body).Decode(&wrappedRequest.Body)
-	fmt.Println(wrappedRequest.Body["type"])
+	if req.Body != nil {
+		json.NewDecoder(req.Body).Decode(&wrappedRequest.Body)
+	}
 
 	return wrappedRequest, nil
 }

--- a/pkg/playback/http_serializer.go
+++ b/pkg/playback/http_serializer.go
@@ -4,6 +4,7 @@ package playback
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -47,7 +48,7 @@ func httpResponsefromBytes(input *io.Reader) (val interface{}, err error) {
 
 type httpResponse struct {
 	Headers    http.Header
-	Body       []byte
+	Body       map[string]interface{}
 	StatusCode int
 }
 
@@ -57,20 +58,21 @@ func newHTTPResponse(resp *http.Response) (wrappedResponse httpResponse, err err
 	wrappedResponse.Headers = resp.Header
 	wrappedResponse.StatusCode = resp.StatusCode
 
-	var bodyBytes []byte
-	bodyBytes, err = ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
-	if err != nil {
-		return wrappedResponse, err
-	}
-	wrappedResponse.Body = bodyBytes
+	// var bodyBytes []byte
+	// bodyBytes, err = ioutil.ReadAll(resp.Body)
+	// defer resp.Body.Close()
+	// if err != nil {
+	// 	return wrappedResponse, err
+	// }
+	// json.Unmarshal(bodyBytes, &wrappedResponse.Body)
+	json.NewDecoder(resp.Body).Decode(&wrappedResponse.Body)
 
 	return wrappedResponse, nil
 }
 
 type httpRequest struct {
 	Method  string
-	Body    []byte
+	Body    map[string]interface{}
 	Headers http.Header
 	URL     url.URL
 }
@@ -82,13 +84,15 @@ func newHTTPRequest(req *http.Request) (wrappedRequest httpRequest, err error) {
 	wrappedRequest.Headers = req.Header
 	wrappedRequest.URL = *req.URL
 
-	var bodyBytes []byte
-	bodyBytes, err = ioutil.ReadAll(req.Body)
-	defer req.Body.Close()
-	if err != nil {
-		return wrappedRequest, err
-	}
-	wrappedRequest.Body = bodyBytes
+	// var bodyBytes []byte
+	// bodyBytes, err = ioutil.ReadAll(req.Body)
+	// defer req.Body.Close()
+	// if err != nil {
+	// 	return wrappedRequest, err
+	// }
+	// wrappedRequest.Body = bodyBytes
+	json.NewDecoder(req.Body).Decode(&wrappedRequest.Body)
+	fmt.Println(wrappedRequest.Body["type"])
 
 	return wrappedRequest, nil
 }

--- a/pkg/playback/http_serializer.go
+++ b/pkg/playback/http_serializer.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-
-	"gopkg.in/yaml.v2"
 )
 
 type serializer interface {
@@ -29,38 +27,10 @@ type httpRequest struct {
 	URL     url.URL
 }
 
-type YAMLRequest struct {
-	Method  string      `yaml:"method"`
-	Body    string      `yaml:"body"`
-	Headers http.Header `yaml:"headers"`
-	URL     url.URL     `yaml:"url"`
-}
-
 type httpResponse struct {
 	Headers    http.Header
 	Body       []byte
 	StatusCode int
-}
-
-type YAMLResponse struct {
-	Headers    http.Header `yaml:"headers"`
-	Body       string      `yaml:"body"`
-	StatusCode int         `yaml: "status"`
-}
-
-func httpRequestToBytes(input interface{}) (data []byte, err error) {
-	return json.Marshal(input)
-}
-
-func httpRequestToYAML(input interface{}) ([]byte, error) {
-	req := input.(httpRequest)
-	yml := YAMLRequest{
-		req.Method,
-		string(req.Body),
-		req.Headers,
-		req.URL,
-	}
-	return yaml.Marshal(yml)
 }
 
 func httpRequestfromBytes(input *io.Reader) (val interface{}, err error) {
@@ -73,20 +43,6 @@ func httpRequestfromBytes(input *io.Reader) (val interface{}, err error) {
 
 	err = json.Unmarshal(inputBytes, &output)
 	return output, err
-}
-
-func httpResponseToBytes(input interface{}) (data []byte, err error) {
-	return json.Marshal(input)
-}
-
-func httpResponseToYAML(input interface{}) ([]byte, error) {
-	res := input.(httpResponse)
-	yml := YAMLResponse{
-		res.Headers,
-		string(res.Body),
-		res.StatusCode,
-	}
-	return yaml.Marshal(yml)
 }
 
 func httpResponsefromBytes(input *io.Reader) (val interface{}, err error) {

--- a/pkg/playback/http_serializer_test.go
+++ b/pkg/playback/http_serializer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewHTTPRequestReturnsWrappedRequest(t *testing.T) {
-	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req, _ := http.NewRequest("GET", "http://example.com", bytes.NewBuffer([]byte{}))
 	wrappedRequest, err := newHTTPRequest(req)
 	check(t, err)
 	assert.Equal(t, wrappedRequest.Method, req.Method)
@@ -32,4 +32,8 @@ func TestNewHTTPResponseReturnsWrappedResponse(t *testing.T) {
 	wrappedResponse, err := newHTTPResponse(&res)
 	check(t, err)
 	assert.Equal(t, wrappedResponse.StatusCode, res.StatusCode)
+	var jsonBody map[string]interface{}
+	json.NewDecoder(res.Body).Decode(&jsonBody)
+	check(t, err)
+	assert.Equal(t, wrappedResponse.Body, jsonBody)
 }

--- a/pkg/playback/http_serializer_test.go
+++ b/pkg/playback/http_serializer_test.go
@@ -24,16 +24,15 @@ func TestNewHTTPRequestReturnsWrappedRequest(t *testing.T) {
 }
 
 func TestNewHTTPResponseReturnsWrappedResponse(t *testing.T) {
+	body := ioutil.NopCloser(bytes.NewBuffer([]byte("Hello World")))
 	res := http.Response{
 		Header:     http.Header{},
-		Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+		Body:       body,
 		StatusCode: 200,
 	}
 	wrappedResponse, err := newHTTPResponse(&res)
 	check(t, err)
+
 	assert.Equal(t, wrappedResponse.StatusCode, res.StatusCode)
-	var jsonBody map[string]interface{}
-	json.NewDecoder(res.Body).Decode(&jsonBody)
-	check(t, err)
-	assert.Equal(t, wrappedResponse.Body, jsonBody)
+	assert.Equal(t, string(wrappedResponse.Body), "Hello World")
 }

--- a/pkg/playback/http_serializer_test.go
+++ b/pkg/playback/http_serializer_test.go
@@ -1,0 +1,35 @@
+package playback
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHTTPRequestReturnsWrappedRequest(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	wrappedRequest, err := newHTTPRequest(req)
+	check(t, err)
+	assert.Equal(t, wrappedRequest.Method, req.Method)
+
+	bodyBytes, _ := json.Marshal("some json body")
+	post, _ := http.NewRequest("POST", "example.com", bytes.NewBuffer(bodyBytes))
+	wrappedPost, err := newHTTPRequest(post)
+	check(t, err)
+	assert.Equal(t, &wrappedPost.URL, post.URL)
+}
+
+func TestNewHTTPResponseReturnsWrappedResponse(t *testing.T) {
+	res := http.Response{
+		Header:     http.Header{},
+		Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
+		StatusCode: 200,
+	}
+	wrappedResponse, err := newHTTPResponse(&res)
+	check(t, err)
+	assert.Equal(t, wrappedResponse.StatusCode, res.StatusCode)
+}

--- a/pkg/playback/interactions.go
+++ b/pkg/playback/interactions.go
@@ -55,31 +55,24 @@ func newInteractionRecorder(writer io.Writer, reqSerializer serializer, respSeri
 
 // write adds a new interaction to the current cassette.
 func (recorder *interactionRecorder) write(typeOfInteraction interactionType, req httpRequest, resp httpResponse) error {
-	// reqBytes, err := recorder.reqSerializer(req)
-
-	// if err != nil {
-	// 	return err
-	// }
-
-	// respBytes, err := recorder.respSerializer(resp)
-
-	// if err != nil {
-	// 	return err
-	// }
-
 	recorder.cassette = append(recorder.cassette, interaction{Type: typeOfInteraction, Request: req, Response: resp})
-	// return err
 	return nil
 }
 
 // saveAndClose persists the cassette to the filesystem.
-// do not marshal here, have "write" use a setup serializer, in our case yaml
-// saveAndClose should just persist to the file and that's it.
 func (recorder *interactionRecorder) saveAndClose() error {
-	yaml, err := yaml.Marshal(recorder.cassette)
-	if err != nil {
-		return err
-	}
+	// open cassette file
+	// loop over interactions
+	// format interactions with recorder.interactionSerializer
+	// write to file
+	// end of loop => close file
+
+	// yaml, err := yaml.Marshal(recorder.cassette)
+	// if err != nil {
+	// 	return err
+	// }
+
+	var serializedInteractions []interface{}
 
 	_, err = recorder.writer.Write(yaml)
 	return err

--- a/pkg/playback/interactions.go
+++ b/pkg/playback/interactions.go
@@ -2,7 +2,6 @@ package playback
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -112,25 +111,10 @@ func (replayer *interactionReplayer) write(req *httpRequest) (resp *interface{},
 	var lastAccepted interface{}
 	acceptedIdx := -1
 
-	fmt.Println("WRITE HERE")
 	for idx, interaction := range replayer.cassette {
-		fmt.Println("IN LOOP")
-		// var reader io.Reader = bytes.NewReader(val.Request)
-		// requestStruct, err := replayer.reqDeserializer(&reader)
-		// if err != nil {
-		// 	return nil, fmt.Errorf("error when deserializing cassette: %w", err)
-		// }
-
 		accept, shortCircuit := replayer.comparator(interaction.Request, *req)
 
 		if accept {
-			// var reader io.Reader = bytes.NewReader(val.Response)
-			// responseStruct, err := replayer.respDeserializer(&reader)
-
-			// if err != nil {
-			// 	return nil, fmt.Errorf("error when deserializing cassette: %w", err)
-			// }
-
 			lastAccepted = interaction.Response
 			acceptedIdx = idx
 

--- a/pkg/playback/interactions.go
+++ b/pkg/playback/interactions.go
@@ -122,14 +122,14 @@ func (replayer *interactionReplayer) write(req interface{}) (resp *interface{}, 
 	var lastAccepted interface{}
 	acceptedIdx := -1
 
-	for idx, val := range replayer.cassette {
+	for idx, interaction := range replayer.cassette {
 		// var reader io.Reader = bytes.NewReader(val.Request)
 		// requestStruct, err := replayer.reqDeserializer(&reader)
 		// if err != nil {
 		// 	return nil, fmt.Errorf("error when deserializing cassette: %w", err)
 		// }
 
-		accept, shortCircuit := replayer.comparator(val.Request, req)
+		accept, shortCircuit := replayer.comparator(interaction.Request, req)
 
 		if accept {
 			// var reader io.Reader = bytes.NewReader(val.Response)
@@ -139,7 +139,7 @@ func (replayer *interactionReplayer) write(req interface{}) (resp *interface{}, 
 			// 	return nil, fmt.Errorf("error when deserializing cassette: %w", err)
 			// }
 
-			lastAccepted = val.Response
+			lastAccepted = interaction.Response
 			acceptedIdx = idx
 
 			if shortCircuit {
@@ -148,6 +148,7 @@ func (replayer *interactionReplayer) write(req interface{}) (resp *interface{}, 
 		}
 	}
 	if acceptedIdx != -1 {
+		// remove interactions that were accepted from tape
 		replayer.cassette = append(replayer.cassette[:acceptedIdx], replayer.cassette[acceptedIdx+1:]...)
 		return &lastAccepted, nil
 	}

--- a/pkg/playback/interactions.go
+++ b/pkg/playback/interactions.go
@@ -38,11 +38,9 @@ type cassette []interaction
 // An interactionRecorder can read in a cassette, and write them out
 // in a serialized format.
 type interactionRecorder struct {
-	writer         io.Writer
-	cassette       cassette
-	serializer     YAMLSerializer
-	reqSerializer  serializer
-	respSerializer serializer
+	writer     io.Writer
+	cassette   cassette
+	serializer YAMLSerializer
 }
 
 func newInteractionRecorder(writer io.Writer, serializer serializer) (recorder *interactionRecorder, err error) {

--- a/pkg/playback/interactions_test.go
+++ b/pkg/playback/interactions_test.go
@@ -242,7 +242,7 @@ func TestSaveAndCloseToYaml(t *testing.T) {
   response:
     headers: {}
     body: ""
-    statuscode: 200
+    status_code: 200
 `
 
 	dat, _ := ioutil.ReadFile(cassetteFile.Name())

--- a/pkg/playback/interactions_test.go
+++ b/pkg/playback/interactions_test.go
@@ -70,7 +70,7 @@ func TestSequentialPlayback(t *testing.T) {
 	}
 
 	var writeBuffer bytes.Buffer
-	recorder, err := newInteractionRecorder(&writeBuffer, httpRequestToBytes, httpRequestToBytes)
+	recorder, err := newInteractionRecorder(&writeBuffer, YAMLSerializer{})
 
 	if err != nil {
 		t.Fatal(err)
@@ -116,7 +116,7 @@ func TestFirstMatchingEvent(t *testing.T) {
 	}
 
 	var writeBuffer bytes.Buffer
-	recorder, err := newInteractionRecorder(&writeBuffer, BasicEventToBytes, BasicEventToBytes)
+	recorder, err := newInteractionRecorder(&writeBuffer, YAMLSerializer{})
 
 	if err != nil {
 		t.Fatal(err)
@@ -166,7 +166,7 @@ func TestLastMatchingEvent(t *testing.T) {
 	}
 
 	var writeBuffer bytes.Buffer
-	recorder, err := newInteractionRecorder(&writeBuffer, BasicEventToBytes, BasicEventToBytes)
+	recorder, err := newInteractionRecorder(&writeBuffer, YAMLSerializer{})
 
 	if err != nil {
 		t.Fatal(err)
@@ -211,7 +211,7 @@ func TestSaveAndCloseToYaml(t *testing.T) {
 	check(t, err)
 
 	// create new recorder
-	recorder, err := newInteractionRecorder(cassetteFile, httpRequestToBytes, httpResponseToBytes)
+	recorder, err := newInteractionRecorder(cassetteFile, YAMLSerializer{})
 	check(t, err)
 
 	// write req/resp interaction to cassette
@@ -226,7 +226,7 @@ func TestSaveAndCloseToYaml(t *testing.T) {
 		`- type: 0
   request:
     method: POST
-    body: "hellow world"
+    body: hello world
     headers: {}
     url:
       scheme: ""

--- a/pkg/playback/interactions_test.go
+++ b/pkg/playback/interactions_test.go
@@ -215,7 +215,7 @@ func TestSaveAndCloseToYaml(t *testing.T) {
 	check(t, err)
 
 	// write req/resp interaction to cassette
-	s1 := httpRequest{Method: "POST"}
+	s1 := httpRequest{Method: "POST", Body: []byte("hello world")}
 	r1 := httpResponse{StatusCode: 200}
 	recorder.write(outgoingInteraction, s1, r1)
 
@@ -226,7 +226,7 @@ func TestSaveAndCloseToYaml(t *testing.T) {
 		`- type: 0
   request:
     method: POST
-    body: {}
+    body: "hellow world"
     headers: {}
     url:
       scheme: ""
@@ -241,7 +241,7 @@ func TestSaveAndCloseToYaml(t *testing.T) {
       rawfragment: ""
   response:
     headers: {}
-    body: {}
+    body: ""
     statuscode: 200
 `
 

--- a/pkg/playback/interactions_test.go
+++ b/pkg/playback/interactions_test.go
@@ -77,11 +77,11 @@ func TestSequentialPlayback(t *testing.T) {
 	}
 
 	s1 := httpRequest{Method: "POST"}
-	r1 := httpResponse{Headers: http.Header{}, Body: map[string]interface{}{"valid": "json"}, StatusCode: 200}
+	r1 := httpResponse{Headers: http.Header{}, Body: []byte("body 1"), StatusCode: 200}
 	recorder.write(outgoingInteraction, s1, r1)
 
 	s2 := httpRequest{Method: "GET"}
-	r2 := httpResponse{Headers: http.Header{}, Body: map[string]interface{}{"valid": "json2"}, StatusCode: 300}
+	r2 := httpResponse{Headers: http.Header{}, Body: []byte("body 2"), StatusCode: 300}
 	recorder.write(outgoingInteraction, s2, r2)
 
 	err = recorder.saveAndClose()
@@ -123,11 +123,11 @@ func TestFirstMatchingEvent(t *testing.T) {
 	}
 
 	s1 := httpRequest{Method: "POST"}
-	r1 := httpResponse{Headers: http.Header{}, Body: map[string]interface{}{"valid": "json"}, StatusCode: 200}
+	r1 := httpResponse{Headers: http.Header{}, Body: []byte("body 1"), StatusCode: 200}
 	recorder.write(outgoingInteraction, s1, r1)
 
 	s2 := httpRequest{Method: "GET"}
-	r2 := httpResponse{Headers: http.Header{}, Body: map[string]interface{}{"valid": "json2"}, StatusCode: 300}
+	r2 := httpResponse{Headers: http.Header{}, Body: []byte("body 2"), StatusCode: 300}
 	recorder.write(outgoingInteraction, s2, r2)
 
 	err = recorder.saveAndClose()

--- a/pkg/playback/interactions_test.go
+++ b/pkg/playback/interactions_test.go
@@ -222,7 +222,8 @@ func TestSaveAndCloseToYaml(t *testing.T) {
 	// persist cassette to file
 	recorder.saveAndClose()
 
-	expectedYAML := `- type: 0
+	expectedYAML :=
+		`- type: 0
   request:
     method: POST
     body: {}
@@ -237,6 +238,7 @@ func TestSaveAndCloseToYaml(t *testing.T) {
       forcequery: false
       rawquery: ""
       fragment: ""
+      rawfragment: ""
   response:
     headers: {}
     body: {}

--- a/pkg/playback/yaml_serializer.go
+++ b/pkg/playback/yaml_serializer.go
@@ -1,12 +1,34 @@
 package playback
 
 import (
+	"net/http"
+	"net/url"
+
 	"gopkg.in/yaml.v2"
 )
 
 // YAMLSerializer encodes/persists cassettes to files and decodes yaml cassette files.
 type YAMLSerializer struct{}
 
+// YAMLRequest is a playback.httpRequest interface that can be encoded to YAML
+type YAMLRequest struct {
+	Method  string      `yaml:"method"`
+	Body    string      `yaml:"body"`
+	Headers http.Header `yaml:"headers"`
+	URL     url.URL     `yaml:"url"`
+}
+
+// YAMLResponse is a playback.httpRequest interface that can be encoded to YAML
+type YAMLResponse struct {
+	Headers    http.Header `yaml:"headers"`
+	Body       string      `yaml:"body"`
+	StatusCode int         `yaml:"status_code"`
+}
+
+// -------- SERIALIZATION
+
+// serializeReq takes in an httpRequest and returns a []byte representing YAML
+// the []byte can be stringified to print the actual human-readable YAML
 func (s YAMLSerializer) serializeReq(input interface{}) ([]byte, error) {
 	req := input.(httpRequest)
 	yml := YAMLRequest{
@@ -18,6 +40,8 @@ func (s YAMLSerializer) serializeReq(input interface{}) ([]byte, error) {
 	return yaml.Marshal(yml)
 }
 
+// serializeResp takes in an httpResponse and returns a []byte representing YAML
+// the []byte can be stringified to print the actual human-readable YAML
 func (s YAMLSerializer) serializeResp(input interface{}) ([]byte, error) {
 	res := input.(httpResponse)
 	yml := YAMLResponse{
@@ -28,6 +52,41 @@ func (s YAMLSerializer) serializeResp(input interface{}) ([]byte, error) {
 	return yaml.Marshal(yml)
 }
 
+// -------- DESERIALIZATION
+// deserializeReq takes the []byte representing YAML and returns an httpRequest
+func (s YAMLSerializer) deserializeReq(data []byte) (httpRequest, error) {
+	var req httpRequest
+
+	var yamlReq YAMLRequest
+	err := yaml.Unmarshal(data, &yamlReq)
+	if err != nil {
+		return req, err
+	}
+
+	req.Method = yamlReq.Method
+	req.Body = []byte(yamlReq.Body)
+	req.Headers = yamlReq.Headers
+	req.URL = yamlReq.URL
+	return req, nil
+}
+
+// deserializeReq takes the []byte representing YAML and returns an httpResponse
+func (s YAMLSerializer) deserializeResp(data []byte) (httpResponse, error) {
+	var resp httpResponse
+
+	var yamlResp YAMLResponse
+	err := yaml.Unmarshal(data, &yamlResp)
+	if err != nil {
+		return resp, err
+	}
+
+	resp.Headers = yamlResp.Headers
+	resp.Body = []byte(yamlResp.Body)
+	resp.StatusCode = yamlResp.StatusCode
+	return resp, nil
+}
+
+// newInteraction creates a new interaction interface with Request and Response that can be encoded in YAML
 func (s YAMLSerializer) newInteraction(typeOfInteraction interactionType, req httpRequest, res httpResponse) interaction {
 	sReq, _ := s.serializeReq(req)
 	var yamlReq YAMLRequest
@@ -44,6 +103,8 @@ func (s YAMLSerializer) newInteraction(typeOfInteraction interactionType, req ht
 	}
 }
 
+// encodeCassetteToBytes takes in a cassette and return an []byte of the YAML-encoded cassette
+// string() can be called on the []byte for the actual human-readable YAML
 func (s YAMLSerializer) encodeCassetteToBytes(cassette cassette) ([]byte, error) {
 	return yaml.Marshal(cassette)
 }

--- a/pkg/playback/yaml_serializer.go
+++ b/pkg/playback/yaml_serializer.go
@@ -10,49 +10,75 @@ import (
 // YAMLSerializer encodes/persists cassettes to files and decodes yaml cassette files.
 type YAMLSerializer struct{}
 
-// YAMLRequest is a playback.httpRequest interface that can be encoded to YAML
-type YAMLRequest struct {
-	Method  string      `yaml:"method"`
-	Body    string      `yaml:"body"`
-	Headers http.Header `yaml:"headers"`
-	URL     url.URL     `yaml:"url"`
+// EncodeCassette takes in a playback.cassette and returns an []byte of the YAML-encoded cassette
+func (s YAMLSerializer) EncodeCassette(cassette Cassette) ([]byte, error) {
+	var encodedCassette YAMLCassette
+	for _, inter := range cassette {
+		yamlReq, err := s.serializeReq(inter.Request)
+		if err != nil {
+			return nil, err
+		}
+
+		yamlRes, err := s.serializeResp(inter.Response)
+		if err != nil {
+			return nil, err
+		}
+
+		encodedCassette = append(encodedCassette, YAMLInteraction{Type: inter.Type, Request: yamlReq.(YAMLRequest), Response: yamlRes.(YAMLResponse)})
+	}
+
+	return yaml.Marshal(encodedCassette)
 }
 
-// YAMLResponse is a playback.httpRequest interface that can be encoded to YAML
-type YAMLResponse struct {
-	Headers    http.Header `yaml:"headers"`
-	Body       string      `yaml:"body"`
-	StatusCode int         `yaml:"status_code"`
+// DecodeCassette takes in a []byte of YAML and returns a playback.cassette of it
+func (s YAMLSerializer) DecodeCassette(data []byte) (Cassette, error) {
+	yamlCassette := YAMLCassette{}
+	yaml.Unmarshal(data, &yamlCassette)
+
+	var decodedCassette Cassette
+	for _, inter := range yamlCassette {
+		decodedCassette = append(decodedCassette, interaction{
+			Type: inter.Type,
+			Request: httpRequest{
+				Headers: inter.Request.Headers,
+				Body:    []byte(inter.Request.Body),
+				Method:  inter.Request.Method,
+				URL:     inter.Request.URL,
+			},
+			Response: httpResponse{
+				Headers:    inter.Response.Headers,
+				Body:       []byte(inter.Response.Body),
+				StatusCode: inter.Response.StatusCode,
+			},
+		})
+	}
+
+	return decodedCassette, nil
 }
 
-// -------- SERIALIZATION
-
+// -------- SERIALIZATION is used to encode interfaces to YAML
 // serializeReq takes in an httpRequest and returns a []byte representing YAML
 // the []byte can be stringified to print the actual human-readable YAML
-func (s YAMLSerializer) serializeReq(input interface{}) ([]byte, error) {
-	req := input.(httpRequest)
-	yml := YAMLRequest{
+func (s YAMLSerializer) serializeReq(req httpRequest) (interface{}, error) {
+	return YAMLRequest{
 		req.Method,
 		string(req.Body),
 		req.Headers,
 		req.URL,
-	}
-	return yaml.Marshal(yml)
+	}, nil
 }
 
 // serializeResp takes in an httpResponse and returns a []byte representing YAML
 // the []byte can be stringified to print the actual human-readable YAML
-func (s YAMLSerializer) serializeResp(input interface{}) ([]byte, error) {
-	res := input.(httpResponse)
-	yml := YAMLResponse{
+func (s YAMLSerializer) serializeResp(res httpResponse) (interface{}, error) {
+	return YAMLResponse{
 		res.Headers,
 		string(res.Body),
 		res.StatusCode,
-	}
-	return yaml.Marshal(yml)
+	}, nil
 }
 
-// -------- DESERIALIZATION
+// -------- DESERIALIZATION is used to decode YAML to interfaces
 // deserializeReq takes the []byte representing YAML and returns an httpRequest
 func (s YAMLSerializer) deserializeReq(data []byte) (httpRequest, error) {
 	var req httpRequest
@@ -86,25 +112,29 @@ func (s YAMLSerializer) deserializeResp(data []byte) (httpResponse, error) {
 	return resp, nil
 }
 
-// newInteraction creates a new interaction interface with Request and Response that can be encoded in YAML
-func (s YAMLSerializer) newInteraction(typeOfInteraction interactionType, req httpRequest, res httpResponse) interaction {
-	sReq, _ := s.serializeReq(req)
-	var yamlReq YAMLRequest
-	yaml.Unmarshal(sReq, &yamlReq)
+// ----------- The following structs are used internally for conversion to and from YAML
 
-	sRes, _ := s.serializeResp(res)
-	var yamlRes YAMLResponse
-	yaml.Unmarshal(sRes, &yamlRes)
-
-	return interaction{
-		Type:     typeOfInteraction,
-		Request:  yamlReq,
-		Response: yamlRes,
-	}
+// YAMLRequest is a playback.httpRequest interface encoded to YAML
+type YAMLRequest struct {
+	Method  string      `yaml:"method"`
+	Body    string      `yaml:"body"`
+	Headers http.Header `yaml:"headers"`
+	URL     url.URL     `yaml:"url"`
 }
 
-// encodeCassette takes in a cassette and return an []byte of the YAML-encoded cassette
-// string() can be called on the []byte for the actual human-readable YAML
-func (s YAMLSerializer) encodeCassette(cassette cassette) ([]byte, error) {
-	return yaml.Marshal(cassette)
+// YAMLResponse is a playback.httpResponse interface encoded to YAML
+type YAMLResponse struct {
+	Headers    http.Header `yaml:"headers"`
+	Body       string      `yaml:"body"`
+	StatusCode int         `yaml:"status_code"`
 }
+
+// YAMLInteraction is a playback.interaction interface encoded to YAML
+type YAMLInteraction struct {
+	Type     interactionType
+	Request  YAMLRequest
+	Response YAMLResponse
+}
+
+// YAMLCassette is a playback.cassette interface encoded to YAML
+type YAMLCassette []YAMLInteraction

--- a/pkg/playback/yaml_serializer.go
+++ b/pkg/playback/yaml_serializer.go
@@ -57,8 +57,7 @@ func (s YAMLSerializer) DecodeCassette(data []byte) (Cassette, error) {
 }
 
 // -------- SERIALIZATION is used to encode interfaces to YAML
-// serializeReq takes in an httpRequest and returns a []byte representing YAML
-// the []byte can be stringified to print the actual human-readable YAML
+// serializeReq takes in an httpRequest and returns a YAMLRequest
 func (s YAMLSerializer) serializeReq(req httpRequest) (interface{}, error) {
 	return YAMLRequest{
 		req.Method,
@@ -68,8 +67,7 @@ func (s YAMLSerializer) serializeReq(req httpRequest) (interface{}, error) {
 	}, nil
 }
 
-// serializeResp takes in an httpResponse and returns a []byte representing YAML
-// the []byte can be stringified to print the actual human-readable YAML
+// serializeResp takes in an httpResponse and returns a YAMLResponse
 func (s YAMLSerializer) serializeResp(res httpResponse) (interface{}, error) {
 	return YAMLResponse{
 		res.Headers,

--- a/pkg/playback/yaml_serializer.go
+++ b/pkg/playback/yaml_serializer.go
@@ -103,8 +103,8 @@ func (s YAMLSerializer) newInteraction(typeOfInteraction interactionType, req ht
 	}
 }
 
-// encodeCassetteToBytes takes in a cassette and return an []byte of the YAML-encoded cassette
+// encodeCassette takes in a cassette and return an []byte of the YAML-encoded cassette
 // string() can be called on the []byte for the actual human-readable YAML
-func (s YAMLSerializer) encodeCassetteToBytes(cassette cassette) ([]byte, error) {
+func (s YAMLSerializer) encodeCassette(cassette cassette) ([]byte, error) {
 	return yaml.Marshal(cassette)
 }

--- a/pkg/playback/yaml_serializer.go
+++ b/pkg/playback/yaml_serializer.go
@@ -1,0 +1,49 @@
+package playback
+
+import (
+	"gopkg.in/yaml.v2"
+)
+
+// YAMLSerializer encodes/persists cassettes to files and decodes yaml cassette files.
+type YAMLSerializer struct{}
+
+func (s YAMLSerializer) serializeReq(input interface{}) ([]byte, error) {
+	req := input.(httpRequest)
+	yml := YAMLRequest{
+		req.Method,
+		string(req.Body),
+		req.Headers,
+		req.URL,
+	}
+	return yaml.Marshal(yml)
+}
+
+func (s YAMLSerializer) serializeResp(input interface{}) ([]byte, error) {
+	res := input.(httpResponse)
+	yml := YAMLResponse{
+		res.Headers,
+		string(res.Body),
+		res.StatusCode,
+	}
+	return yaml.Marshal(yml)
+}
+
+func (s YAMLSerializer) newInteraction(typeOfInteraction interactionType, req httpRequest, res httpResponse) interaction {
+	sReq, _ := s.serializeReq(req)
+	var yamlReq YAMLRequest
+	yaml.Unmarshal(sReq, &yamlReq)
+
+	sRes, _ := s.serializeResp(res)
+	var yamlRes YAMLResponse
+	yaml.Unmarshal(sRes, &yamlRes)
+
+	return interaction{
+		Type:     typeOfInteraction,
+		Request:  yamlReq,
+		Response: yamlRes,
+	}
+}
+
+func (s YAMLSerializer) encodeCassetteToBytes(cassette cassette) ([]byte, error) {
+	return yaml.Marshal(cassette)
+}

--- a/pkg/playback/yaml_serializer_test.go
+++ b/pkg/playback/yaml_serializer_test.go
@@ -121,19 +121,19 @@ func TestNewInteraction(t *testing.T) {
 	assert.Equal(t, resp.StatusCode, 200)
 }
 
-func TestEncodeCassetteToBytes(t *testing.T) {
+func TestEncodeCassette(t *testing.T) {
 	serializer := YAMLSerializer{}
 
 	interaction1 := serializer.newInteraction(1, request(), response())
 	interaction2 := serializer.newInteraction(0, request(), response())
 	cassette := cassette{interaction1, interaction2}
 
-	encoded, err := serializer.encodeCassetteToBytes(cassette)
+	encoded, err := serializer.encodeCassette(cassette)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expected := "- type: 1\n  request:\n    method: POST\n    body: hello world\n    headers: {}\n    url:\n      scheme: \"\"\n      opaque: \"\"\n      user: null\n      host: \"\"\n      path: \"\"\n      rawpath: \"\"\n      forcequery: false\n      rawquery: \"\"\n      fragment: \"\"\n      rawfragment: \"\"\n  response:\n    headers: {}\n    body: \"\"\n    statuscode: 200\n- type: 0\n  request:\n    method: POST\n    body: hello world\n    headers: {}\n    url:\n      scheme: \"\"\n      opaque: \"\"\n      user: null\n      host: \"\"\n      path: \"\"\n      rawpath: \"\"\n      forcequery: false\n      rawquery: \"\"\n      fragment: \"\"\n      rawfragment: \"\"\n  response:\n    headers: {}\n    body: \"\"\n    statuscode: 200\n"
+	expected := "- type: 1\n  request:\n    method: POST\n    body: hello world\n    headers: {}\n    url:\n      scheme: \"\"\n      opaque: \"\"\n      user: null\n      host: \"\"\n      path: \"\"\n      rawpath: \"\"\n      forcequery: false\n      rawquery: \"\"\n      fragment: \"\"\n      rawfragment: \"\"\n  response:\n    headers: {}\n    body: response body\n    status_code: 200\n- type: 0\n  request:\n    method: POST\n    body: hello world\n    headers: {}\n    url:\n      scheme: \"\"\n      opaque: \"\"\n      user: null\n      host: \"\"\n      path: \"\"\n      rawpath: \"\"\n      forcequery: false\n      rawquery: \"\"\n      fragment: \"\"\n      rawfragment: \"\"\n  response:\n    headers: {}\n    body: response body\n    status_code: 200\n"
 
 	assert.Equal(t, expected, string(encoded))
 }

--- a/pkg/playback/yaml_serializer_test.go
+++ b/pkg/playback/yaml_serializer_test.go
@@ -1,0 +1,139 @@
+package playback
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func request() httpRequest {
+	return httpRequest{
+		Method:  "POST",
+		Body:    []byte("hello world"),
+		Headers: http.Header{},
+		URL:     url.URL{},
+	}
+}
+
+func response() httpResponse {
+	return httpResponse{
+		Headers:    http.Header{},
+		StatusCode: 200,
+		Body:       []byte("response body"),
+	}
+}
+
+func TestSerializeReq(t *testing.T) {
+	serializer := YAMLSerializer{}
+
+	expected := `method: POST
+body: hello world
+headers: {}
+url:
+  scheme: ""
+  opaque: ""
+  user: null
+  host: ""
+  path: ""
+  rawpath: ""
+  forcequery: false
+  rawquery: ""
+  fragment: ""
+  rawfragment: ""
+`
+
+	req := request()
+	bytes, err := serializer.serializeReq(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, expected, string(bytes))
+}
+
+func TestSerializeResp(t *testing.T) {
+	serializer := YAMLSerializer{}
+
+	expected := `headers: {}
+body: response body
+status_code: 200
+`
+
+	resp := response()
+	bytes, err := serializer.serializeResp(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, expected, string(bytes))
+}
+
+func TestDeserializeReq(t *testing.T) {
+	serializer := YAMLSerializer{}
+
+	data := []byte(`method: POST
+body: hello world
+headers: {}
+url:
+  scheme: ""
+  opaque: ""
+  user: null
+  host: ""
+  path: ""
+  rawpath: ""
+  forcequery: false
+  rawquery: ""
+  fragment: ""
+  rawfragment: ""
+`)
+	req, err := serializer.deserializeReq(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, request(), req)
+}
+
+func TestDeserializeResp(t *testing.T) {
+	serializer := YAMLSerializer{}
+
+	data := []byte(`headers: {}
+body: response body
+status_code: 200
+`)
+
+	resp, err := serializer.deserializeResp(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, response(), resp)
+}
+
+func TestNewInteraction(t *testing.T) {
+	serializer := YAMLSerializer{}
+
+	interaction := serializer.newInteraction(1, request(), response())
+	req := interaction.Request.(YAMLRequest)
+	resp := interaction.Response.(YAMLResponse)
+	assert.Equal(t, incomingInteraction, interaction.Type)
+	assert.Equal(t, req.Body, "hello world")
+	assert.Equal(t, resp.StatusCode, 200)
+}
+
+func TestEncodeCassetteToBytes(t *testing.T) {
+	serializer := YAMLSerializer{}
+
+	interaction1 := serializer.newInteraction(1, request(), response())
+	interaction2 := serializer.newInteraction(0, request(), response())
+	cassette := cassette{interaction1, interaction2}
+
+	encoded, err := serializer.encodeCassetteToBytes(cassette)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "- type: 1\n  request:\n    method: POST\n    body: hello world\n    headers: {}\n    url:\n      scheme: \"\"\n      opaque: \"\"\n      user: null\n      host: \"\"\n      path: \"\"\n      rawpath: \"\"\n      forcequery: false\n      rawquery: \"\"\n      fragment: \"\"\n      rawfragment: \"\"\n  response:\n    headers: {}\n    body: \"\"\n    statuscode: 200\n- type: 0\n  request:\n    method: POST\n    body: hello world\n    headers: {}\n    url:\n      scheme: \"\"\n      opaque: \"\"\n      user: null\n      host: \"\"\n      path: \"\"\n      rawpath: \"\"\n      forcequery: false\n      rawquery: \"\"\n      fragment: \"\"\n      rawfragment: \"\"\n  response:\n    headers: {}\n    body: \"\"\n    statuscode: 200\n"
+
+	assert.Equal(t, expected, string(encoded))
+}


### PR DESCRIPTION
 ### Reviewers
r? @richardm-stripe 
cc @stripe/developer-products @tjfontaine-stripe @tomer-stripe 

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
This creates a new `yaml_serializer` system to properly serialize cassettes to yaml and back.
It refactors `interactionRecorder` and `interactionReplayer` to take a `serializer` (in our case the yaml serializer` instead of a `serialize` and `deserialize` methods.

Seems like everything is still working, added some tests, all tests (not enough) pass and below are the logs from playback while I manually tested 
- creating a new customer, getting the req/resp stored
- catching the `customer.create` webhook event and getting it stored
- replaying both the create request and the webhook

> Note: Now that I've done that, I feel like json might be a better serialization since requests/responses are done in json. Right now it looks a bit weird to have some json strings embedded into the cassette's yaml. But that's ok for now.

```
Setting up playback server...


------ Server Running ------
In "record" mode.
Will always record interactions, and write (or overwrite) to the given cassette filepath.

Cassettes directory: "/Users/pepin/stripe/stripe-cli".
Using cassette: "default_cassette.yaml".

Listening via HTTP on localhost:13111

Accepting webhooks on localhost:13111/playback/webhooks
Forwarding webhooks to http://localhost:4567/webhook
-----------------------------

Starting `stripe listen` to proxy webhooks to playback server...
> Ready! Your webhook signing secret is whsec_CouGIhSJyGR7imkzzbbBf7BvYMinUpaH (^C to quit)
INFO[0021] --> POST to /v1/customers
INFO[0022] <-- 200 OK from HTTPS://API.STRIPE.COM
2020-11-06 07:53:08   --> customer.created [evt_1HkXFOBBSRoi2Th6pvGtTYG4]
INFO[0024] [WEBHOOK] POST [customer.created] to /playback/webhooks --> FORWARDED to http://localhost:4567/webhook
2020-11-06 07:53:08  <--  [200] POST http://localhost:13111/playback/webhooks [evt_1HkXFOBBSRoi2Th6pvGtTYG4]
INFO[0035] /playback/cassette/eject: Ejected cassette
INFO[0074] /playback/mode: Set mode to REPLAY
INFO[0078] Replaying from default_cassette.yaml
INFO[0086] --> POST to /v1/customers
{map[Access-Control-Allow-Credentials:[true] Access-Control-Allow-Methods:[GET, POST, HEAD, OPTIONS, DELETE] Access-Control-Allow-Origin:[*] Access-Control-Expose-Headers:[Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required] Access-Control-Max-Age:[300] Cache-Control:[no-cache, no-store] Content-Length:[1070] Content-Type:[application/json] Date:[Fri, 06 Nov 2020 15:53:06 GMT] Request-Id:[req_c9r2IjlG0BFt8Q] Server:[nginx] Strict-Transport-Security:[max-age=31556926; includeSubDomains; preload] Stripe-Version:[2020-03-02]] [123 10 32 32 34 105 100 34 58 32 34 99 117 115 95 73 76 68 103 110 85 109 113 100 83 116 80 106 85 34 44 10 32 32 34 111 98 106 101 99 116 34 58 32 34 99 117 115 116 111 109 101 114 34 44 10 32 32 34 97 100 100 114 101 115 115 34 58 32 110 117 108 108 44 10 32 32 34 98 97 108 97 110 99 101 34 58 32 48 44 10 32 32 34 99 114 101 97 116 101 100 34 58 32 49 54 48 52 54 55 55 57 56 54 44 10 32 32 34 99 117 114 114 101 110 99 121 34 58 32 110 117 108 108 44 10 32 32 34 100 101 102 97 117 108 116 95 115 111 117 114 99 101 34 58 32 110 117 108 108 44 10 32 32 34 100 101 108 105 110 113 117 101 110 116 34 58 32 102 97 108 115 101 44 10 32 32 34 100 101 115 99 114 105 112 116 105 111 110 34 58 32 110 117 108 108 44 10 32 32 34 100 105 115 99 111 117 110 116 34 58 32 110 117 108 108 44 10 32 32 34 101 109 97 105 108 34 58 32 110 117 108 108 44 10 32 32 34 105 110 118 111 105 99 101 95 112 114 101 102 105 120 34 58 32 34 55 66 52 54 51 53 68 66 34 44 10 32 32 34 105 110 118 111 105 99 101 95 115 101 116 116 105 110 103 115 34 58 32 123 10 32 32 32 32 34 99 117 115 116 111 109 95 102 105 101 108 100 115 34 58 32 110 117 108 108 44 10 32 32 32 32 34 100 101 102 97 117 108 116 95 112 97 121 109 101 110 116 95 109 101 116 104 111 100 34 58 32 110 117 108 108 44 10 32 32 32 32 34 102 111 111 116 101 114 34 58 32 110 117 108 108 10 32 32 125 44 10 32 32 34 108 105 118 101 109 111 100 101 34 58 32 102 97 108 115 101 44 10 32 32 34 109 101 116 97 100 97 116 97 34 58 32 123 10 32 32 125 44 10 32 32 34 110 97 109 101 34 58 32 110 117 108 108 44 10 32 32 34 110 101 120 116 95 105 110 118 111 105 99 101 95 115 101 113 117 101 110 99 101 34 58 32 49 44 10 32 32 34 112 104 111 110 101 34 58 32 110 117 108 108 44 10 32 32 34 112 114 101 102 101 114 114 101 100 95 108 111 99 97 108 101 115 34 58 32 91 10 10 32 32 93 44 10 32 32 34 115 104 105 112 112 105 110 103 34 58 32 110 117 108 108 44 10 32 32 34 115 111 117 114 99 101 115 34 58 32 123 10 32 32 32 32 34 111 98 106 101 99 116 34 58 32 34 108 105 115 116 34 44 10 32 32 32 32 34 100 97 116 97 34 58 32 91 10 10 32 32 32 32 93 44 10 32 32 32 32 34 104 97 115 95 109 111 114 101 34 58 32 102 97 108 115 101 44 10 32 32 32 32 34 116 111 116 97 108 95 99 111 117 110 116 34 58 32 48 44 10 32 32 32 32 34 117 114 108 34 58 32 34 47 118 49 47 99 117 115 116 111 109 101 114 115 47 99 117 115 95 73 76 68 103 110 85 109 113 100 83 116 80 106 85 47 115 111 117 114 99 101 115 34 10 32 32 125 44 10 32 32 34 115 117 98 115 99 114 105 112 116 105 111 110 115 34 58 32 123 10 32 32 32 32 34 111 98 106 101 99 116 34 58 32 34 108 105 115 116 34 44 10 32 32 32 32 34 100 97 116 97 34 58 32 91 10 10 32 32 32 32 93 44 10 32 32 32 32 34 104 97 115 95 109 111 114 101 34 58 32 102 97 108 115 101 44 10 32 32 32 32 34 116 111 116 97 108 95 99 111 117 110 116 34 58 32 48 44 10 32 32 32 32 34 117 114 108 34 58 32 34 47 118 49 47 99 117 115 116 111 109 101 114 115 47 99 117 115 95 73 76 68 103 110 85 109 113 100 83 116 80 106 85 47 115 117 98 115 99 114 105 112 116 105 111 110 115 34 10 32 32 125 44 10 32 32 34 116 97 120 95 101 120 101 109 112 116 34 58 32 34 110 111 110 101 34 44 10 32 32 34 116 97 120 95 105 100 115 34 58 32 123 10 32 32 32 32 34 111 98 106 101 99 116 34 58 32 34 108 105 115 116 34 44 10 32 32 32 32 34 100 97 116 97 34 58 32 91 10 10 32 32 32 32 93 44 10 32 32 32 32 34 104 97 115 95 109 111 114 101 34 58 32 102 97 108 115 101 44 10 32 32 32 32 34 116 111 116 97 108 95 99 111 117 110 116 34 58 32 48 44 10 32 32 32 32 34 117 114 108 34 58 32 34 47 118 49 47 99 117 115 116 111 109 101 114 115 47 99 117 115 95 73 76 68 103 110 85 109 113 100 83 116 80 106 85 47 116 97 120 95 105 100 115 34 10 32 32 125 10 125 10] 200}
INFO[0086] <-- 200 from CASSETTE
INFO[0086] Replaying 1 webhooks
INFO[0086] 	> Forwarding webhook [customer.created].
INFO[0086] 	> Received 200 from client. Expected 200.
```

And here is the cassette
```
- type: 0
  request:
    method: POST
    body: ""
    headers:
      Accept-Encoding:
      - identity
      Authorization:
      - Bearer <redacted>
      Content-Length:
      - "0"
      Content-Type:
      - application/x-www-form-urlencoded
      Stripe-Cli-Telemetry:
      - '{"command_path":"stripe customers create","device_name":"st-pepin1","generated_resource":false}'
      User-Agent:
      - Stripe/v1 stripe-cli/master
      X-Stripe-Client-User-Agent:
      - '{"name":"stripe-cli","os":"darwin","publisher":"stripe","uname":"Darwin st-pepin1 19.6.0 Darwin Kernel Version 19.6.0: Thu Oct 29 22:56:45 PDT 2020; root:xnu-6153.141.2.2~1/RELEASE_X86_64 x86_64","version":"master"}'
    url:
      scheme: ""
      opaque: ""
      user: null
      host: ""
      path: /v1/customers
      rawpath: ""
      forcequery: false
      rawquery: ""
      fragment: ""
      rawfragment: ""
  response:
    headers:
      Access-Control-Allow-Credentials:
      - "true"
      Access-Control-Allow-Methods:
      - GET, POST, HEAD, OPTIONS, DELETE
      Access-Control-Allow-Origin:
      - '*'
      Access-Control-Expose-Headers:
      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
      Access-Control-Max-Age:
      - "300"
      Cache-Control:
      - no-cache, no-store
      Content-Length:
      - "1070"
      Content-Type:
      - application/json
      Date:
      - Fri, 06 Nov 2020 15:53:06 GMT
      Request-Id:
      - req_c9r2IjlG0BFt8Q
      Server:
      - nginx
      Strict-Transport-Security:
      - max-age=31556926; includeSubDomains; preload
      Stripe-Version:
      - "2020-03-02"
    body: |
      {
        "id": "cus_ILDgnUmqdStPjU",
        "object": "customer",
        "address": null,
        "balance": 0,
        "created": 1604677986,
        "currency": null,
        "default_source": null,
        "delinquent": false,
        "description": null,
        "discount": null,
        "email": null,
        "invoice_prefix": "7B4635DB",
        "invoice_settings": {
          "custom_fields": null,
          "default_payment_method": null,
          "footer": null
        },
        "livemode": false,
        "metadata": {
        },
        "name": null,
        "next_invoice_sequence": 1,
        "phone": null,
        "preferred_locales": [

        ],
        "shipping": null,
        "sources": {
          "object": "list",
          "data": [

          ],
          "has_more": false,
          "total_count": 0,
          "url": "/v1/customers/cus_ILDgnUmqdStPjU/sources"
        },
        "subscriptions": {
          "object": "list",
          "data": [

          ],
          "has_more": false,
          "total_count": 0,
          "url": "/v1/customers/cus_ILDgnUmqdStPjU/subscriptions"
        },
        "tax_exempt": "none",
        "tax_ids": {
          "object": "list",
          "data": [

          ],
          "has_more": false,
          "total_count": 0,
          "url": "/v1/customers/cus_ILDgnUmqdStPjU/tax_ids"
        }
      }
    status_code: 200
- type: 1
  request:
    method: POST
    body: |-
      {
        "id": "evt_1HkXFOBBSRoi2Th6pvGtTYG4",
        "object": "event",
        "api_version": "2020-03-02",
        "created": 1604677986,
        "data": {
          "object": {
            "id": "cus_ILDgnUmqdStPjU",
            "object": "customer",
            "address": null,
            "balance": 0,
            "created": 1604677986,
            "currency": null,
            "default_source": null,
            "delinquent": false,
            "description": null,
            "discount": null,
            "email": null,
            "invoice_prefix": "7B4635DB",
            "invoice_settings": {
              "custom_fields": null,
              "default_payment_method": null,
              "footer": null
            },
            "livemode": false,
            "metadata": {
            },
            "name": null,
            "next_invoice_sequence": 1,
            "phone": null,
            "preferred_locales": [

            ],
            "shipping": null,
            "sources": {
              "object": "list",
              "data": [

              ],
              "has_more": false,
              "total_count": 0,
              "url": "/v1/customers/cus_ILDgnUmqdStPjU/sources"
            },
            "subscriptions": {
              "object": "list",
              "data": [

              ],
              "has_more": false,
              "total_count": 0,
              "url": "/v1/customers/cus_ILDgnUmqdStPjU/subscriptions"
            },
            "tax_exempt": "none",
            "tax_ids": {
              "object": "list",
              "data": [

              ],
              "has_more": false,
              "total_count": 0,
              "url": "/v1/customers/cus_ILDgnUmqdStPjU/tax_ids"
            }
          }
        },
        "livemode": false,
        "pending_webhooks": 1,
        "request": {
          "id": "req_c9r2IjlG0BFt8Q",
          "idempotency_key": null
        },
        "type": "customer.created"
      }
    headers:
      Accept:
      - '*/*; q=0.5, application/xml'
      Accept-Encoding:
      - gzip
      Cache-Control:
      - no-cache
      Content-Length:
      - "1584"
      Content-Type:
      - application/json; charset=utf-8
      Stripe-Signature:
      - t=1604677988,v1=f4baa4ed4a8c38347f425a84d783f01f58d88e8decee44e48bbcd963dd43b5dd,v0=9b01f536191b0f4b22ffd443aa680f3a84bd5537c5b98b9d1c05521df74fb079
      User-Agent:
      - Stripe/1.0 (+https://stripe.com/docs/webhooks)
    url:
      scheme: ""
      opaque: ""
      user: null
      host: ""
      path: /playback/webhooks
      rawpath: ""
      forcequery: false
      rawquery: ""
      fragment: ""
      rawfragment: ""
  response:
    headers:
      Connection:
      - keep-alive
      Content-Length:
      - "36"
      Content-Type:
      - application/json
      Server:
      - thin 1.2.8 codename Does It Offend You, Yeah?
      X-Content-Type-Options:
      - nosniff
    body: '{"thisis":"a cli webhook response!"}'
    status_code: 200
```