### PR TITLE
Adding ability to show URL when no browser is detected on linux

### DIFF
--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -20,7 +20,7 @@ import (
 )
 
 var openBrowser = open.Browser
-var lacksBrowser = open.LacksBrowser
+var canOpenBrowser = open.CanOpenBrowser
 
 const stripeCLIAuthPath = "/stripecli/auth"
 
@@ -52,7 +52,7 @@ func Login(baseURL string, config *config.Config, input io.Reader) error {
 
 	var s *spinner.Spinner
 
-	if isSSH() || lacksBrowser() {
+	if isSSH() || !canOpenBrowser() {
 		fmt.Printf("To authenticate with Stripe, please go to: %s\n", links.BrowserURL)
 
 		s = ansi.StartNewSpinner("Waiting for confirmation...", os.Stdout)

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -20,6 +20,7 @@ import (
 )
 
 var openBrowser = open.Browser
+var lacksBrowser = open.LacksBrowser
 
 const stripeCLIAuthPath = "/stripecli/auth"
 
@@ -51,7 +52,7 @@ func Login(baseURL string, config *config.Config, input io.Reader) error {
 
 	var s *spinner.Spinner
 
-	if isSSH() {
+	if isSSH() || lacksBrowser() {
 		fmt.Printf("To authenticate with Stripe, please go to: %s\n", links.BrowserURL)
 
 		s = ansi.StartNewSpinner("Waiting for confirmation...", os.Stdout)

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -29,3 +29,24 @@ func Browser(url string) error {
 
 	return nil
 }
+
+// LacksBrowser determines if no browser is set in linux
+func LacksBrowser() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+
+	var err error
+
+	output, err := execCommand("xdg-settings", "get", "default-web-browser").Output()
+
+	if err != nil {
+		return true
+	}
+
+	if string(output) == "" {
+		return true
+	}
+
+	return false
+}

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -30,21 +30,21 @@ func Browser(url string) error {
 	return nil
 }
 
-// LacksBrowser determines if no browser is set in linux
-func LacksBrowser() bool {
-	if runtime.GOOS != "linux" {
-		return false
+// CanOpenBrowser determines if no browser is set in linux
+func CanOpenBrowser() bool {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		return true
 	}
 
 	output, err := execCommand("xdg-settings", "get", "default-web-browser").Output()
 
 	if err != nil {
-		return true
+		return false
 	}
 
 	if string(output) == "" {
-		return true
+		return false
 	}
 
-	return false
+	return true
 }

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -36,8 +36,6 @@ func LacksBrowser() bool {
 		return false
 	}
 
-	var err error
-
 	output, err := execCommand("xdg-settings", "get", "default-web-browser").Output()
 
 	if err != nil {


### PR DESCRIPTION
 ### Reviewers
r? @pepin-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

When a user runs `stripe login` a browser is needed. Not all environments have one available. This attempts to detect if the environment lacks a browser in linux. If it lacks a browser then show the URL to the user for them to login. 

### Testing

Built the CLI and copied to a docker container running ubuntu without a browser. URL displayed properly. 


Attempts to fix #499 and RUN_DX-1