### PR TITLE
run scripts in bash for double bracket compat

### DIFF
--- a/scripts/publish-deb-to-bintray.sh
+++ b/scripts/publish-deb-to-bintray.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Adapted from https://github.com/leopardslab/dunner/blob/master/release/publish_deb_to_bintray.sh
 

--- a/scripts/publish-rpm-to-bintray.sh
+++ b/scripts/publish-rpm-to-bintray.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Adapted from https://github.com/leopardslab/dunner/blob/master/release/publish_rpm_to_bintray.sh
 

--- a/scripts/upload-zip-to-virustotal.sh
+++ b/scripts/upload-zip-to-virustotal.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products 
cc @stripe/developer-products

 ### Summary
Our scripts were breaking due to a `sh` env incompatibility with double bracket conditionals on GH Actions. I changed the shebangs to `bash` for the affected scripts in order to fix this.
