### PR TITLE
use fetch depth in checkout step for changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
       -
         name: Code checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       -
         name: Run goreleaser
         uses: ./.github/actions/releaser


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products 
cc @stripe/developer-products

 ### Summary
We noticed a weird changelog issue since we switched to GitHub Actions for releasing the CLI. After some research, it appears that [Goreleaser recommends](https://goreleaser.com/ci/actions/) using `fetch-depth: 0` for the code checkout step for the Changelog to be generated properly. I missed this in the documentation when initially putting this workflow together.

Also noted from their [GH Action repo README](https://github.com/goreleaser/goreleaser-action#workflow):
> IMPORTANT: note the fetch-depth: 0 input in Checkout step. It is required for the changelog to work correctly.

This should ensure we get all PRs listed in their respective changelogs going forward.
