### PR TITLE
Adding telemetry to gPRC calls

### DIFF
--- a/cmd/stripe/main.go
+++ b/cmd/stripe/main.go
@@ -22,7 +22,7 @@ func main() {
 			Timeout: time.Second * 3,
 		}
 		telemetryClient := &stripe.AnalyticsTelemetryClient{HTTPClient: httpClient}
-		contextWithTelemetry := stripe.WithAnalyticsTelemetryClient(ctx, telemetryClient)
+		contextWithTelemetry := stripe.WithTelemetryClient(ctx, telemetryClient)
 
 		cmd.Execute(contextWithTelemetry)
 

--- a/pkg/cmd/daemon.go
+++ b/pkg/cmd/daemon.go
@@ -39,7 +39,6 @@ Currently, stripe daemon only supports a subset of CLI commands. Documentation i
 
 func (dc *daemonCmd) runDaemonCmd(cmd *cobra.Command, args []string) {
 	telemetryClient := stripe.GetTelemetryClient(cmd.Context())
-	// pass in the telemetry client from here!
 	srv := rpcservice.New(&rpcservice.Config{
 		Port:    dc.port,
 		Log:     log.StandardLogger(),

--- a/pkg/cmd/daemon.go
+++ b/pkg/cmd/daemon.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/rpcservice"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
@@ -37,11 +38,13 @@ Currently, stripe daemon only supports a subset of CLI commands. Documentation i
 }
 
 func (dc *daemonCmd) runDaemonCmd(cmd *cobra.Command, args []string) {
+	telemetryClient := stripe.GetTelemetryClient(cmd.Context())
+	// pass in the telemetry client from here!
 	srv := rpcservice.New(&rpcservice.Config{
 		Port:    dc.port,
 		Log:     log.StandardLogger(),
 		UserCfg: dc.cfg,
-	})
+	}, telemetryClient)
 
 	ctx := withSIGTERMCancel(cmd.Context(), func() {
 		log.WithFields(log.Fields{

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/cmd/resource"
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/stripe"
+	"github.com/stripe/stripe-cli/pkg/useragent"
 	"github.com/stripe/stripe-cli/pkg/validators"
 	"github.com/stripe/stripe-cli/pkg/version"
 )
@@ -54,6 +55,8 @@ var rootCmd = &cobra.Command{
 		telemetryMetadata := stripe.GetEventMetadata(cmd.Context())
 		telemetryMetadata.SetCobraCommandContext(cmd)
 		telemetryMetadata.SetMerchant(merchant)
+		telemetryMetadata.SetUserAgent(useragent.GetEncodedUserAgent())
+
 	},
 }
 

--- a/pkg/rpcservice/middleware.go
+++ b/pkg/rpcservice/middleware.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
+
 	"github.com/stripe/stripe-cli/pkg/stripe"
 
 	"google.golang.org/grpc"
@@ -15,19 +16,20 @@ import (
 
 const requiredHeader = "sec-x-stripe-cli"
 
-// It's not easy to pass values through context for streams
+// WrappedServerStream wraps a ServerSteam so that we can pass values through context.
 // https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware#hdr-Writing_Your_Own
 type WrappedServerStream struct {
 	grpc.ServerStream
 	ctx context.Context
 }
 
+// Context returns the context for this stream.
 func (w WrappedServerStream) Context() context.Context {
 	return w.ctx
 }
 
-func newWrappedStream(server *RPCService, stream grpc.ServerStream, methodName string) grpc.ServerStream {
-	newCtx := initializeTelemetryContext(stream.Context(), methodName, server)
+func newWrappedStream(stream grpc.ServerStream, methodName string, server *RPCService) grpc.ServerStream {
+	newCtx := updateContextWithTelemetry(stream.Context(), methodName, server)
 	return &WrappedServerStream{stream, newCtx}
 }
 
@@ -46,7 +48,10 @@ func authorize(ctx context.Context) error {
 	return nil
 }
 
-func initializeTelemetryContext(ctx context.Context, methodName string, server *RPCService) context.Context {
+// Populate the context with:
+// 1. The telemetry client from the RPC Service
+// 2. The event metadata
+func updateContextWithTelemetry(ctx context.Context, methodName string, server *RPCService) context.Context {
 	// if getting the config errors, don't fail running the command
 	merchant, _ := server.cfg.UserCfg.Profile.GetAccountID()
 
@@ -71,7 +76,7 @@ func serverStreamInterceptor(
 	if err := authorize(stream.Context()); err != nil {
 		return err
 	}
-	wrappedStream := newWrappedStream(srv.(*RPCService), stream, info.FullMethod)
+	wrappedStream := newWrappedStream(stream, info.FullMethod, srv.(*RPCService))
 	return handler(srv, wrappedStream)
 }
 
@@ -88,6 +93,6 @@ func serverUnaryInterceptor(
 	if err := authorize(ctx); err != nil {
 		return nil, err
 	}
-	newCtx := initializeTelemetryContext(ctx, info.FullMethod, info.Server.(*RPCService))
+	newCtx := updateContextWithTelemetry(ctx, info.FullMethod, info.Server.(*RPCService))
 	return handler(newCtx, req)
 }

--- a/pkg/rpcservice/middleware.go
+++ b/pkg/rpcservice/middleware.go
@@ -3,6 +3,7 @@ package rpcservice
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -75,12 +76,7 @@ func getUserAgentFromGrpcMetadata(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
-
-	if len(md["user-agent"]) != 1 {
-		return ""
-	}
-
-	return md["user-agent"][0]
+	return strings.Join(md["user-agent"], ",")
 }
 
 // Middleware for stream requests

--- a/pkg/rpcservice/middleware_test.go
+++ b/pkg/rpcservice/middleware_test.go
@@ -87,3 +87,25 @@ func TestUpdateContextWithTelemetry(t *testing.T) {
 	assert.Equal(t, eventMetadata.UserAgent, "unit_test")
 	assert.Equal(t, stripe.GetTelemetryClient(newCtx), telemetryClient)
 }
+
+func TestGetUserAgentFromGRPCMetadata(t *testing.T) {
+	// No grpc metadata
+	assert.Equal(t, getUserAgentFromGrpcMetadata(context.Background()), "")
+}
+
+func TestGetUserAgentFromGRPCMetadataWithNoUserAgent(t *testing.T) {
+	// no user-agent key
+	md := metadata.Pairs("hello", "world")
+
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	assert.Equal(t, getUserAgentFromGrpcMetadata(ctx), "")
+}
+
+func TestGetUserAgentFromGRPCMetadataWitMultipleUserAgents(t *testing.T) {
+	// no user-agent key
+	md := metadata.Pairs("user-agent", "unit_test")
+	md.Append("user-agent", "hello")
+
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	assert.Equal(t, getUserAgentFromGrpcMetadata(ctx), "unit_test,hello")
+}

--- a/pkg/rpcservice/middleware_test.go
+++ b/pkg/rpcservice/middleware_test.go
@@ -72,8 +72,18 @@ func TestUpdateContextWithTelemetry(t *testing.T) {
 			},
 		}}
 	rpcService := New(config, telemetryClient)
-	newCtx := updateContextWithTelemetry(context.Background(), "method", rpcService)
 
-	assert.NotNil(t, stripe.GetEventMetadata(newCtx))
+	// Add grpc Metadata to context
+	md := metadata.Pairs("user-agent", "unit_test")
+
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	newCtx := updateContextWithTelemetry(ctx, "method", rpcService)
+
+	eventMetadata := stripe.GetEventMetadata(newCtx)
+	assert.NotNil(t, eventMetadata)
+	assert.Equal(t, eventMetadata.Merchant, "acct_xxx")
+	assert.Equal(t, eventMetadata.CommandPath, "method")
+	assert.Equal(t, eventMetadata.UserAgent, "unit_test")
 	assert.Equal(t, stripe.GetTelemetryClient(newCtx), telemetryClient)
 }

--- a/pkg/rpcservice/middleware_test.go
+++ b/pkg/rpcservice/middleware_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/rpc"
 )
 
@@ -59,4 +61,19 @@ func TestRejectRequestIfMetadataEmpty(t *testing.T) {
 	expected := status.Errorf(codes.Unauthenticated, fmt.Sprintf("%s header is not supplied", requiredHeader))
 
 	assert.Equal(t, expected.Error(), err.Error())
+}
+
+func TestUpdateContextWithTelemetry(t *testing.T) {
+	telemetryClient := &stripe.NoOpTelemetryClient{}
+	config := &Config{
+		UserCfg: &config.Config{
+			Profile: config.Profile{
+				AccountID: "acct_xxx",
+			},
+		}}
+	rpcService := New(config, telemetryClient)
+	newCtx := updateContextWithTelemetry(context.Background(), "method", rpcService)
+
+	assert.NotNil(t, stripe.GetEventMetadata(newCtx))
+	assert.Equal(t, stripe.GetTelemetryClient(newCtx), telemetryClient)
 }

--- a/pkg/rpcservice/rpc_service.go
+++ b/pkg/rpcservice/rpc_service.go
@@ -51,8 +51,10 @@ type ConfigOutput struct {
 }
 
 // New creates a new RPC service
-func New(cfg *Config,
-	telemetryClient stripe.TelemetryClient) *RPCService {
+func New(
+	cfg *Config,
+	telemetryClient stripe.TelemetryClient,
+) *RPCService {
 	if cfg.Log == nil {
 		cfg.Log = &log.Logger{Out: ioutil.Discard}
 	}

--- a/pkg/rpcservice/rpc_service.go
+++ b/pkg/rpcservice/rpc_service.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/rpc"
 )
 
@@ -34,6 +35,9 @@ type RPCService struct {
 	cfg *Config
 
 	grpcServer *grpc.Server
+
+	// TelemetryClient to use for sending telemetry events
+	TelemetryClient stripe.TelemetryClient
 }
 
 // ConfigOutput is the config that clients will need to connect to the gRPC server. This is printed
@@ -47,7 +51,8 @@ type ConfigOutput struct {
 }
 
 // New creates a new RPC service
-func New(cfg *Config) *RPCService {
+func New(cfg *Config,
+	telemetryClient stripe.TelemetryClient) *RPCService {
 	if cfg.Log == nil {
 		cfg.Log = &log.Logger{Out: ioutil.Discard}
 	}
@@ -58,8 +63,9 @@ func New(cfg *Config) *RPCService {
 	)
 
 	return &RPCService{
-		cfg:        cfg,
-		grpcServer: grpcServer,
+		cfg:             cfg,
+		grpcServer:      grpcServer,
+		TelemetryClient: telemetryClient,
 	}
 }
 

--- a/pkg/rpcservice/rpc_service_test.go
+++ b/pkg/rpcservice/rpc_service_test.go
@@ -25,7 +25,7 @@ func init() {
 				DeviceName: "rpc_test_device_name",
 			},
 		},
-	})
+	}, nil)
 
 	rpc.RegisterStripeCLIServer(srv.grpcServer, srv)
 

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/stripe/stripe-cli/pkg/useragent"
 	"github.com/stripe/stripe-cli/pkg/version"
 )
 
