### PR TITLE
return nil instead of log.Fatal when ctx is closed during Listen and Tailer Run

### DIFF
--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -174,7 +174,7 @@ func (t *Tailer) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			ansi.StopSpinner(s, "", t.cfg.Log.Out)
-			t.cfg.Log.Fatalf("Aborting")
+			return nil
 		case <-t.webSocketClient.NotifyExpired:
 			if nAttempts < maxConnectAttempts {
 				ansi.StartSpinner(s, "Session expired, reconnecting...", t.cfg.Log.Out)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -146,7 +146,7 @@ func (p *Proxy) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			ansi.StopSpinner(s, "", p.cfg.Log.Out)
-			p.cfg.Log.Fatalf("Aborting")
+			return nil
 		case <-p.webSocketClient.NotifyExpired:
 			if nAttempts < maxConnectAttempts {
 				ansi.StartSpinner(s, "Session expired, reconnecting...", p.cfg.Log.Out)


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe @richardm-stripe
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Fixes #539 

Commit a023543c63cd2719ae3d980ca2173934653773fc introduced `Log.Fatalf` when `ctx.Done()` happens, which logs a FATAL line to the user terminal when they press CTRL+C.

It is not necessary to log FATAL here since closing the process is the intended purpose by the user when pressing CTRL+C