### PR TITLE
Fix validation for invalid commands

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -68,6 +68,18 @@ func Execute() {
 		isLoginRequiredError := sort.SearchStrings(loginRequiredErrors, errString) < len(loginRequiredErrors)
 
 		switch {
+		case strings.Contains(errString, "unknown command"):
+			suggStr := "\nS"
+
+			suggestions := rootCmd.SuggestionsFor(os.Args[1])
+			if len(suggestions) > 0 {
+				suggStr = fmt.Sprintf(" Did you mean \"%s\"?\nIf not, s", suggestions[0])
+			}
+
+			fmt.Println(fmt.Sprintf("Unknown command \"%s\" for \"%s\".%s"+
+				"ee \"stripe --help\" for a list of available commands.",
+				os.Args[1], rootCmd.CommandPath(), suggStr))
+
 		case isLoginRequiredError:
 			// capitalize first letter of error because linter
 			errRunes := []rune(errString)
@@ -85,18 +97,6 @@ func Execute() {
 			if err != nil {
 				fmt.Println(err)
 			}
-
-		case strings.Contains(errString, "unknown command"):
-			suggStr := "\nS"
-
-			suggestions := rootCmd.SuggestionsFor(os.Args[1])
-			if len(suggestions) > 0 {
-				suggStr = fmt.Sprintf(" Did you mean \"%s\"?\nIf not, s", suggestions[0])
-			}
-
-			fmt.Println(fmt.Sprintf("Unknown command \"%s\" for \"%s\".%s"+
-				"ee \"stripe --help\" for a list of available commands.",
-				os.Args[1], rootCmd.CommandPath(), suggStr))
 
 		default:
 			fmt.Println(err)


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

When running an invalid command we attempt to login first. This PR reverses that to do command validation first. 

<img width="1047" alt="Screen Shot 2021-01-19 at 3 38 05 PM" src="https://user-images.githubusercontent.com/49962232/105107558-4164eb00-5a6d-11eb-8134-54aeb67cba38.png">

<img width="891" alt="Screen Shot 2021-01-19 at 3 42 32 PM" src="https://user-images.githubusercontent.com/49962232/105107554-4033be00-5a6d-11eb-938d-890ccafe448d.png">
