### PR TITLE
Add debug logs for gRPC method invocation

### DIFF
--- a/pkg/rpcservice/middleware.go
+++ b/pkg/rpcservice/middleware.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -34,6 +36,9 @@ func serverStreamInterceptor(
 	info *grpc.StreamServerInfo,
 	handler grpc.StreamHandler,
 ) error {
+	log.WithFields(log.Fields{
+		"prefix": "gRPC",
+	}).Debugf("Streaming method invoked: %v", info.FullMethod)
 	if err := authorize(stream.Context()); err != nil {
 		return err
 	}
@@ -47,6 +52,9 @@ func serverUnaryInterceptor(
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (interface{}, error) {
+	log.WithFields(log.Fields{
+		"prefix": "gRPC",
+	}).Debugf("Unary method invoked: %v, req: %v", info.FullMethod, req)
 	if err := authorize(ctx); err != nil {
 		return nil, err
 	}

--- a/pkg/rpcservice/rpc_service.go
+++ b/pkg/rpcservice/rpc_service.go
@@ -116,6 +116,6 @@ func (srv *RPCService) printConfig(configOutput ConfigOutput) {
 	if configOutputMarshalled, err := json.Marshal(configOutput); err != nil {
 		srv.cfg.Log.Fatalf("Failed to write server config to stderr: %v", err)
 	} else {
-		fmt.Fprintln(os.Stderr, string(configOutputMarshalled))
+		fmt.Println(string(configOutputMarshalled))
 	}
 }


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
For debugging purposes, write debug logs when gRPC methods are invoked. Move the gRPC config output (in the screenshot, this is the host and port number on the first line) from stderr to stdout. For convenience, stderr will be reserved for logs only.

<img width="1260" alt="Screen Shot 2021-05-20 at 5 15 06 PM" src="https://user-images.githubusercontent.com/71457708/119063895-ff05d900-b98e-11eb-974b-11c69124698e.png">

