### PR TITLE
patch quickstart to use new base_url attr for reader hostname

### DIFF
--- a/pkg/terminal/p400/rabbit_service.go
+++ b/pkg/terminal/p400/rabbit_service.go
@@ -64,7 +64,7 @@ func CallRabbitService(tsCtx TerminalSessionContext, method string, methodConten
 	formattedIP := strings.Join(strings.Split(tsCtx.IPAddress, "."), "-")
 	t := &Transport{}
 
-	rabbitServiceURL := fmt.Sprintf(readerURL, formattedIP, tsCtx.BaseUrl)
+	rabbitServiceURL := fmt.Sprintf(readerURL, formattedIP, tsCtx.BaseURL)
 	req, err := http.NewRequest("POST", rabbitServiceURL, &payload)
 
 	if err != nil {

--- a/pkg/terminal/p400/rabbit_service.go
+++ b/pkg/terminal/p400/rabbit_service.go
@@ -64,7 +64,7 @@ func CallRabbitService(tsCtx TerminalSessionContext, method string, methodConten
 	formattedIP := strings.Join(strings.Split(tsCtx.IPAddress, "."), "-")
 	t := &Transport{}
 
-	rabbitServiceURL := fmt.Sprintf(readerURL, formattedIP)
+	rabbitServiceURL := fmt.Sprintf(readerURL, formattedIP, tsCtx.BaseUrl)
 	req, err := http.NewRequest("POST", rabbitServiceURL, &payload)
 
 	if err != nil {

--- a/pkg/terminal/p400/reader_constants.go
+++ b/pkg/terminal/p400/reader_constants.go
@@ -1,8 +1,8 @@
 package p400
 
 var (
-	readerURL                          = "https://%v.device.stripe-terminal-local-reader.net:4443/protojsonservice/JackRabbitService"
-	stripeTerminalReadersPath          = "/v1/terminal/readers?device_type=verifone_P400"
+	readerURL                          = "https://%v.%v:4443/protojsonservice/JackRabbitService"
+	stripeTerminalReadersPath          = "/v1/terminal/readers?device_type=verifone_P400&limit=100&compatible_sdk_type=js&compatible_sdk_version=1.3.2"
 	rpcSessionPath                     = "/v1/terminal/connection_tokens/generate_pos_rpc_session"
 	stripeTerminalConnectionTokensPath = "/v1/terminal/connection_tokens"
 	stripeTerminalRegisterPath         = "/v1/terminal/readers"

--- a/pkg/terminal/p400/reader_methods.go
+++ b/pkg/terminal/p400/reader_methods.go
@@ -15,6 +15,7 @@ import (
 type TerminalSessionContext struct {
 	APIKey             string
 	IPAddress          string
+	BaseUrl            string
 	LocationID         string
 	PstToken           string
 	SessionToken       string

--- a/pkg/terminal/p400/reader_methods.go
+++ b/pkg/terminal/p400/reader_methods.go
@@ -15,7 +15,7 @@ import (
 type TerminalSessionContext struct {
 	APIKey             string
 	IPAddress          string
-	BaseUrl            string
+	BaseURL            string
 	LocationID         string
 	PstToken           string
 	SessionToken       string

--- a/pkg/terminal/p400/reader_registration.go
+++ b/pkg/terminal/p400/reader_registration.go
@@ -23,31 +23,42 @@ const (
 // AttemptRegisterReader prompt the user for their p400 registration code, and tries to register the reader via Stripe API
 // it tries three times before returning an error
 // returns the registered reader's IP address if successful
-func AttemptRegisterReader(tsCtx TerminalSessionContext, tries int) (string, error) {
+func AttemptRegisterReader(tsCtx TerminalSessionContext, tries int) (Reader, error) {
 	regcode, err := ReaderRegistrationCodePrompt()
+	var newReader Reader
 
 	if err != nil {
-		return "", err
+		return newReader, err
 	}
 
 	spinner := ansi.StartNewSpinner("Registering your reader with Stripe...", os.Stdout)
 
-	IPAddress, err := RegisterReader(regcode, tsCtx)
-
-	ansi.StopSpinner(spinner, "", os.Stdout)
+	newReader, err = RegisterReader(regcode, tsCtx)
 
 	if err != nil {
 		tries++
+		ansi.StopSpinner(spinner, "", os.Stdout)
 		fmt.Println("Could not register the Reader - please try your code again.")
 
 		if tries < 3 {
 			return AttemptRegisterReader(tsCtx, tries)
 		}
 
-		return "", ErrRegisterReaderFailed
+		return newReader, ErrRegisterReaderFailed
 	}
 
-	return IPAddress, nil
+	// we need to get the reader list again in order to source the base_url attr which you don't get back after registering it
+	readerList, err := DiscoverReaders(tsCtx)
+	for _, reader := range readerList {
+		if reader.Label == regcode {
+			newReader = reader
+			break
+		}
+	}
+
+	ansi.StopSpinner(spinner, "", os.Stdout)
+
+	return newReader, nil
 }
 
 // RegisterAndActivateReader prompts the user to either add a new reader or choose an existing reader on their account
@@ -55,9 +66,19 @@ func AttemptRegisterReader(tsCtx TerminalSessionContext, tries int) (string, err
 // it returns an updated TerminalSessionContext containing the session's connection token and rpc session token
 func RegisterAndActivateReader(tsCtx TerminalSessionContext) (TerminalSessionContext, error) {
 	var (
-		IPAddress      string
+		reader         Reader
 		activationType string
 	)
+
+	spinner := ansi.StartNewSpinner("Requesting connection token...", os.Stdout)
+	pstToken, err := GetNewConnectionToken(tsCtx)
+
+	if err != nil {
+		return tsCtx, err
+	}
+
+	tsCtx.PstToken = pstToken
+	ansi.StopSpinner(spinner, ansi.Faint("Received new connection token"), os.Stdout)
 
 	// check if user has a reader already registered that they might want to use
 	readerList, err := DiscoverReaders(tsCtx)
@@ -76,13 +97,13 @@ func RegisterAndActivateReader(tsCtx TerminalSessionContext) (TerminalSessionCon
 	}
 
 	if activationType == ActivationTypeLabels[RegisteredReaderChoice] {
-		IPAddress, err = RegisteredReaderChoicePrompt(readerList, tsCtx)
+		reader, err = RegisteredReaderChoicePrompt(readerList, tsCtx)
 
 		if err != nil {
 			return tsCtx, err
 		}
 	} else {
-		IPAddress, err = AttemptRegisterReader(tsCtx, 0)
+		reader, err = AttemptRegisterReader(tsCtx, 0)
 
 		if err != nil {
 			return tsCtx, err
@@ -91,16 +112,8 @@ func RegisterAndActivateReader(tsCtx TerminalSessionContext) (TerminalSessionCon
 		fmt.Printf("> %s", ansi.Faint("Finished registering reader\n"))
 	}
 
-	tsCtx.IPAddress = IPAddress
-
-	spinner := ansi.StartNewSpinner("Requesting connection token...", os.Stdout)
-	tsCtx.PstToken, err = GetNewConnectionToken(tsCtx)
-
-	if err != nil {
-		return tsCtx, err
-	}
-
-	ansi.StopSpinner(spinner, ansi.Faint("Received new connection token"), os.Stdout)
+	tsCtx.IPAddress = reader.IPAddress
+	tsCtx.BaseUrl = reader.BaseUrl
 
 	spinner = ansi.StartNewSpinner("Connecting to Reader...", os.Stdout)
 	tsCtx.TransactionContext = SetTransactionContext(tsCtx)

--- a/pkg/terminal/p400/reader_registration.go
+++ b/pkg/terminal/p400/reader_registration.go
@@ -49,6 +49,11 @@ func AttemptRegisterReader(tsCtx TerminalSessionContext, tries int) (Reader, err
 
 	// we need to get the reader list again in order to source the base_url attr which you don't get back after registering it
 	readerList, err := DiscoverReaders(tsCtx)
+
+	if err != nil {
+		return newReader, err
+	}
+
 	for _, reader := range readerList {
 		if reader.Label == regcode {
 			newReader = reader
@@ -113,7 +118,7 @@ func RegisterAndActivateReader(tsCtx TerminalSessionContext) (TerminalSessionCon
 	}
 
 	tsCtx.IPAddress = reader.IPAddress
-	tsCtx.BaseUrl = reader.BaseUrl
+	tsCtx.BaseURL = reader.BaseURL
 
 	spinner = ansi.StartNewSpinner("Connecting to Reader...", os.Stdout)
 	tsCtx.TransactionContext = SetTransactionContext(tsCtx)

--- a/pkg/terminal/p400/stripe_requests.go
+++ b/pkg/terminal/p400/stripe_requests.go
@@ -29,7 +29,7 @@ type Reader struct {
 	SerialNumber    string   `json:"serial_number"`
 	Status          string   `json:"status"`
 	Metadata        Metadata `json:"metadata"`
-	BaseUrl         string   `json:"base_url"`
+	BaseURL         string   `json:"base_url"`
 }
 
 type readersResponse struct {

--- a/pkg/terminal/p400/stripe_requests.go
+++ b/pkg/terminal/p400/stripe_requests.go
@@ -29,6 +29,7 @@ type Reader struct {
 	SerialNumber    string   `json:"serial_number"`
 	Status          string   `json:"status"`
 	Metadata        Metadata `json:"metadata"`
+	BaseUrl         string   `json:"base_url"`
 }
 
 type readersResponse struct {
@@ -51,10 +52,6 @@ type getConnectionTokenResponse struct {
 	Secret string `json:"secret"`
 }
 
-type registerReaderResponse struct {
-	IPAddress string `json:"ip_address"`
-}
-
 // DiscoverReaders calls the Stripe API to get a list of currently registered P400 readers on the account
 // it returns a map of Reader types
 func DiscoverReaders(tsCtx TerminalSessionContext) ([]Reader, error) {
@@ -72,7 +69,7 @@ func DiscoverReaders(tsCtx TerminalSessionContext) ([]Reader, error) {
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
-		APIKey:  tsCtx.APIKey,
+		APIKey:  tsCtx.PstToken,
 		Verbose: false,
 	}
 
@@ -292,11 +289,12 @@ func CapturePaymentIntent(tsCtx TerminalSessionContext) error {
 
 // RegisterReader calls the Stripe API to register a new P400 reader to an account
 // it returns the IP address of the reader if successful
-func RegisterReader(regcode string, tsCtx TerminalSessionContext) (string, error) {
+func RegisterReader(regcode string, tsCtx TerminalSessionContext) (Reader, error) {
 	parsedBaseURL, err := url.Parse(stripe.DefaultAPIBaseURL)
+	var result Reader
 
 	if err != nil {
-		return "", err
+		return result, err
 	}
 
 	client := &stripe.Client{
@@ -311,7 +309,7 @@ func RegisterReader(regcode string, tsCtx TerminalSessionContext) (string, error
 	res, err := client.PerformRequest(context.TODO(), http.MethodPost, stripeTerminalRegisterPath, data.Encode(), nil)
 
 	if err != nil {
-		return "", err
+		return result, err
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -323,15 +321,11 @@ func RegisterReader(regcode string, tsCtx TerminalSessionContext) (string, error
 			err = ErrStripeGenericResponse
 		}
 
-		return "", err
+		return result, err
 	}
-
-	var result registerReaderResponse
 
 	defer res.Body.Close()
 	json.NewDecoder(res.Body).Decode(&result)
 
-	IPAddress := result.IPAddress
-
-	return IPAddress, nil
+	return result, nil
 }

--- a/pkg/terminal/p400/user_prompts.go
+++ b/pkg/terminal/p400/user_prompts.go
@@ -78,7 +78,9 @@ func ReaderNewOrExistingPrompt() (string, error) {
 
 // RegisteredReaderChoicePrompt takes a list of registered p400 readers and prompts the reader to choose one to use
 // it returns the IP address of the chosen reader
-func RegisteredReaderChoicePrompt(readerList []Reader, tsCtx TerminalSessionContext) (string, error) {
+func RegisteredReaderChoicePrompt(readerList []Reader, tsCtx TerminalSessionContext) (Reader, error) {
+	var reader Reader
+
 	templates := &promptui.SelectTemplates{
 		Label:    "{{ .Label }} ({{ .Status }}) ",
 		Active:   "▸ {{ .Label | underline }} ({{ .Status }})",
@@ -89,12 +91,12 @@ func RegisteredReaderChoicePrompt(readerList []Reader, tsCtx TerminalSessionCont
 	index, _, err := selectOptions(templates, "Select a reader:", readerList)
 
 	if err != nil {
-		return "", err
+		return reader, err
 	}
 
-	IPAddress := readerList[index].IPAddress
+	reader = readerList[index]
 
-	return IPAddress, nil
+	return reader, nil
 }
 
 func textPrompt(label string, validator promptui.ValidateFunc) (string, error) {


### PR DESCRIPTION
 ### Reviewers
r? @pepin-stripe 
cc @stripe/developer-products

 ### Summary
The P400 readers have gone through certificate updates for the [new PQDN format](https://stripe.com/docs/terminal/readers/verifone-p400#reader-has-ip-address-and-can-communicate-with-stripe,-but-not-with-your-point-of-sale-application), which adds a random string to the hostname in order to make them fully unique. This was done because using private IPs alone create much higher chances of collisions. The reader firmware now rejects ingress requests the from old hostname format due to the resulting certificate mismatch.

Quickstart was still using the old hostname format and so the feature was broken. I updated it to extract the `base_url` to use in combination with the private IP. 

I manually tested all three flows:
1. Registering new reader, with no existing readers on account
2. Registering new reader, with existing readers on account
3. Choosing an existing registered reader from list

This change was a bit fiddly and required me to move some stuff around / refactor the registration flow, so HMU if you have any questions around this 🙇 

