### PR TITLE
Saving accountId to the user profile

### DIFF
--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -22,6 +22,7 @@ type Profile struct {
 	TestModePublishableKey string
 	TerminalPOSDeviceID    string
 	DisplayName            string
+	AccountID              string
 }
 
 // CreateProfile creates a profile when logging in
@@ -206,6 +207,10 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 
 	if p.DisplayName != "" {
 		runtimeViper.Set(p.GetConfigField("display_name"), strings.TrimSpace(p.DisplayName))
+	}
+
+	if p.AccountID != "" {
+		runtimeViper.Set(p.GetConfigField("account_id"), strings.TrimSpace(p.AccountID))
 	}
 
 	runtimeViper.MergeInConfig()

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -86,6 +86,7 @@ func Login(baseURL string, config *config.Config, input io.Reader) error {
 	config.Profile.TestModeAPIKey = response.TestModeAPIKey
 	config.Profile.TestModePublishableKey = response.TestModePublishableKey
 	config.Profile.DisplayName = response.AccountDisplayName
+	config.Profile.AccountID = response.AccountID
 
 	profileErr := config.Profile.CreateProfile()
 	if profileErr != nil {


### PR DESCRIPTION
 ### Reviewers
r? @pepin-stripe 
cc @stripe/developer-products

 ### Summary
We want to add the accountId as a dimension in our VSCode telemetry. Instead of making a network call to poll for changes in the accountId, I'd like to be able to check the values locally by checking the value listed in the user's cli config. 

Before: 
```
stripe-dev config --list
color = ""

[default]
  device_name = "st-gracegoo1"
  display_name = "Cheese Foundation"
  live_mode_api_key = "rk_live_123"
  live_mode_publishable_key = "pk_live_123"
  stripe_samples_price_recurring_basic_id = "price_1IVjRkIMIxZxvOV4gAKEAOQc"
  stripe_samples_price_recurring_pro_id = "price_1IVjRlIMIxZxvOV4X0SvuKxf"
  test_mode_api_key = "sk_test_123
  test_mode_publishable_key = "pk_test_123"
```

After:
```
stripe-dev config --list
color = ""

[default]
  account_id = "acct_1HzAHfIMIxZxvOV4"
  device_name = "st-gracegoo1"
  display_name = "Cheese Foundation"
  live_mode_api_key = "rk_live_123"
  live_mode_publishable_key = "pk_live_123"
  stripe_samples_price_recurring_basic_id = "price_1IVjRkIMIxZxvOV4gAKEAOQc"
  stripe_samples_price_recurring_pro_id = "price_1IVjRlIMIxZxvOV4X0SvuKxf"
  test_mode_api_key = "sk_test_123
  test_mode_publishable_key = "pk_test_123"
```