### PR TITLE
More detailed API key error

### DIFF
--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -135,7 +136,7 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 			p.RegisterAlias(TestModeAPIKeyName, "api_key")
 		}
 
-		if err := viper.ReadInConfig(); err == nil {
+		if err = viper.ReadInConfig(); err == nil {
 			key = viper.GetString(p.GetConfigField(TestModeAPIKeyName))
 		}
 	} else {
@@ -151,6 +152,13 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 			return "", err
 		}
 		return key, nil
+	}
+
+	// If the log level is debug, return the raw error message. otherwise
+	// return a generic configuration message
+	level := log.GetLevel()
+	if level == log.DebugLevel {
+		return "", err
 	}
 
 	return "", validators.ErrAPIKeyNotConfigured

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -120,7 +120,7 @@ func TestAPIKeyLogLevel(t *testing.T) {
 	// For debug mode, the error should complain about a config file missing
 	// since we did not init the config
 	key, err := c.Profile.GetAPIKey(false)
-	assert.EqualError(t, err, `Config File "config" Not Found in "[]"`)
+	assert.ErrorContains(t, err, `stripe/config.toml: no such file or directory`)
 	assert.Equal(t, "", key)
 
 	// In info mode, it should give a cleaner error about the key not being

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -122,12 +123,13 @@ func TestAPIKeyLogLevel(t *testing.T) {
 	key, err := c.Profile.GetAPIKey(false)
 
 	// Little weird but windows returns a different error message than others
-    os := runtime.GOOS
-    switch os {
-    case "windows":
+	os := runtime.GOOS
+	switch os {
+	case "windows":
 		assert.ErrorContains(t, err, `config.toml: The system cannot find the file specified.`)
 	default:
 		assert.ErrorContains(t, err, `config.toml: no such file or directory`)
+	}
 
 	assert.Equal(t, "", key)
 

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -120,7 +120,7 @@ func TestAPIKeyLogLevel(t *testing.T) {
 	// For debug mode, the error should complain about a config file missing
 	// since we did not init the config
 	key, err := c.Profile.GetAPIKey(false)
-	assert.ErrorContains(t, err, `stripe/config.toml: no such file or directory`)
+	assert.ErrorContains(t, err, `config.toml: no such file or directory`)
 	assert.Equal(t, "", key)
 
 	// In info mode, it should give a cleaner error about the key not being

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -120,7 +120,15 @@ func TestAPIKeyLogLevel(t *testing.T) {
 	// For debug mode, the error should complain about a config file missing
 	// since we did not init the config
 	key, err := c.Profile.GetAPIKey(false)
-	assert.ErrorContains(t, err, `config.toml: no such file or directory`)
+
+	// Little weird but windows returns a different error message than others
+    os := runtime.GOOS
+    switch os {
+    case "windows":
+		assert.ErrorContains(t, err, `config.toml: The system cannot find the file specified.`)
+	default:
+		assert.ErrorContains(t, err, `config.toml: no such file or directory`)
+
 	assert.Equal(t, "", key)
 
 	// In info mode, it should give a cleaner error about the key not being


### PR DESCRIPTION
Noticed that we were swallowing config errors when returning API keys if something on the config-level was busted. We probably want that for general usage but I made this configurable depending on the log-level.