### PR TITLE
Send close frame when terminating websocket connection

### DIFF
--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -519,7 +519,7 @@ const (
 
 	defaultReconnectInterval = 60 * time.Second
 
-	defaultCloseDelayPeriod = 10 * time.Second
+	defaultCloseDelayPeriod = 1 * time.Second
 
 	defaultWriteWait = 1 * time.Second
 )

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -167,7 +167,7 @@ func (c *Client) Run(ctx context.Context) {
 			}).Debug("Resetting the connection")
 			close(c.stopReadPump)
 			close(c.stopWritePump)
-			c.SendCloseFrame(ws.CloseServiceRestart, "Resetting the connection")
+			c.SendCloseFrame(ws.CloseNormalClosure, "Resetting the connection")
 			c.wg.Wait()
 		}
 	}

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -521,7 +521,7 @@ const (
 
 	defaultCloseDelayPeriod = 10 * time.Second
 
-	defaultWriteWait = 10 * time.Second
+	defaultWriteWait = 1 * time.Second
 )
 
 //

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -171,6 +171,8 @@ func (c *Client) Run(ctx context.Context) {
 // Close executes a proper closure handshake then closes the connection
 // list of close codes: https://datatracker.ietf.org/doc/html/rfc6455#section-7.4
 func (c *Client) Close(closeCode int, text string) {
+	close(c.stopReadPump)
+	close(c.stopWritePump)
 	if c.conn != nil {
 		message := ws.FormatCloseMessage(closeCode, text)
 
@@ -184,8 +186,6 @@ func (c *Client) Close(closeCode int, text string) {
 		time.Sleep(c.cfg.CloseDelayPeriod)
 		c.conn.Close()
 	}
-	close(c.stopReadPump)
-	close(c.stopWritePump)
 }
 
 // Stop stops listening for incoming webhook events.


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe 
cc @stripe/developer-products

 ### Summary
This change adds a new function that sends a proper close frame during the websocket connection termination. 
The codes are from https://datatracker.ietf.org/doc/html/rfc6455#section-7.4. 

### Testing
I added a log on the server that outputs the code and reason received on the server side. If you have other suggestions for testing let me know and I will run through those as well. 

Without this change we seem to have been getting a code anyway: 
```
DX_RUN-377: beginning close: reason="" code=1000
DX_RUN-220: beginning finalize_close of websocket: merchant_token=acct_28DT589O8KAxCGbLmxyZ websocket_id="cliws_{22078}_OKpaGryJBTOluaZzRd83q2euKIxYzJWJRTFksySl9zClrJbxuz" websocket_state=2
REDIS-EVENT-LOOP: Going to exit since we have no active conns: hash_slot=10000
```

With this change: 
```
DX_RUN-377: beginning close: reason="Connection Done" code=1000
DX_RUN-220: beginning finalize_close of websocket: merchant_token=acct_28DT589O8KAxCGbLmxyZ websocket_id="cliws_{5879}_QXr9LtFVuuxstuSnKvtrDCeOCeSFnBM2ckSnWU4nszo3lvcitG" websocket_state=2

```