### PR TITLE
Delegate plugin --help flag to the plugin

### DIFF
--- a/pkg/cmd/plugin_cmds_test.go
+++ b/pkg/cmd/plugin_cmds_test.go
@@ -50,3 +50,23 @@ func TestFlagsArePassedAsArgs(t *testing.T) {
 	require.Equal(t, 2, len(pluginCmd.ParsedArgs))
 	require.Equal(t, "testarg --log-level=info", strings.Join(pluginCmd.ParsedArgs, " "))
 }
+
+// TestHelpFlagIsPassedAsArgs ensures that the plugin is passing the "help" flag as expected.
+// This is needed because we override cobra's default "help" flag behavior.
+func TestHelpFlagIsPassedAsArgs(t *testing.T) {
+	pluginCmd := createPluginCmd()
+	rootCmd.AddCommand(pluginCmd.cmd)
+
+	Execute(context.Background())
+
+	// temp override for the os.Args so that the pluginCmd can use them
+	oldArgs := os.Args
+	os.Args = []string{"stripe", "test", "testarg", "--help"}
+	defer func() { os.Args = oldArgs }()
+
+	rootCmd.SetArgs([]string{"test", "testarg", "--help"})
+	executeCommandC(rootCmd, "test", "testarg", "--help")
+
+	require.Equal(t, 2, len(pluginCmd.ParsedArgs))
+	require.Equal(t, "testarg --help", strings.Join(pluginCmd.ParsedArgs, " "))
+}


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
There is a bug where if you run a plugin command with --help or -h, you get the wrong output. This is because cobra parses the --help flag in the mainline CLI, bypassing the plugin process completely.

Expected:
```
❯ stripe apps --help
Commands for building Stripe apps

Usage:
  stripe apps [command]

Available Commands:
  add         Add a building block for developing your app
  create      Create a new Stripe app
  grant       Grant configuration access to your app
  help        Help about any command
  remove      Remove a building block from your stripe-app json
  revoke      Revoke configuration access to your app
  start       Start a development server for viewing your app in the Stripe dashboard
  upload      Upload your app to be submitted for review

Flags:
      --api-key string        Your API key to use for the command
      --color string          turn on/off color output (on, off, auto)
      --config string         config file (default is $HOME/.config/stripe/config.toml)
      --device-name string    device name
  -h, --help                  help for apps
      --log-level string      log level (debug, info, trace, warn, error) (default "info")
  -p, --project-name string   the project name to read from for config (default "default")

Use "stripe apps [command] --help" for more information about a command.
```

Actual:
```
❯ stripe apps --help
Usage:
  stripe apps [flags]

Flags:
  -h, --help   help for apps

Global flags:
      --api-key string        Your API key to use for the command
      --color string          turn on/off color output (on, off, auto)
      --config string         config file (default is $HOME/.config/stripe/config.toml)
      --device-name string    device name
      --log-level string      log level (debug, info, trace, warn, error) (default "info")
  -p, --project-name string   the project name to read from for config (default "default")
```

We fix this bug by overriding the default `help` function in the mainline CLI's plugin command: we call into the plugin process, passing along the --help flag so that the plugin process's `help` function gets invoked. 
