### PR TITLE
do not parse flags separately from args in plugin cmd

### DIFF
--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -14,9 +14,10 @@ import (
 )
 
 type pluginTemplateCmd struct {
-	cfg *config.Config
-	cmd *cobra.Command
-	fs  afero.Fs
+	cfg        *config.Config
+	cmd        *cobra.Command
+	fs         afero.Fs
+	ParsedArgs []string
 }
 
 // newPluginTemplateCmd is a generic plugin command template to dynamically use
@@ -27,10 +28,11 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 	ptc.cfg = config
 
 	ptc.cmd = &cobra.Command{
-		Use:         plugin.Shortname,
-		Short:       plugin.Shortdesc,
-		RunE:        ptc.runPluginCmd,
-		Annotations: map[string]string{"scope": "plugin"},
+		Use:                plugin.Shortname,
+		Short:              plugin.Shortdesc,
+		RunE:               ptc.runPluginCmd,
+		Annotations:        map[string]string{"scope": "plugin"},
+		DisableFlagParsing: true,
 	}
 
 	// override the CLI's help command and let the plugin supply the help text instead
@@ -50,6 +52,7 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
+	ptc.ParsedArgs = args
 	fs := afero.NewOsFs()
 	plugin, err := plugins.LookUpPlugin(ctx, ptc.cfg, fs, cmd.CalledAs())
 

--- a/pkg/cmd/plugin_cmds_test.go
+++ b/pkg/cmd/plugin_cmds_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -34,8 +33,7 @@ func TestFlagsArePassedAsArgs(t *testing.T) {
 
 	pluginCmd := createPluginCmd()
 	rootCmd.AddCommand(pluginCmd.cmd)
-	c, _, _ := executeCommandC(rootCmd, "test", "testarg", "--testflag")
-	fmt.Println(c.Args)
+	executeCommandC(rootCmd, "test", "testarg", "--testflag")
 
 	require.Equal(t, len(pluginCmd.ParsedArgs), 2)
 	require.Equal(t, strings.Join(pluginCmd.ParsedArgs, " "), "testarg --testflag")

--- a/pkg/cmd/plugin_cmds_test.go
+++ b/pkg/cmd/plugin_cmds_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/stripe/stripe-cli/pkg/plugins"
 )
 

--- a/pkg/cmd/plugin_cmds_test.go
+++ b/pkg/cmd/plugin_cmds_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-cli/pkg/plugins"
+)
+
+func createPluginCmd() *pluginTemplateCmd {
+	plugin := plugins.Plugin{
+		Shortname:        "test",
+		Shortdesc:        "test your stuff",
+		Binary:           "stripe-cli-test",
+		MagicCookieValue: "magic",
+		Releases: []plugins.Release{{
+			Arch:    "amd64",
+			OS:      "darwin",
+			Version: "0.0.1",
+			Sum:     "c53a98c3fa63563227eb8b5601acedb5e0e70fed2e1d52a5918a17ac755f17f7",
+		}},
+	}
+
+	pluginCmd := newPluginTemplateCmd(&Config, &plugin)
+
+	return pluginCmd
+}
+
+func TestFlagsArePassedAsArgs(t *testing.T) {
+	Execute(context.Background())
+
+	pluginCmd := createPluginCmd()
+	rootCmd.AddCommand(pluginCmd.cmd)
+	c, _, _ := executeCommandC(rootCmd, "test", "testarg", "--testflag")
+	fmt.Println(c.Args)
+
+	require.Equal(t, len(pluginCmd.ParsedArgs), 2)
+	require.Equal(t, strings.Join(pluginCmd.ParsedArgs, " "), "testarg --testflag")
+}


### PR DESCRIPTION
 ### Reviewers
r? @bernerd-stripe 
cc @stripe/developer-products

 ### Summary
Fixes an issue where flags were not passed all the way into plugins. We skip the flag parsing in the CLI and pass them as args, letting the plugin parse them instead.
