### PR TITLE
clean up duplicated plugin versions from archive install

### DIFF
--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -47,11 +47,10 @@ type PluginList struct {
 
 // Release is the type that holds release data for a specific build of a plugin
 type Release struct {
-	Arch      string `toml:"Arch"`
-	OS        string `toml:"OS"`
-	Version   string `toml:"Version"`
-	Sum       string `toml:"Sum"`
-	Unmanaged bool   `toml:"Unmanaged"`
+	Arch    string `toml:"Arch"`
+	OS      string `toml:"OS"`
+	Version string `toml:"Version"`
+	Sum     string `toml:"Sum"`
 }
 
 // getPluginInterface computes the correct metadata needed for starting the hcplugin client

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -149,7 +149,10 @@ func AddEntryToPluginManifest(ctx context.Context, config config.IConfig, fs afe
 			entryRelease := entry.Releases[0]
 			foundRelease := false
 			for _, release := range plugin.Releases {
-				if release.Version == entryRelease.Version && release.Unmanaged == entryRelease.Unmanaged {
+				if release.Version == entryRelease.Version {
+					if release.Sum != entryRelease.Sum {
+						return fmt.Errorf("version '%s' is already installed but checksums do not match", release.Version)
+					}
 					foundRelease = true
 					break
 				}
@@ -343,18 +346,23 @@ func extractAndInstall(ctx context.Context, config config.IConfig, tarReader *ta
 		case tar.TypeDir:
 			continue
 		case tar.TypeReg:
-			if name == "manifest.toml" {
+			filename := filepath.Base(name)
+			if strings.HasPrefix(filename, "._") {
+				continue
+			}
+
+			if filename == "manifest.toml" {
 				tomlBytes, _ := io.ReadAll(tarReader)
 				err = toml.Unmarshal(tomlBytes, &manifest)
 				if err != nil {
 					return err
 				}
 
-				fmt.Println(color.Green(fmt.Sprintf("✔ extracted manifest '%s'", name)))
-			} else if strings.Contains(name, "stripe-cli-") {
-				extractedPluginName = name
+				fmt.Println(color.Green(fmt.Sprintf("✔ extracted manifest '%s'", filename)))
+			} else if strings.Contains(filename, "stripe-cli-") {
+				extractedPluginName = filename
 				pluginData, _ = io.ReadAll(tarReader)
-				fmt.Println(color.Green(fmt.Sprintf("✔ extracted plugin '%s'", name)))
+				fmt.Println(color.Green(fmt.Sprintf("✔ extracted plugin '%s'", filename)))
 			}
 
 		default:
@@ -365,7 +373,6 @@ func extractAndInstall(ctx context.Context, config config.IConfig, tarReader *ta
 	// update plugin manifest and config manifest
 	if len(manifest.Plugins) == 1 && len(manifest.Plugins[0].Releases) == 1 && len(pluginData) > 0 {
 		plugin := manifest.Plugins[0]
-		plugin.Releases[0].Unmanaged = true
 
 		if extractedPluginName != plugin.Binary {
 			return fmt.Errorf(
@@ -379,10 +386,14 @@ func extractAndInstall(ctx context.Context, config config.IConfig, tarReader *ta
 			return err
 		}
 
-		err = plugin.verifychecksumAndSavePlugin(pluginData, config, fs, plugin.Releases[0].Version)
+		version := plugin.Releases[0].Version
+		err = plugin.verifychecksumAndSavePlugin(pluginData, config, fs, version)
 		if err != nil {
 			return err
 		}
+
+		// clean up other plugin versions
+		plugin.cleanUpPluginPath(config, fs, version)
 	} else {
 		return fmt.Errorf("missing required manifest.toml or plugin in the archive")
 	}


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
- remove `unmanaged` field in plugin manifest
- remove old plugin versions after installation by archive completes
- ignore directories in archives