### PR TITLE
Fix mac checksums file, add virus total step, update goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.157.0
+          version: v0.159.0
           args: release -f .goreleaser/mac.yml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.157.0
+          version: v0.159.0
           args: release -f .goreleaser/linux.yml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
@@ -74,10 +74,17 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.157.0
+          version: v0.159.0
           args: release -f .goreleaser/windows.yml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+
+  upload-to-virustotal:
+    needs: [build-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
       - name: Upload to VirusTotal
         run: scripts/upload-zip-to-virustotal.sh
         shell: bash

--- a/.goreleaser/mac.yml
+++ b/.goreleaser/mac.yml
@@ -30,7 +30,7 @@ changelog:
       - "^docs:"
       - "^test:"
 checksum:
-  name_template: "{{ .ProjectName }}-checksums.txt"
+  name_template: "{{ .ProjectName }}-mac-checksums.txt"
 snapshot:
   name_template: "{{ .Tag }}-next"
 brews:

--- a/scripts/upload-zip-to-virustotal.sh
+++ b/scripts/upload-zip-to-virustotal.sh
@@ -31,7 +31,8 @@ downloadWindowsArtifacts() {
   echo "Dowloading Windows artifacts..."
   FILES=$(curl -s "https://api.github.com/repos/stripe/stripe-cli/releases/latest" -u $GITHUB_TOKEN: \
 | jq -r ".assets[].browser_download_url" \
-| grep "windows")
+| grep "windows" \
+| grep "zip")
   echo "$FILES"
   for i in $FILES; do
     RESPONSE_CODE=$(curl -L -O -w "%{response_code}" "$i")


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe 
cc @stripe/developer-products @tjfontaine-stripe 

 ### Summary
* Update mac checksums file name
* Add a separate step for uploading to virustotal (https://github.com/tomelm/stripe-cli-temp/actions/runs/647103038)
* Updating to goreleaser 0.159.0 (that's what the temp repo had been using this whole time)
