### PR TITLE
Pinning protoc-gen-doc to 1.5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install protoc deps
       run: |
         go get github.com/golang/protobuf/protoc-gen-go
-        go get github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
+        go get github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.0
       shell: bash
     - name: Run Tests
       run: make ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install protoc deps
       run: |
         go get github.com/golang/protobuf/protoc-gen-go
-        go get github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.0
+        go get github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
       shell: bash
     - name: Run Tests
       run: make ci


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe 
cc @stripe/developer-products

 ### Summary
Pinning the doc generation version to 1.5.1. We can always update this or remove it if we find we need the latest documentation format but it'll be nice to not have to worry about updating unless we want to. 
