### PR TITLE
Updating the help docs for the header params in the listen command.

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -58,10 +58,10 @@ Stripe account.`,
 		RunE: lc.runListenCmd,
 	}
 
-	lc.cmd.Flags().StringSliceVar(&lc.forwardConnectHeaders, "connect-headers", []string{}, "A comma-separated list of custom headers to forward for Connect")
+	lc.cmd.Flags().StringSliceVar(&lc.forwardConnectHeaders, "connect-headers", []string{}, "A comma-separated list of custom headers to forward for Connect. Ex: \"Key1:Value1, Key2:Value2\"")
 	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{"*"}, "A comma-separated list of specific events to listen for. For a list of all possible events, see: https://stripe.com/docs/api/events/types")
 	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward webhook events to")
-	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward")
+	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward. Ex: \"Key1:Value1, Key2:Value2\"")
 	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect webhook events to (default: same as normal events)")
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
 	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test)")


### PR DESCRIPTION
 ### Reviewers
cc @stripe/developer-products
r? @stripe/developer-products 

 ### Summary
A user opened an issue recently because they were getting an index out of bounds error when trying to use the headers param.
They were using the wrong delimiter for separating the Key and Value of the header, updating the docs to make that more clear for the users.

https://github.com/stripe/stripe-cli/issues/662

### Testing

Before:
![Screen Shot 2021-05-10 at 4 04 45 PM](https://user-images.githubusercontent.com/75757829/117734977-71193980-b1a9-11eb-9098-f5d6d05b73fc.png)

After:
![Screen Shot 2021-05-10 at 4 04 24 PM](https://user-images.githubusercontent.com/75757829/117734955-65c60e00-b1a9-11eb-8908-d9c350ab960f.png)
