### PR TITLE
Updating resource tests to run with cmd.Execute instead of calling th…

### DIFF
--- a/pkg/cmd/resource/events_resend_test.go
+++ b/pkg/cmd/resource/events_resend_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -39,7 +40,8 @@ func TestRunEventsResendCmd(t *testing.T) {
 	erc := NewEventsResendCmd(parentCmd, &config.Config{Profile: profile})
 	erc.opCmd.APIBaseURL = ts.URL
 
-	err := erc.runEventsResendCmd(erc.opCmd.Cmd, []string{"evt_123"})
+	parentCmd.SetArgs([]string{"resend", "evt_123"})
+	err := parentCmd.ExecuteContext(context.Background())
 
 	require.NoError(t, err)
 }
@@ -71,7 +73,8 @@ func TestRunEventsResendCmd_WithWebhookEndpoint(t *testing.T) {
 
 	erc.opCmd.Cmd.Flags().Set("webhook-endpoint", "we_123")
 
-	err := erc.runEventsResendCmd(erc.opCmd.Cmd, []string{"evt_123"})
+	parentCmd.SetArgs([]string{"resend", "evt_123"})
+	err := parentCmd.ExecuteContext(context.Background())
 
 	require.NoError(t, err)
 }

--- a/pkg/cmd/resource/operation_test.go
+++ b/pkg/cmd/resource/operation_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -66,7 +67,9 @@ func TestRunOperationCmd(t *testing.T) {
 	oc.Cmd.Flags().Set("param1", "value1")
 	oc.Cmd.Flags().Set("param2", "value2")
 	oc.Cmd.Flags().Set("param-with-underscores", "some_value")
-	err := oc.runOperationCmd(oc.Cmd, []string{"bar_123"})
+
+	parentCmd.SetArgs([]string{"foo", "bar_123"})
+	err := parentCmd.ExecuteContext(context.Background())
 
 	require.NoError(t, err)
 }
@@ -104,7 +107,9 @@ func TestRunOperationCmd_ExtraParams(t *testing.T) {
 	oc.Cmd.Flags().Set("param1", "value1")
 	oc.Cmd.Flags().Set("data", "shipping[address][line1]=123 Main St")
 	oc.Cmd.Flags().Set("data", "shipping[name]=name")
-	err := oc.runOperationCmd(oc.Cmd, []string{"bar_123"})
+
+	parentCmd.SetArgs([]string{"foo", "bar_123"})
+	err := parentCmd.ExecuteContext(context.Background())
 
 	require.NoError(t, err)
 }


### PR DESCRIPTION
…e run function directly

 ### Reviewers
r? @suz-stripe 
cc @stripe/developer-products

 ### Summary
While working on the telemetry migration, I noticed that any references to the `context.Context` in the runtime code would cause the test cases in the resource pkg to panic:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x139943a]
```

This is because no context is ever set in the cobra command set up by the tests. We can only pass in context to a cobra command by passing it in to any of the `Execute` functions. So this change updates the unit tests to execute the command using `ExecuteContext` instead of calling the `runE` command directly. 