### PR TITLE
Refactor trigger command

### DIFF
--- a/pkg/cmd/fixtures.go
+++ b/pkg/cmd/fixtures.go
@@ -61,7 +61,7 @@ func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = fixture.Execute()
+	_, err = fixture.Execute()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -55,11 +55,6 @@ needed to create the triggered event as well as the corresponding API objects.
 func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 	version.CheckLatestVersion()
 
-	apiKey, err := Config.Profile.GetAPIKey(false)
-	if err != nil {
-		return err
-	}
-
 	if len(args) == 0 {
 		cmd.Help()
 
@@ -68,30 +63,11 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 
 	event := args[0]
 
-	var fixture *fixtures.Fixture
-	if file, ok := fixtures.Events[event]; ok {
-		fixture, err = fixtures.BuildFromFixture(tc.fs, apiKey, tc.stripeAccount, tc.apiBaseURL, file)
-		if err != nil {
-			return err
-		}
-	} else {
-		exists, _ := afero.Exists(tc.fs, event)
-		if !exists {
-			return fmt.Errorf(fmt.Sprintf("The event ‘%s’ is not supported by the Stripe CLI.", event))
-		}
-
-		fixture, err = fixtures.BuildFromFixture(tc.fs, apiKey, tc.stripeAccount, tc.apiBaseURL, event)
-		if err != nil {
-			return err
-		}
+	_, err := fixtures.Trigger(event, tc.stripeAccount, tc.apiBaseURL, &Config)
+	if err != nil {
+		return err
 	}
 
-	err = fixture.Execute()
-	if err == nil {
-		fmt.Println("Trigger succeeded! Check dashboard for event details.")
-	} else {
-		fmt.Printf("Trigger failed: %s\n", err)
-	}
-
-	return err
+	fmt.Println("Trigger succeeded! Check dashboard for event details.")
+	return nil
 }

--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -104,19 +104,21 @@ func NewFixture(fs afero.Fs, apiKey, stripeAccount, baseURL, file string) (*Fixt
 
 // Execute takes the parsed fixture file and runs through all the requests
 // defined to populate the user's account
-func (fxt *Fixture) Execute() error {
-	for _, data := range fxt.fixture.Fixtures {
+func (fxt *Fixture) Execute() ([]string, error) {
+	requestNames := make([]string, len(fxt.fixture.Fixtures))
+	for i, data := range fxt.fixture.Fixtures {
 		fmt.Printf("Setting up fixture for: %s\n", data.Name)
+		requestNames[i] = data.Name
 
 		resp, err := fxt.makeRequest(data)
 		if err != nil && !errWasExpected(err, data.ExpectedErrorType) {
-			return err
+			return nil, err
 		}
 
 		fxt.responses[data.Name] = gojsonq.New().FromString(string(resp))
 	}
 
-	return nil
+	return requestNames, nil
 }
 
 func errWasExpected(err error, expectedErrorType string) bool {


### PR DESCRIPTION
 ### Reviewers
r? @gracegoo-stripe
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

- Move the logic from the `stripe trigger` cobra command into its own method, `fixtures.Trigger()`. This method will be reused in the `Trigger` gRPC method.
- Make `fixture.Execute()` return the names of the requests made. For example, if you run `stripe trigger customer.created`, then `fixture.Execute()` returns ["customer", "customer_deleted"]. This list is ignored by the cobra command, but the gRPC method response will use it.

This is merging into master. Afterwards I'll rebase https://github.com/stripe/stripe-cli/pull/646 on it and add `Trigger` for grpc.

I ran tests and manually ran stripe trigger with different args and flags to verify nothing changed.