### PR TITLE
os.Exit when ctrlc

### DIFF
--- a/pkg/cmd/playback.go
+++ b/pkg/cmd/playback.go
@@ -195,8 +195,7 @@ func startListenCmdLoop(mode string, address string, httpWrapper *playback.Serve
 	lc.forwardURL = address + "/playback/webhooks"
 	startListenCmd := func() {
 		fmt.Println("Starting `stripe listen` to proxy webhooks to playback server...")
-		err := lc.runListenCmd(lc.cmd, []string{})
-		fmt.Fprint(os.Stderr, err.Error())
+		lc.runListenCmd(lc.cmd, []string{})
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe @richardm-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Now we are facing conflicts with `WithSIGTERMCancel` between the playback and listen commands when playback runs listen in the background.
Just making sure here we correct exist the process without printing any unnecessary errors.

for #540 we'll have to extract the listen logic outside of the command, so we make sure `WithSIGTERMCancel` is setup at the correct level (cobra command) and not setup twice.