### PR TITLE
Use the default github token in the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           version: v0.184.0
           args: release -f .goreleaser/mac.yml --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-linux:
     runs-on: ubuntu-latest
@@ -49,7 +49,7 @@ jobs:
           version: v0.184.0
           args: release -f .goreleaser/linux.yml --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACTORY_SECRET: ${{ secrets.ARTIFACTORY_SECRET }}
 
   build-windows:
@@ -69,7 +69,7 @@ jobs:
           version: v0.184.0
           args: release -f .goreleaser/windows.yml --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   upload-to-virustotal:
     needs: [build-windows]
@@ -81,5 +81,5 @@ jobs:
         run: scripts/upload-zip-to-virustotal.sh
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VIRUSTOTAL_API_KEY: ${{ secrets.VIRUSTOTAL_API_KEY }}


### PR DESCRIPTION
 ### Reviewers
r? @gracegoo-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Replace the GORELEASER_GITHUB_TOKEN with the default one as recommended here: https://docs.github.com/en/actions/security-guides/automatic-token-authentication

I think this will make releases no longer look like they're being made by Tomer.

Not sure how to test this other than making a release, which I will do after this.