### PR TITLE
Pass github token from repo to goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
           args: release -f .goreleaser/mac.yml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
 
   build-linux:
     runs-on: ubuntu-latest
@@ -70,6 +71,7 @@ jobs:
           args: release -f .goreleaser/windows.yml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
 
   upload-to-virustotal:
     needs: [build-windows]


### PR DESCRIPTION
 ### Reviewers
r? @suz-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Context: After merging https://github.com/stripe/stripe-cli/pull/884, I released v.1.10.1 to trigger the release action. The release action failed because it couldn't find the environment variable I was reading: https://github.com/stripe/stripe-cli/runs/6694623367?check_suite_focus=true. This PR will hopefully set the environment variable correctly. As always, not sure how to test other than to make a release, so I'll release v1.10.2 after this.
