### PR TITLE
Remove deprecated `--live` flag from the logs tail command

### DIFF
--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -22,7 +22,6 @@ type TailCmd struct {
 	cfg        *config.Config
 	Cmd        *cobra.Command
 	format     string
-	livemode   bool
 	LogFilters *logTailing.LogFilters
 	noWSS      bool
 }
@@ -54,13 +53,6 @@ HTTP methods, IP addresses, paths, response status, and more.`,
 		`Specifies the output format of request logs
 Acceptable values:
 	'JSON' - Output logs in JSON format`,
-	)
-
-	tailCmd.Cmd.Flags().BoolVar(
-		&tailCmd.livemode,
-		"live",
-		false,
-		"[WARNING: experimental] Tail live logs (default: test)",
 	)
 
 	// Log filters
@@ -142,7 +134,7 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	key, err := tailCmd.cfg.Profile.GetAPIKey(tailCmd.livemode)
+	key, err := tailCmd.cfg.Profile.GetAPIKey(false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
 ### Reviewers
r? @pepin-stripe 
cc @stripe/developer-products

 ### Summary
This flag was marked as experimental and due to limited usage has been deprecated. This PR removes the logic for the flag.

**No longer listed in help output:**
![Screen Shot 2021-04-30 at 10 23 16 AM](https://user-images.githubusercontent.com/58703040/116735288-2591af00-a9a3-11eb-83ea-7519b0882634.png)

**Flag is not recognized by the CLI:**
![Screen Shot 2021-04-30 at 10 24 04 AM](https://user-images.githubusercontent.com/58703040/116735292-26c2dc00-a9a3-11eb-8455-0f555fe7cfd4.png)

**Example of logs tail still working:**
![Screen Shot 2021-04-30 at 10 25 54 AM](https://user-images.githubusercontent.com/58703040/116735550-891bdc80-a9a3-11eb-974b-61ffc73ef7c0.png)