### PR TITLE
Update gopkg.in/yaml.v2 to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,13 +43,14 @@ require (
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/ini.v1 v1.63.2 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 require (
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/joho/godotenv v1.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 require (
@@ -79,5 +80,4 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/pkg/playback/interactions_test.go
+++ b/pkg/playback/interactions_test.go
@@ -205,19 +205,19 @@ func TestSaveAndCloseToYaml(t *testing.T) {
     method: POST
     body: hello world
     headers:
-      Test:
-      - header 1
+        Test:
+            - header 1
     url:
-      scheme: ""
-      opaque: ""
-      user: null
-      host: ""
-      path: ""
-      rawpath: ""
-      forcequery: false
-      rawquery: ""
-      fragment: ""
-      rawfragment: ""
+        scheme: ""
+        opaque: ""
+        user: null
+        host: ""
+        path: ""
+        rawpath: ""
+        forcequery: false
+        rawquery: ""
+        fragment: ""
+        rawfragment: ""
   response:
     headers: {}
     body: ""

--- a/pkg/playback/server_test.go
+++ b/pkg/playback/server_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const defaultLocalAddress = "localhost:8080"
-const defaultLocalWebhookAddress = "localhost:8888"
+const defaultLocalAddress = "127.0.0.1:8080"
+const defaultLocalWebhookAddress = "127.0.0.1:8888"
 
 func assertHTTPResponsesAreEqual(t *testing.T, resp1 *http.Response, resp2 *http.Response) error {
 	// Read the response bodies
@@ -130,16 +130,16 @@ func TestSimpleRecordReplayServerSeparately(t *testing.T) {
 	<-serverReady
 
 	// Send it 2 requests
-	res1, err := http.Get("http://localhost:8080/")
+	res1, err := http.Get("http://127.0.0.1:8080/")
 	assert.NoError(t, err)
 	assert.Equal(t, mockResponse1.StatusCode, res1.StatusCode)
 
-	res2, err := http.Get("http://localhost:8080/")
+	res2, err := http.Get("http://127.0.0.1:8080/")
 	assert.NoError(t, err)
 	assert.Equal(t, mockResponse2.StatusCode, res2.StatusCode)
 
 	// Shutdown record server
-	resShutdown, err := http.Get("http://localhost:8080/playback/cassette/eject")
+	resShutdown, err := http.Get("http://127.0.0.1:8080/playback/cassette/eject")
 	server.Shutdown(context.Background())
 	assert.NoError(t, err)
 	defer resShutdown.Body.Close()
@@ -160,9 +160,9 @@ func TestSimpleRecordReplayServerSeparately(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Send it the same 2 requests:
-	replay1, err := http.Get("http://localhost:8080/")
+	replay1, err := http.Get("http://127.0.0.1:8080/")
 	assert.NoError(t, err)
-	replay2, err := http.Get("http://localhost:8080/")
+	replay2, err := http.Get("http://127.0.0.1:8080/")
 	assert.NoError(t, err)
 
 	// Assert that the original responses and replayed responses are the same
@@ -205,7 +205,7 @@ func TestPlaybackSingleRunCreateCustomerAndStandaloneCharge(t *testing.T) {
 	remoteURL = ts.URL
 
 	// -- Setup Playback server
-	addressString := "localhost:13111"
+	addressString := "127.0.0.1:13111"
 	cassetteFilepath := "test_record_replay_single_run.yaml"
 
 	tempCassetteDir, err := ioutil.TempDir("", "playback-test-data-")

--- a/pkg/playback/yaml_serializer.go
+++ b/pkg/playback/yaml_serializer.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // YAMLSerializer encodes/persists cassettes to files and decodes yaml cassette files.

--- a/pkg/playback/yaml_serializer_test.go
+++ b/pkg/playback/yaml_serializer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func request() httpRequest {
@@ -33,16 +33,16 @@ func TestSerializeReq(t *testing.T) {
 body: hello world
 headers: {}
 url:
-  scheme: ""
-  opaque: ""
-  user: null
-  host: ""
-  path: ""
-  rawpath: ""
-  forcequery: false
-  rawquery: ""
-  fragment: ""
-  rawfragment: ""
+    scheme: ""
+    opaque: ""
+    user: null
+    host: ""
+    path: ""
+    rawpath: ""
+    forcequery: false
+    rawquery: ""
+    fragment: ""
+    rawfragment: ""
 `
 
 	req := request()
@@ -125,7 +125,48 @@ func TestEncodeCassette(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := "- type: 1\n  request:\n    method: POST\n    body: hello world\n    headers: {}\n    url:\n      scheme: \"\"\n      opaque: \"\"\n      user: null\n      host: \"\"\n      path: \"\"\n      rawpath: \"\"\n      forcequery: false\n      rawquery: \"\"\n      fragment: \"\"\n      rawfragment: \"\"\n  response:\n    headers: {}\n    body: response body\n    status_code: 200\n- type: 0\n  request:\n    method: POST\n    body: hello world\n    headers: {}\n    url:\n      scheme: \"\"\n      opaque: \"\"\n      user: null\n      host: \"\"\n      path: \"\"\n      rawpath: \"\"\n      forcequery: false\n      rawquery: \"\"\n      fragment: \"\"\n      rawfragment: \"\"\n  response:\n    headers: {}\n    body: response body\n    status_code: 200\n"
+	expected :=
+		`- type: 1
+  request:
+    method: POST
+    body: hello world
+    headers: {}
+    url:
+        scheme: ""
+        opaque: ""
+        user: null
+        host: ""
+        path: ""
+        rawpath: ""
+        forcequery: false
+        rawquery: ""
+        fragment: ""
+        rawfragment: ""
+  response:
+    headers: {}
+    body: response body
+    status_code: 200
+- type: 0
+  request:
+    method: POST
+    body: hello world
+    headers: {}
+    url:
+        scheme: ""
+        opaque: ""
+        user: null
+        host: ""
+        path: ""
+        rawpath: ""
+        forcequery: false
+        rawquery: ""
+        fragment: ""
+        rawfragment: ""
+  response:
+    headers: {}
+    body: response body
+    status_code: 200
+`
 
 	assert.Equal(t, expected, string(encoded))
 }


### PR DESCRIPTION
 ### Reviewers
r? @gracegoo-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Fix Dependabot alert which says to upgrade gopkg.in/yaml from v2 to v3.
This is a breaking change, however:
- This package is only used by the playback code, which technically isn't publicly usable.
- The only thing that broke after updating was how the YAML output is indented, which doesn't matter. At least this was all that our existing tests caught.