### PR TITLE
remove incorrect usage of SearchStrings for login check

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 	"unicode"
 
@@ -64,8 +63,7 @@ func Execute() {
 
 	if err := rootCmd.Execute(); err != nil {
 		errString := err.Error()
-		loginRequiredErrors := []string{validators.ErrAPIKeyNotConfigured.Error(), validators.ErrDeviceNameNotConfigured.Error()}
-		isLoginRequiredError := sort.SearchStrings(loginRequiredErrors, errString) < len(loginRequiredErrors)
+		isLoginRequiredError := errString == validators.ErrAPIKeyNotConfigured.Error() || errString == validators.ErrDeviceNameNotConfigured.Error()
 
 		switch {
 		case isLoginRequiredError:


### PR DESCRIPTION
 ### Reviewers
r? @ctrudeau-stripe 
cc @stripe/developer-products

 ### Summary
Turns out that I misunderstood the return value logic of `sort.SearchStrings` which returns a valid slice index _even if the string you're searching for is not present in the slice_ 🤦  

I have removed the usage entirely and converted to a simple pair of conditionals instead which is less fancy and much easier to read.

This was breaking our login checker if an unknown command is run, or if a command is run with the incorrect arguments.
