### PR TITLE
Payout.* fixtures updates

### DIFF
--- a/pkg/fixtures/triggers/payout.created.json
+++ b/pkg/fixtures/triggers/payout.created.json
@@ -4,6 +4,19 @@
   },
   "fixtures": [
     {
+      "name": "payment_intent",
+      "path": "/v1/payment_intents",
+      "method": "post",
+      "params": {
+        "amount": 1100,
+        "confirm": "true",
+        "currency": "usd",
+        "description": "(created by Stripe CLI)",
+        "payment_method": "pm_card_bypassPending",
+        "payment_method_types": ["card"]
+      }
+    },
+    {
       "name": "payout",
       "path": "/v1/payouts",
       "method": "post",
@@ -15,3 +28,4 @@
     }
   ]
 }
+

--- a/pkg/fixtures/triggers/payout.created.json
+++ b/pkg/fixtures/triggers/payout.created.json
@@ -8,7 +8,7 @@
       "path": "/v1/payment_intents",
       "method": "post",
       "params": {
-        "amount": 1100,
+        "amount": 2000,
         "confirm": "true",
         "currency": "usd",
         "description": "(created by Stripe CLI)",

--- a/pkg/fixtures/triggers/payout.updated.json
+++ b/pkg/fixtures/triggers/payout.updated.json
@@ -4,6 +4,19 @@
   },
   "fixtures": [
     {
+      "name": "payment_intent",
+      "path": "/v1/payment_intents",
+      "method": "post",
+      "params": {
+        "amount": 1100,
+        "confirm": "true",
+        "currency": "usd",
+        "description": "(created by Stripe CLI)",
+        "payment_method": "pm_card_bypassPending",
+        "payment_method_types": ["card"]
+      }
+    },
+    {
       "name": "payout",
       "path": "/v1/payouts",
       "method": "post",

--- a/pkg/fixtures/triggers/payout.updated.json
+++ b/pkg/fixtures/triggers/payout.updated.json
@@ -8,7 +8,7 @@
       "path": "/v1/payment_intents",
       "method": "post",
       "params": {
-        "amount": 1300,
+        "amount": 2000,
         "confirm": "true",
         "currency": "usd",
         "description": "(created by Stripe CLI)",

--- a/pkg/fixtures/triggers/payout.updated.json
+++ b/pkg/fixtures/triggers/payout.updated.json
@@ -8,7 +8,7 @@
       "path": "/v1/payment_intents",
       "method": "post",
       "params": {
-        "amount": 1100,
+        "amount": 1300,
         "confirm": "true",
         "currency": "usd",
         "description": "(created by Stripe CLI)",


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Updating payout.created and payout.updated fixtures to include a PaymentIntent creation that bypasses pending balance to ensure there is available balance for these triggers to succeed.

Tested locally for both triggers and works great!
