### PR TITLE
Add community command

### DIFF
--- a/pkg/cmd/community.go
+++ b/pkg/cmd/community.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/stripe/stripe-cli/pkg/open"
 )
 

--- a/pkg/cmd/community.go
+++ b/pkg/cmd/community.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/stripe/stripe-cli/pkg/open"
+)
+
+const communityURL = "https://stripe.com/go/developer-chat"
+
+var openBrowser = open.Browser
+var canOpenBrowser = open.CanOpenBrowser
+
+type communityCmd struct {
+	cmd *cobra.Command
+}
+
+func newCommunityCmd() *communityCmd {
+	cc := &communityCmd{}
+
+	cc.cmd = &cobra.Command{
+		Use:     "community",
+		Short:   "Chat with Stripe engineers and other developers",
+		Long:    "Chat with Stripe engineers and other developers in the official Stripe Developer Community Discord server",
+		Example: "stripe community",
+		RunE:    cc.runCommunityCmd,
+	}
+
+	return cc
+}
+
+func (cc *communityCmd) runCommunityCmd(cmd *cobra.Command, args []string) error {
+	if !canOpenBrowser() {
+		fmt.Printf("Chat with other developers and Stripe engineers in the official Stripe Discord server: %s\n", communityURL)
+		return nil
+	}
+
+	fmt.Printf("Chat with other developers and Stripe engineers in the official Stripe Discord server.\n\nPress Enter to open the browser or visit %s", communityURL)
+
+	input := os.Stdin
+	fmt.Fscanln(input)
+
+	err := openBrowser(communityURL)
+	if err != nil {
+		fmt.Printf("Failed to open browser, please go to %s manually.", communityURL)
+	}
+
+	return nil
+}

--- a/pkg/cmd/community.go
+++ b/pkg/cmd/community.go
@@ -23,8 +23,8 @@ func newCommunityCmd() *communityCmd {
 
 	cc.cmd = &cobra.Command{
 		Use:     "community",
+		Aliases: []string{"discord", "chat"},
 		Short:   "Chat with Stripe engineers and other developers",
-		Long:    "Chat with Stripe engineers and other developers in the official Stripe Developer Community Discord server",
 		Example: "stripe community",
 		RunE:    cc.runCommunityCmd,
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -138,6 +138,7 @@ func init() {
 	rootCmd.AddCommand(newVersionCmd().cmd)
 	rootCmd.AddCommand(newPlaybackCmd().cmd)
 	rootCmd.AddCommand(newPostinstallCmd(&Config).cmd)
+	rootCmd.AddCommand(newCommunityCmd().cmd)
 
 	addAllResourcesCmds(rootCmd)
 


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Adds a new `community` command which directs users to the Stripe Developer Community Discord server.

![Screenshot 2021-07-01 at 3 39 15 PM](https://user-images.githubusercontent.com/46610432/124085343-86606500-da82-11eb-9593-404e3617399c.png)

