### PR TITLE
Show URL when you `stripe login`

### DIFF
--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -57,7 +57,7 @@ func Login(baseURL string, config *config.Config, input io.Reader) error {
 
 		s = ansi.StartNewSpinner("Waiting for confirmation...", os.Stdout)
 	} else {
-		fmt.Printf("Press Enter to open the browser (^C to quit)")
+		fmt.Printf("Press Enter to open the browser or visit %s (^C to quit)", links.BrowserURL)
 		fmt.Fscanln(input)
 
 		s = ansi.StartNewSpinner("Waiting for confirmation...", os.Stdout)


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Today, you would have to open the default browser whether you want to or not. This prints the URL so you can copy and paste it somewhere else.

Before:
![Screen Shot 2021-07-15 at 3 41 11 PM](https://user-images.githubusercontent.com/71457708/125867066-abab09ca-697a-4bff-bee2-1296bbd0fa6f.png)

After:
![Screen Shot 2021-07-15 at 3 44 22 PM](https://user-images.githubusercontent.com/71457708/125867147-c411632a-954e-4626-9ec5-53bda11c5214.png)
