### PR TITLE
Fix samples create always failing

### DIFF
--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -99,6 +99,8 @@ func (cc *CreateCmd) runCreateCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		switch res.State {
+		case samples.WillInitialize:
+		case samples.DidInitialize:
 		case samples.WillCopy:
 			spinner = ansi.StartNewSpinner(fmt.Sprintf("Copying files over... %s", destination), os.Stdout)
 		case samples.DidCopy:

--- a/pkg/samples/create.go
+++ b/pkg/samples/create.go
@@ -18,11 +18,11 @@ import (
 type CreationStatus int
 
 const (
-	// WillDownload means this sample will be downloaded
-	WillDownload CreationStatus = iota
+	// WillInitialize means this sample will be initialized
+	WillInitialize CreationStatus = iota
 
-	// DidDownload means this sample has finished downloading
-	DidDownload
+	// DidInitialize means this sample has finished initializing
+	DidInitialize
 
 	// WillCopy means the downloaded sample will be copied to the target path
 	WillCopy
@@ -85,7 +85,7 @@ func Create(
 		}
 	}
 
-	resultChan <- CreationResult{State: WillDownload}
+	resultChan <- CreationResult{State: WillInitialize}
 
 	// Initialize the selected sample in the local cache directory.
 	// This will either clone or update the specified sample,
@@ -110,7 +110,7 @@ func Create(
 		}
 	}
 
-	resultChan <- CreationResult{State: DidDownload}
+	resultChan <- CreationResult{State: DidInitialize}
 
 	sample.SelectedConfig = *selectedConfig
 


### PR DESCRIPTION
 ### Reviewers
r? @pepin-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
In https://github.com/stripe/stripe-cli/pull/652, I made a mistake in the switch statement. Because I didn't include all the cases, we would hit the default case every time. The default case returns an error so sample creation would fail every time.

This adds those unused cases to the switch statement and also renames them to be more accurate.