### PR TITLE
Updating checkout.session.async_payment_suceeded with US payment method

### DIFF
--- a/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
@@ -10,13 +10,13 @@
       "params": {
         "success_url": "https://httpbin.org/post",
         "cancel_url": "https://httpbin.org/post",
-        "payment_method_types": ["bacs_debit"],
+        "payment_method_types": ["card"],
         "line_items": [
           {
             "name": "t-shirt",
             "description": "comfortable cotton t-shirt",
             "amount": 1500,
-            "currency": "gbp",
+            "currency": "usd",
             "quantity": 2
           }
         ],
@@ -45,21 +45,12 @@
       "path": "/v1/payment_methods",
       "method": "post",
       "params": {
-        "type": "bacs_debit",
-        "bacs_debit": {
-          "account_number": "00012345",
-          "sort_code": "108800"
+        "type": "card",
+        "card": {
+          "token": "tok_visa"
         },
         "billing_details": {
-          "email": "stripe@example.com",
-          "name": "Jenny Rosen",
-          "phone": "1234567890",
-          "address": {
-            "line1": "71 Crown Street",
-            "city": "London",
-            "postal_code": "W10 2WB",
-            "country": "GB"
-          }
+          "email": "stripe@example.com"
         }
       }
     },


### PR DESCRIPTION
 ### Reviewers
r? @etsai-stripe 
cc @stripe/developer-products

 ### Summary
I noticed that the `checkout.session.async_payment_succeeded` fixture is identical to its failure counterpart minus the expected error. This means one of those will always fail to trigger depending on the account. I updated the fixture to use US payment methods.

Before:
```
➜  stripe-cli git:(master) ✗ stripe-workspace trigger --log-level=debug  checkout.session.async_payment_succeeded 
Fixture: Setting up fixture for: checkout_session
Running fixture for: checkout_session
Trigger failed: Request failed, status=400, body={
  "error": {
    "message": "The payment method type provided: bacs_debit is invalid. Please ensure the provided type is activated in your dashboard (https://dashboard.stripe.com/account/payments/settings) and your account is enabled for any preview features that you are trying to use. See https://stripe.com/docs/payments/payment-methods/integration-options for supported payment method, currency, and country combinations.",
    "param": "payment_method_types",
    "type": "invalid_request_error"
  }
}
```

After:
```
➜  stripe-cli git:(master) ✗ stripe-workspace trigger --log-level=debug  checkout.session.async_payment_succeeded Fixture: Setting up fixture for: checkout_session
Running fixture for: checkout_session
Setting up fixture for: payment_page
Running fixture for: payment_page
Setting up fixture for: payment_method
Running fixture for: payment_method
Setting up fixture for: payment_page_confirm
Running fixture for: payment_page_confirm
Trigger succeeded! Check dashboard for event details.
```