### PR TITLE
Replace exec package with execabs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/BurntSushi/toml"
 	"github.com/mitchellh/go-homedir"

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -2,8 +2,9 @@ package open
 
 import (
 	"fmt"
-	"os/exec"
 	"runtime"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 var execCommand = exec.Command


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
This replacement package always looks for the executable in an absolute path, and throws an error if the executable is in a relative path. Note that this only affects the behavior of certain commands on Windows; other operating systems are unaffected.

Internally, see [here](https://jira.corp.stripe.com/browse/RUN_DX-772) for more info.