### PR TITLE
add post-installation hint to log in

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -106,9 +106,7 @@ brews:
           if [[ -f $e ]]; then source $e; fi
         }
       EOS
-    post_install: |
-     system bin/"stripe", "postinstall"
-     EOS
+    caveats: "❤ Thanks for installing the Stripe CLI! If this is your first time using the CLI, be sure to run `stripe login` first."
 scoop:
   bucket:
     owner: stripe

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,6 +79,8 @@ nfpms:
     formats:
     - deb
     - rpm
+    scripts:
+      postinstall: "scripts/postinstall.sh"
 brews:
   -
     github:
@@ -104,6 +106,9 @@ brews:
           if [[ -f $e ]]; then source $e; fi
         }
       EOS
+    post_install: |
+     system bin/"stripe", "postinstall"
+     EOS
 scoop:
   bucket:
     owner: stripe

--- a/pkg/cmd/postinstall.go
+++ b/pkg/cmd/postinstall.go
@@ -40,7 +40,7 @@ func (pic *postinstallCmd) runPostinstallCmd(cmd *cobra.Command, args []string) 
 	if err != nil {
 		welcomeIcon := color.BrightRed("❤").String()
 		welcomeText := "Thanks for installing the Stripe CLI! To get started, run `stripe login`"
-		fmt.Println(fmt.Sprintf("%s %s", welcomeIcon, welcomeText))
+		fmt.Printf("%s %s\n", welcomeIcon, welcomeText)
 	}
 
 	return nil

--- a/pkg/cmd/postinstall.go
+++ b/pkg/cmd/postinstall.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+type postinstallCmd struct {
+	cfg *config.Config
+	cmd *cobra.Command
+}
+
+func newPostinstallCmd(config *config.Config) *postinstallCmd {
+	pic := &postinstallCmd{
+		cfg: config,
+	}
+	pic.cmd = &cobra.Command{
+		Use:     "postinstall",
+		Args:    validators.NoArgs,
+		Short:   "Run some checks after installation of this CLI and prompt user if needed",
+		Example: `stripe postinstall`,
+		Hidden:  true,
+		RunE:    pic.runPostinstallCmd,
+	}
+	return pic
+}
+
+func (pic *postinstallCmd) runPostinstallCmd(cmd *cobra.Command, args []string) error {
+	color := ansi.Color(os.Stdout)
+	_, err := pic.cfg.Profile.GetAPIKey(false)
+
+	// If we can't get the API key, then it's likely that this is a first install rather than an upgrade.
+	// Suggest the user run `stripe login` to get started as a helpful prompt.
+	if err != nil {
+		welcomeIcon := color.BrightRed("❤").String()
+		welcomeText := "Thanks for installing the Stripe CLI! To get started, run `stripe login`"
+		fmt.Println(fmt.Sprintf("%s %s", welcomeIcon, welcomeText))
+	}
+
+	return nil
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -111,6 +111,7 @@ func init() {
 	rootCmd.AddCommand(newTriggerCmd().cmd)
 	rootCmd.AddCommand(newVersionCmd().cmd)
 	rootCmd.AddCommand(newPlaybackCmd().cmd)
+	rootCmd.AddCommand(newPostinstallCmd(&Config).cmd)
 
 	addAllResourcesCmds(rootCmd)
 

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -70,7 +69,7 @@ func (p *Profile) GetDeviceName() (string, error) {
 		return viper.GetString(p.GetConfigField("device_name")), nil
 	}
 
-	return "", errors.New("your device name has not been configured. Use `stripe login` to set your device name")
+	return "", validators.ErrDeviceNameNotConfigured
 }
 
 // GetAPIKey will return the existing key for the given profile
@@ -116,7 +115,7 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 		return key, nil
 	}
 
-	return "", errors.New("your API key has not been configured. Use `stripe login` to set your API key")
+	return "", validators.ErrAPIKeyNotConfigured
 }
 
 // GetPublishableKey returns the publishable key for the user

--- a/pkg/validators/validate.go
+++ b/pkg/validators/validate.go
@@ -14,9 +14,9 @@ type ArgValidator func(string) error
 
 var (
 	// ErrAPIKeyNotConfigured is the error returned when the loaded profile is missing the api key property
-	ErrAPIKeyNotConfigured = errors.New("you have not configured API keys yet.")
+	ErrAPIKeyNotConfigured = errors.New("you have not configured API keys yet")
 	// ErrDeviceNameNotConfigured is the error returned when the loaded profile is missing the device name property
-	ErrDeviceNameNotConfigured = errors.New("you have not configured your device name yet.")
+	ErrDeviceNameNotConfigured = errors.New("you have not configured your device name yet")
 )
 
 // CallNonEmptyArray calls an argument validator on all non-empty elements of

