### PR TITLE
Add plugin uninstall command

### DIFF
--- a/pkg/cmd/plugin.go
+++ b/pkg/cmd/plugin.go
@@ -24,6 +24,7 @@ func newPluginCmd() *pluginCmd {
 
 	pc.cmd.AddCommand(plugin.NewInstallCmd(&Config).Cmd)
 	pc.cmd.AddCommand(plugin.NewUpgradeCmd(&Config).Cmd)
+	pc.cmd.AddCommand(plugin.NewUninstallCmd(&Config).Cmd)
 
 	return pc
 }

--- a/pkg/cmd/plugin/uninstall.go
+++ b/pkg/cmd/plugin/uninstall.go
@@ -1,0 +1,64 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/plugins"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+// UninstallCmd is the struct used for configuring the plugin uninstall command
+type UninstallCmd struct {
+	cfg *config.Config
+	Cmd *cobra.Command
+	fs  afero.Fs
+}
+
+// NewUninstallCmd creates a new command for uninstalling plugins
+func NewUninstallCmd(config *config.Config) *UninstallCmd {
+	uc := &UninstallCmd{}
+	uc.fs = afero.NewOsFs()
+	uc.cfg = config
+
+	uc.Cmd = &cobra.Command{
+		Use:   "uninstall",
+		Args:  validators.ExactArgs(1),
+		Short: "Uninstall a Stripe CLI plugin",
+		Long:  "Uninstall a Stripe CLI plugin.",
+		RunE:  uc.runUninstallCmd,
+	}
+
+	return uc
+}
+
+func (uc *UninstallCmd) runUninstallCmd(cmd *cobra.Command, args []string) error {
+	ctx := withSIGTERMCancel(cmd.Context(), func() {
+		log.WithFields(log.Fields{
+			"prefix": "cmd.uninstallCmd.runUninstallCmd",
+		}).Debug("Ctrl+C received, cleaning up...")
+	})
+
+	plugin, err := plugins.LookUpPlugin(cmd.Context(), uc.cfg, uc.fs, args[0])
+
+	if err != nil {
+		return errors.New("this plugin doesn't seem to exist")
+	}
+
+	err = plugin.Uninstall(ctx, uc.cfg, uc.fs)
+
+	if err == nil {
+		color := ansi.Color(os.Stdout)
+		successMsg := fmt.Sprintf("✔ %s has been uninstalled.", plugin.Shortname)
+		fmt.Println(color.Green(successMsg))
+	}
+
+	return err
+}

--- a/pkg/cmd/plugin/upgrade.go
+++ b/pkg/cmd/plugin/upgrade.go
@@ -40,20 +40,22 @@ func NewUpgradeCmd(config *config.Config) *UpgradeCmd {
 }
 
 func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
