### PR TITLE
Download golangci-lint at new link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint: bin/golangci-lint
 .PHONY: lint
 
 bin/golangci-lint:
-	curl -fsSL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s $(GOLANGCI_LINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 
 # Clean go.mod
 go-mod-tidy:


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Our GitHub Action was failing because it couldn't find golangci-lint. This updates the link to a new one from golangci-lint docs: https://golangci-lint.run/usage/install/#other-ci

I verified this works on my local repo.