### PR TITLE
Display error message if flags were given without commands

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -101,6 +101,11 @@ func Execute() {
 		}
 
 		os.Exit(1)
+	} else {
+		userInput := strings.Join(os.Args[1:], " ")
+		if strings.Contains(userInput, "--") {
+			fmt.Println("You provided flags but did not specify any command.")
+		}
 	}
 }
 


### PR DESCRIPTION
 ### Reviewers
r? @richardm-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
issue: https://github.com/stripe/stripe-cli/issues/349

```
st-etsai1:stripe-cli etsai$ stripe-dev
The official command-line tool to interact with Stripe.

Usage:
  stripe [command]

Webhook commands:
  listen                        Listen for webhook events
  trigger                       Trigger test webhook events

Stripe commands:
  logs                          Interact with Stripe API request logs
  status                        Check the status of the Stripe API

Resource commands:
  get                           Quickly retrieve resources from Stripe
  charges                       Make requests (capture, create, list, etc) on charges
  customers                     Make requests (create, delete, list, etc) on customers
  payment_intents               Make requests (cancel, capture, confirm, etc) on payment intents
  ...                           To see more resource commands, run `stripe resources help`

Other commands:
  community                     Chat with Stripe engineers and other developers
  completion                    Generate bash and zsh completion scripts
  config                        Manually change the config values for the CLI
  feedback                      Provide us with feedback on the CLI
  fixtures                      Run fixtures to populate your account with data
  help                          Help about any command
  login                         Login to your Stripe account
  logout                        Logout of your Stripe account
  open                          Quickly open Stripe pages
  samples                       Sample integrations built by Stripe
  serve                         Serve static files locally
  version                       Get the version of the Stripe CLI

Flags:
      --api-key string        Your API key to use for the command
      --color string          turn on/off color output (on, off, auto)
      --config string         config file (default is $HOME/.config/stripe/config.toml)
      --device-name string    device name
  -h, --help                  help for stripe
      --log-level string      log level (debug, info, trace, warn, error) (default "info")
  -p, --project-name string   the project name to read from for config (default "default")
  -v, --version               Get the version of the Stripe CLI

Use "stripe [command] --help" for more information about a command.
st-etsai1:stripe-cli etsai$ stripe-dev --color on
The official command-line tool to interact with Stripe.

Usage:
  stripe [command]

Webhook commands:
  listen                        Listen for webhook events
  trigger                       Trigger test webhook events

Stripe commands:
  logs                          Interact with Stripe API request logs
  status                        Check the status of the Stripe API

Resource commands:
  get                           Quickly retrieve resources from Stripe
  charges                       Make requests (capture, create, list, etc) on charges
  customers                     Make requests (create, delete, list, etc) on customers
  payment_intents               Make requests (cancel, capture, confirm, etc) on payment intents
  ...                           To see more resource commands, run `stripe resources help`

Other commands:
  community                     Chat with Stripe engineers and other developers
  completion                    Generate bash and zsh completion scripts
  config                        Manually change the config values for the CLI
  feedback                      Provide us with feedback on the CLI
  fixtures                      Run fixtures to populate your account with data
  help                          Help about any command
  login                         Login to your Stripe account
  logout                        Logout of your Stripe account
  open                          Quickly open Stripe pages
  samples                       Sample integrations built by Stripe
  serve                         Serve static files locally
  version                       Get the version of the Stripe CLI

Flags:
      --api-key string        Your API key to use for the command
      --color string          turn on/off color output (on, off, auto)
      --config string         config file (default is $HOME/.config/stripe/config.toml)
      --device-name string    device name
  -h, --help                  help for stripe
      --log-level string      log level (debug, info, trace, warn, error) (default "info")
  -p, --project-name string   the project name to read from for config (default "default")
  -v, --version               Get the version of the Stripe CLI

Use "stripe [command] --help" for more information about a command.
You provided flags but did not specify any command.
```