### PR TITLE
plugin fixes for windows and root level flags

### DIFF
--- a/pkg/cmd/plugin_cmds_test.go
+++ b/pkg/cmd/plugin_cmds_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -29,13 +30,23 @@ func createPluginCmd() *pluginTemplateCmd {
 	return pluginCmd
 }
 
+// TestFlagsArePassedAsArgs ensures that the plugin is passing all args and flags as expected.
+// This is a complex dance between the CLI itself and the plugin, so the flags come from
+// two different sources as a result. This test is here to catch any non-obvious regressions
 func TestFlagsArePassedAsArgs(t *testing.T) {
-	Execute(context.Background())
-
 	pluginCmd := createPluginCmd()
 	rootCmd.AddCommand(pluginCmd.cmd)
-	executeCommandC(rootCmd, "test", "testarg", "--testflag")
 
-	require.Equal(t, len(pluginCmd.ParsedArgs), 2)
-	require.Equal(t, strings.Join(pluginCmd.ParsedArgs, " "), "testarg --testflag")
+	Execute(context.Background())
+
+	// temp override for the os.Args so that the pluginCmd can use them
+	oldArgs := os.Args
+	os.Args = []string{"stripe", "test", "testarg", "--log-level=info"}
+	defer func() { os.Args = oldArgs }()
+
+	rootCmd.SetArgs([]string{"test", "testarg", "--log-level=info"})
+	executeCommandC(rootCmd, "test", "testarg", "--log-level=info")
+
+	require.Equal(t, 2, len(pluginCmd.ParsedArgs))
+	require.Equal(t, "testarg --log-level=info", strings.Join(pluginCmd.ParsedArgs, " "))
 }

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -225,6 +225,10 @@ func (p *Plugin) downloadAndSavePlugin(config config.IConfig, pluginDownloadURL 
 	pluginDir := p.getPluginInstallPath(config, version)
 	pluginFilePath := filepath.Join(pluginDir, p.Binary)
 
+	if runtime.GOOS == "windows" {
+		pluginFilePath += ".exe"
+	}
+
 	logger.Debugf("installing %s to %s...", p.Shortname, pluginFilePath)
 
 	body, err := FetchRemoteResource(pluginDownloadURL)
@@ -313,6 +317,10 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 
 	pluginDir := p.getPluginInstallPath(config, version)
 	pluginBinaryPath := filepath.Join(pluginDir, p.Binary)
+
+	if runtime.GOOS == "windows" {
+		pluginBinaryPath += ".exe"
+	}
 
 	cmd := exec.Command(pluginBinaryPath)
 

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -224,10 +224,7 @@ func (p *Plugin) downloadAndSavePlugin(config config.IConfig, pluginDownloadURL 
 
 	pluginDir := p.getPluginInstallPath(config, version)
 	pluginFilePath := filepath.Join(pluginDir, p.Binary)
-
-	if runtime.GOOS == "windows" {
-		pluginFilePath += ".exe"
-	}
+	pluginFilePath += GetBinaryExtension()
 
 	logger.Debugf("installing %s to %s...", p.Shortname, pluginFilePath)
 
@@ -317,10 +314,7 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 
 	pluginDir := p.getPluginInstallPath(config, version)
 	pluginBinaryPath := filepath.Join(pluginDir, p.Binary)
-
-	if runtime.GOOS == "windows" {
-		pluginBinaryPath += ".exe"
-	}
+	pluginBinaryPath += GetBinaryExtension()
 
 	cmd := exec.Command(pluginBinaryPath)
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -2,12 +2,22 @@ package plugins
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
+
+func getBinaryExtension() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+
+	return ""
+}
 
 func TestLookUpLatestVersion(t *testing.T) {
 	fs := setUpFS()
@@ -27,7 +37,8 @@ func TestInstall(t *testing.T) {
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
 	require.Nil(t, err)
-	fileExists, err := afero.Exists(fs, "/plugins/appA/2.0.1/stripe-cli-app-a")
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", getBinaryExtension())
+	fileExists, err := afero.Exists(fs, file)
 	require.Nil(t, err)
 	require.True(t, fileExists)
 }
@@ -43,7 +54,8 @@ func TestInstallFailsIfChecksumCouldNotBeFound(t *testing.T) {
 	require.EqualError(t, err, "Could not locate a valid checksum for appA version 0.0.0")
 
 	// Require that we don't save the binary if checkum does not match
-	fileExists, err := afero.Exists(fs, "/plugins/appA/0.0.1/stripe-cli-app-a")
+	file := fmt.Sprintf("/plugins/appA/0.0.0/stripe-cli-app-a%s", getBinaryExtension())
+	fileExists, err := afero.Exists(fs, file)
 	require.Nil(t, err)
 	require.False(t, fileExists)
 }
@@ -59,7 +71,8 @@ func TestInstallationFailsIfChecksumDoesNotMatch(t *testing.T) {
 	require.EqualError(t, err, "installed plugin 'appB' could not be verified, aborting installation")
 
 	// Require that we don't save the binary if checkum does not match
-	fileExists, err := afero.Exists(fs, "/plugins/appB/1.2.1/stripe-cli-app-b")
+	file := fmt.Sprintf("/plugins/appB/1.2.1/stripe-cli-app-b%s", getBinaryExtension())
+	fileExists, err := afero.Exists(fs, file)
 	require.Nil(t, err)
 	require.False(t, fileExists)
 }
@@ -74,17 +87,19 @@ func TestInstallCleansOtherVersionsOfPlugin(t *testing.T) {
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "0.0.1", testServers.StripeServer.URL)
 	require.Nil(t, err)
-	fileExists, _ := afero.Exists(fs, "/plugins/appA/0.0.1/stripe-cli-app-a")
+	file := fmt.Sprintf("/plugins/appA/0.0.1/stripe-cli-app-a%s", getBinaryExtension())
+	fileExists, _ := afero.Exists(fs, file)
 	require.True(t, fileExists, "Test setup failed -- did not download plugin version 0.0.1")
 
 	// Download valid plugin
 	err = plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
 	require.Nil(t, err)
-	fileExists, _ = afero.Exists(fs, "/plugins/appA/2.0.1/stripe-cli-app-a")
+	newFile := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", getBinaryExtension())
+	fileExists, _ = afero.Exists(fs, newFile)
 	require.True(t, fileExists, "Test setup failed -- did not download plugin version 2.0.1")
 
 	// Require that the older version got removed from the fs
-	fileExists, _ = afero.Exists(fs, "/plugins/appA/0.0.1/stripe-cli-app-a")
+	fileExists, _ = afero.Exists(fs, file)
 	require.False(t, fileExists, "Expected the original version of the plugin to be deleted.")
 }
 
@@ -98,16 +113,18 @@ func TestInstallDoesNotCleanIfInstallFails(t *testing.T) {
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
 	require.Nil(t, err)
-	fileExists, _ := afero.Exists(fs, "/plugins/appA/2.0.1/stripe-cli-app-a")
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", getBinaryExtension())
+	fileExists, _ := afero.Exists(fs, file)
 	require.True(t, fileExists, "Test setup failed -- did not download valid plugin")
 
 	// Install fails for the same plugin because the checksum could not be found in manifest
 	err = plugin.Install(context.Background(), config, fs, "0.0.0", testServers.StripeServer.URL)
 	require.EqualError(t, err, "Could not locate a valid checksum for appA version 0.0.0")
-	fileExists, _ = afero.Exists(fs, "/plugins/appA/0.0.1/stripe-cli-app-a")
+	failedFile := fmt.Sprintf("/plugins/appA/0.0.0/stripe-cli-app-a%s", getBinaryExtension())
+	fileExists, _ = afero.Exists(fs, failedFile)
 	require.False(t, fileExists, "Test setup failed -- did not expect plugin to be downloaded")
 
 	// Require that we did not delete the initial version of the plugin
-	fileExists, _ = afero.Exists(fs, "/plugins/appA/2.0.1/stripe-cli-app-a")
+	fileExists, _ = afero.Exists(fs, file)
 	require.True(t, fileExists, "Did not expect the original version of the plugin to be deleted.")
 }

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -4,20 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
-
-func getBinaryExtension() string {
-	if runtime.GOOS == "windows" {
-		return ".exe"
-	}
-
-	return ""
-}
 
 func TestLookUpLatestVersion(t *testing.T) {
 	fs := setUpFS()
@@ -37,7 +28,7 @@ func TestInstall(t *testing.T) {
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
 	require.Nil(t, err)
-	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", getBinaryExtension())
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, err := afero.Exists(fs, file)
 	require.Nil(t, err)
 	require.True(t, fileExists)
@@ -54,7 +45,7 @@ func TestInstallFailsIfChecksumCouldNotBeFound(t *testing.T) {
 	require.EqualError(t, err, "Could not locate a valid checksum for appA version 0.0.0")
 
 	// Require that we don't save the binary if checkum does not match
-	file := fmt.Sprintf("/plugins/appA/0.0.0/stripe-cli-app-a%s", getBinaryExtension())
+	file := fmt.Sprintf("/plugins/appA/0.0.0/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, err := afero.Exists(fs, file)
 	require.Nil(t, err)
 	require.False(t, fileExists)
@@ -71,7 +62,7 @@ func TestInstallationFailsIfChecksumDoesNotMatch(t *testing.T) {
 	require.EqualError(t, err, "installed plugin 'appB' could not be verified, aborting installation")
 
 	// Require that we don't save the binary if checkum does not match
-	file := fmt.Sprintf("/plugins/appB/1.2.1/stripe-cli-app-b%s", getBinaryExtension())
+	file := fmt.Sprintf("/plugins/appB/1.2.1/stripe-cli-app-b%s", GetBinaryExtension())
 	fileExists, err := afero.Exists(fs, file)
 	require.Nil(t, err)
 	require.False(t, fileExists)
@@ -87,14 +78,14 @@ func TestInstallCleansOtherVersionsOfPlugin(t *testing.T) {
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "0.0.1", testServers.StripeServer.URL)
 	require.Nil(t, err)
-	file := fmt.Sprintf("/plugins/appA/0.0.1/stripe-cli-app-a%s", getBinaryExtension())
+	file := fmt.Sprintf("/plugins/appA/0.0.1/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, _ := afero.Exists(fs, file)
 	require.True(t, fileExists, "Test setup failed -- did not download plugin version 0.0.1")
 
 	// Download valid plugin
 	err = plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
 	require.Nil(t, err)
-	newFile := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", getBinaryExtension())
+	newFile := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, _ = afero.Exists(fs, newFile)
 	require.True(t, fileExists, "Test setup failed -- did not download plugin version 2.0.1")
 
@@ -113,14 +104,14 @@ func TestInstallDoesNotCleanIfInstallFails(t *testing.T) {
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
 	require.Nil(t, err)
-	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", getBinaryExtension())
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, _ := afero.Exists(fs, file)
 	require.True(t, fileExists, "Test setup failed -- did not download valid plugin")
 
 	// Install fails for the same plugin because the checksum could not be found in manifest
 	err = plugin.Install(context.Background(), config, fs, "0.0.0", testServers.StripeServer.URL)
 	require.EqualError(t, err, "Could not locate a valid checksum for appA version 0.0.0")
-	failedFile := fmt.Sprintf("/plugins/appA/0.0.0/stripe-cli-app-a%s", getBinaryExtension())
+	failedFile := fmt.Sprintf("/plugins/appA/0.0.0/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, _ = afero.Exists(fs, failedFile)
 	require.False(t, fileExists, "Test setup failed -- did not expect plugin to be downloaded")
 

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptrace"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	log "github.com/sirupsen/logrus"
 
@@ -21,6 +22,15 @@ import (
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 )
+
+// GetBinaryExtension returns the appropriate file extension for plugin binary
+func GetBinaryExtension() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+
+	return ""
+}
 
 // getPluginsDir computes where plugins are installed locally
 func getPluginsDir(config config.IConfig) string {


### PR DESCRIPTION
 ### Reviewers
r? @gracegoo-stripe @etsai-stripe 
cc @stripe/developer-products

 ### Summary
I made an assumption that executables on Windows do not need a file extension in order to run successfully via a golang `exec` child process. This assumption turned out to be incorrect. Adding an urgent temporary patch to fix this with a lighter touch, before deciding on a more permanent solution.

Also modified the plugin cmd template to parse the flags on the cli side but send the raw args to the plugin child, which gets us the best of both worlds wrt flag compatibility.
