### PR TITLE
run stripe login with project name flag if config not found

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -93,6 +93,7 @@ func showSuggestion() {
 func Execute(ctx context.Context) {
 	telemetryMetadata := stripe.NewEventMetadata()
 	updatedCtx := stripe.WithEventMetadata(ctx, telemetryMetadata)
+	userInput := os.Args[1:]
 
 	rootCmd.SetUsageTemplate(getUsageTemplate())
 	rootCmd.SetVersionTemplate(version.Template)
@@ -104,6 +105,8 @@ func Execute(ctx context.Context) {
 		switch {
 		case requests.IsAPIKeyExpiredError(err):
 			fmt.Fprintln(os.Stderr, "The API key provided has expired. Obtain a new key from the Dashboard or run `stripe login` and try again.")
+		case isLoginRequiredError && userInput[2] == "--project-name":
+			fmt.Println("Please run `stripe login --project-name=`...")
 		case isLoginRequiredError:
 			// capitalize first letter of error because linter
 			errRunes := []rune(errString)
@@ -126,7 +129,6 @@ func Execute(ctx context.Context) {
 
 		os.Exit(1)
 	} else {
-		userInput := os.Args[1:]
 		// --color on/off/auto
 		if len(userInput) == 2 && userInput[0] == "--color" {
 			fmt.Println("You provided the \"--color\" flag but did not specify any command. The \"--color\" flag configures the color output of a specified command.")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -106,7 +106,7 @@ func Execute(ctx context.Context) {
 		case requests.IsAPIKeyExpiredError(err):
 			fmt.Fprintln(os.Stderr, "The API key provided has expired. Obtain a new key from the Dashboard or run `stripe login` and try again.")
 		case isLoginRequiredError && userInput[2] == "--project-name":
-			fmt.Println("Please run `stripe login --project-name=`...")
+			fmt.Println("You provided the \"--project-name\" flag, but no config for that project was found. Please run `stripe login --project-name=`...")
 		case isLoginRequiredError:
 			// capitalize first letter of error because linter
 			errRunes := []rune(errString)
@@ -128,11 +128,9 @@ func Execute(ctx context.Context) {
 		}
 
 		os.Exit(1)
-	} else {
+	} else if len(userInput) == 2 && userInput[0] == "--color" {
 		// --color on/off/auto
-		if len(userInput) == 2 && userInput[0] == "--color" {
-			fmt.Println("You provided the \"--color\" flag but did not specify any command. The \"--color\" flag configures the color output of a specified command.")
-		}
+		fmt.Println("You provided the \"--color\" flag but did not specify any command. The \"--color\" flag configures the color output of a specified command.")
 	}
 }
 


### PR DESCRIPTION
 ### Reviewers
r? @etsai-stripe 
cc @stripe/developer-products

 ### Summary
When running command with the `--project-name=...` flag, the CLI would run `stripe login...` like so:

<img width="1267" alt="Screen Shot 2022-06-24 at 11 13 42 AM" src="https://user-images.githubusercontent.com/106203059/176010425-c8507b18-aa84-4c74-b2b4-4e9633e437f9.png">


Changes this message so that it instead asks the user to run `stripe login --project-name...`:

<img width="1225" alt="Screen Shot 2022-06-27 at 12 35 32 PM" src="https://user-images.githubusercontent.com/106203059/176021726-66db05f7-5414-44ed-b3ff-4cfe9174f214.png">

The same message should show up when the shorthand flag `-p` is used, and when multiple flags are used in the command:

<img width="1123" alt="Screen Shot 2022-06-29 at 6 10 53 PM" src="https://user-images.githubusercontent.com/106203059/176571825-2e9d2cee-42c1-452c-a3c7-1db2c5de5c20.png">

<img width="1320" alt="Screen Shot 2022-06-29 at 6 10 36 PM" src="https://user-images.githubusercontent.com/106203059/176571856-d031404e-1ab3-456f-8936-ca81bc09d058.png">






