### PR TITLE
Update goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.159.0
+          version: v0.179.0
           args: release -f .goreleaser/mac.yml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.159.0
+          version: v0.179.0
           args: release -f .goreleaser/linux.yml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.159.0
+          version: v0.179.0
           args: release -f .goreleaser/windows.yml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}


### PR DESCRIPTION
 ### Reviewers
r? @pepin-stripe 
cc @stripe/developer-products

 ### Summary
Update goreleaser -- confirm macOS ARM builds. I ran `goreleaser release --config .goreleaser/mac.yml --rm-dist --skip-publish` locally, which created:
1. `stripe_1.7.2_mac-os_arm64.tar.gz` and `stripe_1.7.2_mac-os_x86_64.tar.gz` files (along with the binaries)
2. a `stripe.rb` homebrew file with the macos ARM line:
```
➜ cat dist/stripe.rb
# typed: false
# frozen_string_literal: true

# This file was generated by GoReleaser. DO NOT EDIT.
class Stripe < Formula
  desc "Stripe CLI utility"
  homepage "https://stripe.com"
  version "1.7.2"
  bottle :unneeded
  depends_on :macos

  on_macos do
    if Hardware::CPU.intel?
      url "https://github.com/stripe/stripe-cli/releases/download/v1.7.2/stripe_1.7.2_mac-os_x86_64.tar.gz"
      sha256 "ffc5262c26471eeae9a5c50e4be5a9270b3969c8d42398ace14425849e0aea83"
    end
    if Hardware::CPU.arm?
      url "https://github.com/stripe/stripe-cli/releases/download/v1.7.2/stripe_1.7.2_mac-os_arm64.tar.gz"
      sha256 "3736d0881465d31dba3c6d6604d690b0c00274073da74251967d7b5d532b7d41"
    end
  end

  def install
    bin.install "stripe"
    rm Dir["#{bin}/{stripe-completion.bash,stripe-completion.zsh}"]
    system bin/"stripe", "completion", "--shell", "bash"
    system bin/"stripe", "completion", "--shell", "zsh"
    bash_completion.install "stripe-completion.bash"
    zsh_completion.install "stripe-completion.zsh"
    (zsh_completion/"_stripe").write <<~EOS
      #compdef stripe
      _stripe () {
        local e
        e=$(dirname ${funcsourcetrace[1]%:*})/stripe-completion.zsh
        if [[ -f $e ]]; then source $e; fi
      }
    EOS
  end

  def caveats; <<~EOS
    ❤ Thanks for installing the Stripe CLI! If this is your first time using the CLI, be sure to run `stripe login` first.
  EOS
  end
end

```