### PR TITLE
Fix plugin flags not recognized by main stripe CLI

### DIFF
--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -29,10 +29,11 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 	ptc.cfg = config
 
 	ptc.cmd = &cobra.Command{
-		Use:         plugin.Shortname,
-		Short:       plugin.Shortdesc,
-		RunE:        ptc.runPluginCmd,
-		Annotations: map[string]string{"scope": "plugin"},
+		Use:                plugin.Shortname,
+		Short:              plugin.Shortdesc,
+		RunE:               ptc.runPluginCmd,
+		Annotations:        map[string]string{"scope": "plugin"},
+		DisableFlagParsing: true,
 	}
 
 	// override the CLI's help command and let the plugin supply the help text instead


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe 
cc @stripe/developer-products

 ### Summary
Fix plugin flags not recognized by main Stripe CLI.
