### PR TITLE
Fix Checkout related fixtures to not use legacy line items path

### DIFF
--- a/pkg/fixtures/triggers/checkout.session.async_payment_failed.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_failed.json
@@ -4,6 +4,25 @@
   },
   "fixtures": [
     {
+      "name": "product",
+      "path": "/v1/products",
+      "method": "post",
+      "params": {
+          "name": "myproduct",
+          "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "price",
+      "path": "/v1/prices",
+      "method": "post",
+      "params": {
+        "product": "${product:id}",
+        "unit_amount": "1500",
+        "currency": "gbp"
+      }
+    },
+    {
       "name": "checkout_session",
       "expected_error_type": "invalid_request_error",
       "path": "/v1/checkout/sessions",
@@ -12,12 +31,10 @@
         "success_url": "https://httpbin.org/post",
         "cancel_url": "https://httpbin.org/post",
         "payment_method_types": ["bacs_debit"],
+        "mode": "payment",
         "line_items": [
           {
-            "name": "t-shirt",
-            "description": "comfortable cotton t-shirt",
-            "amount": 1500,
-            "currency": "gbp",
+            "price": "${price:id}",
             "quantity": 2
           }
         ],

--- a/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
@@ -4,19 +4,36 @@
   },
   "fixtures": [
     {
+      "name": "product",
+      "path": "/v1/products",
+      "method": "post",
+      "params": {
+          "name": "myproduct",
+          "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "price",
+      "path": "/v1/prices",
+      "method": "post",
+      "params": {
+        "product": "${product:id}",
+        "unit_amount": "1500",
+        "currency": "gbp"
+      }
+    },
+    {
       "name": "checkout_session",
       "path": "/v1/checkout/sessions",
       "method": "post",
       "params": {
         "success_url": "https://httpbin.org/post",
         "cancel_url": "https://httpbin.org/post",
-        "payment_method_types": ["card"],
+        "payment_method_types": ["bacs_debit"],
+        "mode": "payment",
         "line_items": [
           {
-            "name": "t-shirt",
-            "description": "comfortable cotton t-shirt",
-            "amount": 1500,
-            "currency": "usd",
+            "price": "${price:id}",
             "quantity": 2
           }
         ],

--- a/pkg/fixtures/triggers/checkout.session.completed.json
+++ b/pkg/fixtures/triggers/checkout.session.completed.json
@@ -4,19 +4,35 @@
   },
   "fixtures": [
     {
+      "name": "product",
+      "path": "/v1/products",
+      "method": "post",
+      "params": {
+          "name": "myproduct",
+          "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "price",
+      "path": "/v1/prices",
+      "method": "post",
+      "params": {
+        "product": "${product:id}",
+        "unit_amount": "1500",
+        "currency": "usd"
+      }
+    },
+    {
       "name": "checkout_session",
       "path": "/v1/checkout/sessions",
       "method": "post",
       "params": {
         "success_url": "https://httpbin.org/post",
         "cancel_url": "https://httpbin.org/post",
-        "payment_method_types": ["card"],
+        "mode": "payment",
         "line_items": [
           {
-            "name": "t-shirt",
-            "description": "comfortable cotton t-shirt",
-            "amount": 1500,
-            "currency": "usd",
+            "price": "${price:id}",
             "quantity": 2
           }
         ],


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
Fix Checkout related fixtures to not use legacy line items path as it doesn't work on the latest API version. 