### PR TITLE
Send forward-to URLs when connecting via `stripe listen`

### DIFF
--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -200,7 +200,7 @@ func (t *Tailer) createSession(ctx context.Context) (*stripeauth.StripeCLISessio
 		// Try to authorize at least 5 times before failing. Sometimes we have random
 		// transient errors that we just need to retry for.
 		for i := 0; i <= 5; i++ {
-			session, err = t.stripeAuthClient.Authorize(ctx, t.cfg.DeviceName, requestLogsWebSocketFeature, &filters)
+			session, err = t.stripeAuthClient.Authorize(ctx, t.cfg.DeviceName, requestLogsWebSocketFeature, &filters, nil)
 
 			if err == nil {
 				exitCh <- struct{}{}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -241,7 +241,12 @@ func (p *Proxy) createSession(ctx context.Context) (*stripeauth.StripeCLISession
 		// Try to authorize at least 5 times before failing. Sometimes we have random
 		// transient errors that we just need to retry for.
 		for i := 0; i <= 5; i++ {
-			session, err = p.stripeAuthClient.Authorize(ctx, p.cfg.DeviceName, p.cfg.WebSocketFeature, nil)
+			devURLMap := stripeauth.DeviceURLMap{
+				ForwardURL:        p.cfg.ForwardURL,
+				ForwardConnectURL: p.cfg.ForwardConnectURL,
+			}
+
+			session, err = p.stripeAuthClient.Authorize(ctx, p.cfg.DeviceName, p.cfg.WebSocketFeature, nil, &devURLMap)
 
 			if err == nil {
 				exitCh <- struct{}{}

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -307,7 +307,7 @@ func (s *Samples) ConfigureDotEnv(sampleLocation string) error {
 
 		authClient := stripeauth.NewClient(apiKey, nil)
 
-		authSession, err := authClient.Authorize(context.TODO(), deviceName, "webhooks", nil)
+		authSession, err := authClient.Authorize(context.TODO(), deviceName, "webhooks", nil, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -36,8 +36,15 @@ type Client struct {
 	cfg *Config
 }
 
+// DeviceURLMap is a mapping of the urls that the device is listening
+// for forwarded events on.
+type DeviceURLMap struct {
+	ForwardURL        string
+	ForwardConnectURL string
+}
+
 // Authorize sends a request to Stripe to initiate a new CLI session.
-func (c *Client) Authorize(ctx context.Context, deviceName string, websocketFeature string, filters *string) (*StripeCLISession, error) {
+func (c *Client) Authorize(ctx context.Context, deviceName string, websocketFeature string, filters *string, devURLMap *DeviceURLMap) (*StripeCLISession, error) {
 	c.cfg.Log.WithFields(log.Fields{
 		"prefix": "stripeauth.client.Authorize",
 	}).Debug("Authenticating with Stripe...")
@@ -53,6 +60,14 @@ func (c *Client) Authorize(ctx context.Context, deviceName string, websocketFeat
 
 	if filters != nil {
 		form.Add("filters", *filters)
+	}
+
+	if devURLMap != nil && len(devURLMap.ForwardURL) > 0 {
+		form.Add("forward_to_url", devURLMap.ForwardURL)
+	}
+
+	if devURLMap != nil && len(devURLMap.ForwardConnectURL) > 0 {
+		form.Add("forward_connect_to_url", devURLMap.ForwardConnectURL)
 	}
 
 	client := &stripe.Client{


### PR DESCRIPTION
### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
Updated the Stripe Auth client to optionally send the forward and connect forward URLs to the CLI API service when connecting via `stripe listen`.

I wrote a test to verify the query params get properly included in the request and manually verified in production as well:

#### `stripe listen` with forward urls set
![forwarding_urls](https://user-images.githubusercontent.com/58703040/133524288-4aa4ca99-83df-46b8-92cc-d7dab98bd4df.png)

### `stripe listen` without forward urls set
![no_forwarding_urls](https://user-images.githubusercontent.com/58703040/133524287-74618e23-a99e-41b0-8586-5a34c9a6d0cd.png)