### PR TITLE
Use previous github token to release to homebrew and scoop

### DIFF
--- a/.goreleaser/mac.yml
+++ b/.goreleaser/mac.yml
@@ -46,6 +46,7 @@ brews:
   - tap:
       owner: stripe
       name: homebrew-stripe-cli
+      token: "{{ .Env.GORELEASER_GITHUB_TOKEN }}" # This token can access the repo, but GITHUB_TOKEN cannot
     commit_author:
       name: stripe-ci
       email: support@stripe.com

--- a/.goreleaser/windows.yml
+++ b/.goreleaser/windows.yml
@@ -44,6 +44,7 @@ scoop:
   bucket:
     owner: stripe
     name: scoop-stripe-cli
+    token: "{{ .Env.GORELEASER_GITHUB_TOKEN }}" # This token can access the repo, but GITHUB_TOKEN cannot
   commit_author:
     name: stripe-ci
     email: support@stripe.com


### PR DESCRIPTION
 ### Reviewers
r? @gracegoo-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

After merging https://github.com/stripe/stripe-cli/pull/881, I released v1.10.0 to test it out, but it failed to publish to homebrew and scoop: https://github.com/stripe/stripe-cli/runs/6680336742?check_suite_focus=true

I can't give more permissions to the new token, but it turns out I can manually override the token for publishing to [homebrew](https://goreleaser.com/customization/homebrew/) and [scoop](https://goreleaser.com/customization/scoop/), so this PR uses the original token for that.

As with the last PR, not sure how to test this other than making another release, so I guess I'll release v1.10.1 next.
