### PR TITLE
fix: deadlock when resetting connection

### DIFF
--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -438,7 +438,7 @@ func (c *Client) writePump() {
 					c.cfg.Log.Error("write error: ", err)
 				}
 
-				// writing to notifyClose during
+				// writing to notifyClose during a reset will cause a deadlock
 				select {
 				case c.notifyClose <- err:
 					c.cfg.Log.WithFields(log.Fields{

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -443,11 +443,11 @@ func (c *Client) writePump() {
 				case c.notifyClose <- err:
 					c.cfg.Log.WithFields(log.Fields{
 						"prefix": "websocket.Client.writePump",
-					}).Debug("ping notifyClose")
+					}).Debug("Failed to send ping; closing connection")
 				case <-c.stopWritePump:
 					c.cfg.Log.WithFields(log.Fields{
 						"prefix": "websocket.Client.writePump",
-					}).Debug("ping stopWritePump")
+					}).Debug("Failed to send ping; connection is resetting")
 				}
 				return
 			}

--- a/pkg/websocket/client_test.go
+++ b/pkg/websocket/client_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	ws "github.com/gorilla/websocket"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -174,3 +175,56 @@ func TestClientExpiredError(t *testing.T) {
 		require.FailNow(t, "Timed out waiting for response from test server")
 	}
 }
+
+/* func TestClientWebhookReconnect(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	wg := &sync.WaitGroup{}
+	wg.Add(20)
+	upgrader := ws.Upgrader{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+
+		defer c.Close()
+
+		swg := &sync.WaitGroup{}
+		swg.Add(1)
+
+		go func() {
+			for {
+				if _, _, err := c.ReadMessage(); err != nil {
+					swg.Done()
+					return
+				}
+			}
+		}()
+
+		swg.Wait()
+		wg.Done()
+	}))
+
+	defer ts.Close()
+
+	url := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	rcvMsgChan := make(chan WebhookEvent)
+
+	client := NewClient(
+		url,
+		"websocket-random-id",
+		"webhook-payloads",
+		&Config{
+			EventHandler: EventHandlerFunc(func(msg IncomingMessage) {
+				rcvMsgChan <- *msg.WebhookEvent
+			}),
+			Log:               log.StandardLogger(),
+			ReconnectInterval: 10 * time.Second,
+		},
+	)
+
+	go client.Run(context.Background())
+
+	defer client.Stop()
+
+	wg.Wait()
+} */

--- a/pkg/websocket/client_test.go
+++ b/pkg/websocket/client_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	ws "github.com/gorilla/websocket"
-	log "github.com/sirupsen/logrus"
+	// log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
 ### Reviewers
r? @pepin-stripe 
cc @stripe/developer-products

 ### Summary
When the timer triggers to reset the connection, a deadlock can occur if the ping write fails during that period.
