### PR TITLE
Update Checkout Sessions fixtures with session ID and expected_amount

### DIFF
--- a/pkg/fixtures/triggers/checkout.session.async_payment_failed.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_failed.json
@@ -72,7 +72,8 @@
       "path": "/v1/payment_pages/${payment_page:id}/confirm",
       "method": "post",
       "params": {
-        "payment_method": "${payment_method:id}"
+        "payment_method": "${payment_method:id}",
+        "expected_amount": 3000
       }
     }
   ]

--- a/pkg/fixtures/triggers/checkout.session.async_payment_failed.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_failed.json
@@ -69,7 +69,7 @@
     {
       "name": "payment_page_confirm",
       "expected_error_type": "invalid_request_error",
-      "path": "/v1/payment_pages/${payment_page:id}/confirm",
+      "path": "/v1/payment_pages/${checkout_session:id}/confirm",
       "method": "post",
       "params": {
         "payment_method": "${payment_method:id}",

--- a/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
@@ -68,7 +68,8 @@
       "path": "/v1/payment_pages/${payment_page:id}/confirm",
       "method": "post",
       "params": {
-        "payment_method": "${payment_method:id}"
+        "payment_method": "${payment_method:id}",
+        "expected_amount": 3000
       }
     }
   ]

--- a/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
@@ -65,7 +65,7 @@
     },
     {
       "name": "payment_page_confirm",
-      "path": "/v1/payment_pages/${payment_page:id}/confirm",
+      "path": "/v1/payment_pages/${checkout_session:id}/confirm",
       "method": "post",
       "params": {
         "payment_method": "${payment_method:id}",

--- a/pkg/fixtures/triggers/checkout.session.completed.json
+++ b/pkg/fixtures/triggers/checkout.session.completed.json
@@ -55,7 +55,7 @@
     },
     {
       "name": "payment_page_confirm",
-      "path": "/v1/payment_pages/${payment_page:id}/confirm",
+      "path": "/v1/payment_pages/${checkout_session:id}/confirm",
       "method": "post",
       "params": {
         "payment_method": "${payment_method:id}",

--- a/pkg/fixtures/triggers/checkout.session.completed.json
+++ b/pkg/fixtures/triggers/checkout.session.completed.json
@@ -58,7 +58,8 @@
       "path": "/v1/payment_pages/${payment_page:id}/confirm",
       "method": "post",
       "params": {
-        "payment_method": "${payment_method:id}"
+        "payment_method": "${payment_method:id}",
+        "expected_amount": 3000
       }
     }
   ]


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
Update the Checkout fixtures to use the session ID for /confirm similar to https://github.com/stripe/stripe-cli/pull/623 and to pass `expected_amount`

I ran all 3 triggers manually to verify they still work.