### PR TITLE
Adding check for DO_NOT_TRACK env var

### DIFF
--- a/cmd/stripe/main.go
+++ b/cmd/stripe/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	if stripe.TelemetryOptedOut(os.Getenv("STRIPE_CLI_TELEMETRY_OPTOUT")) {
+	if stripe.TelemetryOptedOut(os.Getenv("STRIPE_CLI_TELEMETRY_OPTOUT")) || stripe.TelemetryOptedOut(os.Getenv("DO_NOT_TRACK")) {
 		// Proceed without the telemetry client if client opted out.
 		cmd.Execute(ctx)
 	} else {


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe 
cc @stripe/developer-products

 ### Summary
Adding check for industry standard flag DO_NOT_TRACK before enabling telemetry: https://consoledonottrack.com/

### Testing
Tested with some print functions 
```
➜  stripe-cli git:(gracegoo-check-DNT-flag) ✗ export STRIPE_CLI_TELEMETRY_OPTOUT=1     
➜  stripe-cli git:(gracegoo-check-DNT-flag) ✗ stripe-workspace --version
stripe version master
Opted out of telemetry
➜  stripe-cli git:(gracegoo-check-DNT-flag) ✗ unset STRIPE_CLI_TELEMETRY_OPTOUT
➜  stripe-cli git:(gracegoo-check-DNT-flag) ✗ stripe-workspace --version       
Starting process with telemetry client
stripe version master
➜  stripe-cli git:(gracegoo-check-DNT-flag) ✗ export DO_NOT_TRACK=1     
➜  stripe-cli git:(gracegoo-check-DNT-flag) ✗ stripe-workspace --version
stripe version master
Opted out of telemetry
➜  stripe-cli git:(gracegoo-check-DNT-flag) ✗ 
```