### PR TITLE
handle multiple release versions in the archived manifest

### DIFF
--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -146,22 +146,22 @@ func AddEntryToPluginManifest(ctx context.Context, config config.IConfig, fs afe
 			// plugin already installed. append a new release version
 			foundPlugin = true
 
-			entryRelease := entry.Releases[0]
-			foundRelease := false
-			for _, release := range plugin.Releases {
-				if release.Version == entryRelease.Version {
-					if release.Sum != entryRelease.Sum {
-						return fmt.Errorf("version '%s' is already installed but checksums do not match", release.Version)
+			for _, entryRelease := range entry.Releases {
+				foundRelease := false
+				for _, release := range plugin.Releases {
+					if release.Version == entryRelease.Version {
+						if release.Sum != entryRelease.Sum {
+							return fmt.Errorf("release version '%s/%s/%s' is already installed but checksums do not match", release.Arch, release.OS, release.Version)
+						}
+						foundRelease = true
+						break
 					}
-					foundRelease = true
-					break
+				}
+
+				if !foundRelease {
+					currentPluginList.Plugins[i].Releases = append(currentPluginList.Plugins[i].Releases, entryRelease)
 				}
 			}
-
-			if !foundRelease {
-				currentPluginList.Plugins[i].Releases = append(currentPluginList.Plugins[i].Releases, entry.Releases[0])
-			}
-			break
 		}
 	}
 
@@ -371,7 +371,7 @@ func extractAndInstall(ctx context.Context, config config.IConfig, tarReader *ta
 	}
 
 	// update plugin manifest and config manifest
-	if len(manifest.Plugins) == 1 && len(manifest.Plugins[0].Releases) == 1 && len(pluginData) > 0 {
+	if len(manifest.Plugins) == 1 && len(manifest.Plugins[0].Releases) >= 1 && len(pluginData) > 0 {
 		plugin := manifest.Plugins[0]
 
 		if extractedPluginName != plugin.Binary {


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

#### happy path by archive-path
```
st-etsai1:stripe-cli etsai$ stripe-dev plugin install --archive-path ~/Downloads/stripe-cli-next-v0.2.1-macos-all.tar.gz
extracting tarball at /Users/etsai/Downloads/stripe-cli-next-v0.2.1-macos-all.tar.gz...
✔ extracted manifest 'manifest.toml'
✔ extracted plugin 'stripe-cli-next'
✔ updated '/Users/etsai/.config/stripe/plugins.toml' with a release entry for 'stripe-cli-next'
✔ installation complete.
```

#### happy path by sc-curl
```
st-etsai1:stripe-cli etsai$ sc-curl https://artifactory.stripe.build/artifactory/thirdparty-managed/stripe-cli/plugins/stripe-cli-next/stripe-cli-next-v0.2.1-macos-all.tar.gz/01aba21d7d64c44afba936a71379fb40c45f00023168fa35c3c952d958bf87fc/stripe-cli-next-v0.2.1-macos-all.tar.gz | stripe-dev plugin install -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0✔ extracted manifest 'manifest.toml'
100 10.0M  100 10.0M    0     0  3876k      0  0:00:02  0:00:02 --:--:-- 3875k
✔ extracted plugin 'stripe-cli-next'
✔ updated '/Users/etsai/.config/stripe/plugins.toml' with a release entry for 'stripe-cli-next'
✔ installation complete.
st-etsai1:stripe-cli etsai$ stripe-dev next version
next version 0.2.1
```

#### checksums dont match with existing pluging.toml
```
st-etsai1:stripe-cli etsai$ stripe-dev plugin install --archive-path ~/Downloads/stripe-cli-next-v0.2.1-macos-all.tar.gz
extracting tarball at /Users/etsai/Downloads/stripe-cli-next-v0.2.1-macos-all.tar.gz...
✔ extracted manifest 'manifest.toml'
✔ extracted plugin 'stripe-cli-next'
release version 'amd64/darwin/v0.2.1' is already installed but checksums do not match
```