### PR TITLE
Updating login logic to call login directly instead of invoking the c…

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/cmd/resource"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/login"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/useragent"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -88,13 +89,8 @@ func Execute(ctx context.Context) {
 			errRunes[0] = unicode.ToUpper(errRunes[0])
 
 			fmt.Printf("%s. Running `stripe login`...\n", string(errRunes))
-			loginCommand, _, err := rootCmd.Find([]string{"login"})
 
-			if err != nil {
-				fmt.Println(err)
-			}
-
-			err = loginCommand.RunE(&cobra.Command{}, []string{})
+			err = login.Login(updatedCtx, stripe.DefaultDashboardBaseURL, &Config, os.Stdin)
 
 			if err != nil {
 				fmt.Println(err)


### PR DESCRIPTION
…obra command

If the user is not logged for a command that requires them to be, we automatically try to run the login logic for them. 
The previous logic resulted in us losing the context when running the login command.
Fixes #774



 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary

Before:
![Screen Shot 2021-11-02 at 12 52 05 PM](https://user-images.githubusercontent.com/75757829/139942909-a257c8a9-b650-4d46-9f3b-dc5cd88bcc97.png)

After:
![Screen Shot 2021-11-02 at 12 53 05 PM](https://user-images.githubusercontent.com/75757829/139942957-a32e8b20-d8cc-478d-8c37-e0da5079fefb.png)

Note the login succeeds but we still return a status 1 because the original run failed. I believe this was the case before as well, should we try to re-run the original command after login automatically? 

