### PR TITLE
bug fix for --color warning message

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -102,9 +102,10 @@ func Execute(ctx context.Context) {
 
 		os.Exit(1)
 	} else {
-		userInput := strings.Join(os.Args[1:], " ")
-		if strings.Contains(userInput, "--") {
-			fmt.Println("You provided flags but did not specify any command.")
+		userInput := os.Args[1:]
+		// --color on/off/auto
+		if len(userInput) == 2 && userInput[0] == "--color" {
+			fmt.Println("You provided the \"--color\" flag but did not specify any command. The \"--color\" flag configures the color output of a specified command.")
 		}
 	}
 }


### PR DESCRIPTION
 ### Reviewers
r? @gracegoo-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
previous PR https://github.com/stripe/stripe-cli/pull/745 checks if a flag was given without command, and shows an error message when it happens. this breaks the other flags like `--version` flag experience when it does not require any command

the original issue was that the `--color` flag was confusing and it was not apparent to users that it needed a command

we will only prompt the user to include a command when `--color` flag was given
cobra also did not output any error message when user enter `stripe --color`
other scenarios where a flag was incorrectly entered would be caught by cobra

![Screen Shot 2021-09-17 at 1 47 52 PM](https://user-images.githubusercontent.com/88805634/133851979-158e687b-50a8-4038-b765-da331794e65d.png)
![Screen Shot 2021-09-17 at 1 51 22 PM](https://user-images.githubusercontent.com/88805634/133852226-1acba999-2270-4911-9b55-98c1f43405fc.png)

