### PR TITLE
Releaser Action: remove branches from trigger list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: do_release
 
 on:
   push:
-    branches:
-     - 'master'
     tags:
       - '*'
 


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
I made a mistake and thought that the two triggers were parsed as an `AND` operation, rather than a list of separate triggers. In other words, "only if branch `master` AND there is a new tag". So I have removed the branches clause for now.

