### PR TITLE
Add fixtures to trigger new BT payment intent events

### DIFF
--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -50,6 +50,8 @@ var Events = map[string]string{
 	"payment_intent.canceled":                  "triggers/payment_intent.canceled.json",
 	"payment_link.created":                     "triggers/payment_link.created.json",
 	"payment_link.updated":                     "triggers/payment_link.updated.json",
+	"payment_intent.partially_funded":          "triggers/payment_intent.partially_funded.json",
+	"payment_intent.requires_action":           "triggers/payment_intent.requires_action.json",
 	"payment_method.attached":                  "triggers/payment_method.attached.json",
 	"payout.created":                           "triggers/payout.created.json",
 	"payout.updated":                           "triggers/payout.updated.json",

--- a/pkg/fixtures/triggers/payment_intent.partially_funded.json
+++ b/pkg/fixtures/triggers/payment_intent.partially_funded.json
@@ -1,0 +1,41 @@
+
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "customer",
+      "path": "/v1/customers",
+      "method": "post",
+      "params": {
+        "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "payment_intent",
+      "path": "/v1/payment_intents",
+      "method": "post",
+      "params": {
+        "amount": 20000,
+        "currency": "jpy",
+        "customer": "${customer:id}",
+        "description": "(created by Stripe CLI)",
+        "payment_method_types[]": "customer_balance",
+        "payment_method_data[type]": "customer_balance",
+        "payment_method_options[customer_balance][funding_type]": "bank_transfer",
+        "payment_method_options[customer_balance][bank_transfer][type]": "jp_bank_account",
+        "confirm": "true"
+      }
+    },
+    {
+      "name": "fund_cash_balance",
+      "path": "/v1/test_helpers/customers/${customer:id}/fund_cash_balance",
+      "method": "post",
+      "params": {
+        "amount": 10000,
+        "currency": "jpy"
+      }
+    }
+  ]
+}

--- a/pkg/fixtures/triggers/payment_intent.requires_action.json
+++ b/pkg/fixtures/triggers/payment_intent.requires_action.json
@@ -1,0 +1,32 @@
+
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "customer",
+      "path": "/v1/customers",
+      "method": "post",
+      "params": {
+        "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "payment_intent",
+      "path": "/v1/payment_intents",
+      "method": "post",
+      "params": {
+        "amount": 20000,
+        "currency": "jpy",
+        "customer": "${customer:id}",
+        "description": "(created by Stripe CLI)",
+        "payment_method_types[]": "customer_balance",
+        "payment_method_data[type]": "customer_balance",
+        "payment_method_options[customer_balance][funding_type]": "bank_transfer",
+        "payment_method_options[customer_balance][bank_transfer][type]": "jp_bank_account",
+        "confirm": "true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Adds fixtures to trigger partially_funded and requires_action. This will allow testing of bank transfer payment methods.

Let me know if there's any hygiene changes I should add - I didn't run any codegen or pull the latest API spec etc.