### PR TITLE
[718] Prevent truncation of env var queries

### DIFF
--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -44,7 +44,7 @@ type fixture struct {
 }
 
 type fixtureQuery struct {
-	Match        string
+	Match        string // The substring that matched the query pattern regex
 	Name         string
 	Query        string
 	DefaultValue string
@@ -401,7 +401,8 @@ func (fxt *Fixture) parseQuery(queryString string) (string, error) {
 				return value, nil
 			}
 
-			fmt.Printf("value:  %s\n", value)
+			// Handle the case where only a substring of the original queryString was a query.
+			// Ex: ${.env:BLAH}/blah/blah
 			value = strings.ReplaceAll(queryString, query.Match, envValue)
 			return value, nil
 		}

--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -44,6 +44,7 @@ type fixture struct {
 }
 
 type fixtureQuery struct {
+	Match        string
 	Name         string
 	Query        string
 	DefaultValue string
@@ -381,8 +382,10 @@ func findSimilarQueryNames(fxt *Fixture, name string) ([]string, bool) {
 	return keys, len(keys) > 0
 }
 
-func (fxt *Fixture) parseQuery(value string) (string, error) {
-	if query, isQuery := toFixtureQuery(value); isQuery {
+func (fxt *Fixture) parseQuery(queryString string) (string, error) {
+	value := queryString
+
+	if query, isQuery := toFixtureQuery(queryString); isQuery {
 		name := query.Name
 
 		// Check if there is a default value specified
@@ -392,26 +395,15 @@ func (fxt *Fixture) parseQuery(value string) (string, error) {
 
 		// Catch and insert .env values
 		if name == ".env" {
-			key := query.Query
 			// Check if env variable is present
-			envValue := os.Getenv(key)
-			if envValue == "" {
-				// Try to load from .env file
-				dir, err := os.Getwd()
-				if err != nil {
-					dir = ""
-				}
-				err = godotenv.Load(path.Join(dir, ".env"))
-				if err != nil {
-					return value, nil
-				}
-				envValue = os.Getenv(key)
-			}
-			if envValue == "" {
-				fmt.Printf("No value for env var: %s\n", key)
+			envValue, err := getEnvVar(query)
+			if err != nil || envValue == "" {
 				return value, nil
 			}
-			return envValue, nil
+
+			fmt.Printf("value:  %s\n", value)
+			value = strings.ReplaceAll(queryString, query.Match, envValue)
+			return value, nil
 		}
 
 		if _, ok := fxt.responses[name]; ok {
@@ -452,6 +444,30 @@ func (fxt *Fixture) parseQuery(value string) (string, error) {
 	}
 
 	return value, nil
+}
+
+func getEnvVar(query fixtureQuery) (string, error) {
+	key := query.Query
+	// Check if env variable is present
+	envValue := os.Getenv(key)
+	if envValue == "" {
+		// Try to load from .env file
+		dir, err := os.Getwd()
+		if err != nil {
+			dir = ""
+		}
+		err = godotenv.Load(path.Join(dir, ".env"))
+		if err != nil {
+			return "", nil
+		}
+		envValue = os.Getenv(key)
+	}
+	if envValue == "" {
+		fmt.Printf("No value for env var: %s\n", key)
+		return "", nil
+	}
+
+	return envValue, nil
 }
 
 func (fxt *Fixture) updateEnv(env map[string]string) error {
@@ -506,7 +522,7 @@ func toFixtureQuery(value string) (fixtureQuery, bool) {
 	if r, didMatch := matchFixtureQuery(value); didMatch {
 		isQuery = true
 		match := r.FindStringSubmatch(value)
-		query = fixtureQuery{Name: match[1], Query: match[2], DefaultValue: match[3]}
+		query = fixtureQuery{Match: match[0], Name: match[1], Query: match[2], DefaultValue: match[3]}
 	}
 
 	return query, isQuery


### PR DESCRIPTION
 ### Reviewers
r? @ianjabour-stripe @suz-stripe 
cc @stripe/developer-products

 ### Summary
A user reported a bug where variables with a query embedded were losing all information outside of that query.
For example, a webhook create fixture with the url param set to `"${.env:BASE_API_URL}/hook/stripe"` was being saved with just the base API because we only keep the result of the query. 

I moved the .env query logic out and added a string replace to add the value back into the original query string. I only did this for the .env variables because I figured this didn't make as much sense for the resourceIds from responses but let me know if we think this will be useful for all query values, because I can also attempt to just move this logic outside of `parseQuery`

https://github.com/stripe/stripe-cli/issues/718

### Testing 
Added a unit test and also verified with the manual fixture