### PR TITLE
Unsupported event type: Show more detailed error message

### DIFF
--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -77,7 +77,7 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 	} else {
 		exists, _ := afero.Exists(tc.fs, event)
 		if !exists {
-			return fmt.Errorf(fmt.Sprintf("event %s is not supported.", event))
+			return fmt.Errorf(fmt.Sprintf("The event ‘%s’ is not supported by the Stripe CLI.", event))
 		}
 
 		fixture, err = fixtures.BuildFromFixture(tc.fs, apiKey, tc.stripeAccount, tc.apiBaseURL, event)


### PR DESCRIPTION
### Reviewers
r? @tomer-stripe
cc @stripe/developer-products

### Summary
I executed the following command in my Bash:
```bash
stripe trigger payout.failed
```

The command failed with the output "event payout.failed is not supported."

I was not sure if the message came from the Stripe servers (e.g. no endpoint configured for event) or my own app server. Only after researching that neither is probable, I decided to search the Stripe CLI source. I'd like to save other developers some time. 
