### PR TITLE
Show friendly message when API key is expired

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -85,7 +85,7 @@ func Execute(ctx context.Context) {
 
 		switch {
 		case requests.IsAPIKeyExpiredError(err):
-			fmt.Fprintln(os.Stderr, "The API key provided has expired. Obtain a new key from the Dashboard or run `stripe login` to continue")
+			fmt.Fprintln(os.Stderr, "The API key provided has expired. Obtain a new key from the Dashboard or run `stripe login` and try again.")
 		case isLoginRequiredError:
 			// capitalize first letter of error because linter
 			errRunes := []rune(errString)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/cmd/resource"
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/login"
+	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/useragent"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -83,6 +84,8 @@ func Execute(ctx context.Context) {
 		isLoginRequiredError := errString == validators.ErrAPIKeyNotConfigured.Error() || errString == validators.ErrDeviceNameNotConfigured.Error()
 
 		switch {
+		case requests.IsAPIKeyExpiredError(err):
+			fmt.Fprintln(os.Stderr, "The API key provided has expired. Obtain a new key from the Dashboard or run `stripe login` to continue")
 		case isLoginRequiredError:
 			// capitalize first letter of error because linter
 			errRunes := []rune(errString)

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -69,6 +69,10 @@ func (e RequestError) Error() string {
 	return fmt.Sprintf("%s, status=%d, body=%s", e.msg, e.StatusCode, e.Body)
 }
 
+// IsAPIKeyExpiredError returns true if the provided error was caused by a
+// request returning an `api_key_expired` error code.
+//
+// See https://stripe.com/docs/error-codes/api-key-expired.
 func IsAPIKeyExpiredError(err error) bool {
 	var reqErr RequestError
 	if errors.As(err, &reqErr) {

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -60,11 +61,20 @@ type RequestError struct {
 	msg        string
 	StatusCode int
 	ErrorType  string
+	ErrorCode  string
 	Body       interface{} // the raw response body
 }
 
 func (e RequestError) Error() string {
 	return fmt.Sprintf("%s, status=%d, body=%s", e.msg, e.StatusCode, e.Body)
+}
+
+func IsAPIKeyExpiredError(err error) bool {
+	var reqErr RequestError
+	if errors.As(err, &reqErr) {
+		return reqErr.StatusCode == 401 && reqErr.ErrorCode == "api_key_expired"
+	}
+	return false
 }
 
 // Base encapsulates the required information needed to make requests to the API
@@ -192,7 +202,7 @@ func (rb *Base) MakeRequest(ctx context.Context, apiKey, path string, params *Re
 
 	body, err := ioutil.ReadAll(resp.Body)
 
-	if errOnStatus && resp.StatusCode >= 300 {
+	if resp.StatusCode == 401 || (errOnStatus && resp.StatusCode >= 300) {
 		requestError := compileRequestError(body, resp.StatusCode)
 		return nil, requestError
 	}
@@ -211,6 +221,7 @@ func (rb *Base) MakeRequest(ctx context.Context, apiKey, path string, params *Re
 
 func compileRequestError(body []byte, statusCode int) RequestError {
 	type requestErrorContent struct {
+		Code string `json:"code"`
 		Type string `json:"type"`
 	}
 
@@ -220,7 +231,13 @@ func compileRequestError(body []byte, statusCode int) RequestError {
 
 	var errorBody requestErrorBody
 	json.Unmarshal(body, &errorBody)
-	return RequestError{"Request failed", statusCode, errorBody.Content.Type, string(body)}
+	return RequestError{
+		msg:        "Request failed",
+		StatusCode: statusCode,
+		ErrorType:  errorBody.Content.Type,
+		ErrorCode:  errorBody.Content.Code,
+		Body:       string(body),
+	}
 }
 
 // Confirm calls the confirmCommand() function, triggering the confirmation process


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products
cc @remi-stripe 

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

The restricted API keys created by the CLI expire after 90 days, but any restricted API key can also be forcibly expired by rolling. Previously, when invoking the CLI with an expired key we would render the entire error response body (and also returned a successful exit code):

```
$ stripe accounts retrieve
{
  "error": {
    "code": "api_key_expired",
    "doc_url": "https://stripe.com/docs/error-codes/api-key-expired",
    "message": "Expired API Key provided: rk_test_*********************************************************************************************aaaaaa",
    "type": "invalid_request_error"
  }
}
$ echo $?
0
```

This updates the CLI to handle the `api_key_expired` error and show a tailored error message:

```
$ stripe accounts retrieve
The API key provided has expired. Obtain a new key from the Dashboard or run `stripe login` and try again.
$ echo $?
1
```