### PR TITLE
move WithSIGTERMCancel from Proby pkg to cobra command

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -185,7 +188,12 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	err = p.Run(context.Background())
+	ctx := withSIGTERMCancel(context.Background(), func() {
+		log.WithFields(log.Fields{
+			"prefix": "proxy.Proxy.Run",
+		}).Debug("Ctrl+C received, cleaning up...")
+	})
+	err = p.Run(ctx)
 	if err != nil {
 		return err
 	}
@@ -267,4 +275,19 @@ func buildForwardURL(forwardURL string, destination *url.URL) string {
 		strings.TrimSuffix(f.Path, "/"), // avoids having a double "//"
 		destination.Path,
 	)
+}
+
+func withSIGTERMCancel(ctx context.Context, onCancel func()) context.Context {
+	// Create a context that will be canceled when Ctrl+C is pressed
+	ctx, cancel := context.WithCancel(ctx)
+
+	interruptCh := make(chan os.Signal, 1)
+	signal.Notify(interruptCh, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-interruptCh
+		onCancel()
+		cancel()
+	}()
+	return ctx
 }


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe 
cc @stripe/developer-products

 ### Summary
This avoids printing "FATAL [...]" when a user closes stripe playback with cmd+c.

It is also a first step in term of decoupling cobra cmd and their core functionality, making it easier and cleaner to have commands triggering multiple core modules (for example stripe playback running listen in the background).

after
<img width="717" alt="Screen Shot 2021-01-20 at 11 52 40 AM" src="https://user-images.githubusercontent.com/62569738/105227455-34500680-5b16-11eb-9601-467693685f7a.png">

before
<img width="717" alt="Screen Shot 2021-01-20 at 11 52 10 AM" src="https://user-images.githubusercontent.com/62569738/105227461-3619ca00-5b16-11eb-935a-16fa860c6dc4.png">
