### PR TITLE
Fix Invoice fixtures to work with latest API version

### DIFF
--- a/pkg/fixtures/triggers/invoice.created.json
+++ b/pkg/fixtures/triggers/invoice.created.json
@@ -8,8 +8,7 @@
       "path": "/v1/customers",
       "method": "post",
       "params": {
-        "description": "(created by Stripe CLI)",
-        "source": "tok_visa"
+        "description": "(created by Stripe CLI)"
       }
     },
     {
@@ -29,7 +28,8 @@
       "method": "post",
       "params": {
         "customer": "${customer:id}",
-        "description": "(created by Stripe CLI)"
+        "description": "(created by Stripe CLI)",
+        "pending_invoice_items_behavior": "include"
       }
     }
   ]

--- a/pkg/fixtures/triggers/invoice.finalized.json
+++ b/pkg/fixtures/triggers/invoice.finalized.json
@@ -8,8 +8,7 @@
       "path": "/v1/customers",
       "method": "post",
       "params": {
-        "description": "(created by Stripe CLI)",
-        "source": "tok_visa"
+        "description": "(created by Stripe CLI)"
       }
     },
     {
@@ -29,7 +28,8 @@
       "method": "post",
       "params": {
         "customer": "${customer:id}",
-        "description": "(created by Stripe CLI)"
+        "description": "(created by Stripe CLI)",
+        "pending_invoice_items_behavior": "include"
       }
     },
     {

--- a/pkg/fixtures/triggers/invoice.paid.json
+++ b/pkg/fixtures/triggers/invoice.paid.json
@@ -8,8 +8,15 @@
       "path": "/v1/customers",
       "method": "post",
       "params": {
-        "description": "(created by Stripe CLI)",
-        "source": "tok_visa"
+        "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "payment_method",
+      "path": "/v1/payment_methods/pm_card_visa/attach",
+      "method": "post",
+      "params": {
+        "customer": "${customer:id}"
       }
     },
     {
@@ -29,13 +36,17 @@
       "method": "post",
       "params": {
         "customer": "${customer:id}",
-        "description": "(created by Stripe CLI)"
+        "description": "(created by Stripe CLI)",
+        "pending_invoice_items_behavior": "include"
       }
     },
     {
       "name": "invoice_pay",
       "path": "/v1/invoices/${invoice:id}/pay",
-      "method": "post"
+      "method": "post",
+      "params": {
+        "payment_method": "${payment_method:id}"
+      }
     }
   ]
 }

--- a/pkg/fixtures/triggers/invoice.payment_action_required.json
+++ b/pkg/fixtures/triggers/invoice.payment_action_required.json
@@ -8,8 +8,15 @@
       "path": "/v1/customers",
       "method": "post",
       "params": {
-        "description": "(created by Stripe CLI)",
-        "source": "tok_visa"
+        "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "payment_method",
+      "path": "/v1/payment_methods/pm_card_threeDSecure2Required/attach",
+      "method": "post",
+      "params": {
+        "customer": "${customer:id}"
       }
     },
     {
@@ -29,29 +36,8 @@
       "method": "post",
       "params": {
         "customer": "${customer:id}",
-        "description": "(created by Stripe CLI)"
-      }
-    },
-    {
-      "name": "payment_method",
-      "path": "/v1/payment_methods",
-      "method": "post",
-      "params": {
-        "type": "card",
-        "card": {
-          "exp_month": 7,
-          "exp_year": 25,
-          "number": "4000000000003220",
-          "cvc": "424"
-        }
-      }
-    },
-    {
-      "name": "attach_payment_method",
-      "path": "/v1/payment_methods/${payment_method:id}/attach",
-      "method": "post",
-      "params": {
-        "customer": "${customer:id}"
+        "description": "(created by Stripe CLI)",
+        "pending_invoice_items_behavior": "include"
       }
     },
     {

--- a/pkg/fixtures/triggers/invoice.payment_failed.json
+++ b/pkg/fixtures/triggers/invoice.payment_failed.json
@@ -8,8 +8,15 @@
       "path": "/v1/customers",
       "method": "post",
       "params": {
-        "description": "(created by Stripe CLI)",
-        "source": "tok_chargeCustomerFail"
+        "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "payment_method",
+      "path": "/v1/payment_methods/pm_card_chargeCustomerFail/attach",
+      "method": "post",
+      "params": {
+        "customer": "${customer:id}"
       }
     },
     {
@@ -29,14 +36,18 @@
       "method": "post",
       "params": {
         "customer": "${customer:id}",
-        "description": "(created by Stripe CLI)"
+        "description": "(created by Stripe CLI)",
+        "pending_invoice_items_behavior": "include"
       }
     },
     {
       "name": "invoice_pay",
       "expected_error_type": "card_error",
       "path": "/v1/invoices/${invoice:id}/pay",
-      "method": "post"
+      "method": "post",
+      "params": {
+        "payment_method": "${payment_method:id}"
+      }
     }
   ]
 }

--- a/pkg/fixtures/triggers/invoice.payment_succeeded.json
+++ b/pkg/fixtures/triggers/invoice.payment_succeeded.json
@@ -8,8 +8,15 @@
       "path": "/v1/customers",
       "method": "post",
       "params": {
-        "description": "(created by Stripe CLI)",
-        "source": "tok_visa"
+        "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "payment_method",
+      "path": "/v1/payment_methods/pm_card_visa/attach",
+      "method": "post",
+      "params": {
+        "customer": "${customer:id}"
       }
     },
     {
@@ -29,13 +36,17 @@
       "method": "post",
       "params": {
         "customer": "${customer:id}",
-        "description": "(created by Stripe CLI)"
+        "description": "(created by Stripe CLI)",
+        "pending_invoice_items_behavior": "include"
       }
     },
     {
       "name": "invoice_pay",
       "path": "/v1/invoices/${invoice:id}/pay",
-      "method": "post"
+      "method": "post",
+      "params": {
+        "payment_method": "${payment_method:id}"
+      }
     }
   ]
 }

--- a/pkg/fixtures/triggers/invoice.updated.json
+++ b/pkg/fixtures/triggers/invoice.updated.json
@@ -28,7 +28,8 @@
       "method": "post",
       "params": {
         "customer": "${customer:id}",
-        "description": "(created by Stripe CLI)"
+        "description": "(created by Stripe CLI)",
+        "pending_invoice_items_behavior": "include"
       }
     },
     {


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
Fix Invoice fixtures to properly work for the latest API version. There's a breaking change that doesn't pull existing pending invoice items by default and so all fixtures needed to be fixed to pass `pending_invoice_items_behavior: 'include'` to ensure it works on all API versions.
Additionally, move away from Token/Card as those have been deprecated for years and use PaymentMethod directly everywhere.
