### PR TITLE
Remove GOPROXY https://gocenter.io from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ TEST_OPTIONS?=
 export GO111MODULE := on
 export GOBIN := $(shell pwd)/bin
 export PATH := $(GOBIN):$(PATH)
-export GOPROXY := https://gocenter.io
 export GOLANGCI_LINT_VERSION := v1.37.1
 
 # Install all the build and lint dependencies


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
fixes #643

This removes gocenter as the download source.

`make setup` fails when gocenter is under maintenance: https://status.gocenter.io/. Moreover, gocenter will no longer be available starting May 1.

`make setup` works locally after removing GOPROXY.