### PR TITLE
Updating charge.captured to use PI instead of Charge

### DIFF
--- a/pkg/fixtures/triggers/charge.captured.json
+++ b/pkg/fixtures/triggers/charge.captured.json
@@ -4,20 +4,22 @@
   },
   "fixtures": [
     {
-      "name": "charge",
-      "path": "/v1/charges",
+      "name": "payment_intent",
+      "path": "/v1/payment_intents",
       "method": "post",
       "params": {
-        "source": "tok_visa",
-        "amount": 100,
+        "amount": 2000,
+        "capture_method": "manual",
+        "confirm": true,
         "currency": "usd",
-        "capture": false,
-        "description": "(created by Stripe CLI)"
+        "description": "(created by Stripe CLI)",
+        "payment_method": "pm_card_visa",
+        "payment_method_types": ["card"]
       }
     },
     {
       "name": "capture",
-      "path": "/v1/charges/${charge:id}/capture",
+      "path": "/v1/payment_intents/${payment_intent:id}/capture",
       "method": "post"
     }
   ]


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Updating the charge.captured trigger to create a PaymentIntent instead of creating a Charge. 

Tested locally and looks good:
<img width="425" alt="Screen Shot 2022-08-30 at 6 06 54 PM" src="https://user-images.githubusercontent.com/47830399/187570763-4dcc64f4-816d-4d32-ab53-5f114a76b8e6.png">
<img width="1277" alt="Screen Shot 2022-08-30 at 6 06 47 PM" src="https://user-images.githubusercontent.com/47830399/187570766-359a522c-d879-41e4-9811-6ba0f7d1be6c.png">


