### PR TITLE
Support events <= 2017-05-25 without request data

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -575,7 +575,6 @@ func ExtractRequestData(data interface{}) (StripeRequest, error) {
 		return StripeRequest{ID: v}, nil
 	case nil:
 		return StripeRequest{}, nil
-
 	}
 
 	return StripeRequest{}, errors.New("Received malformed event from Stripe")


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
In API versions up to and including 2017-05-25, the event schema included the
request ID that triggered the event as a string in the event object. However,
this ID is only populated for direct Stripe API calls, and is null when the
event was triggered for another reason (e.g., internal Stripe systems, 3DS
verification callbacks, etc.).

This updates `ExtractRequestData` to handle missing request IDs for older API
versions. It also switches from using reflect to a type switch, which requires
less boilerplate.