-	// Refresh the plugin before proceeding
-	plugins.RefreshPluginManifest(cmd.Context(), uc.cfg, uc.fs, stripe.DefaultAPIBaseURL)
-
-	plugin, err := plugins.LookUpPlugin(cmd.Context(), uc.cfg, uc.fs, args[0])
-	if err != nil {
-		return err
-	}
-	version := plugin.LookUpLatestVersion()
-
 	ctx := withSIGTERMCancel(cmd.Context(), func() {
 		log.WithFields(log.Fields{
 			"prefix": "cmd.upgradeCmd.runUpgradeCmd",
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
+
+	// Refresh the plugin info before proceeding
+	plugins.RefreshPluginManifest(cmd.Context(), uc.cfg, uc.fs, stripe.DefaultAPIBaseURL)
+
+	plugin, err := plugins.LookUpPlugin(cmd.Context(), uc.cfg, uc.fs, args[0])
+
+	if err != nil {
+		return err
+	}
+
+	version := plugin.LookUpLatestVersion()
 
 	err = plugin.Install(ctx, uc.cfg, uc.fs, version, stripe.DefaultAPIBaseURL)
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -189,7 +189,7 @@ func init() {
 	// get a list of installed plugins, validate against the manifest
 	// and finally add each validated plugin as a command
 	nfs := afero.NewOsFs()
-	pluginList := Config.Profile.GetInstalledPlugins()
+	pluginList := Config.GetInstalledPlugins()
 
 	for _, p := range pluginList {
 		plugin, err := plugins.LookUpPlugin(context.Background(), &Config, nfs, p)

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -163,16 +163,6 @@ func (p *Profile) GetTerminalPOSDeviceID() string {
 	return ""
 }
 
-// GetInstalledPlugins returns a list of locally installed plugins.
-// This does not vary by profile
-func (p *Profile) GetInstalledPlugins() []string {
-	if err := viper.ReadInConfig(); err == nil {
-		return viper.GetStringSlice("installed_plugins")
-	}
-
-	return []string{}
-}
-
 // GetConfigField returns the configuration field for the specific profile
 func (p *Profile) GetConfigField(field string) string {
 	return p.ProfileName + "." + field

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -75,8 +75,9 @@ func (p *Plugin) getPluginInterface() (hcplugin.HandshakeConfig, map[int]hcplugi
 func (p *Plugin) getPluginInstallPath(config config.IConfig, version string) string {
 	pluginsDir := getPluginsDir(config)
 	pluginPath := filepath.Join(pluginsDir, p.Shortname, version)
+	cleanedPath := filepath.Clean(pluginPath)
 
-	return pluginPath
+	return cleanedPath
 }
 
 // cleanUpPluginPath empties the plugin folder except for the version specified
@@ -186,8 +187,7 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 		return err
 	}
 
-	profile := cfg.GetProfile()
-	installedList := profile.GetInstalledPlugins()
+	installedList := cfg.GetInstalledPlugins()
 
 	// check for plugin already in list (ie. in the case of an upgrade)
 	isInstalled := false
@@ -213,6 +213,37 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	p.cleanUpPluginPath(cfg, fs, version)
 
 	ansi.StopSpinner(spinner, "", os.Stdout)
+
+	return nil
+}
+
+func (p *Plugin) Uninstall(ctx context.Context, config config.IConfig, fs afero.Fs) error {
+	pluginList := config.GetInstalledPlugins()
+	pluginIdx := -1
+
+	for i, name := range pluginList {
+		if name == p.Shortname {
+			pluginIdx = i
+		}
+	}
+
+	if pluginIdx == -1 {
+		return errors.New("this plugin doesn't seem to be installed, canceling")
+	}
+
+	pluginDir := p.getPluginInstallPath(config, "")
+
+	err := fs.RemoveAll(pluginDir)
+
+	if err != nil {
+		return err
+	}
+
+	// remove plugin from installed plugins list in profile
+	installedList := make([]string, 0)
+	installedList = append(installedList, pluginList[:pluginIdx]...)
+	installedList = append(installedList, pluginList[pluginIdx+1:]...)
+	config.WriteConfigField("installed_plugins", installedList)
 
 	return nil
 }

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -217,6 +217,7 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	return nil
 }
 
+// Uninstall removes a plugin from the disk and from the config's installed plugins list
 func (p *Plugin) Uninstall(ctx context.Context, config config.IConfig, fs afero.Fs) error {
 	pluginList := config.GetInstalledPlugins()
 	pluginIdx := -1

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -148,7 +148,7 @@ func TestUninstall(t *testing.T) {
 	pluginDir := "/plugins/appA"
 	err = plugin.Uninstall(context.Background(), config, fs)
 	require.Nil(t, err)
-	dirExists, err := afero.Exists(fs, pluginDir)
+	dirExists, _ := afero.Exists(fs, pluginDir)
 	require.False(t, dirExists)
 
 	require.Equal(t, 0, len(config.GetInstalledPlugins()))

--- a/pkg/plugins/test_utils.go
+++ b/pkg/plugins/test_utils.go
@@ -13,16 +13,16 @@ import (
 	"github.com/stripe/stripe-cli/pkg/config"
 )
 
-// TestConfig Implementation out the GetConfigFolder function
+// TestConfig Implementations out several methods
 type TestConfig struct {
 	config.Config
 }
 
-// GetProfile returns the Mock Profile
-func (c *TestConfig) GetProfile() *config.Profile {
-	return &config.Profile{
-		APIKey: "rk_test_11111111111111111111111111",
-	}
+// WriteConfigField mocks out the method so that we can ensure installed plugins data is written
+func (c *TestConfig) WriteConfigField(field string, value interface{}) error {
+	c.InstalledPlugins = value.([]string)
+
+	return nil
 }
 
 // GetConfigFolder returns the absolute path for the TestConfig
@@ -30,8 +30,15 @@ func (c *TestConfig) GetConfigFolder(xdgPath string) string {
 	return "/"
 }
 
-// InitConfig is not implemented
-func (c *TestConfig) InitConfig() {}
+// GetInstalledPlugins returns the mocked out list of installed plugins
+func (c *TestConfig) GetInstalledPlugins() []string {
+	return c.InstalledPlugins
+}
+
+// InitConfig initializes the config with the values we need
+func (c *TestConfig) InitConfig() {
+	c.Profile.APIKey = "rk_test_11111111111111111111111111"
+}
 
 // setUpFS Sets up a memMap that contains the manifest
 func setUpFS() afero.Fs {

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -13,6 +13,7 @@ import (
 func TestGetPluginList(t *testing.T) {
 	fs := setUpFS()
 	config := &TestConfig{}
+	config.InitConfig()
 
 	pluginList, err := GetPluginList(context.Background(), config, fs)
 
@@ -46,6 +47,7 @@ func TestLookUpPlugin(t *testing.T) {
 func TestRefreshPluginManifest(t *testing.T) {
 	fs := setUpFS()
 	config := &TestConfig{}
+	config.InitConfig()
 	updatedManifestContent, _ := os.ReadFile("./test_artifacts/plugins_updated.toml")
 	testServers := setUpServers(t, updatedManifestContent)
 	defer func() { testServers.CloseAll() }()


### PR DESCRIPTION
 ### Reviewers
r? @gracegoo-stripe 
cc @stripe/developer-products

 ### Summary
1. Adds an uninstall command for plugins
2. Fixes a bug to do with logging within the config initialization flow
3. Updates some of the plugin test mocking utilities to expand on what details we can assert
4. Moves the `GetInstalledPlugins` method from the user profile to the user config instead
