### PR TITLE
Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @stripe/developer-products


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe @pepin-stripe 
cc @stripe/developer-products

 ### Summary
Add codeowners file that lists our team as owners of everything in the repo (meaning one of us will be required for code reviews).

Syntax from docs here: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
