### PR TITLE
Change references in a test that refers to a Stripe Sample that will be archived soon

### DIFF
--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -37,7 +37,7 @@ func NewCreateCmd(config *config.Config) *CreateCmd {
 		Long: `The create command will locally clone a sample, let you select which integration,
 client, and server you want to run. It then automatically bootstraps the
 local configuration to let you get started faster.`,
-		Example: `stripe samples create adding-sales-tax
+		Example: `stripe samples create accept-a-payment
   stripe samples create react-elements-card-payment my-payments-form`,
 		RunE: createCmd.runCreateCmd,
 	}

--- a/pkg/samples/samples_test.go
+++ b/pkg/samples/samples_test.go
@@ -53,7 +53,7 @@ func makeRecipe(fs afero.Fs, path string, integrations []string, languages []str
 
 func TestInitialize(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	name := "adding-sales-tax"
+	name := "accept-a-payment"
 
 	sample := Samples{
 		Fs: fs,
@@ -61,10 +61,10 @@ func TestInitialize(t *testing.T) {
 			fs: fs,
 		},
 		SamplesList: map[string]*SampleData{
-			"adding-sales-tax": {
-				Name:        "adding-sales-tax",
-				Description: "Learn how to use PaymentIntents to build a simple checkout flow",
-				URL:         "https://github.com/stripe-samples/adding-sales-tax",
+			"accept-a-payment": {
+				Name:        "accept-a-payment",
+				Description: "Learn how to accept a payment",
+				URL:         "https://github.com/stripe-samples/accept-a-payment",
 			},
 		},
 	}
@@ -85,10 +85,10 @@ func TestInitializeFailsWithEmptyName(t *testing.T) {
 			fs: fs,
 		},
 		SamplesList: map[string]*SampleData{
-			"adding-sales-tax": {
-				Name:        "adding-sales-tax",
-				Description: "Learn how to use PaymentIntents to build a simple checkout flow",
-				URL:         "https://github.com/stripe-samples/adding-sales-tax",
+			"accept-a-payment": {
+				Name:        "accept-a-payment",
+				Description: "Learn how to accept a payment",
+				URL:         "https://github.com/stripe-samples/accept-a-payment",
 			},
 		},
 	}
@@ -107,10 +107,10 @@ func TestInitializeFailsWithNonexistentSample(t *testing.T) {
 			fs: fs,
 		},
 		SamplesList: map[string]*SampleData{
-			"adding-sales-tax": {
-				Name:        "adding-sales-tax",
-				Description: "Learn how to use PaymentIntents to build a simple checkout flow",
-				URL:         "https://github.com/stripe-samples/adding-sales-tax",
+			"accept-a-payment": {
+				Name:        "accept-a-payment",
+				Description: "Learn how to accept a payment",
+				URL:         "https://github.com/stripe-samples/accept-a-payment",
 			},
 		},
 	}


### PR DESCRIPTION
### Reviewers
r? @stripe/developer-products
cc @stripe/developer-products

 ### Summary
This commit changes references in the samples_test.go from https://github.com/stripe-samples/adding-sales-tax to  https://github.com/stripe-samples/accept-a-payment  as the prior repo will be archived soon.

