### PR TITLE
Fix --forward-connect-to not forwarding events

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -493,22 +493,26 @@ func Init(ctx context.Context, cfg *Config) (*Proxy, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else if len(cfg.ForwardURL) > 0 {
-		// non-connect endpoints
-		endpointRoutes = append(endpointRoutes, EndpointRoute{
-			URL:            parseURL(cfg.ForwardURL),
-			ForwardHeaders: cfg.ForwardHeaders,
-			Connect:        false,
-			EventTypes:     cfg.Events,
-		})
+	} else {
+		if len(cfg.ForwardURL) > 0 {
+			// non-connect endpoints
+			endpointRoutes = append(endpointRoutes, EndpointRoute{
+				URL:            parseURL(cfg.ForwardURL),
+				ForwardHeaders: cfg.ForwardHeaders,
+				Connect:        false,
+				EventTypes:     cfg.Events,
+			})
+		}
 
-		// connect endpoints
-		endpointRoutes = append(endpointRoutes, EndpointRoute{
-			URL:            parseURL(cfg.ForwardConnectURL),
-			ForwardHeaders: cfg.ForwardConnectHeaders,
-			Connect:        true,
-			EventTypes:     cfg.Events,
-		})
+		if len(cfg.ForwardConnectURL) > 0 {
+			// connect endpoints
+			endpointRoutes = append(endpointRoutes, EndpointRoute{
+				URL:            parseURL(cfg.ForwardConnectURL),
+				ForwardHeaders: cfg.ForwardConnectHeaders,
+				Connect:        true,
+				EventTypes:     cfg.Events,
+			})
+		}
 	}
 
 	p := &Proxy{

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -139,3 +139,43 @@ func TestParseUrl(t *testing.T) {
 
 	require.Equal(t, "http://localhost:3000", parseURL("3000"))
 }
+
+func TestForwardToOnly(t *testing.T) {
+	cfg := Config{
+		ForwardURL:        "http://localhost:4242",
+		ForwardConnectURL: "",
+	}
+	p, err := Init(context.Background(), &cfg)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(p.endpointClients))
+	require.EqualValues(t, "http://localhost:4242", p.endpointClients[0].URL)
+	require.EqualValues(t, false, p.endpointClients[0].connect)
+	require.EqualValues(t, "http://localhost:4242", p.endpointClients[1].URL)
+	require.EqualValues(t, true, p.endpointClients[1].connect)
+}
+
+func TestForwardConnectToOnly(t *testing.T) {
+	cfg := Config{
+		ForwardURL:        "",
+		ForwardConnectURL: "http://localhost:4242/connect",
+	}
+	p, err := Init(context.Background(), &cfg)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(p.endpointClients))
+	require.EqualValues(t, "http://localhost:4242/connect", p.endpointClients[0].URL)
+	require.EqualValues(t, true, p.endpointClients[0].connect)
+}
+
+func TestForwardToAndForwardConnectTo(t *testing.T) {
+	cfg := Config{
+		ForwardURL:        "http://localhost:4242",
+		ForwardConnectURL: "http://localhost:4242/connect",
+	}
+	p, err := Init(context.Background(), &cfg)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(p.endpointClients))
+	require.EqualValues(t, "http://localhost:4242", p.endpointClients[0].URL)
+	require.EqualValues(t, false, p.endpointClients[0].connect)
+	require.EqualValues(t, "http://localhost:4242/connect", p.endpointClients[1].URL)
+	require.EqualValues(t, true, p.endpointClients[1].connect)
+}


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Fix a bug where running `stripe listen` with `--forward-connect-to` would not forward events.

#### Before:

Using `--forward-to <url>` only:
✅ direct events are forwarded to `<url>`
✅ connect events are forwarded to `<url>`

Using both `--forward-to <url 1>` and `--forward-connect-to <url 2>`:
✅ direct events are forwarded to `<url 1>`
✅ connect events are forwarded to `<url 2>`

Using `--forward-connect-to <url>` only:
✅ direct events are NOT forwarded to `<url>`
❌ connect events are NOT forwarded to `<url>`

#### After:

Using `--forward-to <url>` only:
✅ direct events are forwarded to `<url>`
✅ connect events are forwarded to `<url>`

Using both `--forward-to <url 1>` and `--forward-connect-to <url 2>`:
✅ direct events are forwarded to `<url 1>`
✅ connect events are forwarded to `<url 2>`

Using `--forward-connect-to <url>` only:
✅ direct events are NOT forwarded to `<url>`
✅ connect events are forwarded to `<url>`

I added unit tests for each of these and tested manually as well.