### PR TITLE
Update the vscode requirements

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
     "recommendations": [
-        // Go Language plugins (~required)
-        "ms-vscode.go",
+        // Go language plugin
+        "golang.go",
 
         // Highly recommended
         "eamodio.gitlens",


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products
cc @stripe/developer-products

 ### Summary
`ms-vscode.go` has been deprecated: https://github.com/microsoft/vscode-go. It's been replaced with `golang.go`: https://github.com/golang/vscode-go. This'll stop that popup that keeps saying `ms-vscode.go` is missing in the bottom right.