### PR TITLE
Migrate fixtures off Checkout endpoint that will be deprecated

### DIFF
--- a/pkg/fixtures/triggers/checkout.session.async_payment_failed.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_failed.json
@@ -39,11 +39,8 @@
     {
       "name": "payment_page",
       "expected_error_type": "invalid_request_error",
-      "path": "/v1/payment_pages",
-      "method": "get",
-      "params": {
-        "session_id": "${checkout_session:id}"
-      }
+      "path": "/v1/payment_pages/${checkout_session:id}",
+      "method": "get"
     },
     {
       "name": "payment_method",

--- a/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
@@ -37,11 +37,8 @@
     },
     {
       "name": "payment_page",
-      "path": "/v1/payment_pages",
-      "method": "get",
-      "params": {
-        "session_id": "${checkout_session:id}"
-      }
+      "path": "/v1/payment_pages/${checkout_session:id}",
+      "method": "get"
     },
     {
       "name": "payment_method",

--- a/pkg/fixtures/triggers/checkout.session.completed.json
+++ b/pkg/fixtures/triggers/checkout.session.completed.json
@@ -36,11 +36,8 @@
     },
     {
       "name": "payment_page",
-      "path": "/v1/payment_pages",
-      "method": "get",
-      "params": {
-        "session_id": "${checkout_session:id}"
-      }
+      "path": "/v1/payment_pages/${checkout_session:id}",
+      "method": "get"
     },
     {
       "name": "payment_method",


### PR DESCRIPTION
 ### Reviewers
r? @gracegoo-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Update fixtures to use `/v1/payment_pages/cs_` because `/v1/payment_pages?session_id=cs_` is soon to be deprecated. There are 3 of them.

I ran all 3 triggers manually to verify they still work. 