### PR TITLE
downgrade go releaser action to avoid downloading universal darwin go releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.17
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v2.7.0
         with:
           version: v0.179.0
           args: release -f .goreleaser/mac.yml --rm-dist


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
https://github.com/goreleaser/goreleaser/pull/2572
this PR forces downloading an universal go releaser but universal binaries dont exist for version < 0.182

since CLI is using verion 0.179, this caused the build release to fail
https://github.com/stripe/stripe-cli/runs/4073154456?check_suite_focus=true
because we couldnt find the universal binary in the assets list for v0.179

use an older version of go releaser action instead
https://github.com/goreleaser/goreleaser-action/releases