### PR TITLE
DX-7509: redact livemode values in existing configs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -166,6 +166,24 @@ func (c *Config) InitConfig() {
 	KeyRing, _ = keyring.Open(keyring.Config{
 		ServiceName: "Stripe CLI Key Storage",
 	})
+
+	// redact livemode values for existing configs
+	if err := viper.ReadInConfig(); err == nil {
+		// if the config file has expires at date, then it is using the new livemode key storage
+		if viper.IsSet(c.Profile.GetConfigField(LiveModeAPIKeyName)) {
+			key := viper.GetString(c.Profile.GetConfigField(LiveModeAPIKeyName))
+			if !IsRedactedAPIKey(key) {
+				c.Profile.WriteConfigField(LiveModeAPIKeyName, RedactAPIKey(key))
+			}
+		}
+
+		if viper.IsSet(c.Profile.GetConfigField(LiveModePubKeyName)) {
+			key := viper.GetString(c.Profile.GetConfigField(LiveModePubKeyName))
+			if !IsRedactedAPIKey(key) {
+				c.Profile.WriteConfigField(LiveModePubKeyName, RedactAPIKey(key))
+			}
+		}
+	}
 }
 
 // EditConfig opens the configuration file in the default editor.

--- a/pkg/config/profile_livemode.go
+++ b/pkg/config/profile_livemode.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/99designs/keyring"
+
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 

--- a/pkg/config/profile_livemode.go
+++ b/pkg/config/profile_livemode.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/99designs/keyring"
+	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
 // DateStringFormat ...
@@ -27,10 +28,37 @@ func (p *Profile) storeLivemodeValue(field, value, description string) {
 }
 
 // RetrieveLivemodeValue ...
-func (p *Profile) RetrieveLivemodeValue(key string) string {
+func (p *Profile) RetrieveLivemodeValue(key string) (string, error) {
 	fieldID := p.GetConfigField(key)
-	value, _ := KeyRing.Get(fieldID)
-	return string(value.Data)
+	existingKeys, err := KeyRing.Keys()
+	if err != nil {
+		return "", err
+	}
+
+	for _, item := range existingKeys {
+		if item == fieldID {
+			value, _ := KeyRing.Get(fieldID)
+			return string(value.Data), nil
+		}
+	}
+
+	return "", validators.ErrAPIKeyNotConfigured
+}
+
+// DeleteLivemodeValue ...
+func (p *Profile) DeleteLivemodeValue(key string) error {
+	fieldID := p.GetConfigField(key)
+	existingKeys, err := KeyRing.Keys()
+	if err != nil {
+		return err
+	}
+	for _, item := range existingKeys {
+		if item == fieldID {
+			KeyRing.Remove(fieldID)
+			return nil
+		}
+	}
+	return nil
 }
 
 // RedactAPIKey returns a redacted version of API keys. The first 8 and last 4
@@ -45,4 +73,22 @@ func RedactAPIKey(apiKey string) string {
 	b.WriteString(apiKey[len(apiKey)-4:])              // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
 
 	return b.String()
+}
+
+// IsRedactedAPIKey ...
+func IsRedactedAPIKey(apiKey string) bool {
+	keyParts := strings.Split(apiKey, "_")
+	if len(keyParts) < 3 {
+		return false
+	}
+
+	if keyParts[0] != "sk" && keyParts[0] != "rk" {
+		return false
+	}
+
+	if RedactAPIKey(apiKey) != apiKey {
+		return false
+	}
+
+	return true
 }

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -290,7 +290,7 @@ func (s *Samples) ConfigureDotEnv(ctx context.Context, sampleLocation string) er
 			return err
 		}
 
-		publishableKey := s.Config.Profile.GetPublishableKey(false)
+		publishableKey, _ := s.Config.Profile.GetPublishableKey(false)
 		if publishableKey == "" {
 			return fmt.Errorf("we could not set the publishable key in the .env file; please set this manually or login again to set it automatically next time")
 		}


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

- redact livemode values from existing configs
- rename publishable keys to fix the `stripe config --list --project-name <project_name>` issue; viper has a limit on the key name length
- return `login is required` error when livemode keys are not present in the secure storage. this will force users to log in even when they have old livemode key values in existing configs
- add ability to remove livemode values from secure storage