### PR TITLE
Add format flag to listen cmd

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -66,7 +66,7 @@ Stripe account.`,
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
 	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test)")
 	lc.cmd.Flags().BoolVarP(&lc.printJSON, "print-json", "j", false, "Print full JSON objects to stdout.")
-	lc.cmd.Flags().MarkDeprecated("print-json", "Please use `--format JSON` instead")
+	lc.cmd.Flags().MarkDeprecated("print-json", "Please use `--format JSON` instead and use `jq` if you need to process the JSON in the terminal.")
 	lc.cmd.Flags().StringVar(&lc.format, "format", "", `Specifies the output format of webhook events
 	Acceptable values:
 		'JSON' - Output webhook events in JSON format`)

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -66,10 +66,10 @@ Stripe account.`,
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
 	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test)")
 	lc.cmd.Flags().BoolVarP(&lc.printJSON, "print-json", "j", false, "Print full JSON objects to stdout.")
-	lc.cmd.Flags().MarkDeprecated("print-json", " This flag is deprecated. Please use `--format JSON` instead")
-	lc.cmd.Flags().StringVar(&lc.format, "format", "", `Specifies the output format of request logs
+	lc.cmd.Flags().MarkDeprecated("print-json", "Please use `--format JSON` instead")
+	lc.cmd.Flags().StringVar(&lc.format, "format", "", `Specifies the output format of webhook events
 	Acceptable values:
-		'JSON' - Output logs in JSON format`)
+		'JSON' - Output webhook events in JSON format`)
 	lc.cmd.Flags().BoolVarP(&lc.useConfiguredWebhooks, "use-configured-webhooks", "a", false, "Load webhook endpoint configuration from the webhooks API/dashboard")
 	lc.cmd.Flags().BoolVarP(&lc.skipVerify, "skip-verify", "", false, "Skip certificate verification when forwarding to HTTPS endpoints")
 	lc.cmd.Flags().BoolVar(&lc.onlyPrintSecret, "print-secret", false, "Only print the webhook signing secret and exit")

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -33,6 +33,7 @@ type listenCmd struct {
 	livemode              bool
 	useConfiguredWebhooks bool
 	printJSON             bool
+	format                string
 	skipVerify            bool
 	onlyPrintSecret       bool
 	skipUpdate            bool
@@ -64,7 +65,11 @@ Stripe account.`,
 	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect webhook events to (default: same as normal events)")
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
 	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test)")
-	lc.cmd.Flags().BoolVarP(&lc.printJSON, "print-json", "j", false, "Print full JSON objects to stdout")
+	lc.cmd.Flags().BoolVarP(&lc.printJSON, "print-json", "j", false, "Print full JSON objects to stdout.")
+	lc.cmd.Flags().MarkDeprecated("print-json", " This flag is deprecated. Please use `--format JSON` instead")
+	lc.cmd.Flags().StringVar(&lc.format, "format", "", `Specifies the output format of request logs
+	Acceptable values:
+		'JSON' - Output logs in JSON format`)
 	lc.cmd.Flags().BoolVarP(&lc.useConfiguredWebhooks, "use-configured-webhooks", "a", false, "Load webhook endpoint configuration from the webhooks API/dashboard")
 	lc.cmd.Flags().BoolVarP(&lc.skipVerify, "skip-verify", "", false, "Skip certificate verification when forwarding to HTTPS endpoints")
 	lc.cmd.Flags().BoolVar(&lc.onlyPrintSecret, "print-secret", false, "Only print the webhook signing secret and exit")
@@ -170,6 +175,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		APIBaseURL:          lc.apiBaseURL,
 		WebSocketFeature:    webhooksWebSocketFeature,
 		PrintJSON:           lc.printJSON,
+		Format:              lc.format,
 		UseLatestAPIVersion: lc.latestAPIVersion,
 		SkipVerify:          lc.skipVerify,
 		Log:                 log.StandardLogger(),

--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"strings"
 	"syscall"
 	"time"
 
@@ -257,7 +258,7 @@ func (t *Tailer) processRequestLogEvent(msg websocket.IncomingMessage) {
 		return
 	}
 
-	if t.cfg.OutputFormat == outputFormatJSON {
+	if strings.ToUpper(t.cfg.OutputFormat) == outputFormatJSON {
 		fmt.Println(ansi.ColorizeJSON(requestLogEvent.EventPayload, false, os.Stdout))
 		return
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -242,11 +243,11 @@ func (p *Proxy) formatOutput(format string, eventPayload string) {
 		p.cfg.Log.Debug("Received malformed event from Stripe, ignoring")
 		return
 	}
-	switch format {
+	switch strings.ToUpper(format) {
 	// The distinction between this and PrintJSON is that this output is stripped of all pretty format.
 	case outputFormatJSON:
 		outputJSON, _ := json.Marshal(event)
-		fmt.Printf("%s\n", outputJSON)
+		fmt.Println(ansi.ColorizeJSON(string(outputJSON), false, os.Stdout))
 	default:
 		fmt.Printf("Unrecognized output format %s\n" + format)
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -59,6 +59,9 @@ type Config struct {
 	// Indicates whether to print full JSON objects to stdout
 	PrintJSON bool
 
+	// Specifies the format to print to stdout.
+	Format string
+
 	// Indicates whether to filter events formatted with the default or latest API version
 	UseLatestAPIVersion bool
 
@@ -230,6 +233,25 @@ func (p *Proxy) filterWebhookEvent(msg *websocket.WebhookEvent) bool {
 	return false
 }
 
+// This function outputs the event payload in the format specified.
+// Currently, only supports JSON.
+func (p *Proxy) formatOutput(format string, eventPayload string) {
+	var event map[string]interface{}
+	err := json.Unmarshal([]byte(eventPayload), &event)
+	if err != nil {
+		p.cfg.Log.Debug("Received malformed event from Stripe, ignoring")
+		return
+	}
+	switch format {
+	// The distinction between this and PrintJSON is that this output is stripped of all pretty format.
+	case outputFormatJSON:
+		outputJSON, _ := json.Marshal(event)
+		fmt.Printf("%s\n", outputJSON)
+	default:
+		fmt.Printf("Unrecognized output format %s" + format)
+	}
+}
+
 func (p *Proxy) processWebhookEvent(msg websocket.IncomingMessage) {
 	if msg.WebhookEvent == nil {
 		p.cfg.Log.Debug("WebSocket specified for Webhooks received non-webhook event")
@@ -263,9 +285,12 @@ func (p *Proxy) processWebhookEvent(msg websocket.IncomingMessage) {
 	}
 
 	if p.events["*"] || p.events[evt.Type] {
-		if p.cfg.PrintJSON {
+		switch {
+		case p.cfg.PrintJSON:
 			fmt.Println(webhookEvent.EventPayload)
-		} else {
+		case len(p.cfg.Format) > 0:
+			p.formatOutput(p.cfg.Format, webhookEvent.EventPayload)
+		default:
 			maybeConnect := ""
 			if evt.isConnect() {
 				maybeConnect = "connect "
@@ -416,6 +441,8 @@ const (
 	maxHeaderKeySize   = 50
 	maxHeaderValueSize = 200
 )
+
+const outputFormatJSON = "JSON"
 
 //
 // Private functions

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -234,7 +234,7 @@ func (p *Proxy) filterWebhookEvent(msg *websocket.WebhookEvent) bool {
 }
 
 // This function outputs the event payload in the format specified.
-// Currently, only supports JSON.
+// Currently only supports JSON.
 func (p *Proxy) formatOutput(format string, eventPayload string) {
 	var event map[string]interface{}
 	err := json.Unmarshal([]byte(eventPayload), &event)
@@ -248,7 +248,7 @@ func (p *Proxy) formatOutput(format string, eventPayload string) {
 		outputJSON, _ := json.Marshal(event)
 		fmt.Printf("%s\n", outputJSON)
 	default:
-		fmt.Printf("Unrecognized output format %s" + format)
+		fmt.Printf("Unrecognized output format %s\n" + format)
 	}
 }
 


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
The --format flag is a string that currently only takes in JSON as a valid input option, similar to the log tailing command.
It's intended to replace the --print-json for the listen cmd. The difference in behavior between --format JSON and --print-json is that the new flag will stripe out all formatting in the payload. 

While working on the event streaming feature in VSCode, the stream was getting partial json because the json was being pretty-printed. This PR updates the listen cmd to behave the same way as the log tail command. 

### Testing
With the deprecated flag:
![Screen Shot 2021-03-17 at 9 54 54 AM](https://user-images.githubusercontent.com/75757829/111506458-e1a25d80-8706-11eb-84ae-853b10929832.png)

New flag:
![Screen Shot 2021-03-17 at 9 52 56 AM](https://user-images.githubusercontent.com/75757829/111506474-e49d4e00-8706-11eb-8443-437c0a7dbb88.png)

No flag:
![Screen Shot 2021-03-17 at 9 54 12 AM](https://user-images.githubusercontent.com/75757829/111506469-e36c2100-8706-11eb-843a-0b7a15fe1b2c.png)

