### PR TITLE
RUN_DX-1388: append query from webhook endpoint if exists

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -724,13 +724,19 @@ func buildForwardURL(forwardURL string, destination *url.URL) (string, error) {
 		return "", fmt.Errorf("Provided forward url cannot be parsed: %s", forwardURL)
 	}
 
-	return fmt.Sprintf(
+	newForwardURL := fmt.Sprintf(
 		"%s://%s%s%s",
 		f.Scheme,
 		f.Host,
 		strings.TrimSuffix(f.Path, "/"), // avoids having a double "//"
 		destination.Path,
-	), nil
+	)
+
+	if destination.RawQuery != "" {
+		newForwardURL = newForwardURL + "?" + destination.RawQuery
+	}
+
+	return newForwardURL, nil
 }
 
 func getAPIVersionString(str *string) string {


### PR DESCRIPTION
 ### Reviewers
r? @gracegoo-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

append query from registered webhook endpoint to the forward-to url
`stripe listen --load-from-webhooks-api --forward-to localhost:5000`