--- a/pkg/validators/validate.go
+++ b/pkg/validators/validate.go
@@ -12,6 +12,13 @@ import (
 // error if the string is invalid, or nil otherwise.
 type ArgValidator func(string) error
 
+var (
+	// ErrAPIKeyNotConfigured is the error returned when the loaded profile is missing the api key property
+	ErrAPIKeyNotConfigured = errors.New("you have not configured API keys yet.")
+	// ErrDeviceNameNotConfigured is the error returned when the loaded profile is missing the device name property
+	ErrDeviceNameNotConfigured = errors.New("you have not configured your device name yet.")
+)
+
 // CallNonEmptyArray calls an argument validator on all non-empty elements of
 // a string array.
 func CallNonEmptyArray(validator ArgValidator, values []string) error {
@@ -42,7 +49,7 @@ func CallNonEmpty(validator ArgValidator, value string) error {
 // APIKey validates that a string looks like an API key.
 func APIKey(input string) error {
 	if len(input) == 0 {
-		return errors.New("you have not configured API keys yet. To do so, run `stripe login` which will configure your API keys from Stripe")
+		return ErrAPIKeyNotConfigured
 	} else if len(input) < 12 {
 		return errors.New("the API key provided is too short, it must be at least 12 characters long")
 	}
@@ -62,7 +69,7 @@ func APIKey(input string) error {
 // APIKeyNotRestricted validates that a string looks like a secret API key and is not a restricted key.
 func APIKeyNotRestricted(input string) error {
 	if len(input) == 0 {
-		return errors.New("you have not configured API keys yet. To do so, run `stripe login` which will configure your API keys from Stripe")
+		return ErrAPIKeyNotConfigured
 	} else if len(input) < 12 {
 		return errors.New("the API key provided is too short, it must be at least 12 characters long")
 	}

--- a/pkg/validators/validate_test.go
+++ b/pkg/validators/validate_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNoKey(t *testing.T) {
 	err := APIKey("")
-	require.EqualError(t, err, "you have not configured API keys yet.")
+	require.EqualError(t, err, "you have not configured API keys yet")
 }
 
 func TestKeyTooShort(t *testing.T) {

--- a/pkg/validators/validate_test.go
+++ b/pkg/validators/validate_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNoKey(t *testing.T) {
 	err := APIKey("")
-	require.EqualError(t, err, "you have not configured API keys yet. To do so, run `stripe login` which will configure your API keys from Stripe")
+	require.EqualError(t, err, "you have not configured API keys yet.")
 }
 
 func TestKeyTooShort(t *testing.T) {

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+stripe postinstall
+


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
We received some feedback about the post installation experience of the CLI. Once installed, it's quite common to jump right into running commands with it. Most commands require a user to be logged in and authenticated with Stripe first, so in this scenario they would immediately see an error asking them to log in. That's a bit of a bummer experience right after installing, so it was suggested that we add a post install greeting to remind users to log in first before anything else.

This homebrew log example demonstrates the greeting added as a postinstall step (6th line from the bottom):

```
$: brew install stripe
==> Installing stripe from stripe/stripe-cli
==> Downloading https://github.com/stripe/stripe-cli/releases/download/v1.5.5/stripe_1.5.5_mac-os_x86_64.tar.gz
Already downloaded: /Users/redacted/Library/Caches/Homebrew/downloads/872c5db6f7bd57b70308810fb007edbefb23144cbb98ef4c4580625683a3b6c1--stripe_1.5.5_mac-os_x86_64.tar.gz
==> /usr/local/Cellar/stripe/1.5.5/bin/stripe completion --shell bash
==> /usr/local/Cellar/stripe/1.5.5/bin/stripe completion --shell zsh
==> Postinstalling stripe
❤ Thanks for installing the Stripe CLI! To get started, run `stripe login`
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
==> Summary
🍺  /usr/local/Cellar/stripe/1.5.5: 6 files, 20.4MB, built in 5 seconds
```

Along with homebrew, APT and RPM configs also have this greeting added as a postinstall step.

 ### Limitations
1. GoReleaser's Scoop implementation is not complete, so right now we do not have a way of running a postinstall script on Windows. [I have opened a PR](https://github.com/goreleaser/goreleaser/pull/1931) on GoReleaser for this. If that is merged at some point, we can add this greeting to Scoop installations in the future. [Here is what it might look like](https://github.com/suz-stripe/scoop-test/runs/1490247874?check_suite_focus=true#step:3:25), which is better than brew's IMO.
2. I thought of placing the greeting as a brew caveat (as caveats comes after the postflight stanza), however GoReleaser only accepts strings for the caveats attribute. We'd want an execution block instead as we check if the user is logged in before deciding to show the greeting.
3. I'm a little worried that users still won't see this instruction because it won't be the very last log line of output for any of the package manage installation processes. I'm interested to hear some creative ideas on this! We _could_ run `stripe login` during postinstall to halt and make them notice, but that feels a bit aggressive and not idiomatic.
4. It is awfully hard to test this stuff manually 🤔   any pointers?

### TODO 
+ [x] Prompt the user to log in immediately after running a command needing credentials and then optionally continue the command