@@ -69,7 +68,6 @@ type NoOpTelemetryClient struct {
 func NewEventMetadata() *CLIAnalyticsEventMetadata {
 	return &CLIAnalyticsEventMetadata{
 		InvocationID: uuid.NewString(),
-		UserAgent:    useragent.GetEncodedUserAgent(),
 		CLIVersion:   version.Version,
 		OS:           runtime.GOOS,
 	}
@@ -120,6 +118,16 @@ func (e *CLIAnalyticsEventMetadata) SetCobraCommandContext(cmd *cobra.Command) {
 // SetMerchant sets the merchant on the CLIAnalyticsEventContext object
 func (e *CLIAnalyticsEventMetadata) SetMerchant(merchant string) {
 	e.Merchant = merchant
+}
+
+// SetUserAgent sets the userAgent on the CLIAnalyticsEventContext object
+func (e *CLIAnalyticsEventMetadata) SetUserAgent(userAgent string) {
+	e.UserAgent = userAgent
+}
+
+// SetCommandPath sets the commandPath on the CLIAnalyticsEventContext object
+func (e *CLIAnalyticsEventMetadata) SetCommandPath(commandPath string) {
+	e.CommandPath = commandPath
 }
 
 // SendAPIRequestEvent is a special function for API requests

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -57,6 +57,10 @@ type AnalyticsTelemetryClient struct {
 	HTTPClient *http.Client
 }
 
+// NoOpTelemetryClient does not call any endpoint and returns an empty response
+type NoOpTelemetryClient struct {
+}
+
 //
 // Public functions
 //
@@ -192,6 +196,16 @@ func (a *AnalyticsTelemetryClient) sendData(ctx context.Context, data url.Values
 // Wait will return when all in-flight telemetry requests are complete.
 func (a *AnalyticsTelemetryClient) Wait() {
 	a.wg.Wait()
+}
+
+// SendAPIRequestEvent does nothing
+func (a *NoOpTelemetryClient) SendAPIRequestEvent(ctx context.Context, requestID string, livemode bool) (*http.Response, error) {
+	return nil, nil
+}
+
+// SendEvent does nothing
+func (a *NoOpTelemetryClient) SendEvent(ctx context.Context, eventName string, eventValue string) (*http.Response, error) {
+	return nil, nil
 }
 
 // TelemetryOptedOut returns true if the user has opted out of telemetry,

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -90,6 +90,11 @@ func WithAnalyticsTelemetryClient(ctx context.Context, client *AnalyticsTelemetr
 	return context.WithValue(ctx, telemetryClientKey{}, client)
 }
 
+// WithTelemetryClient returns a new copy of context.Context with the provided telemetryClient
+func WithTelemetryClient(ctx context.Context, client TelemetryClient) context.Context {
+	return context.WithValue(ctx, telemetryClientKey{}, client)
+}
+
 // GetTelemetryClient returns the CLIAnalyticsEventMetadata from the provided context
 func GetTelemetryClient(ctx context.Context) TelemetryClient {
 	client := ctx.Value(telemetryClientKey{})

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -85,11 +85,6 @@ func GetEventMetadata(ctx context.Context) *CLIAnalyticsEventMetadata {
 	return nil
 }
 
-// WithAnalyticsTelemetryClient returns a new copy of context.Context with the provided AnalyticsTelemetryClient
-func WithAnalyticsTelemetryClient(ctx context.Context, client *AnalyticsTelemetryClient) context.Context {
-	return context.WithValue(ctx, telemetryClientKey{}, client)
-}
-
 // WithTelemetryClient returns a new copy of context.Context with the provided telemetryClient
 func WithTelemetryClient(ctx context.Context, client TelemetryClient) context.Context {
 	return context.WithValue(ctx, telemetryClientKey{}, client)

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -13,6 +13,41 @@ import (
 )
 
 // Context Tests
+func TestEventMetadataWithGet(t *testing.T) {
+	ctx := context.Background()
+	event := &CLIAnalyticsEventMetadata{
+		InvocationID: "hello",
+		UserAgent:    "uesr",
+		CLIVersion:   "1.0",
+		OS:           "os",
+	}
+	newCtx := WithEventMetadata(ctx, event)
+
+	require.Equal(t, GetEventMetadata(newCtx), event)
+}
+
+func TestGetEventMetadata_DoesNotExistInCtx(t *testing.T) {
+	ctx := context.Background()
+	require.Nil(t, GetEventMetadata(ctx))
+}
+
+func TestTelemetryClientWithGet(t *testing.T) {
+	ctx := context.Background()
+	url, _ := url.Parse("http://hello.com")
+	telemetryClient := &AnalyticsTelemetryClient{
+		BaseURL:    url,
+		HTTPClient: &http.Client{},
+	}
+	newCtx := WithTelemetryClient(ctx, telemetryClient)
+
+	require.Equal(t, GetTelemetryClient(newCtx), telemetryClient)
+}
+
+func TestGetTelemetryClient_DoesNotExistInCtx(t *testing.T) {
+	ctx := context.Background()
+	require.Nil(t, GetTelemetryClient(ctx))
+}
+
 func TestSetCobraCommandContext(t *testing.T) {
 	tel := NewEventMetadata()
 	cmd := &cobra.Command{


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

### Summary
This change adds additional logic in the middleware interceptors to add the `telemetryClient` and `eventMetadata` to the context passed into the RPC functions. This allows us to get telemetry events for each separate RPC call instead of sharing one metadata for the whole of the daemon process. 

An instance of an `eventMetadata` is created on each method call to gRPC.

We use the same instance of `telemetryClient` for the duration the RPC service is up. The instance of the `telemeryClient` is passed to the RPC service when it is created by the daemon command. 

### Testing
An example of data sent to the analytics service through manual testing
```
 p_invocation_id=1beaa848-7919-407d-81e5-96aeb9d6c24c p_user_agent="Stripe/v1 stripe-cli/master" p_os=darwin p_cli_version=master p_livemode=false p_generated_resource=false p_event_value= p_client_id=stripe-cli p_event_id=01f20da5-258b-4fe4-8a96-52813f1b9bc3 p_request_id=req_t1MWVF7KlGFz54 p_command_path=/rpc.StripeCLI/LogsTail p_created=1632951950 p_merchant=acct_1HzAHfIMIxZxvOV4 p_event_name="API Request"

p_invocation_id=eb1fb4ac-dff7-4de7-9e11-561b14e1072b p_user_agent="Stripe/v1 stripe-cli/master" p_os=darwin p_cli_version=master p_livemode=false p_generated_resource=false p_event_value= p_client_id=stripe-cli p_event_id=006011c9-c4cf-4a9c-aa6e-aa0ade98a679 p_request_id=req_Sseb1LmF1NhqVj p_command_path=/rpc.StripeCLI/Listen p_created=1632951941 p_merchant=acct_1HzAHfIMIxZxvOV4 p_event_name="API Request"
```

Regarding unit tests: 
I wasn't sure what the best method of adding unit tests to test the new interceptor logic was. Calling `DialContext` allows us to hit the interceptor logic in the middleware.go class but I'm not sure how to assert that the context updated in the way we expected. In the other tests, we pass in a `ctx` directly into the gRPC calls which would bypass the logic we are trying to test. Let me know if anyone has ideas.
