### PR TITLE
Poll for API keys earlier in the login flow

### DIFF
--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/login"
@@ -40,5 +38,5 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 		return login.InteractiveLogin(cmd.Context(), &Config)
 	}
 
-	return login.Login(cmd.Context(), lc.dashboardBaseURL, &Config, os.Stdin)
+	return login.Login(cmd.Context(), lc.dashboardBaseURL, &Config, login.AsyncStdinReader{})
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -114,7 +114,7 @@ func Execute(ctx context.Context) {
 
 			fmt.Printf("%s. Running `stripe login`...\n", string(errRunes))
 
-			err = login.Login(updatedCtx, stripe.DefaultDashboardBaseURL, &Config, os.Stdin)
+			err = login.Login(updatedCtx, stripe.DefaultDashboardBaseURL, &Config, login.AsyncStdinReader{})
 
 			if err != nil {
 				fmt.Println(err)

--- a/pkg/login/client_login_test.go
+++ b/pkg/login/client_login_test.go
@@ -9,15 +9,23 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/open"
 )
+
+type stubInputReader struct {
+}
+
+func (r stubInputReader) scanln(ch chan int) {
+	ch <- 1
+	close(ch)
+}
 
 func TestLogin(t *testing.T) {
 	if os.Getenv("OPEN_URL") == "1" {
@@ -25,7 +33,9 @@ func TestLogin(t *testing.T) {
 		return
 	}
 
+	didOpenBrowser := false
 	openBrowser = func(string) error {
+		didOpenBrowser = true
 		return nil
 	}
 
@@ -75,9 +85,80 @@ func TestLogin(t *testing.T) {
 
 	pollURL = fmt.Sprintf("%s%s", ts.URL, "/stripecli/auth/cliauth_123?secret=cliauth_secret")
 
-	input := strings.NewReader("\n")
-	err := Login(context.Background(), ts.URL, c, input)
+	err := Login(context.Background(), ts.URL, c, &stubInputReader{})
 	require.NoError(t, err)
+	assert.Equal(t, true, didOpenBrowser)
+
+	viper.Reset()
+}
+
+type noInputReader struct {
+}
+
+func (r noInputReader) scanln(ch chan int) {
+}
+
+func TestLoginNoInput(t *testing.T) {
+	if os.Getenv("OPEN_URL") == "1" {
+		os.Exit(0)
+		return
+	}
+
+	didOpenBrowser := false
+	openBrowser = func(string) error {
+		didOpenBrowser = true
+		return nil
+	}
+
+	defer func() { openBrowser = open.Browser }()
+
+	profilesFile := filepath.Join(os.TempDir(), "stripe", "config.toml")
+	viper.SetConfigFile(profilesFile)
+
+	p := config.Profile{
+		DeviceName:  "st-testing",
+		ProfileName: "tests",
+	}
+
+	c := &config.Config{
+		Color:        "auto",
+		LogLevel:     "info",
+		Profile:      p,
+		ProfilesFile: profilesFile,
+	}
+
+	var pollURL string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/stripecli/auth":
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			expectedLinks := Links{
+				BrowserURL:       "https://dashboard.stripe.com/stripecli/confirm_auth?t=cliauth_secret",
+				PollURL:          pollURL,
+				VerificationCode: "dinosaur-pineapple-polkadot",
+			}
+			json.NewEncoder(w).Encode(expectedLinks)
+		case "/stripecli/auth/cliauth_123":
+			require.Equal(t, "cliauth_secret", r.URL.Query().Get("secret"))
+
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			data := []byte(`{"redeemed":  true, "account_id": "acct_123", "testmode_key_secret": "sk_test_1234", "account_display_name": "test_disp_name"}`)
+			fmt.Println(string(data))
+			w.Write(data)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	pollURL = fmt.Sprintf("%s%s", ts.URL, "/stripecli/auth/cliauth_123?secret=cliauth_secret")
+
+	err := Login(context.Background(), ts.URL, c, &noInputReader{})
+	require.NoError(t, err)
+	assert.Equal(t, false, didOpenBrowser)
 
 	viper.Reset()
 }


### PR DESCRIPTION
 ### Reviewers
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Before, when running `stripe login`, the CLI would wait for user input to open the browser, then try to retrieve keys. This caused an issue where if you went to the auth page directly without input, the CLI would not retrieve keys. We fix this by polling for keys concurrently while waiting for input.