### PR TITLE
sleep 10ms to make sure test server is ready

### DIFF
--- a/pkg/playback/server_test.go
+++ b/pkg/playback/server_test.go
@@ -155,6 +155,7 @@ func TestSimpleRecordReplayServerSeparately(t *testing.T) {
 			log.Fatalf("ListenAndServe(): %v", err)
 		}
 	}()
+
 	// make sure server is ready
 	time.Sleep(10 * time.Millisecond)
 

--- a/pkg/playback/server_test.go
+++ b/pkg/playback/server_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -154,6 +155,8 @@ func TestSimpleRecordReplayServerSeparately(t *testing.T) {
 			log.Fatalf("ListenAndServe(): %v", err)
 		}
 	}()
+	// make sure server is ready
+	time.Sleep(10 * time.Millisecond)
 
 	// Send it the same 2 requests:
 	replay1, err := http.Get("http://localhost:8080/")


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
Issue #610 reports flakey tests here. The error seems to be that the test is trying to GET to the server before it's ready. Adding a 10ms sleep to ensure server is ready before we move on.

will try running the tests a few times see if it continues to fails (can't repro locally so far)