### PR TITLE
Refactor stripe samples commands

### DIFF
--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -1,6 +1,7 @@
 package samples
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -113,6 +114,8 @@ func (cc *CreateCmd) runCreateCmd(cmd *cobra.Command, args []string) error {
 			if res.PostInstall != "" {
 				fmt.Println(res.PostInstall)
 			}
+		default:
+			return errors.New("an unknown error occurred during sample creation")
 		}
 	}
 

--- a/pkg/cmd/samples/list.go
+++ b/pkg/cmd/samples/list.go
@@ -5,11 +5,9 @@ import (
 	"os"
 	"sort"
 
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
-	gitpkg "github.com/stripe/stripe-cli/pkg/git"
 	"github.com/stripe/stripe-cli/pkg/samples"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
@@ -36,16 +34,12 @@ the CLI.`,
 }
 
 func (lc *ListCmd) runListCmd(cmd *cobra.Command, args []string) error {
-	sample := samples.Samples{
-		Fs:  afero.NewOsFs(),
-		Git: gitpkg.Operations{},
-	}
-
 	fmt.Println("A list of available Stripe Samples:")
 	fmt.Println()
 
 	spinner := ansi.StartNewSpinner("Loading...", os.Stdout)
-	list, err := sample.GetSamples("list")
+
+	list, err := samples.GetSamples("list")
 	if err != nil {
 		ansi.StopSpinner(spinner, "Error: please check your internet connection and try again!", os.Stdout)
 		return err

--- a/pkg/cmd/samples/list.go
+++ b/pkg/cmd/samples/list.go
@@ -2,11 +2,13 @@ package samples
 
 import (
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	"github.com/stripe/stripe-cli/pkg/ansi"
 	gitpkg "github.com/stripe/stripe-cli/pkg/git"
 	"github.com/stripe/stripe-cli/pkg/samples"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -27,13 +29,13 @@ func NewListCmd() *ListCmd {
 		Short: "List Stripe Samples supported by the CLI",
 		Long: `A list of available Stripe Sample integrations that can be setup and bootstrap by
 the CLI.`,
-		Run: listCmd.runListCmd,
+		RunE: listCmd.runListCmd,
 	}
 
 	return listCmd
 }
 
-func (lc *ListCmd) runListCmd(cmd *cobra.Command, args []string) {
+func (lc *ListCmd) runListCmd(cmd *cobra.Command, args []string) error {
 	sample := samples.Samples{
 		Fs:  afero.NewOsFs(),
 		Git: gitpkg.Operations{},
@@ -42,7 +44,14 @@ func (lc *ListCmd) runListCmd(cmd *cobra.Command, args []string) {
 	fmt.Println("A list of available Stripe Samples:")
 	fmt.Println()
 
-	list := sample.GetSamples("list")
+	spinner := ansi.StartNewSpinner("Loading...", os.Stdout)
+	list, err := sample.GetSamples("list")
+	if err != nil {
+		ansi.StopSpinner(spinner, "Error: please check your internet connection and try again!", os.Stdout)
+		return err
+	}
+	ansi.StopSpinner(spinner, "", os.Stdout)
+
 	names := samples.Names(list)
 	sort.Strings(names)
 
@@ -52,4 +61,6 @@ func (lc *ListCmd) runListCmd(cmd *cobra.Command, args []string) {
 		fmt.Printf("Repo: %s\n", list[name].URL)
 		fmt.Println()
 	}
+
+	return nil
 }

--- a/pkg/samples/create.go
+++ b/pkg/samples/create.go
@@ -68,6 +68,7 @@ func Create(
 	exists, _ := afero.DirExists(sample.Fs, destination)
 	if exists {
 		resultChan <- CreationResult{Err: fmt.Errorf("Path already exists for: %s", destination)}
+		return
 	}
 
 	if forceRefresh {
@@ -105,6 +106,7 @@ func Create(
 			break
 		default:
 			resultChan <- CreationResult{Err: err}
+			return
 		}
 	}
 
@@ -130,6 +132,7 @@ func Create(
 	targetPath, err := sample.MakeFolder(destination)
 	if err != nil {
 		resultChan <- CreationResult{Err: err}
+		return
 	}
 
 	// Perform the copy of the sample given the selected options
@@ -137,6 +140,7 @@ func Create(
 	err = sample.Copy(targetPath)
 	if err != nil {
 		resultChan <- CreationResult{Err: err}
+		return
 	}
 
 	resultChan <- CreationResult{State: DidCopy}
@@ -146,6 +150,7 @@ func Create(
 	err = sample.ConfigureDotEnv(targetPath)
 	if err != nil {
 		resultChan <- CreationResult{Err: err}
+		return
 	}
 
 	resultChan <- CreationResult{State: DidConfigure}

--- a/pkg/samples/create.go
+++ b/pkg/samples/create.go
@@ -1,0 +1,154 @@
+package samples
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	gitpkg "github.com/stripe/stripe-cli/pkg/git"
+
+	"gopkg.in/src-d/go-git.v4"
+)
+
+// CreationStatus is the current step in the sample creation routine
+type CreationStatus int
+
+const (
+	// WillDownload means this sample will be downloaded
+	WillDownload CreationStatus = iota
+
+	// DidDownload means this sample has finished downloading
+	DidDownload
+
+	// WillCopy means the downloaded sample will be copied to the target path
+	WillCopy
+
+	// DidCopy means the downloaded sample has finished being copied to the target path
+	DidCopy
+
+	// WillConfigure means the .env of the sample will be configured with the user's Stripe account details
+	WillConfigure
+
+	// DidConfigure means the .env of the sample has finished being configured with the user's Stripe account details
+	DidConfigure
+
+	// Done means sample creation is complete
+	Done
+)
+
+// CreationResult ...
+type CreationResult struct {
+	State       CreationStatus
+	Path        string
+	PostInstall string
+	Err         error
+}
+
+// Create ...
+func Create(
+	config *config.Config,
+	sampleName string,
+	selectedConfig *SelectedConfig,
+	destination string,
+	forceRefresh bool,
+	resultChan chan<- CreationResult,
+) {
+	defer close(resultChan)
+
+	sample := Samples{
+		Config: config,
+		Fs:     afero.NewOsFs(),
+		Git:    gitpkg.Operations{},
+	}
+
+	exists, _ := afero.DirExists(sample.Fs, destination)
+	if exists {
+		resultChan <- CreationResult{Err: fmt.Errorf("Path already exists for: %s", destination)}
+	}
+
+	if forceRefresh {
+		err := sample.DeleteCache(sampleName)
+		if err != nil {
+			logger := log.Logger{
+				Out: os.Stdout,
+			}
+
+			logger.WithFields(log.Fields{
+				"prefix": "samples.create.forceRefresh",
+				"error":  err,
+			}).Debug("Could not clear cache")
+		}
+	}
+
+	resultChan <- CreationResult{State: WillDownload}
+
+	// Initialize the selected sample in the local cache directory.
+	// This will either clone or update the specified sample,
+	// depending on whether or not it's. Additionally, this
+	// identifies if the sample has multiple integrations and what
+	// languages it supports.
+	err := sample.Initialize(sampleName)
+	if err != nil {
+		switch e := err.Error(); e {
+		case git.NoErrAlreadyUpToDate.Error():
+			// Repo is already up to date. This isn't a program
+			// error to continue as normal
+			break
+		case git.ErrRepositoryAlreadyExists.Error():
+			// If the repository already exists and we don't pull
+			// for some reason, that's fine as we can use the existing
+			// repository
+			break
+		default:
+			resultChan <- CreationResult{Err: err}
+		}
+	}
+
+	resultChan <- CreationResult{State: DidDownload}
+
+	sample.SelectedConfig = *selectedConfig
+
+	// Setup to intercept ctrl+c
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
+	go func() {
+		<-c
+		sample.Cleanup(sampleName)
+		os.Exit(1)
+	}()
+
+	resultChan <- CreationResult{State: WillCopy}
+
+	// Create the target folder to copy the sample in to. We do
+	// this here in case any of the steps above fail, minimizing
+	// the change that we create a dangling empty folder
+	targetPath, err := sample.MakeFolder(destination)
+	if err != nil {
+		resultChan <- CreationResult{Err: err}
+	}
+
+	// Perform the copy of the sample given the selected options
+	// from the selections above
+	err = sample.Copy(targetPath)
+	if err != nil {
+		resultChan <- CreationResult{Err: err}
+	}
+
+	resultChan <- CreationResult{State: DidCopy}
+
+	resultChan <- CreationResult{State: WillConfigure}
+
+	err = sample.ConfigureDotEnv(targetPath)
+	if err != nil {
+		resultChan <- CreationResult{Err: err}
+	}
+
+	resultChan <- CreationResult{State: DidConfigure}
+
+	resultChan <- CreationResult{State: Done, Path: targetPath, PostInstall: sample.PostInstall()}
+}

--- a/pkg/samples/create.go
+++ b/pkg/samples/create.go
@@ -40,7 +40,7 @@ const (
 	Done
 )
 
-// CreationResult ...
+// CreationResult is the return value sent over a channel
 type CreationResult struct {
 	State       CreationStatus
 	Path        string
@@ -48,7 +48,7 @@ type CreationResult struct {
 	Err         error
 }
 
-// Create ...
+// Create creates a sample at a destination with the selected integration, client language, and server language
 func Create(
 	config *config.Config,
 	sampleName string,

--- a/pkg/samples/list.go
+++ b/pkg/samples/list.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/src-d/go-git.v4"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
+	gitpkg "github.com/stripe/stripe-cli/pkg/git"
 )
 
 const sampleListGithubURL = "https://github.com/stripe-samples/samples-list.git"
@@ -94,11 +95,7 @@ func (s *Samples) getFromCacheOrGithub(noNetwork bool) error {
 	return nil
 }
 
-// GetSamples returns a list that contains a mapping of Stripe Samples that
-// we want to be available in the CLI to some of their metadata.
-// TODO: what do we want to name these for it to be easier for users to select?
-// TODO: should we group them by products for easier exploring?
-func (s *Samples) GetSamples(mode string) (map[string]*SampleData, error) {
+func (s *Samples) getSamples(mode string) (map[string]*SampleData, error) {
 	if len(s.SamplesList) != 0 {
 		return s.SamplesList, nil
 	}
@@ -121,4 +118,17 @@ func (s *Samples) GetSamples(mode string) (map[string]*SampleData, error) {
 	}
 
 	return s.SamplesList, nil
+}
+
+// GetSamples returns a list that contains a mapping of Stripe Samples that
+// we want to be available in the CLI to some of their metadata.
+// TODO: what do we want to name these for it to be easier for users to select?
+// TODO: should we group them by products for easier exploring?
+func GetSamples(mode string) (map[string]*SampleData, error) {
+	sample := Samples{
+		Fs:  afero.NewOsFs(),
+		Git: gitpkg.Operations{},
+	}
+
+	return sample.getSamples(mode)
 }

--- a/pkg/samples/list.go
+++ b/pkg/samples/list.go
@@ -47,9 +47,6 @@ func Names(list map[string]*SampleData) []string {
 	return keys
 }
 
-// Returns a list that contains a mapping of Stripe Samples
-var list = map[string]*SampleData{}
-
 func (s *Samples) getFromCacheOrGithub(noNetwork bool) error {
 	listPath, err := s.appCacheFolder("samples-list")
 	if err != nil {
@@ -89,8 +86,9 @@ func (s *Samples) getFromCacheOrGithub(noNetwork bool) error {
 		return err
 	}
 
+	s.SamplesList = make(map[string]*SampleData)
 	for i, sample := range allSamples.Samples {
-		list[sample.Name] = &allSamples.Samples[i]
+		s.SamplesList[sample.Name] = &allSamples.Samples[i]
 	}
 
 	return nil
@@ -100,12 +98,9 @@ func (s *Samples) getFromCacheOrGithub(noNetwork bool) error {
 // we want to be available in the CLI to some of their metadata.
 // TODO: what do we want to name these for it to be easier for users to select?
 // TODO: should we group them by products for easier exploring?
-func (s *Samples) GetSamples(mode string) map[string]*SampleData {
-	spinner := ansi.StartNewSpinner("Loading...", os.Stdout)
-
-	if len(list) != 0 {
-		ansi.StopSpinner(spinner, "", os.Stdout)
-		return list
+func (s *Samples) GetSamples(mode string) (map[string]*SampleData, error) {
+	if len(s.SamplesList) != 0 {
+		return s.SamplesList, nil
 	}
 
 	// Reduce the amount of request to GitHub
@@ -122,9 +117,8 @@ func (s *Samples) GetSamples(mode string) map[string]*SampleData {
 	// Get the samples from the cache or GitHub
 	err := s.getFromCacheOrGithub(noNetwork)
 	if err != nil {
-		ansi.StopSpinner(spinner, "Error: please check your internet connection and try again!", os.Stdout)
+		return nil, err
 	}
 
-	ansi.StopSpinner(spinner, "", os.Stdout)
-	return list
+	return s.SamplesList, nil
 }

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/stripeauth"
 )
 
-// SampleConfig ..
+// SampleConfig contains all the configuration options for a sample
 type SampleConfig struct {
 	Name            string                    `json:"name"`
 	ConfigureDotEnv bool                      `json:"configureDotEnv"`
@@ -25,12 +25,12 @@ type SampleConfig struct {
 	Integrations    []SampleConfigIntegration `json:"integrations"`
 }
 
-// HasIntegrations ...
+// HasIntegrations returns true if the sample has multiple integrations
 func (sc *SampleConfig) HasIntegrations() bool {
 	return len(sc.Integrations) > 1
 }
 
-// IntegrationNames ..
+// IntegrationNames returns the names of the available integrations for the sample
 func (sc *SampleConfig) IntegrationNames() []string {
 	names := []string{}
 	for _, integration := range sc.Integrations {
@@ -50,7 +50,7 @@ func (sc *SampleConfig) integrationServers(name string) []string {
 	return []string{}
 }
 
-// SampleConfigIntegration is ...
+// SampleConfigIntegration is a particular integration for a sample
 type SampleConfigIntegration struct {
 	Name string `json:"name"`
 	// Clients are the frontend clients built for each sample
@@ -67,12 +67,12 @@ func (i *SampleConfigIntegration) hasServers() bool {
 	return len(i.Servers) > 0
 }
 
-// HasMultipleClients ...
+// HasMultipleClients returns true if this integration has multiple options for the client language
 func (i *SampleConfigIntegration) HasMultipleClients() bool {
 	return len(i.Clients) > 1
 }
 
-// HasMultipleServers ...
+// HasMultipleServers returns true if this integration has multiple options for the server language
 func (i *SampleConfigIntegration) HasMultipleServers() bool {
 	return len(i.Servers) > 1
 }
@@ -85,7 +85,7 @@ func (i *SampleConfigIntegration) name() string {
 	return i.Name
 }
 
-// SelectedConfig ...
+// SelectedConfig is the sample config that the user has selected to create
 type SelectedConfig struct {
 	Integration *SampleConfigIntegration
 	Client      string

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -190,7 +190,8 @@ func (s *Samples) Copy(target string) error {
 	integration := s.SelectedConfig.Integration.name()
 
 	if s.SelectedConfig.Integration.hasServers() {
-		if !contains(s.SelectedConfig.Integration.Servers, s.SelectedConfig.Server) {
+		// empty string is a valid option
+		if s.SelectedConfig.Server != "" && !contains(s.SelectedConfig.Integration.Servers, s.SelectedConfig.Server) {
 			return fmt.Errorf(
 				"Server %s doesn't exist for sample integration %s. Available servers: %v",
 				s.SelectedConfig.Server,
@@ -209,7 +210,8 @@ func (s *Samples) Copy(target string) error {
 	}
 
 	if s.SelectedConfig.Integration.hasClients() {
-		if !contains(s.SelectedConfig.Integration.Clients, s.SelectedConfig.Client) {
+		// empty string is a valid option
+		if s.SelectedConfig.Client != "" && !contains(s.SelectedConfig.Integration.Clients, s.SelectedConfig.Client) {
 			return fmt.Errorf(
 				"Client %s doesn't exist for sample integration %s. Available clients: %v",
 				s.SelectedConfig.Client,

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -3,6 +3,7 @@ package samples
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -118,6 +119,10 @@ type Samples struct {
 // 4. if the selected app does exist in the local cache folder, pull changes
 // 5. parse the sample cli config file
 func (s *Samples) Initialize(app string) error {
+	if app == "" {
+		return errors.New("Sample name is empty")
+	}
+
 	s.name = app
 
 	appPath, err := s.appCacheFolder(app)
@@ -135,7 +140,12 @@ func (s *Samples) Initialize(app string) error {
 	}
 
 	if _, err := s.Fs.Stat(appPath); os.IsNotExist(err) {
-		err = s.Git.Clone(appPath, list[app].GitRepo())
+		sampleData, ok := list[app]
+		if !ok {
+			return fmt.Errorf("Sample %s does not exist", app)
+		}
+		err = s.Git.Clone(appPath, sampleData.GitRepo())
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
- Hoisted the spinners, user IO, and error handling up to the cobra command
  - This removes IO concerns from the samples package
- Added new fields to the `Samples` struct to make it easier to work with 
- Updated and added a couple tests in the samples package

Verified manually by running stripe samples list and creating a variety of stripe samples with and without --force-refresh, with and without a path.

Motivated by https://github.com/stripe/stripe-cli/pull/646, which will be rebased on this.