### PR TITLE
Early plugin bug fixes 

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -127,6 +127,8 @@ func Execute(ctx context.Context) {
 			} else {
 				// we found a plugin, so run it
 				err = plugin.Run(updatedCtx, &Config, fs, os.Args[2:])
+				// ensure we fully tear down the plugin before exiting the CLI
+				plugins.CleanupAllClients()
 				if err != nil {
 					if err == validators.ErrAPIKeyNotConfigured {
 						fmt.Println(color.Red("Install failed due to API key not configured. Please run `stripe login` or specify the `--api-key`"))

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -131,7 +131,9 @@ func Execute(ctx context.Context) {
 					if err == validators.ErrAPIKeyNotConfigured {
 						fmt.Println(color.Red("Install failed due to API key not configured. Please run `stripe login` or specify the `--api-key`"))
 					} else {
-						fmt.Println(err)
+						log.WithFields(log.Fields{
+							"prefix": "plugins.plugin.run",
+						}).Trace(fmt.Sprintf("Plugin command %s exited with error: %s", plugin.Shortname, err))
 					}
 					os.Exit(1)
 				}

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -82,7 +82,7 @@ func (p *Plugin) cleanUpPluginPath(config config.IConfig, fs afero.Fs, versionTo
 	logger := log.WithFields(log.Fields{
 		"prefix": "plugins.plugin.cleanUpPluginPath",
 	})
-	logger.Debug("cleaning up other plugin versions...")
+	logger.Debug("Cleaning up other plugin versions...")
 
 	pluginsDir := getPluginsDir(config)
 	pluginPath := filepath.Join(pluginsDir, p.Shortname)
@@ -96,13 +96,13 @@ func (p *Plugin) cleanUpPluginPath(config config.IConfig, fs afero.Fs, versionTo
 		switch {
 		case path == pluginPath:
 			// Pass the root directory
-			logger.Debugf("skipping directory: %s", path)
+			logger.Debugf("Skipping directory: %s", path)
 			return nil
 		case info.IsDir() && path == versionPathToKeep:
-			logger.Debugf("skipping directory: %s", path)
+			logger.Debugf("Skipping directory: %s", path)
 			return filepath.SkipDir
 		default:
-			logger.Debugf("removing old plugin: %s", path)
+			logger.Debugf("Removing old plugin: %s", path)
 			fs.RemoveAll(path)
 			return nil
 		}
@@ -124,12 +124,12 @@ func (p *Plugin) getChecksum(version string) ([]byte, error) {
 	}
 
 	if expectedSum == "" {
-		return nil, fmt.Errorf("could not locate a valid checksum for %s version %s", p.Shortname, version)
+		return nil, fmt.Errorf("Could not locate a valid checksum for %s version %s", p.Shortname, version)
 	}
 
 	decoded, err := hex.DecodeString(expectedSum)
 	if err != nil {
-		return nil, fmt.Errorf("could not decode checksum for %s version %s", p.Shortname, version)
+		return nil, fmt.Errorf("Could not decode checksum for %s version %s", p.Shortname, version)
 	}
 
 	return decoded, nil
@@ -208,7 +208,7 @@ func (p *Plugin) downloadAndSavePlugin(config config.IConfig, pluginDownloadURL 
 	err = p.verifyChecksum(reader, version)
 
 	if err != nil {
-		logger.Debug("checksum mismatch")
+		logger.Debug("could not match checksum of plugin")
 		return err
 	}
 
@@ -253,6 +253,10 @@ func (p *Plugin) verifyChecksum(binary io.Reader, version string) error {
 
 // Run boots up the binary and then sends the command to it via RPC
 func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, args []string) error {
+	logger := log.WithFields(log.Fields{
+		"prefix": "plugins.plugin.Run",
+	})
+
 	var version string
 
 	if PluginsPath != "" {
@@ -317,14 +321,14 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 	// Connect via RPC to the plugin
 	rpcClient, err := client.Client()
 	if err != nil {
+		logger.Debugf("Could not connect to plugin: %s", err)
 		return err
 	}
-
-	defer client.Kill()
 
 	// Request the plugin's main interface
 	raw, err := rpcClient.Dispense("main")
 	if err != nil {
+		logger.Debugf("Could not dispense plugin interface: %s", err)
 		return err
 	}
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -40,7 +40,7 @@ func TestInstallFailsIfChecksumCouldNotBeFound(t *testing.T) {
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "0.0.0", testServers.StripeServer.URL)
-	require.EqualError(t, err, "could not locate a valid checksum for appA version 0.0.0")
+	require.EqualError(t, err, "Could not locate a valid checksum for appA version 0.0.0")
 
 	// Require that we don't save the binary if checkum does not match
 	fileExists, err := afero.Exists(fs, "/plugins/appA/0.0.1/stripe-cli-app-a")
@@ -103,7 +103,7 @@ func TestInstallDoesNotCleanIfInstallFails(t *testing.T) {
 
 	// Install fails for the same plugin because the checksum could not be found in manifest
 	err = plugin.Install(context.Background(), config, fs, "0.0.0", testServers.StripeServer.URL)
-	require.EqualError(t, err, "could not locate a valid checksum for appA version 0.0.0")
+	require.EqualError(t, err, "Could not locate a valid checksum for appA version 0.0.0")
 	fileExists, _ = afero.Exists(fs, "/plugins/appA/0.0.1/stripe-cli-app-a")
 	require.False(t, fileExists, "Test setup failed -- did not expect plugin to be downloaded")
 

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -144,6 +144,7 @@ func FetchRemoteResource(url string) ([]byte, error) {
 	return body, nil
 }
 
+// CleanupAllClients tears down and disconnects all "managed" plugin clients
 func CleanupAllClients() {
 	log.Debug("Tearing down plugin before exit")
 	hcplugin.CleanupClients()

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	hcplugin "github.com/hashicorp/go-plugin"
 	"github.com/spf13/afero"
 
 	"github.com/stripe/stripe-cli/pkg/config"
@@ -80,7 +81,7 @@ func LookUpPlugin(ctx context.Context, config config.IConfig, fs afero.Fs, plugi
 		}
 	}
 
-	return plugin, fmt.Errorf("could not find a plugin named %s", pluginName)
+	return plugin, fmt.Errorf("Could not find a plugin named %s", pluginName)
 }
 
 // RefreshPluginManifest refreshes the plugin manifest
@@ -141,4 +142,9 @@ func FetchRemoteResource(url string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+func CleanupAllClients() {
+	log.Debug("Tearing down plugin before exit")
+	hcplugin.CleanupClients()
 }


### PR DESCRIPTION
 ### Reviewers
r? @etsai-stripe 
cc @stripe/developer-products

 ### Summary
Fixes the following:

- Plugin run error was logged without a severity filter
- Missed a `master` reference rename to `local.build.dev`
- Plugins should be automatically managed to catch any unexpected exits
- Plugins should have a startup timeout to prevent any hangs (not a reported bug but a "should do")
- Plugin logger instance was logging as too low a severity
- Properly clean up clients before the CLI exits