### PR TITLE
Fixing how we infer generated resource for telemetry

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,9 +35,10 @@
           "args":["trigger", "${input:event}"]
         },
 
-        // Unfortunately, this won't work on resource commands that require more arguments unless we manually add it
-        // becacuse we need to pass in each argument separately for this to work
+        // Unfortunately, this won't work on resource commands that require more arguments
+        // unless we manually add it becacuse we need to pass in each argument separately for this to work.
         // https://github.com/microsoft/vscode/issues/83678
+        // to test those, you can just customize this configuration to include all the args you need.
         {
           "name": "Launch (stripe resource command)",
           "type": "go",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,9 +3,50 @@
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
+    "inputs": [
+      {
+        "id": "event",
+        "description": "The event to trigger",
+        "default": "balance.available",
+        "type": "promptString",
+      },
+      {
+        "id": "resource",
+        "description": "The resource we want to use",
+        "default": "customers",
+        "type": "promptString",
+      },
+      {
+        "id": "action",
+        "description": "The resource we want to use",
+        "default": "create",
+        "type": "promptString",
+      }
+    ],
     "configurations": [
 
+        {
+          "name": "Launch (stripe trigger)",
+          "type": "go",
+          "request": "launch",
+          "mode": "auto",
+          "program": "${workspaceFolder}/cmd/stripe/main.go",
+          "env": {},
+          "args":["trigger", "${input:event}"]
+        },
 
+        // Unfortunately, this won't work on resource commands that require more arguments unless we manually add it
+        // becacuse we need to pass in each argument separately for this to work
+        // https://github.com/microsoft/vscode/issues/83678
+        {
+          "name": "Launch (stripe resource command)",
+          "type": "go",
+          "request": "launch",
+          "mode": "auto",
+          "program": "${workspaceFolder}/cmd/stripe/main.go",
+          "env": {},
+          "args":["${input:resource}", "${input:action}"]
+        },
         {
             "name": "Launch (listen)",
             "type": "go",

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -107,11 +107,13 @@ func (e *CLIAnalyticsEventMetadata) SetCobraCommandContext(cmd *cobra.Command) {
 	e.CommandPath = cmd.CommandPath()
 	e.GeneratedResource = false
 
-	for _, value := range cmd.Annotations {
-		// Generated commands have an annotation called "operation", we can
-		// search for that to let us know it's generated
-		if value == "operation" {
-			e.GeneratedResource = true
+	if cmd.HasParent() {
+		for key, value := range cmd.Parent().Annotations {
+			// Generated commands have an annotation called "operation", we can
+			// search for that to let us know it's generated
+			if key == cmd.Use && value == "operation" {
+				e.GeneratedResource = true
+			}
 		}
 	}
 }


### PR DESCRIPTION
 ### Reviewers
r? @pepin-stripe 
cc @stripe/developer-products

 ### Summary
The "Generated Resource" column in the stripe CLI telemetry table has always been false (in both the old and new tables). Historically, this column was created to indicate commands that were generated from the openAPI spec when we run `make update-openapi-sec`. The logic to determine this checks on the Annotations field of the command for the "operations" tag. However, when commands are created Annotations are added to the parent, not the cmd itself. 
![Screen Shot 2021-10-26 at 2 11 11 PM](https://user-images.githubusercontent.com/75757829/138973291-b15c82fa-30b3-4528-a5c0-a92ad39c4ecd.png)

This change updates the logic to check the parent cmd's annotation. 

I also added a couple more launch targets for debugging purposes.

