### PR TITLE
ignore unknown flags for plugin commands

### DIFF
--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -66,7 +66,6 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 
 	log.WithFields(log.Fields{
 		"prefix": "cmd.pluginCmd.runPluginCmd",
-		"config": ptc.cfg,
 	}).Debug("Running plugin...")
 
 	err = plugin.Run(ctx, ptc.cfg, fs, ptc.ParsedArgs)

--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -33,6 +33,9 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 		Short:       plugin.Shortdesc,
 		RunE:        ptc.runPluginCmd,
 		Annotations: map[string]string{"scope": "plugin"},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
 	}
 
 	// override the CLI's help command and let the plugin supply the help text instead
@@ -60,6 +63,11 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 	if err != nil {
 		return err
 	}
+
+	log.WithFields(log.Fields{
+		"prefix": "cmd.pluginCmd.runPluginCmd",
+		"config": ptc.cfg,
+	}).Debug("Running plugin...")
 
 	err = plugin.Run(ctx, ptc.cfg, fs, ptc.ParsedArgs)
 	plugins.CleanupAllClients()


### PR DESCRIPTION
 ### Reviewers
r? @gracegoo-stripe 
cc @stripe/developer-products @htheodore-stripe 

 ### Summary
The CLI has no context on the valid flags available for each plugin, so we want to skip validation for plugin commands while retaining flag validation for main CLI commands that are knowable. After a couple of iterations on solving this problem, this PR is probably the most balanced and stable. It ensures all flags are parsed correctly for main CLI commands / config overrides, and are delegated correctly to plugins, allowing the plugin to validate the flags from there.
