### PR TITLE
Add support for flag to output completion file to stdout

### DIFF
--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -15,7 +15,8 @@ import (
 type completionCmd struct {
 	cmd *cobra.Command
 
-	shell string
+	shell         string
+	writeToStdout bool
 }
 
 func newCompletionCmd() *completionCmd {
@@ -31,6 +32,7 @@ func newCompletionCmd() *completionCmd {
 	}
 
 	cc.cmd.Flags().StringVar(&cc.shell, "shell", "", "The shell to generate completion commands for. Supports \"bash\" or \"zsh\"")
+	cc.cmd.Flags().BoolVar(&cc.writeToStdout, "write-to-stdout", false, "Print completion script to stdout rather than creating a new file.")
 
 	return cc
 }

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -27,7 +27,7 @@ func newCompletionCmd() *completionCmd {
 		Short: "Generate bash and zsh completion scripts",
 		Args:  validators.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return selectShell(cc.shell)
+			return selectShell(cc.shell, cc.writeToStdout)
 		},
 	}
 
@@ -86,7 +86,7 @@ Set up Stripe autocompletion:
     source ~/.stripe/stripe-completion.bash`
 )
 
-func selectShell(shell string) error {
+func selectShell(shell string, writeToStdout bool) error {
 	selected := shell
 	if selected == "" {
 		selected = detectShell()
@@ -94,26 +94,46 @@ func selectShell(shell string) error {
 
 	switch {
 	case selected == "zsh":
-		fmt.Println("Detected `zsh`, generating zsh completion file: stripe-completion.zsh")
-		err := rootCmd.GenZshCompletionFile("stripe-completion.zsh")
-		if err == nil {
-			fmt.Printf("%s%s\n", instructionsHeader, zshCompletionInstructions)
-		}
-		return err
+		return genZsh(writeToStdout)
 	case selected == "bash":
-		fmt.Println("Detected `bash`, generating bash completion file: stripe-completion.bash")
-		err := rootCmd.GenBashCompletionFile("stripe-completion.bash")
-		if err == nil {
-			if runtime.GOOS == "darwin" {
-				fmt.Printf("%s%s\n", instructionsHeader, bashCompletionInstructionsMac)
-			} else if runtime.GOOS == "linux" {
-				fmt.Printf("%s%s\n", instructionsHeader, bashCompletionInstructionsLinux)
-			}
-		}
-		return err
+		return genBash(writeToStdout)
 	default:
 		return fmt.Errorf("Could not automatically detect your shell. Please run the command with the `--shell` flag for either bash or zsh")
 	}
+}
+
+func genZsh(writeToStdout bool) error {
+	if writeToStdout {
+		return rootCmd.GenZshCompletion(os.Stdout)
+	}
+
+	fmt.Println("Detected `zsh`, generating zsh completion file: stripe-completion.zsh")
+
+	err := rootCmd.GenZshCompletionFile("stripe-completion.zsh")
+	if err == nil {
+		fmt.Printf("%s%s\n", instructionsHeader, zshCompletionInstructions)
+	}
+
+	return err
+}
+
+func genBash(writeToStdout bool) error {
+	if writeToStdout {
+		return rootCmd.GenBashCompletion(os.Stdout)
+	}
+
+	fmt.Println("Detected `bash`, generating bash completion file: stripe-completion.bash")
+
+	err := rootCmd.GenBashCompletionFile("stripe-completion.bash")
+	if err == nil {
+		if runtime.GOOS == "darwin" {
+			fmt.Printf("%s%s\n", instructionsHeader, bashCompletionInstructionsMac)
+		} else if runtime.GOOS == "linux" {
+			fmt.Printf("%s%s\n", instructionsHeader, bashCompletionInstructionsLinux)
+		}
+	}
+
+	return err
 }
 
 func detectShell() string {


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products 

 ### Summary
Fixes #829 , adding support for a new flag `--write-to-stdout` which, rather than creating a file with the appropriate completion script, prints it to standard out.

![Screen Shot 2022-03-02 at 4 54 54 PM](https://user-images.githubusercontent.com/58703040/156475670-683a0818-a475-40f7-99c7-dac8a9a328b2.png)
![Screen Shot 2022-03-02 at 4 55 24 PM](https://user-images.githubusercontent.com/58703040/156475674-c4b1432f-9f9b-40bf-b37c-2e59230fd12a.png)

