### PR TITLE
stripe.Client supports custom list of printable headers

### DIFF
--- a/pkg/stripe/verbosetransport_test.go
+++ b/pkg/stripe/verbosetransport_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestVerboseTransport_Verbose(t *testing.T) {
+func TestVerboseTransport(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Request-Id", "req_123")
 		w.Header().Set("Non-Whitelisted-Header", "foo")
@@ -22,9 +22,9 @@ func TestVerboseTransport_Verbose(t *testing.T) {
 
 	httpTransport := &http.Transport{}
 	tr := &verboseTransport{
-		Transport: httpTransport,
-		Verbose:   true,
-		Out:       &b,
+		Transport:        httpTransport,
+		Out:              &b,
+		PrintableHeaders: inspectHeaders,
 	}
 	client := &http.Client{Transport: tr}
 	req, err := http.NewRequest("POST", ts.URL+"/test", nil)


### PR DESCRIPTION
 ### Reviewers
r? @acomley-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

This updates the stripe Client to make the list of headers printed in verbose mode to be configurable. This is not exposed through CLI flags, but is useful for plugins or potential usage of the CLI's stripe client package.

It also applies some light refactoring to use the `http.Transport` interface instead of `*http.Transport`.