### PR TITLE
auto-create "required resources" on stripe sample create

### DIFF
--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -13,15 +13,16 @@ import (
 
 // Profile handles all things related to managing the project specific configurations
 type Profile struct {
-	DeviceName             string
-	ProfileName            string
-	APIKey                 string
-	LiveModeAPIKey         string
-	LiveModePublishableKey string
-	TestModeAPIKey         string
-	TestModePublishableKey string
-	TerminalPOSDeviceID    string
-	DisplayName            string
+	DeviceName              string
+	ProfileName             string
+	APIKey                  string
+	LiveModeAPIKey          string
+	LiveModePublishableKey  string
+	TestModeAPIKey          string
+	TestModePublishableKey  string
+	TerminalPOSDeviceID     string
+	DisplayName             string
+	StripeSampleResourceIDs map[string]string
 }
 
 // CreateProfile creates a profile when logging in
@@ -140,6 +141,25 @@ func (p *Profile) GetDisplayName() string {
 	return ""
 }
 
+// GetStripeSampleResourceID gets the id from the config for a Stripe Sample "required resource"
+// with a particular name.
+func (p *Profile) GetStripeSampleResourceID(resourceName string) string {
+	if err := viper.ReadInConfig(); err == nil {
+		return viper.GetString(p.GetConfigField(resourceName))
+	}
+
+	return ""
+}
+
+// SetStripeSampleResourceID sets the id in the config for a Stripe Sample "required resource"
+// with a particular name.
+func (p *Profile) SetStripeSampleResourceID(resourceName string, id string) {
+	if p.StripeSampleResourceIDs == nil {
+		p.StripeSampleResourceIDs = map[string]string{}
+	}
+	p.StripeSampleResourceIDs[resourceName] = id
+}
+
 // GetTerminalPOSDeviceID returns the device id from the config for Terminal quickstart to use
 func (p *Profile) GetTerminalPOSDeviceID() string {
 	if err := viper.ReadInConfig(); err == nil {
@@ -206,6 +226,10 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 
 	if p.DisplayName != "" {
 		runtimeViper.Set(p.GetConfigField("display_name"), strings.TrimSpace(p.DisplayName))
+	}
+
+	for name, id := range p.StripeSampleResourceIDs {
+		runtimeViper.Set(p.GetConfigField(name), strings.TrimSpace(id))
 	}
 
 	runtimeViper.MergeInConfig()

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -18,6 +18,9 @@ func TestWriteProfile(t *testing.T) {
 		ProfileName:    "tests",
 		TestModeAPIKey: "sk_test_123",
 		DisplayName:    "test-account-display-name",
+		StripeSampleResourceIDs: map[string]string{
+			"stripe_samples_price_recurring_basic_id": "pr_xyz",
+		},
 	}
 
 	c := &Config{
@@ -42,6 +45,7 @@ func TestWriteProfile(t *testing.T) {
 [tests]
   device_name = "st-testing"
   display_name = "test-account-display-name"
+  stripe_samples_price_recurring_basic_id = "pr_xyz"
   test_mode_api_key = "sk_test_123"
 `
 	require.EqualValues(t, expectedConfig, string(configValues))

--- a/pkg/samples/list.go
+++ b/pkg/samples/list.go
@@ -108,7 +108,7 @@ func (s *Samples) GetSamples(mode string) map[string]*SampleData {
 		return list
 	}
 
-	// Reduce the amount of request to GitHub
+	// Reduce the number of requests to GitHub
 	var noNetwork bool
 	switch mode {
 	case "list":

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -3,7 +3,6 @@ package samples
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -294,10 +293,10 @@ func (s *Samples) Copy(target string) error {
 
 // In order to work properly, some stripe samples require the .env file to be
 // populated with the ids of resources -- often of a product or price -- that
-// needs to exist on the user's account. The `requiredResource` struct is
+// needs to exist on the user's account. The `RequiredResource` struct is
 // a template for a particular kind of required resource.
-type requiredResource struct {
-	// `name` describes how the requiredResource is identified both inside
+type RequiredResource struct {
+	// `name` describes how the RequiredResource is identified both inside
 	// the stripe sample's .cli.json and how it is persisted inside the
 	// user's stripe-cli profile.
 	name string
@@ -310,7 +309,7 @@ type requiredResource struct {
 	data     []string
 }
 
-var requiredResources []requiredResource = []requiredResource{
+var requiredResources []RequiredResource = []RequiredResource{
 	{
 		name:        "stripe_samples_price_recurring_basic_id",
 		description: "recurring price for a 'basic' plan",
@@ -335,7 +334,7 @@ var requiredResources []requiredResource = []requiredResource{
 	},
 }
 
-func getRequiredResource(name string) *requiredResource {
+func getRequiredResource(name string) *RequiredResource {
 	for _, rr := range requiredResources {
 		if rr.name == name {
 			return &rr
@@ -350,7 +349,7 @@ func getRequiredResource(name string) *requiredResource {
 func (s *Samples) CreateRequiredResource(requiredResourceName string) (string, error) {
 	rr := getRequiredResource(requiredResourceName)
 	if rr == nil {
-		return "", errors.New(fmt.Sprintf("Unexpected: tried to create unknown required resource %s", requiredResourceName))
+		return "", fmt.Errorf("Unexpected: tried to create unknown required resource %s", requiredResourceName)
 	}
 
 	base := requests.Base{
@@ -377,7 +376,7 @@ func (s *Samples) CreateRequiredResource(requiredResourceName string) (string, e
 
 	id, ok := fields["id"].(string)
 	if !ok {
-		return "", errors.New(fmt.Sprintf("Unexpected response from stripe API when creating %s, did not contain ID: %s", requiredResourceName, string(bytes)))
+		return "", fmt.Errorf("Unexpected response from stripe API when creating %s, did not contain ID: %s", requiredResourceName, string(bytes))
 	}
 
 	return id, nil
@@ -391,11 +390,11 @@ func (s *Samples) PersistRequiredResourceID(resourceName string, id string) erro
 	return nil
 }
 
-// MissingRequiredResources returns the list of requiredResources that are
+// MissingRequiredResources returns the list of RequiredResources that are
 // indicated in the stripe sample's .cli.json, but don't (yet) have an id
 // stored in the user's stripe-cli config profile.
-func (s *Samples) MissingRequiredResources() []requiredResource {
-	ret := []requiredResource{}
+func (s *Samples) MissingRequiredResources() []RequiredResource {
+	ret := []RequiredResource{}
 	for _, rrConfig := range s.sampleConfig.RequiredResources {
 		rr := getRequiredResource(rrConfig.Name)
 		if rr == nil {

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -28,8 +28,7 @@ type sampleConfig struct {
 	PostInstall     map[string]string         `json:"postInstall"`
 	Integrations    []sampleConfigIntegration `json:"integrations"`
 
-	// Some samples need to be configured with the ids of
-	// particular stripe resources (typically products or prices)
+	// For auto-creating resources during `stripe samples create`.
 	RequiredResources []requiredResourceSampleConfig `json:"requiredResources"`
 }
 
@@ -291,10 +290,13 @@ func (s *Samples) Copy(target string) error {
 	return nil
 }
 
-// In order to work properly, some stripe samples require the .env file to be
-// populated with the ids of resources -- often of a product or price -- that
-// needs to exist on the user's account. The `RequiredResource` struct is
-// a template for a particular kind of required resource.
+// RequiredResource is for auto-creating resources during
+
+// In order to work properly, some stripe samples require the .env
+// file to be populated with the ids of resources -- often of a
+// product or price -- that needs to exist on the user's account.
+// The `RequiredResource` struct is a template for a particular
+// kind of required resource.
 type RequiredResource struct {
 	// `name` describes how the RequiredResource is identified both inside
 	// the stripe sample's .cli.json and how it is persisted inside the


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products

 ### Summary
Paired on this with @cjavilla-stripe, who requested this feature.

Today `stripe samples create` very conveniently will copy over a user's secret key/publishable key/webhook signing secret into the `.env` file of the Stripe Sample.

For some samples, this is all the configuration the sample needs, and it's ready to go! But some samples -- often billing-related -- have additional dependencies. They require the user to create a resource on their account in testmode, and add the corresponding id to the `.env` as well. At best, this is inconvenient. At worst, this is confusing, since it is not always very obvious what kind of resource you will need, or what API call you will need to make to create it -- especially for users who are just trying out Stripe for the first time.

This PR begins to solve that problem by introducing the concept of a "required resource" which can be automatically created and configured during `stripe samples create`.

Here's how it works:
1. Each stripe sample defines their "requiredResources" inside `.cli.json` ([example](https://github.com/stripe-samples/checkout-single-subscription/blob/master/.cli.json#L4-L13)).
2. A hardcoded lookup table inside the stripe-cli code defines a POST request capable of generating that type of resource ([code](https://github.com/stripe/stripe-cli/pull/614/files#diff-1775bc38562f60c6dfb1d49400580f915200dd7cb40866e3552bf19181cb7f0bR313-R336)).
3. When the user runs `stripe samples create <name>`, if the stripe sample defines any resources that have not already been created, they receive a prompt asking permission to automatically create them.
![image](https://user-images.githubusercontent.com/52928443/111369098-09dd7e00-866d-11eb-8008-3fa3fc5e6234.png)
4. If they select yes, then a POST request is made to testmode underneath the currently active profile. If the post request is successful, the value of the "id" field in the response is written to the user's profile in their stripe-cli config (so that it can be re-used on future invocations of `stripe samples create`)
5. When the `.env` file is copied from the example, any of the required resource IDs present in the user's profile are written as environment variables there as well (like is already happening for secret key/publishable key)

Notes:
- There's a hardcoded list here in stripe-cli. If somebody wants to add a new type of "required resource", they will need to add an entry to that list.
- If the user deletes one of these auto-created resources but doesn't clear it from their stripe-cli config, they won't see the prompt anymore and `stripe samples create` will copy over an id that doesn't exist and so the sample will not work.