### PR TITLE
Improve validation of fixture name references

### DIFF
--- a/pkg/fixtures/fixtures_test.go
+++ b/pkg/fixtures/fixtures_test.go
@@ -89,7 +89,7 @@ func TestParseInterfaceFromRaw(t *testing.T) {
 
 	fxt := Fixture{}
 
-	output := (fxt.parseInterface(parsedFixtureData))
+	output, _ := (fxt.parseInterface(parsedFixtureData))
 	sort.Strings(output)
 
 	require.Equal(t, len(output), 2)
@@ -120,7 +120,7 @@ func TestParseInterface(t *testing.T) {
 	data["tax_id_data"] = taxIDData
 	fxt := Fixture{}
 
-	output := (fxt.parseInterface(data))
+	output, _ := (fxt.parseInterface(data))
 	sort.Strings(output)
 
 	require.Equal(t, len(output), 8)
@@ -147,7 +147,7 @@ func TestParseWithQueryIgnoreDefault(t *testing.T) {
 	data["amount"] = "100"
 	data["currency"] = "${cust_bender:currency|usd}"
 
-	output := (fxt.parseInterface(data))
+	output, _ := (fxt.parseInterface(data))
 	sort.Strings(output)
 
 	require.Equal(t, len(output), 4)
@@ -167,7 +167,7 @@ func TestParseWithQueryDefaultValue(t *testing.T) {
 	data := make(map[string]interface{})
 	data["currency"] = "${cust_bender:currency|usd}"
 
-	output := (fxt.parseInterface(data))
+	output, _ := (fxt.parseInterface(data))
 
 	require.Equal(t, len(output), 1)
 	require.Equal(t, "currency=usd", output[0])
@@ -178,7 +178,7 @@ func TestParseNoEnv(t *testing.T) {
 	data := make(map[string]interface{})
 	data["phone"] = "${.env:PHONE_NOT_SET|+1234567890}"
 
-	output := (fxt.parseInterface(data))
+	output, _ := (fxt.parseInterface(data))
 
 	require.Equal(t, len(output), 1)
 	require.Equal(t, "phone=+1234567890", output[0])
@@ -196,10 +196,10 @@ func TestParseWithLocalEnv(t *testing.T) {
 		Path: "/v1/customers/${.env:CUST_ID}",
 	}
 
-	path := fxt.parsePath(http)
+	path, _ := fxt.parsePath(http)
 	assert.Equal(t, "/v1/customers/cust_12345", path)
 
-	output := (fxt.parseInterface(data))
+	output, _ := (fxt.parseInterface(data))
 
 	require.Equal(t, len(output), 1)
 	require.Equal(t, "phone=+1234", output[0])
@@ -216,7 +216,7 @@ func TestParseWithEnvFile(t *testing.T) {
 	fxt := Fixture{}
 	data := make(map[string]interface{})
 	data["phone"] = "${.env:PHONE_FILE|+1234567890}"
-	output := (fxt.parseInterface(data))
+	output, _ := (fxt.parseInterface(data))
 
 	require.Equal(t, len(output), 1)
 	require.Equal(t, "phone=+1234", output[0])
@@ -303,7 +303,7 @@ func TestParsePathDoNothing(t *testing.T) {
 		Path: "/v1/charges",
 	}
 
-	path := fxt.parsePath(http)
+	path, _ := fxt.parsePath(http)
 	assert.Equal(t, http.Path, path)
 }
 
@@ -317,7 +317,7 @@ func TestParseOneParam(t *testing.T) {
 		Path: "/v1/charges/${char_bender:id}",
 	}
 
-	path := fxt.parsePath(http)
+	path, _ := fxt.parsePath(http)
 	assert.Equal(t, "/v1/charges/cust_12345", path)
 }
 
@@ -331,7 +331,7 @@ func TestParseOneParamWithTrailing(t *testing.T) {
 		Path: "/v1/charges/${char_bender:id}/capture",
 	}
 
-	path := fxt.parsePath(http)
+	path, _ := fxt.parsePath(http)
 	assert.Equal(t, "/v1/charges/char_12345/capture", path)
 }
 
@@ -346,7 +346,7 @@ func TestParseTwoParam(t *testing.T) {
 		Path: "/v1/charges/${char_bender:id}/capture/${cust_bender:id}",
 	}
 
-	path := fxt.parsePath(http)
+	path, _ := fxt.parsePath(http)
 	assert.Equal(t, "/v1/charges/char_12345/capture/cust_12345", path)
 }
 


### PR DESCRIPTION
### Reviewers
r? @stripe/developer-products 
cc @stripe/developer-products 

 ### Summary
As seen in https://github.com/stripe/stripe-cli/issues/635 when a fixture file references a fixture name that does not exist a null pointer reference error is hit and the user is faced with a stacktrace that makes the CLI look broken.

![Screen Shot 2021-04-23 at 1 56 16 PM](https://user-images.githubusercontent.com/58703040/115928886-b44e7b00-a43b-11eb-9456-192bcb780261.png)


This PR adds logic to raise a validation error when an undefined fixture is referenced, optionally providing hints as to what fixture the user might be attempting to use.

**Printing validation error with suggestions based on previously defined fixtures:**
![Screen Shot 2021-04-23 at 1 30 48 PM](https://user-images.githubusercontent.com/58703040/115928544-24a8cc80-a43b-11eb-964a-b1b9e5afb775.png)

**In the case no suggestions were found:**
![Screen Shot 2021-04-23 at 1 32 05 PM](https://user-images.githubusercontent.com/58703040/115928559-2e323480-a43b-11eb-8cc0-be67f77f7e64.png)

### Further enhancements
This can definitely be improved by referencing the line/column which caused the failure, however, this would require a larger rewrite in that the necessary context does not seem available at this time.

