### PR TITLE
Fix fixture logic which parsed large numbers into scientific notation

### DIFF
--- a/pkg/fixtures/fixtures_test.go
+++ b/pkg/fixtures/fixtures_test.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -76,6 +77,25 @@ const failureTestFixture = `
 	  }
 	]
   }`
+
+func TestParseInterfaceFromRaw(t *testing.T) {
+	var rawFixtureData = []byte(`{
+		"salary": 1000000000,
+		"email": "person@example.com"
+	}`)
+
+	parsedFixtureData := make(map[string]interface{})
+	json.Unmarshal(rawFixtureData, &parsedFixtureData)
+
+	fxt := Fixture{}
+
+	output := (fxt.parseInterface(parsedFixtureData))
+	sort.Strings(output)
+
+	require.Equal(t, len(output), 2)
+	require.Equal(t, output[0], "email=person@example.com")
+	require.Equal(t, output[1], "salary=1000000000")
+}
 
 func TestParseInterface(t *testing.T) {
 	address := make(map[string]interface{})


### PR DESCRIPTION
### Reviewers
r? @stripe/developer-products 
cc @stripe/developer-products

 ### Summary
When we unmarshal fixtures from a file we represent `params` as an empty interface. This means that numeric values are parsed as `float64`.

In our logic which translates the values to request params we used the `%v` for float which is translated to `%g` under the hood. The `%g` format will use:
> %e for large exponents, %f otherwise

For more context reference the [docs](https://golang.org/pkg/fmt/) and the comment that was added.

### Testing
 
I was able to reproduce the failure in a test case and verify that it is now resolved.

![Screen Shot 2021-02-02 at 12 59 02 PM](https://user-images.githubusercontent.com/58703040/106664241-a2a2b900-6559-11eb-8b26-10603df51843.png)