### PR TITLE
[wip] display API version when running listen

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -228,7 +228,7 @@ func createVisitor(logger *log.Logger, format string, printJSON bool) *websocket
 			case websocket.Reconnecting:
 				ansi.StartSpinner(s, "Session expired, reconnecting...", logger.Out)
 			case websocket.Ready:
-				ansi.StopSpinner(s, fmt.Sprintf("Ready! Your webhook signing secret is %s (^C to quit)", ansi.Bold(se.Data[0])), logger.Out)
+				ansi.StopSpinner(s, fmt.Sprintf("Ready! %sYour webhook signing secret is %s (^C to quit)", se.Data[0], ansi.Bold(se.Data[1])), logger.Out)
 			case websocket.Done:
 				ansi.StopSpinner(s, "", logger.Out)
 			}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -162,9 +162,16 @@ func (p *Proxy) Run(ctx context.Context) error {
 			<-p.webSocketClient.Connected()
 			nAttempts = 0
 
+			displayedAPIVersion := ""
+			if p.cfg.UseLatestAPIVersion && session.LatestVersion != "" {
+				displayedAPIVersion = "You are using Stripe API Version [" + session.LatestVersion + "]. "
+			} else if !p.cfg.UseLatestAPIVersion && session.DefaultVersion != "" {
+				displayedAPIVersion = "You are using Stripe API Version [" + session.DefaultVersion + "]. "
+			}
+
 			p.cfg.OutCh <- websocket.StateElement{
 				State: websocket.Ready,
-				Data:  []string{session.Secret},
+				Data:  []string{displayedAPIVersion, session.Secret},
 			}
 		}()
 

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -104,6 +104,8 @@ func (c *Client) Authorize(ctx context.Context, deviceName string, websocketFeat
 		"websocket_authorized_feature":   session.WebSocketAuthorizedFeature,
 		"reconnect_delay":                session.ReconnectDelay,
 		"display_connect_filter_warning": session.DisplayConnectFilterWarning,
+		"default_version":                session.DefaultVersion,
+		"latest_version":                 session.LatestVersion,
 	}).Debug("Got successful response from Stripe")
 
 	return session, nil

--- a/pkg/stripeauth/messages.go
+++ b/pkg/stripeauth/messages.go
@@ -9,4 +9,6 @@ type StripeCLISession struct {
 	WebSocketAuthorizedFeature  string `json:"websocket_authorized_feature"`
 	WebSocketID                 string `json:"websocket_id"`
 	WebSocketURL                string `json:"websocket_url"`
+	DefaultVersion              string `json:"default_version"`
+	LatestVersion               string `json:"latest_version"`
 }


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
This PR addresses a backlogged issue, which was to display the user's stripe API version when running `stripe listen`. This was previously addressed and an implementation was attempted in #401 #404. However, that implementation was reverted in #406 because it relied on the HTTP response which could be inaccurate. This new implementation relies on a backend API change that has been made recently which provides a user's `latest_version` and `default_version` API versions directly to the CLI.

running `stripe listen` uses the default API version:
![defaultAPI](https://user-images.githubusercontent.com/90791687/137819050-67feb0d0-1fc5-46d9-b5e5-d5ba6f0ffca5.png)

running `stripe listen --l` uses the latest API version:
![latestAPI](https://user-images.githubusercontent.com/90791687/137819078-7aa601b6-4dd0-4cf6-b452-b11a7e958c82.png)

note: it is possible for `latest_version` and `default_version` returned from the backend to be `nil`. In the case where we want to display the default API and it is `nil` or we want to display the latest API and it is `nil`, we instead do not display anything:
![noAPI](https://user-images.githubusercontent.com/90791687/137819089-ea87ecb1-b35a-434d-81ca-c5ed804eb4f7.png)

