### PR TITLE
Add trigger support for charge.refund.updated event

### DIFF
--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -22,6 +22,7 @@ var Events = map[string]string{
 	"charge.dispute.created":                   "triggers/charge.disputed.created.json",
 	"charge.failed":                            "triggers/charge.failed.json",
 	"charge.refunded":                          "triggers/charge.refunded.json",
+	"charge.refund.updated":                    "triggers/charge.refund.updated.json",
 	"charge.succeeded":                         "triggers/charge.succeeded.json",
 	"checkout.session.async_payment_failed":    "triggers/checkout.session.async_payment_failed.json",
 	"checkout.session.async_payment_succeeded": "triggers/checkout.session.async_payment_succeeded.json",

--- a/pkg/fixtures/triggers/charge.refund.updated.json
+++ b/pkg/fixtures/triggers/charge.refund.updated.json
@@ -1,0 +1,34 @@
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "charge",
+      "path": "/v1/charges",
+      "method": "post",
+      "params": {
+        "source": "tok_visa",
+        "amount": 100,
+        "currency": "usd",
+        "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "refund",
+      "path": "/v1/refunds",
+      "method": "post",
+      "params": {
+        "charge": "${charge:id}"
+      }
+    },
+    {
+      "name": "updated_refund",
+      "path": "/v1/refunds/${refund:id}",
+      "method": "post",
+      "params": {
+        "metadata": {"order_id": "6735"}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products 

 ### Summary
Fixes #828 , adding support for the `charge.refund.updated` event.

![charge_refund_updated](https://user-images.githubusercontent.com/58703040/156239294-6b887ccf-8766-47da-8920-3e8e0d84eda2.png)
