### PR TITLE
Refactor logs tail command with channel and visitors

### DIFF
--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -1,20 +1,29 @@
 package logs
 
 import (
+	"fmt"
+	"os"
+	"os/signal"
+	"reflect"
 	"strings"
+	"syscall"
+	"time"
 
+	"github.com/briandowns/spinner"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"context"
 
+	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/logtailing"
 	logTailing "github.com/stripe/stripe-cli/pkg/logtailing"
 	"github.com/stripe/stripe-cli/pkg/validators"
 	"github.com/stripe/stripe-cli/pkg/version"
 )
 
-const requestLogsWebSocketFeature = "request_logs"
+const outputFormatJSON = "JSON"
 
 // TailCmd wraps the configuration for the tail command
 type TailCmd struct {
@@ -118,6 +127,21 @@ Acceptable values:
 	return tailCmd
 }
 
+func withSIGTERMCancel(ctx context.Context, onCancel func()) context.Context {
+	// Create a context that will be canceled when Ctrl+C is pressed
+	ctx, cancel := context.WithCancel(ctx)
+
+	interruptCh := make(chan os.Signal, 1)
+	signal.Notify(interruptCh, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-interruptCh
+		onCancel()
+		cancel()
+	}()
+	return ctx
+}
+
 func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 	err := tailCmd.validateArgs()
 	if err != nil {
@@ -141,20 +165,35 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 
 	version.CheckLatestVersion()
 
+	logger := log.StandardLogger()
+
+	streamElementVisitor := createVisitor(logger, tailCmd.format)
+
+	streamElementCh := make(chan logTailing.StreamElement)
+
 	tailer := logTailing.New(&logTailing.Config{
-		APIBaseURL:       tailCmd.apiBaseURL,
-		DeviceName:       deviceName,
-		Filters:          tailCmd.LogFilters,
-		Key:              key,
-		Log:              log.StandardLogger(),
-		NoWSS:            tailCmd.noWSS,
-		OutputFormat:     strings.ToUpper(tailCmd.format),
-		WebSocketFeature: requestLogsWebSocketFeature,
+		APIBaseURL:      tailCmd.apiBaseURL,
+		DeviceName:      deviceName,
+		Filters:         tailCmd.LogFilters,
+		Key:             key,
+		Log:             logger,
+		NoWSS:           tailCmd.noWSS,
+		StreamElementCh: streamElementCh,
 	})
 
-	err = tailer.Run(context.Background())
-	if err != nil {
-		return err
+	ctx := withSIGTERMCancel(context.Background(), func() {
+		log.WithFields(log.Fields{
+			"prefix": "logtailing.Tailer.Run",
+		}).Debug("Ctrl+C received, cleaning up...")
+	})
+
+	go tailer.Run(ctx)
+
+	for el := range streamElementCh {
+		err := el.Visit(streamElementVisitor)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -203,4 +242,75 @@ func (tailCmd *TailCmd) convertArgs() error {
 	}
 
 	return nil
+}
+
+func createVisitor(logger *log.Logger, format string) logtailing.StreamElementVisitor {
+	var s *spinner.Spinner
+
+	return logtailing.StreamElementVisitor{
+		VisitError: func(ee logTailing.ErrorElement) error {
+			ansi.StopSpinner(s, "", logger.Out)
+			return ee.Error
+		},
+		VisitWarning: func(we logTailing.WarningElement) error {
+			color := ansi.Color(os.Stdout)
+			fmt.Printf("%s%s\n", color.Yellow("Warning"), we.Warning)
+			return nil
+		},
+		VisitStatus: func(se logTailing.StatusElement) error {
+			switch se.Status {
+			case logTailing.Loading:
+				s = ansi.StartNewSpinner("Getting ready...", logger.Out)
+			case logtailing.Reconnecting:
+				ansi.StartSpinner(s, "Session expired, reconnecting...", logger.Out)
+			case logtailing.Ready:
+				ansi.StopSpinner(s, "Ready! You're now waiting to receive API request logs (^C to quit)", logger.Out)
+			case logtailing.Done:
+				ansi.StopSpinner(s, "", logger.Out)
+			}
+			return nil
+		},
+		VisitLog: func(le logTailing.LogElement) error {
+			if strings.ToUpper(format) == outputFormatJSON {
+				fmt.Println(ansi.ColorizeJSON(le.MarshalledLog, false, os.Stdout))
+				return nil
+			}
+
+			coloredStatus := ansi.ColorizeStatus(le.Log.Status)
+
+			url := urlForRequestID(&le.Log)
+			requestLink := ansi.Linkify(le.Log.RequestID, url, os.Stdout)
+
+			if le.Log.URL == "" {
+				le.Log.URL = "[View path in dashboard]"
+			}
+
+			exampleLayout := "2006-01-02 15:04:05"
+			localTime := time.Unix(int64(le.Log.CreatedAt), 0).Format(exampleLayout)
+
+			color := ansi.Color(os.Stdout)
+			outputStr := fmt.Sprintf("%s [%d] %s %s [%s]", color.Faint(localTime), coloredStatus, le.Log.Method, le.Log.URL, requestLink)
+			fmt.Println(outputStr)
+
+			errorValues := reflect.ValueOf(&le.Log.Error).Elem()
+			errType := errorValues.Type()
+
+			for i := 0; i < errorValues.NumField(); i++ {
+				fieldValue := errorValues.Field(i).Interface()
+				if fieldValue != "" {
+					fmt.Printf("%s: %s\n", errType.Field(i).Name, fieldValue)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func urlForRequestID(payload *logtailing.EventPayload) string {
+	maybeTest := ""
+	if !payload.Livemode {
+		maybeTest = "/test"
+	}
+
+	return fmt.Sprintf("https://dashboard.stripe.com%s/logs/%s", maybeTest, payload.RequestID)
 }

--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -190,7 +190,7 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 	go tailer.Run(ctx)
 
 	for el := range streamElementCh {
-		err := el.Visit(streamElementVisitor)
+		err := el.Accept(streamElementVisitor)
 		if err != nil {
 			return err
 		}
@@ -244,10 +244,10 @@ func (tailCmd *TailCmd) convertArgs() error {
 	return nil
 }
 
-func createVisitor(logger *log.Logger, format string) logtailing.StreamElementVisitor {
+func createVisitor(logger *log.Logger, format string) *logtailing.StreamElementVisitor {
 	var s *spinner.Spinner
 
-	return logtailing.StreamElementVisitor{
+	return &logtailing.StreamElementVisitor{
 		VisitError: func(ee logTailing.ErrorElement) error {
 			ansi.StopSpinner(s, "", logger.Out)
 			return ee.Error

--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -47,8 +47,8 @@ type Config struct {
 	// Force use of unencrypted ws:// protocol instead of wss://
 	NoWSS bool
 
-	// StreamElementCh is the channel to send logs and statuses to for processing in other packages
-	StreamElementCh chan StreamElement
+	// OutCh is the channel to send logs and statuses to for processing in other packages
+	OutCh chan IElement
 }
 
 // Tailer is the main interface for running the log tailing session
@@ -102,27 +102,27 @@ const maxConnectAttempts = 3
 
 // Run sets the websocket connection
 func (t *Tailer) Run(ctx context.Context) error {
-	defer close(t.cfg.StreamElementCh)
+	defer close(t.cfg.OutCh)
 
 	var warned = false
 	var nAttempts int = 0
 
-	t.cfg.StreamElementCh <- StatusElement{
-		Status: Loading,
+	t.cfg.OutCh <- StateElement{
+		State: Loading,
 	}
 
 	for nAttempts < maxConnectAttempts {
 		session, err := t.createSession(ctx)
 
 		if err != nil {
-			t.cfg.StreamElementCh <- ErrorElement{
+			t.cfg.OutCh <- ErrorElement{
 				Error: fmt.Errorf("Error while authenticating with Stripe: %v", err),
 			}
 			return err
 		}
 
 		if session.DisplayConnectFilterWarning && !warned {
-			t.cfg.StreamElementCh <- WarningElement{
+			t.cfg.OutCh <- WarningElement{
 				Warning: "you specified the 'account' filter for Connect accounts but are not a Connect user, so the filter will not be applied.",
 			}
 			// Only display this warning once
@@ -144,8 +144,8 @@ func (t *Tailer) Run(ctx context.Context) error {
 		go func() {
 			<-t.webSocketClient.Connected()
 			nAttempts = 0
-			t.cfg.StreamElementCh <- StatusElement{
-				Status: Ready,
+			t.cfg.OutCh <- StateElement{
+				State: Ready,
 			}
 		}()
 
@@ -154,18 +154,18 @@ func (t *Tailer) Run(ctx context.Context) error {
 
 		select {
 		case <-ctx.Done():
-			t.cfg.StreamElementCh <- &StatusElement{
-				Status: Done,
+			t.cfg.OutCh <- &StateElement{
+				State: Done,
 			}
 			return nil
 		case <-t.webSocketClient.NotifyExpired:
 			if nAttempts < maxConnectAttempts {
-				t.cfg.StreamElementCh <- &StatusElement{
-					Status: Reconnecting,
+				t.cfg.OutCh <- &StateElement{
+					State: Reconnecting,
 				}
 			} else {
 				err := fmt.Errorf("Session expired. Terminating after %d failed attempts to reauthorize", nAttempts)
-				t.cfg.StreamElementCh <- ErrorElement{
+				t.cfg.OutCh <- ErrorElement{
 					Error: err,
 				}
 				return err
@@ -246,7 +246,7 @@ func (t *Tailer) processRequestLogEvent(msg websocket.IncomingMessage) {
 		return
 	}
 
-	t.cfg.StreamElementCh <- LogElement{
+	t.cfg.OutCh <- LogElement{
 		Log:           payload,
 		MarshalledLog: requestLogEvent.EventPayload,
 	}

--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -6,20 +6,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/signal"
-	"reflect"
-	"strings"
-	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/stripeauth"
 	"github.com/stripe/stripe-cli/pkg/websocket"
 )
 
-const outputFormatJSON = "JSON"
+const requestLogsWebSocketFeature = "request_logs"
 
 // LogFilters contains all of the potential user-provided filters for log tailing
 type LogFilters struct {
@@ -52,11 +47,8 @@ type Config struct {
 	// Force use of unencrypted ws:// protocol instead of wss://
 	NoWSS bool
 
-	// Output format for request logs
-	OutputFormat string
-
-	// WebSocketFeature is the feature specified for the websocket connection
-	WebSocketFeature string
+	// StreamElementCh is the channel to send logs and statuses to for processing in other packages
+	StreamElementCh chan StreamElement
 }
 
 // Tailer is the main interface for running the log tailing session
@@ -106,47 +98,33 @@ func New(cfg *Config) *Tailer {
 	}
 }
 
-func withSIGTERMCancel(ctx context.Context, onCancel func()) context.Context {
-	// Create a context that will be canceled when Ctrl+C is pressed
-	ctx, cancel := context.WithCancel(ctx)
-
-	interruptCh := make(chan os.Signal, 1)
-	signal.Notify(interruptCh, os.Interrupt, syscall.SIGTERM)
-
-	go func() {
-		<-interruptCh
-		onCancel()
-		cancel()
-	}()
-	return ctx
-}
-
 const maxConnectAttempts = 3
 
 // Run sets the websocket connection
 func (t *Tailer) Run(ctx context.Context) error {
-	s := ansi.StartNewSpinner("Getting ready...", t.cfg.Log.Out)
-
-	ctx = withSIGTERMCancel(ctx, func() {
-		log.WithFields(log.Fields{
-			"prefix": "logtailing.Tailer.Run",
-		}).Debug("Ctrl+C received, cleaning up...")
-	})
+	defer close(t.cfg.StreamElementCh)
 
 	var warned = false
 	var nAttempts int = 0
+
+	t.cfg.StreamElementCh <- StatusElement{
+		Status: Loading,
+	}
 
 	for nAttempts < maxConnectAttempts {
 		session, err := t.createSession(ctx)
 
 		if err != nil {
-			ansi.StopSpinner(s, "", t.cfg.Log.Out)
-			t.cfg.Log.Fatalf("Error while authenticating with Stripe: %v", err)
+			t.cfg.StreamElementCh <- ErrorElement{
+				Error: fmt.Errorf("Error while authenticating with Stripe: %v", err),
+			}
+			return err
 		}
 
 		if session.DisplayConnectFilterWarning && !warned {
-			color := ansi.Color(os.Stdout)
-			fmt.Printf("%s you specified the 'account' filter for Connect accounts but are not a Connect user, so the filter will not be applied.\n", color.Yellow("Warning"))
+			t.cfg.StreamElementCh <- WarningElement{
+				Warning: "you specified the 'account' filter for Connect accounts but are not a Connect user, so the filter will not be applied.",
+			}
 			// Only display this warning once
 			warned = true
 		}
@@ -166,7 +144,9 @@ func (t *Tailer) Run(ctx context.Context) error {
 		go func() {
 			<-t.webSocketClient.Connected()
 			nAttempts = 0
-			ansi.StopSpinner(s, "Ready! You're now waiting to receive API request logs (^C to quit)", t.cfg.Log.Out)
+			t.cfg.StreamElementCh <- StatusElement{
+				Status: Ready,
+			}
 		}()
 
 		go t.webSocketClient.Run(ctx)
@@ -174,13 +154,19 @@ func (t *Tailer) Run(ctx context.Context) error {
 
 		select {
 		case <-ctx.Done():
-			ansi.StopSpinner(s, "", t.cfg.Log.Out)
+			t.cfg.StreamElementCh <- &StatusElement{
+				Status: Done,
+			}
 			return nil
 		case <-t.webSocketClient.NotifyExpired:
 			if nAttempts < maxConnectAttempts {
-				ansi.StartSpinner(s, "Session expired, reconnecting...", t.cfg.Log.Out)
+				t.cfg.StreamElementCh <- &StatusElement{
+					Status: Reconnecting,
+				}
 			} else {
-				t.cfg.Log.Fatalf("Session expired. Terminating after %d failed attempts to reauthorize", nAttempts)
+				t.cfg.StreamElementCh <- ErrorElement{
+					Error: fmt.Errorf("Session expired. Terminating after %d failed attempts to reauthorize", nAttempts),
+				}
 			}
 		}
 	}
@@ -205,14 +191,14 @@ func (t *Tailer) createSession(ctx context.Context) (*stripeauth.StripeCLISessio
 
 	filters, err := jsonifyFilters(t.cfg.Filters)
 	if err != nil {
-		t.cfg.Log.Fatalf("Error while converting log filters to JSON encoding: %v", err)
+		return nil, fmt.Errorf("Error while converting log filters to JSON encoding: %v", err)
 	}
 
 	go func() {
 		// Try to authorize at least 5 times before failing. Sometimes we have random
 		// transient errors that we just need to retry for.
 		for i := 0; i <= 5; i++ {
-			session, err = t.stripeAuthClient.Authorize(ctx, t.cfg.DeviceName, t.cfg.WebSocketFeature, &filters)
+			session, err = t.stripeAuthClient.Authorize(ctx, t.cfg.DeviceName, requestLogsWebSocketFeature, &filters)
 
 			if err == nil {
 				exitCh <- struct{}{}
@@ -258,35 +244,9 @@ func (t *Tailer) processRequestLogEvent(msg websocket.IncomingMessage) {
 		return
 	}
 
-	if strings.ToUpper(t.cfg.OutputFormat) == outputFormatJSON {
-		fmt.Println(ansi.ColorizeJSON(requestLogEvent.EventPayload, false, os.Stdout))
-		return
-	}
-
-	coloredStatus := ansi.ColorizeStatus(payload.Status)
-
-	url := urlForRequestID(&payload)
-	requestLink := ansi.Linkify(payload.RequestID, url, os.Stdout)
-
-	if payload.URL == "" {
-		payload.URL = "[View path in dashboard]"
-	}
-
-	exampleLayout := "2006-01-02 15:04:05"
-	localTime := time.Unix(int64(payload.CreatedAt), 0).Format(exampleLayout)
-
-	color := ansi.Color(os.Stdout)
-	outputStr := fmt.Sprintf("%s [%d] %s %s [%s]", color.Faint(localTime), coloredStatus, payload.Method, payload.URL, requestLink)
-	fmt.Println(outputStr)
-
-	errorValues := reflect.ValueOf(&payload.Error).Elem()
-	errType := errorValues.Type()
-
-	for i := 0; i < errorValues.NumField(); i++ {
-		fieldValue := errorValues.Field(i).Interface()
-		if fieldValue != "" {
-			fmt.Printf("%s: %s\n", errType.Field(i).Name, fieldValue)
-		}
+	t.cfg.StreamElementCh <- LogElement{
+		Log:           payload,
+		MarshalledLog: requestLogEvent.EventPayload,
 	}
 }
 
@@ -299,13 +259,4 @@ func jsonifyFilters(logFilters *LogFilters) (string, error) {
 	jsonStr := string(bytes)
 
 	return jsonStr, nil
-}
-
-func urlForRequestID(payload *EventPayload) string {
-	maybeTest := ""
-	if !payload.Livemode {
-		maybeTest = "/test"
-	}
-
-	return fmt.Sprintf("https://dashboard.stripe.com%s/logs/%s", maybeTest, payload.RequestID)
 }

--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -164,9 +164,11 @@ func (t *Tailer) Run(ctx context.Context) error {
 					Status: Reconnecting,
 				}
 			} else {
+				err := fmt.Errorf("Session expired. Terminating after %d failed attempts to reauthorize", nAttempts)
 				t.cfg.StreamElementCh <- ErrorElement{
-					Error: fmt.Errorf("Session expired. Terminating after %d failed attempts to reauthorize", nAttempts),
+					Error: err,
 				}
+				return err
 			}
 		}
 	}

--- a/pkg/logtailing/tailer_test.go
+++ b/pkg/logtailing/tailer_test.go
@@ -49,11 +49,3 @@ func TestJsonifyFiltersEmpty(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "{}", filtersStr)
 }
-
-func TestURLForRequestID(t *testing.T) {
-	evt := &EventPayload{RequestID: "req_123", Livemode: false}
-	require.Equal(t, "https://dashboard.stripe.com/test/logs/req_123", urlForRequestID(evt))
-
-	evt = &EventPayload{RequestID: "req_123", Livemode: true}
-	require.Equal(t, "https://dashboard.stripe.com/logs/req_123", urlForRequestID(evt))
-}

--- a/pkg/logtailing/visitor.go
+++ b/pkg/logtailing/visitor.go
@@ -39,35 +39,37 @@ type WarningElement struct {
 
 // StreamElement is an element that can be visited. This is visitor pattern boilerplate.
 type StreamElement interface {
-	Visit(v StreamElementVisitor) error
+	Accept(v *StreamElementVisitor) error
 }
 
-// Visit is visitor pattern boilerplate
-func (ee ErrorElement) Visit(v StreamElementVisitor) error {
+// Accept is visitor pattern boilerplate
+func (ee ErrorElement) Accept(v *StreamElementVisitor) error {
+	// This null check prevents segfaults. There isn't a good way to enforce v.VisitLog exists at
+	// compile time.
 	if v.VisitError == nil {
 		return nil
 	}
 	return v.VisitError(ee)
 }
 
-// Visit is visitor pattern boilerplate
-func (le LogElement) Visit(v StreamElementVisitor) error {
+// Accept is visitor pattern boilerplate
+func (le LogElement) Accept(v *StreamElementVisitor) error {
 	if v.VisitLog == nil {
 		return nil
 	}
 	return v.VisitLog(le)
 }
 
-// Visit is visitor pattern boilerplate
-func (we WarningElement) Visit(v StreamElementVisitor) error {
+// Accept is visitor pattern boilerplate
+func (we WarningElement) Accept(v *StreamElementVisitor) error {
 	if v.VisitWarning == nil {
 		return nil
 	}
 	return v.VisitWarning(we)
 }
 
-// Visit is visitor pattern boilerplate
-func (se StatusElement) Visit(v StreamElementVisitor) error {
+// Accept is visitor pattern boilerplate
+func (se StatusElement) Accept(v *StreamElementVisitor) error {
 	if v.VisitStatus == nil {
 		return nil
 	}

--- a/pkg/logtailing/visitor.go
+++ b/pkg/logtailing/visitor.go
@@ -7,11 +7,11 @@ package logtailing
  * - an RPC service, which wants to stream logs to a client
  */
 
-// StreamElementVisitor should implement the handlers for each type of element
-type StreamElementVisitor struct {
+// Visitor should implement the handlers for each type of element
+type Visitor struct {
 	VisitError   func(ErrorElement) error
 	VisitLog     func(LogElement) error
-	VisitStatus  func(StatusElement) error
+	VisitStatus  func(StateElement) error
 	VisitWarning func(WarningElement) error
 }
 
@@ -27,9 +27,9 @@ type LogElement struct {
 	MarshalledLog string
 }
 
-// StatusElement is the current status of the stream: loading, ready, etc.
-type StatusElement struct {
-	Status status
+// StateElement is the current state of the stream: loading, ready, etc.
+type StateElement struct {
+	State state
 }
 
 // WarningElement is a warning from the log tailer
@@ -37,15 +37,15 @@ type WarningElement struct {
 	Warning string
 }
 
-// StreamElement is an element that can be visited. This is visitor pattern boilerplate.
-type StreamElement interface {
-	Accept(v *StreamElementVisitor) error
+// IElement is an element that can be visited. This is visitor pattern boilerplate.
+type IElement interface {
+	Accept(v *Visitor) error
 }
 
 // Accept is visitor pattern boilerplate
-func (ee ErrorElement) Accept(v *StreamElementVisitor) error {
-	// This null check prevents segfaults. There isn't a good way to enforce v.VisitLog exists at
-	// compile time.
+func (ee ErrorElement) Accept(v *Visitor) error {
+	// This null check prevents segfaults. There isn't a good way to enforce the visitor method
+	// exists at compile time.
 	if v.VisitError == nil {
 		return nil
 	}
@@ -53,7 +53,7 @@ func (ee ErrorElement) Accept(v *StreamElementVisitor) error {
 }
 
 // Accept is visitor pattern boilerplate
-func (le LogElement) Accept(v *StreamElementVisitor) error {
+func (le LogElement) Accept(v *Visitor) error {
 	if v.VisitLog == nil {
 		return nil
 	}
@@ -61,7 +61,7 @@ func (le LogElement) Accept(v *StreamElementVisitor) error {
 }
 
 // Accept is visitor pattern boilerplate
-func (we WarningElement) Accept(v *StreamElementVisitor) error {
+func (we WarningElement) Accept(v *Visitor) error {
 	if v.VisitWarning == nil {
 		return nil
 	}
@@ -69,18 +69,18 @@ func (we WarningElement) Accept(v *StreamElementVisitor) error {
 }
 
 // Accept is visitor pattern boilerplate
-func (se StatusElement) Accept(v *StreamElementVisitor) error {
+func (se StateElement) Accept(v *Visitor) error {
 	if v.VisitStatus == nil {
 		return nil
 	}
 	return v.VisitStatus(se)
 }
 
-type status int
+type state int
 
 const (
 	// Loading means the stream is being set up
-	Loading status = iota
+	Loading state = iota
 
 	// Reconnecting means the stream is reconnecting
 	Reconnecting

--- a/pkg/logtailing/visitor.go
+++ b/pkg/logtailing/visitor.go
@@ -1,0 +1,91 @@
+package logtailing
+
+/**
+ * This file contains types for processing streamed logs outside of this package. This is useful for
+ * packages that want to define their own handler, such as
+ * - a Cobra command, which wants to pretty-print logs to the terminal
+ * - an RPC service, which wants to stream logs to a client
+ */
+
+// StreamElementVisitor should implement the handlers for each type of element
+type StreamElementVisitor struct {
+	VisitError   func(ErrorElement) error
+	VisitLog     func(LogElement) error
+	VisitStatus  func(StatusElement) error
+	VisitWarning func(WarningElement) error
+}
+
+// ErrorElement is an error from the log tailer
+type ErrorElement struct {
+	Error error
+}
+
+// LogElement is the log received on the stream
+type LogElement struct {
+	Log EventPayload
+
+	MarshalledLog string
+}
+
+// StatusElement is the current status of the stream: loading, ready, etc.
+type StatusElement struct {
+	Status status
+}
+
+// WarningElement is a worning from the log tailer
+type WarningElement struct {
+	Warning string
+}
+
+// StreamElement is an element that can be visited. This is visitor pattern boilerplate.
+type StreamElement interface {
+	Visit(v StreamElementVisitor) error
+}
+
+// Visit is visitor pattern boilerplate
+func (ee ErrorElement) Visit(v StreamElementVisitor) error {
+	if v.VisitError == nil {
+		return nil
+	}
+	return v.VisitError(ee)
+}
+
+// Visit is visitor pattern boilerplate
+func (le LogElement) Visit(v StreamElementVisitor) error {
+	if v.VisitLog == nil {
+		return nil
+	}
+	return v.VisitLog(le)
+}
+
+// Visit is visitor pattern boilerplate
+func (we WarningElement) Visit(v StreamElementVisitor) error {
+	if v.VisitWarning == nil {
+		return nil
+	}
+	return v.VisitWarning(we)
+}
+
+// Visit is visitor pattern boilerplate
+func (se StatusElement) Visit(v StreamElementVisitor) error {
+	if v.VisitStatus == nil {
+		return nil
+	}
+	return v.VisitStatus(se)
+}
+
+type status int
+
+const (
+	// Loading means the stream is being set up
+	Loading status = iota
+
+	// Reconnecting means the stream is reconnecting
+	Reconnecting
+
+	// Ready means we are ready to receive logs
+	Ready
+
+	// Done means log streaming is done
+	Done
+)

--- a/pkg/logtailing/visitor.go
+++ b/pkg/logtailing/visitor.go
@@ -32,7 +32,7 @@ type StatusElement struct {
 	Status status
 }
 
-// WarningElement is a worning from the log tailer
+// WarningElement is a warning from the log tailer
 type WarningElement struct {
 	Warning string
 }


### PR DESCRIPTION
 ### Reviewers
r? @pepin-stripe
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

This decouples user IO and the receiving of logs.
- The `Tailer` is concerned with sending data on a channel. The data is either a log, an error, a warning, or a connection state.
- The cobra command, as a client of the `Tailer`, receives these different data types and processes them using a visitor object.

This pattern enables `Tailer` to be used by any class that wants to do something with logs, for example a gRPC service that wants to stream logs, errors, and connection state to a gRPC client. All the class has to do is read from the channel and provide its own visitor object.

This pattern might also work well for https://github.com/stripe/stripe-cli/pull/574. This is quite boilerplate heavy, so I am open to other solutions as well.