### PR TITLE
Return Unauthenticated error if user isn't logged in for commands tha…

### DIFF
--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -61,9 +61,14 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	apiKey, err := Config.Profile.GetAPIKey(false)
+	if err != nil {
+		return err
+	}
+
 	event := args[0]
 
-	_, err := fixtures.Trigger(event, tc.stripeAccount, tc.apiBaseURL, &Config)
+	_, err = fixtures.Trigger(event, tc.stripeAccount, tc.apiBaseURL, apiKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -6,8 +6,6 @@ import (
 	"sort"
 
 	"github.com/spf13/afero"
-
-	"github.com/stripe/stripe-cli/pkg/config"
 )
 
 //go:embed triggers/*
@@ -103,14 +101,11 @@ func EventNames() []string {
 }
 
 // Trigger triggers a Stripe event.
-func Trigger(event string, stripeAccount string, baseURL string, config *config.Config) ([]string, error) {
+func Trigger(event string, stripeAccount string, baseURL string, apiKey string) ([]string, error) {
 	fs := afero.NewOsFs()
-	apiKey, err := config.Profile.GetAPIKey(false)
-	if err != nil {
-		return nil, err
-	}
 
 	var fixture *Fixture
+	var err error
 
 	if file, ok := Events[event]; ok {
 		fixture, err = BuildFromFixture(fs, apiKey, stripeAccount, baseURL, file)

--- a/pkg/rpcservice/events_resend.go
+++ b/pkg/rpcservice/events_resend.go
@@ -21,7 +21,7 @@ import (
 func (srv *RPCService) EventsResend(ctx context.Context, req *rpc.EventsResendRequest) (*rpc.EventsResendResponse, error) {
 	apiKey, err := srv.cfg.UserCfg.Profile.GetAPIKey(req.Live)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
 	if req.EventId == "" {

--- a/pkg/rpcservice/listen.go
+++ b/pkg/rpcservice/listen.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/stripe/stripe-cli/pkg/proxy"
@@ -34,12 +36,12 @@ var createProxy = func(cfg *proxy.Config) (IProxy, error) {
 func (srv *RPCService) Listen(req *rpc.ListenRequest, stream rpc.StripeCLI_ListenServer) error {
 	deviceName, err := srv.cfg.UserCfg.Profile.GetDeviceName()
 	if err != nil {
-		return err
+		return status.Error(codes.Unauthenticated, err.Error())
 	}
 
 	key, err := srv.cfg.UserCfg.Profile.GetAPIKey(req.Live)
 	if err != nil {
-		return err
+		return status.Error(codes.Unauthenticated, err.Error())
 	}
 
 	logger := log.StandardLogger()

--- a/pkg/rpcservice/logs_tail.go
+++ b/pkg/rpcservice/logs_tail.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/stripe/stripe-cli/pkg/logtailing"
 	"github.com/stripe/stripe-cli/pkg/websocket"
@@ -24,12 +26,12 @@ var createTailer = func(cfg *logtailing.Config) ITailer {
 func (srv *RPCService) LogsTail(req *rpc.LogsTailRequest, stream rpc.StripeCLI_LogsTailServer) error {
 	deviceName, err := srv.cfg.UserCfg.Profile.GetDeviceName()
 	if err != nil {
-		return err
+		return status.Error(codes.Unauthenticated, err.Error())
 	}
 
 	key, err := srv.cfg.UserCfg.Profile.GetAPIKey(false)
 	if err != nil {
-		return err
+		return status.Error(codes.Unauthenticated, err.Error())
 	}
 
 	filters := getFiltersFromReq(req)

--- a/pkg/rpcservice/trigger.go
+++ b/pkg/rpcservice/trigger.go
@@ -6,13 +6,21 @@ import (
 	"github.com/stripe/stripe-cli/pkg/fixtures"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/rpc"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var baseURL = stripe.DefaultAPIBaseURL
 
 // Trigger triggers a Stripe event.
 func (srv *RPCService) Trigger(ctx context.Context, req *rpc.TriggerRequest) (*rpc.TriggerResponse, error) {
-	requestNames, err := fixtures.Trigger(req.Event, req.StripeAccount, baseURL, srv.cfg.UserCfg)
+	apiKey, err := srv.cfg.UserCfg.Profile.GetAPIKey(false)
+	if err != nil {
+		return nil, status.Error(codes.Unauthenticated, err.Error())
+	}
+
+	requestNames, err := fixtures.Trigger(req.Event, req.StripeAccount, baseURL, apiKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
…t require it

 ### Reviewers
r? @pepin-stripe 
cc @stripe/developer-products
 
 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Right now, there are methods that require logging in before they can run: `EventsResend`, `Listen`, `LogsTail`, or `Trigger`. If a gRPC client invokes these commands before logging in, they will receive the default gRPC error code: `UNKNOWN`.

In this PR, we make the methods return the gRPC error code `UNAUTHENTICATED` instead. This allows gRPC clients to easily handle unauthentication. For example, if the Stripe vscode extension is the client and sees this error code, it could prompt the user log in again.

I had to "unrefactor" trigger.go a little to get this to work.

Tested this manually for all four methods.

This should be the last of the big gRPC changes! Everything after will either be maintenance (docs, CI, logging etc.) or unforeseen bug fixes.
