### PR TITLE
[blocked] Playback - Eject Cassette when CTRL+C is pressed

### DIFF
--- a/pkg/cmd/playback.go
+++ b/pkg/cmd/playback.go
@@ -151,6 +151,7 @@ func (pc *playbackCmd) runPlaybackCmd(cmd *cobra.Command, args []string) error {
 		startListenCmdLoop(pc.mode, addressString, httpWrapper)
 	}
 
+	// pass the signal to the server.ListenAndServe somehow
 	ctx := context.Background()
 	withSIGTERMCancel(ctx, httpWrapper)
 

--- a/pkg/playback/server.go
+++ b/pkg/playback/server.go
@@ -210,7 +210,7 @@ func (rr *Server) InitializeServer(address string) *http.Server {
 	})
 
 	customMux.HandleFunc("/playback/cassette/eject", func(w http.ResponseWriter, r *http.Request) {
-		err := rr.ejectCassette()
+		err := rr.EjectCassette()
 
 		if err != nil {
 			writeErrorToHTTPResponse(w, rr.log, err, 500)
@@ -425,8 +425,8 @@ func (rr *Server) loadCassette(relativeFilepath string) error {
 	return nil
 }
 
-// ejectCassette calls recorder.saveAndClose which persists the cassette to file and closes it.
-func (rr *Server) ejectCassette() error {
+// EjectCassette calls recorder.saveAndClose which persists the cassette to file and closes it.
+func (rr *Server) EjectCassette() error {
 	if !rr.cassetteLoaded {
 		return fmt.Errorf("tried to eject when no cassette is loaded")
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -97,6 +97,7 @@ func withSIGTERMCancel(ctx context.Context, onCancel func()) context.Context {
 		onCancel()
 		cancel()
 	}()
+
 	return ctx
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -85,7 +85,8 @@ type Proxy struct {
 	events map[string]bool
 }
 
-func withSIGTERMCancel(ctx context.Context, onCancel func()) context.Context {
+// WithSIGTERMCancel calls onCancel and closes the context on CTRL+C
+func WithSIGTERMCancel(ctx context.Context, onCancel func()) context.Context {
 	// Create a context that will be canceled when Ctrl+C is pressed
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -108,7 +109,7 @@ const maxConnectAttempts = 3
 func (p *Proxy) Run(ctx context.Context) error {
 	s := ansi.StartNewSpinner("Getting ready...", p.cfg.Log.Out)
 
-	ctx = withSIGTERMCancel(ctx, func() {
+	ctx = WithSIGTERMCancel(ctx, func() {
 		log.WithFields(log.Fields{
 			"prefix": "proxy.Proxy.Run",
 		}).Debug("Ctrl+C received, cleaning up...")


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
In the scenario where the user only want to run playback, record an interaction and stop the server, having to manually eject the cassette to persist it to disk is annoying.

This PR solves this by leveraging `WithSIGTERMCancel` and calling `ejectCassette`.

This is blocked by #539 which cancels the cassette ejection when `listen` exits with FATAL. 
