### PR TITLE
Build Stripe CLI for ARM

### DIFF
--- a/.goreleaser/mac.yml
+++ b/.goreleaser/mac.yml
@@ -17,6 +17,15 @@ builds:
       - darwin
     goarch:
       - amd64
+  - id: stripe-darwin-arm
+    ldflags:
+      - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
+    binary: stripe
+    main: ./cmd/stripe/main.go
+    goos:
+      - darwin
+    goarch:
+      - arm64
 archives:
   - replacements:
       darwin: mac-os


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe @ob-stripe @tjfontaine-stripe 
cc @stripe/developer-products 

 ### Summary
I know I know, I promised I wouldn't mess with GitHub Actions over the weekend, _but_ ...while I was on my personal laptop I noticed that running `brew update` pulled the new Stripe CLI tap, but `brew upgrade` didn't actually upgrade the CLI to 1.5.10. Unfortunately, the updates we made changed how the homebrew tap was written and explicitly removed the ability to install on arm: https://github.com/stripe/homebrew-stripe-cli/commit/bff31d18426242b5236271a42f02048cc4b90a86#diff-cefd878d3ffd3c6e0675e962b88aec27ffba0e756c569a9f9f72063fc46bb5fb

The conditional went from `if OS.mac?` to `if OS.mac? && Hardware::CPU.intel?`. I think goreleaser is trying to be smart here but I'm not sure how to _not_ have it try to fork on intel vs arm.

This adds an `arm64` build, which does add an `#arm?` branch: https://github.com/tomelm/homebrew-stripe-cli-temp/blob/main/stripe.rb#L11-L18. The one thing to note is that because we can't run GitHub Actions on `macos11`, I had to remove the `CGO` build environment variable, otherwise the build step fails saying it's an unsupported environment. golang1.16 supports building for arm64 natively and I don't think we have any explicit requirements for CGO on mac at the moment. I did a quick test locally and I think this should work fine:

```
stripe-cli on  tomer/arm-for-real via 🐹 v1.16.1
➜ echo $CGO


stripe-cli on  tomer/arm-for-real via 🐹 v1.16.1
➜ GOOS=darwin GOARCH=arm64 go build -o stripe cmd/stripe/main.go

stripe-cli on  tomer/arm-for-real via 🐹 v1.16.1
➜ ./stripe listen
> Ready! Your webhook signing secret is whsec_secrets (^C to quit)
2021-03-13 07:43:17   --> customer.created [evt_1IUZcXKylELWUK3AAUo5Xdh0]
^C
```

We don't need to merge this in right now but this will also fix https://github.com/stripe/homebrew-stripe-cli/issues/1