### PR TITLE
Re-enable livemode key management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 )
 
 require (
+	github.com/alessio/shellescape v1.4.1
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-plugin v1.4.4
 	github.com/joho/godotenv v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VM
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -167,7 +167,7 @@ func (c *Config) InitConfig() {
 	})
 
 	// redact livemode values for existing configs
-	// c.Profile.redactAllLivemodeValues()
+	c.Profile.redactAllLivemodeValues()
 }
 
 // EditConfig opens the configuration file in the default editor.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -163,7 +163,7 @@ func (c *Config) InitConfig() {
 
 	// initialize key ring
 	KeyRing, _ = keyring.Open(keyring.Config{
-		ServiceName: "Stripe CLI Key Storage",
+		ServiceName: KeyManagementService,
 	})
 
 	// redact livemode values for existing configs

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -244,6 +244,8 @@ func (c *Config) RemoveProfile(profileName string) error {
 			if err != nil {
 				return err
 			}
+
+			deleteLivemodeKey(LiveModeAPIKeyName, field)
 		}
 	}
 
@@ -261,6 +263,8 @@ func (c *Config) RemoveAllProfiles() error {
 			if err != nil {
 				return err
 			}
+
+			deleteLivemodeKey(LiveModeAPIKeyName, field)
 		}
 	}
 

--- a/pkg/config/config_livemode.go
+++ b/pkg/config/config_livemode.go
@@ -1,0 +1,19 @@
+//go:build !arm64
+// +build !arm64
+
+package config
+
+func deleteLivemodeKey(key string, profile string) error {
+	fieldID := profile + "." + key
+	existingKeys, err := KeyRing.Keys()
+	if err != nil {
+		return err
+	}
+	for _, item := range existingKeys {
+		if item == fieldID {
+			KeyRing.Remove(fieldID)
+			return nil
+		}
+	}
+	return nil
+}

--- a/pkg/config/config_livemode_arm64.go
+++ b/pkg/config/config_livemode_arm64.go
@@ -1,0 +1,19 @@
+//go:build arm64
+// +build arm64
+
+package config
+
+import exec "golang.org/x/sys/execabs"
+
+func deleteLivemodeKey(key string, profile string) error {
+	fieldID := profile + "." + key
+	_, err := exec.Command(
+		execPathKeychain,
+		"delete-generic-password",
+		"-s", fieldID,
+		"-a", KeyManagementService).CombinedOutput()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -160,14 +160,6 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 		if err != nil {
 			return "", err
 		}
-
-		// if err := viper.ReadInConfig(); err == nil {
-		// 	key = viper.GetString(p.GetConfigField(LiveModeAPIKeyName))
-		// }
-
-		// if isRedactedAPIKey(key) {
-		// 	return "", validators.ErrAPIKeyNotConfigured
-		// }
 	}
 
 	if key != "" {
@@ -184,13 +176,8 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 // GetExpiresAt returns the API key expirary date
 func (p *Profile) GetExpiresAt(livemode bool) (time.Time, error) {
 	var timeString string
-	// var err error
 
 	if livemode {
-		// timeString, err = p.retrieveLivemodeValue(LiveModeKeyExpiresAtName)
-		// if err != nil {
-		// 	return time.Time{}, err
-		// }
 		timeString = viper.GetString(p.GetConfigField(LiveModeKeyExpiresAtName))
 	} else {
 		timeString = viper.GetString(p.GetConfigField(TestModeKeyExpiresAtName))
@@ -283,7 +270,7 @@ func (p *Profile) DeleteConfigField(field string) error {
 	}
 
 	// delete livemode redacted values from config and full values from keyring
-	if field == LiveModeAPIKeyName || field == LiveModeKeyExpiresAtName {
+	if field == LiveModeAPIKeyName {
 		p.deleteLivemodeValue(field)
 	}
 
@@ -303,20 +290,14 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 	}
 
 	if p.LiveModeAPIKey != "" {
-		fmt.Println("DEBUG: FOUND LIVE API KEY")
-		// comment out livemode storage until bugs are ironed out
 		expiresAt := getKeyExpiresAt()
+		runtimeViper.Set(p.GetConfigField(LiveModeKeyExpiresAtName), expiresAt)
 
 		// // store redacted key in config
 		runtimeViper.Set(p.GetConfigField(LiveModeAPIKeyName), RedactAPIKey(strings.TrimSpace(p.LiveModeAPIKey)))
-		runtimeViper.Set(p.GetConfigField(LiveModeKeyExpiresAtName), expiresAt)
 
 		// // store actual key in secure keyring
 		p.saveLivemodeValue(LiveModeAPIKeyName, strings.TrimSpace(p.LiveModeAPIKey), "Live mode API key")
-		p.saveLivemodeValue(LiveModeKeyExpiresAtName, expiresAt, "Live mode API key expirary")
-
-		// runtimeViper.Set(p.GetConfigField(LiveModeAPIKeyName), strings.TrimSpace(p.LiveModeAPIKey))
-		// runtimeViper.Set(p.GetConfigField(LiveModeKeyExpiresAtName), getKeyExpiresAt())
 	}
 
 	if p.LiveModePublishableKey != "" {

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -139,19 +139,19 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 			key = viper.GetString(p.GetConfigField(TestModeAPIKeyName))
 		}
 	} else {
-		// p.redactAllLivemodeValues()
-		// key, err = p.retrieveLivemodeValue(LiveModeAPIKeyName)
-		// if err != nil {
-		// 	return "", err
+		p.redactAllLivemodeValues()
+		key, err = p.retrieveLivemodeValue(LiveModeAPIKeyName)
+		if err != nil {
+			return "", err
+		}
+
+		// if err := viper.ReadInConfig(); err == nil {
+		// 	key = viper.GetString(p.GetConfigField(LiveModeAPIKeyName))
 		// }
 
-		if err := viper.ReadInConfig(); err == nil {
-			key = viper.GetString(p.GetConfigField(LiveModeAPIKeyName))
-		}
-
-		if isRedactedAPIKey(key) {
-			return "", validators.ErrAPIKeyNotConfigured
-		}
+		// if isRedactedAPIKey(key) {
+		// 	return "", validators.ErrAPIKeyNotConfigured
+		// }
 	}
 
 	if key != "" {

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -267,9 +267,9 @@ func (p *Profile) DeleteConfigField(field string) error {
 	}
 
 	// delete livemode redacted values from config and full values from keyring
-	// if field == LiveModeAPIKeyName || field == LiveModePubKeyName || field == LiveModeKeyExpiresAtName {
-	// 	p.deleteLivemodeValue(field)
-	// }
+	if field == LiveModeAPIKeyName || field == LiveModeKeyExpiresAtName {
+		p.deleteLivemodeValue(field)
+	}
 
 	return p.writeProfile(v)
 }
@@ -287,19 +287,20 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 	}
 
 	if p.LiveModeAPIKey != "" {
+		fmt.Println("DEBUG: FOUND LIVE API KEY")
 		// comment out livemode storage until bugs are ironed out
-		// expiresAt := getKeyExpiresAt()
+		expiresAt := getKeyExpiresAt()
 
 		// // store redacted key in config
-		// runtimeViper.Set(p.GetConfigField(LiveModeAPIKeyName), RedactAPIKey(strings.TrimSpace(p.LiveModeAPIKey)))
-		// runtimeViper.Set(p.GetConfigField(LiveModeKeyExpiresAtName), expiresAt)
+		runtimeViper.Set(p.GetConfigField(LiveModeAPIKeyName), RedactAPIKey(strings.TrimSpace(p.LiveModeAPIKey)))
+		runtimeViper.Set(p.GetConfigField(LiveModeKeyExpiresAtName), expiresAt)
 
 		// // store actual key in secure keyring
-		// p.saveLivemodeValue(LiveModeAPIKeyName, strings.TrimSpace(p.LiveModeAPIKey), "Live mode API key")
-		// p.saveLivemodeValue(LiveModeKeyExpiresAtName, expiresAt, "Live mode API key expirary")
+		p.saveLivemodeValue(LiveModeAPIKeyName, strings.TrimSpace(p.LiveModeAPIKey), "Live mode API key")
+		p.saveLivemodeValue(LiveModeKeyExpiresAtName, expiresAt, "Live mode API key expirary")
 
-		runtimeViper.Set(p.GetConfigField(LiveModeAPIKeyName), strings.TrimSpace(p.LiveModeAPIKey))
-		runtimeViper.Set(p.GetConfigField(LiveModeKeyExpiresAtName), getKeyExpiresAt())
+		// runtimeViper.Set(p.GetConfigField(LiveModeAPIKeyName), strings.TrimSpace(p.LiveModeAPIKey))
+		// runtimeViper.Set(p.GetConfigField(LiveModeKeyExpiresAtName), getKeyExpiresAt())
 	}
 
 	if p.LiveModePublishableKey != "" {

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -43,7 +43,7 @@ const (
 )
 
 const (
-	// DateStrineFormat is the format for expiredAt date
+	// DateStringFormat is the format for expiredAt date
 	DateStringFormat = "2006-01-02"
 
 	// KeyValidInDays is the number of days the API key is valid for

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -7,8 +7,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/99designs/keyring"
 	"github.com/spf13/viper"
 
+	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
@@ -39,6 +41,20 @@ const (
 	LiveModePubKeyName         = "live_mode_pub_key"
 	LiveModeKeyExpiresAtName   = "live_mode_key_expires_at"
 )
+
+const (
+	// DateStrineFormat is the format for expiredAt date
+	DateStringFormat = "2006-01-02"
+
+	// KeyValidInDays is the number of days the API key is valid for
+	KeyValidInDays = 90
+
+	// KeyManagementService is the key management service name
+	KeyManagementService = "Stripe CLI"
+)
+
+// KeyRing ...
+var KeyRing keyring.Keyring
 
 // CreateProfile creates a profile when logging in
 func (p *Profile) CreateProfile() error {
@@ -360,6 +376,57 @@ func (p *Profile) safeRemove(v *viper.Viper, key string) *viper.Viper {
 	}
 
 	return v
+}
+
+// redactAllLivemodeValues redacts all livemode values in the local config file
+func (p *Profile) redactAllLivemodeValues() {
+	color := ansi.Color(os.Stdout)
+
+	if err := viper.ReadInConfig(); err == nil {
+		// if the config file has expires at date, then it is using the new livemode key storage
+		if viper.IsSet(p.GetConfigField(LiveModeAPIKeyName)) {
+			key := viper.GetString(p.GetConfigField(LiveModeAPIKeyName))
+			if !isRedactedAPIKey(key) {
+				fmt.Println(color.Yellow(`
+(!) Livemode value found for the field '` + LiveModeAPIKeyName + `' in your config file.
+Livemode values from the config file will be redacted and will not be used.`))
+
+				p.WriteConfigField(LiveModeAPIKeyName, RedactAPIKey(key))
+			}
+		}
+	}
+}
+
+// RedactAPIKey returns a redacted version of API keys. The first 8 and last 4
+// characters are not redacted, everything else is replaced by "*" characters.
+//
+// It panics if the provided string has less than 12 characters.
+func RedactAPIKey(apiKey string) string {
+	var b strings.Builder
+
+	b.WriteString(apiKey[0:8])                         // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
+	b.WriteString(strings.Repeat("*", len(apiKey)-12)) // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
+	b.WriteString(apiKey[len(apiKey)-4:])              // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
+
+	return b.String()
+}
+
+// isRedactedAPIKey checks if the input string is a refacted api key
+func isRedactedAPIKey(apiKey string) bool {
+	keyParts := strings.Split(apiKey, "_")
+	if len(keyParts) < 3 {
+		return false
+	}
+
+	if keyParts[0] != "sk" && keyParts[0] != "rk" {
+		return false
+	}
+
+	if RedactAPIKey(apiKey) != apiKey {
+		return false
+	}
+
+	return true
 }
 
 func getKeyExpiresAt() string {

--- a/pkg/config/profile_livemode.go
+++ b/pkg/config/profile_livemode.go
@@ -1,9 +1,17 @@
+//go:build !arm64
+// +build !arm64
+
 package config
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/99designs/keyring"
+	"github.com/spf13/viper"
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
 // DateStringFormat ...
@@ -16,68 +24,68 @@ const KeyValidInDays = 90
 var KeyRing keyring.Keyring
 
 // saveLivemodeValue saves livemode value of given key in keyring
-// func (p *Profile) saveLivemodeValue(field, value, description string) {
-// 	fieldID := p.GetConfigField(field)
-// 	_ = KeyRing.Set(keyring.Item{
-// 		Key:         fieldID,
-// 		Data:        []byte(value),
-// 		Description: description,
-// 		Label:       fieldID,
-// 	})
-// }
+func (p *Profile) saveLivemodeValue(field, value, description string) {
+	fieldID := p.GetConfigField(field)
+	_ = KeyRing.Set(keyring.Item{
+		Key:         fieldID,
+		Data:        []byte(value),
+		Description: description,
+		Label:       fieldID,
+	})
+}
 
 // retrieveLivemodeValue retrieves livemode value of given key in keyring
-// func (p *Profile) retrieveLivemodeValue(key string) (string, error) {
-// 	fieldID := p.GetConfigField(key)
-// 	existingKeys, err := KeyRing.Keys()
-// 	if err != nil {
-// 		return "", err
-// 	}
+func (p *Profile) retrieveLivemodeValue(key string) (string, error) {
+	fieldID := p.GetConfigField(key)
+	existingKeys, err := KeyRing.Keys()
+	if err != nil {
+		return "", err
+	}
 
-// 	for _, item := range existingKeys {
-// 		if item == fieldID {
-// 			value, _ := KeyRing.Get(fieldID)
-// 			return string(value.Data), nil
-// 		}
-// 	}
+	for _, item := range existingKeys {
+		if item == fieldID {
+			value, _ := KeyRing.Get(fieldID)
+			return string(value.Data), nil
+		}
+	}
 
-// 	return "", validators.ErrAPIKeyNotConfigured
-// }
+	return "", validators.ErrAPIKeyNotConfigured
+}
 
 // deleteLivemodeValue deletes livemode value of given key in keyring
-// func (p *Profile) deleteLivemodeValue(key string) error {
-// 	fieldID := p.GetConfigField(key)
-// 	existingKeys, err := KeyRing.Keys()
-// 	if err != nil {
-// 		return err
-// 	}
-// 	for _, item := range existingKeys {
-// 		if item == fieldID {
-// 			KeyRing.Remove(fieldID)
-// 			return nil
-// 		}
-// 	}
-// 	return nil
-// }
+func (p *Profile) deleteLivemodeValue(key string) error {
+	fieldID := p.GetConfigField(key)
+	existingKeys, err := KeyRing.Keys()
+	if err != nil {
+		return err
+	}
+	for _, item := range existingKeys {
+		if item == fieldID {
+			KeyRing.Remove(fieldID)
+			return nil
+		}
+	}
+	return nil
+}
 
 // redactAllLivemodeValues redacts all livemode values in the local config file
-// func (p *Profile) redactAllLivemodeValues() {
-// 	color := ansi.Color(os.Stdout)
+func (p *Profile) redactAllLivemodeValues() {
+	color := ansi.Color(os.Stdout)
 
-// 	if err := viper.ReadInConfig(); err == nil {
-// 		// if the config file has expires at date, then it is using the new livemode key storage
-// 		if viper.IsSet(p.GetConfigField(LiveModeAPIKeyName)) {
-// 			key := viper.GetString(p.GetConfigField(LiveModeAPIKeyName))
-// 			if !isRedactedAPIKey(key) {
-// 				fmt.Println(color.Yellow(`
-// (!) Livemode value found for the field '` + LiveModeAPIKeyName + `' in your config file.
-// Livemode values from the config file will be redacted and will not be used.`))
+	if err := viper.ReadInConfig(); err == nil {
+		// if the config file has expires at date, then it is using the new livemode key storage
+		if viper.IsSet(p.GetConfigField(LiveModeAPIKeyName)) {
+			key := viper.GetString(p.GetConfigField(LiveModeAPIKeyName))
+			if !isRedactedAPIKey(key) {
+				fmt.Println(color.Yellow(`
+(!) Livemode value found for the field '` + LiveModeAPIKeyName + `' in your config file.
+Livemode values from the config file will be redacted and will not be used.`))
 
-// 				p.WriteConfigField(LiveModeAPIKeyName, RedactAPIKey(key))
-// 			}
-// 		}
-// 	}
-// }
+				p.WriteConfigField(LiveModeAPIKeyName, RedactAPIKey(key))
+			}
+		}
+	}
+}
 
 // RedactAPIKey returns a redacted version of API keys. The first 8 and last 4
 // characters are not redacted, everything else is replaced by "*" characters.

--- a/pkg/config/profile_livemode.go
+++ b/pkg/config/profile_livemode.go
@@ -4,10 +4,6 @@
 package config
 
 import (
-	"fmt"
-	"os"
-	"strings"
-
 	"github.com/99designs/keyring"
 	"github.com/spf13/viper"
 	"github.com/stripe/stripe-cli/pkg/ansi"

--- a/pkg/config/profile_livemode.go
+++ b/pkg/config/profile_livemode.go
@@ -5,8 +5,6 @@ package config
 
 import (
 	"github.com/99designs/keyring"
-	"github.com/spf13/viper"
-	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 

--- a/pkg/config/profile_livemode.go
+++ b/pkg/config/profile_livemode.go
@@ -4,8 +4,9 @@
 package config
 
 import (
-	"github.com/99designs/keyring"
 	"github.com/stripe/stripe-cli/pkg/validators"
+
+	"github.com/99designs/keyring"
 )
 
 // saveLivemodeValue saves livemode value of given key in keyring

--- a/pkg/config/profile_livemode.go
+++ b/pkg/config/profile_livemode.go
@@ -14,15 +14,6 @@ import (
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
-// DateStringFormat ...
-const DateStringFormat = "2006-01-02"
-
-// KeyValidInDays ...
-const KeyValidInDays = 90
-
-// KeyRing ...
-var KeyRing keyring.Keyring
-
 // saveLivemodeValue saves livemode value of given key in keyring
 func (p *Profile) saveLivemodeValue(field, value, description string) {
 	fieldID := p.GetConfigField(field)
@@ -66,55 +57,4 @@ func (p *Profile) deleteLivemodeValue(key string) error {
 		}
 	}
 	return nil
-}
-
-// redactAllLivemodeValues redacts all livemode values in the local config file
-func (p *Profile) redactAllLivemodeValues() {
-	color := ansi.Color(os.Stdout)
-
-	if err := viper.ReadInConfig(); err == nil {
-		// if the config file has expires at date, then it is using the new livemode key storage
-		if viper.IsSet(p.GetConfigField(LiveModeAPIKeyName)) {
-			key := viper.GetString(p.GetConfigField(LiveModeAPIKeyName))
-			if !isRedactedAPIKey(key) {
-				fmt.Println(color.Yellow(`
-(!) Livemode value found for the field '` + LiveModeAPIKeyName + `' in your config file.
-Livemode values from the config file will be redacted and will not be used.`))
-
-				p.WriteConfigField(LiveModeAPIKeyName, RedactAPIKey(key))
-			}
-		}
-	}
-}
-
-// RedactAPIKey returns a redacted version of API keys. The first 8 and last 4
-// characters are not redacted, everything else is replaced by "*" characters.
-//
-// It panics if the provided string has less than 12 characters.
-func RedactAPIKey(apiKey string) string {
-	var b strings.Builder
-
-	b.WriteString(apiKey[0:8])                         // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
-	b.WriteString(strings.Repeat("*", len(apiKey)-12)) // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
-	b.WriteString(apiKey[len(apiKey)-4:])              // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
-
-	return b.String()
-}
-
-// isRedactedAPIKey checks if the input string is a refacted api key
-func isRedactedAPIKey(apiKey string) bool {
-	keyParts := strings.Split(apiKey, "_")
-	if len(keyParts) < 3 {
-		return false
-	}
-
-	if keyParts[0] != "sk" && keyParts[0] != "rk" {
-		return false
-	}
-
-	if RedactAPIKey(apiKey) != apiKey {
-		return false
-	}
-
-	return true
 }

--- a/pkg/config/profile_livemode_arm64.go
+++ b/pkg/config/profile_livemode_arm64.go
@@ -7,56 +7,36 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
-	"github.com/99designs/keyring"
 	"github.com/alessio/shellescape"
-	"github.com/spf13/viper"
-	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/validators"
 	exec "golang.org/x/sys/execabs"
 )
 
 const (
-	// DateStringFormat ...
-	DateStringFormat = "2006-01-02"
-
-	// KeyValidInDays ...
-	KeyValidInDays = 90
-
+	// execPathKeychain is the path to the keychain binary
 	execPathKeychain = "/usr/bin/security"
 
 	// encodingPrefix is a well-known prefix added to strings encoded by Set.
 	encodingPrefix = "go-keyring-encoded:"
 )
 
-// KeyRing ...
-var KeyRing keyring.Keyring
-
-var User = "Stripe CLI"
-
 // saveLivemodeValue saves livemode value of given key in keyring
 func (p *Profile) saveLivemodeValue(field, value, description string) {
-	// p.WriteConfigField(field, value)
-
-	color := ansi.Color(os.Stdout)
-	fmt.Println(color.Yellow(`(!) ON ARM64. WRITING TO GOKEYRING`))
-
-	// err := goKeyring.Set(p.GetConfigField(field), User, value)
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-
 	value = encodingPrefix + hex.EncodeToString([]byte(value))
 
 	cmd := exec.Command(execPathKeychain, "-i")
 	stdIn, _ := cmd.StdinPipe()
-
-	// save value
 	cmd.Start()
 
-	command := fmt.Sprintf("add-generic-password -U -s %s -a %s -w %s\n", shellescape.Quote(field), shellescape.Quote(User), shellescape.Quote(value))
+	command := fmt.Sprintf(
+		"add-generic-password -U -s %s -a %s -w %s\n",
+		shellescape.Quote(field),
+		shellescape.Quote(KeyManagementService),
+		shellescape.Quote(value),
+	)
+
 	io.WriteString(stdIn, command)
 	stdIn.Close()
 	cmd.Wait()
@@ -66,26 +46,15 @@ func (p *Profile) saveLivemodeValue(field, value, description string) {
 func (p *Profile) retrieveLivemodeValue(key string) (string, error) {
 	fieldID := p.GetConfigField(key)
 
-	color := ansi.Color(os.Stdout)
-	fmt.Println(color.Yellow(`(!) ON ARM64. READING FROM GOKEYRING`))
-
-	// value, err := goKeyring.Get(fieldID, User)
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-
-	// value := viper.GetString(fieldID)
-
 	out, err := exec.Command(
 		execPathKeychain,
 		"find-generic-password",
 		"-s", fieldID,
-		"-wa", User).CombinedOutput()
+		"-wa", KeyManagementService).CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(out), "could not be found") {
-			err = fmt.Errorf("KEY NOT FOUND")
+			return "", validators.ErrAPIKeyNotConfigured
 		}
-		return "", err
 	}
 
 	value := strings.TrimSpace(string(out[:]))
@@ -104,56 +73,14 @@ func (p *Profile) retrieveLivemodeValue(key string) (string, error) {
 
 // deleteLivemodeValue deletes livemode value of given key in keyring
 func (p *Profile) deleteLivemodeValue(key string) error {
-	return p.DeleteConfigField(key)
-}
-
-// redactAllLivemodeValues redacts all livemode values in the local config file
-func (p *Profile) redactAllLivemodeValues() {
-	color := ansi.Color(os.Stdout)
-
-	if err := viper.ReadInConfig(); err == nil {
-		// if the config file has expires at date, then it is using the new livemode key storage
-		if viper.IsSet(p.GetConfigField(LiveModeAPIKeyName)) {
-			key := viper.GetString(p.GetConfigField(LiveModeAPIKeyName))
-			if !isRedactedAPIKey(key) {
-				fmt.Println(color.Yellow(`
-(!) Livemode value found for the field '` + LiveModeAPIKeyName + `' in your config file.
-Livemode values from the config file will be redacted and will not be used.`))
-
-				p.WriteConfigField(LiveModeAPIKeyName, RedactAPIKey(key))
-			}
-		}
+	fieldID := p.GetConfigField(key)
+	_, err := exec.Command(
+		execPathKeychain,
+		"delete-generic-password",
+		"-s", fieldID,
+		"-a", KeyManagementService).CombinedOutput()
+	if err != nil {
+		return err
 	}
-}
-
-// RedactAPIKey returns a redacted version of API keys. The first 8 and last 4
-// characters are not redacted, everything else is replaced by "*" characters.
-//
-// It panics if the provided string has less than 12 characters.
-func RedactAPIKey(apiKey string) string {
-	var b strings.Builder
-
-	b.WriteString(apiKey[0:8])                         // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
-	b.WriteString(strings.Repeat("*", len(apiKey)-12)) // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
-	b.WriteString(apiKey[len(apiKey)-4:])              // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
-
-	return b.String()
-}
-
-// isRedactedAPIKey checks if the input string is a refacted api key
-func isRedactedAPIKey(apiKey string) bool {
-	keyParts := strings.Split(apiKey, "_")
-	if len(keyParts) < 3 {
-		return false
-	}
-
-	if keyParts[0] != "sk" && keyParts[0] != "rk" {
-		return false
-	}
-
-	if RedactAPIKey(apiKey) != apiKey {
-		return false
-	}
-
-	return true
+	return nil
 }

--- a/pkg/config/profile_livemode_arm64.go
+++ b/pkg/config/profile_livemode_arm64.go
@@ -1,0 +1,63 @@
+//go:build arm64
+// +build arm64
+
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/99designs/keyring"
+	"github.com/spf13/viper"
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+// DateStringFormat ...
+const DateStringFormat = "2006-01-02"
+
+// KeyValidInDays ...
+const KeyValidInDays = 90
+
+// KeyRing ...
+var KeyRing keyring.Keyring
+
+// saveLivemodeValue saves livemode value of given key in keyring
+func (p *Profile) saveLivemodeValue(field, value, description string) {
+	p.WriteConfigField(field, value)
+}
+
+// retrieveLivemodeValue retrieves livemode value of given key in keyring
+func (p *Profile) retrieveLivemodeValue(key string) (string, error) {
+	fieldID := p.GetConfigField(key)
+	value := viper.GetString(fieldID)
+	if value != "" {
+		return value, nil
+	}
+
+	return "", validators.ErrAPIKeyNotConfigured
+}
+
+// deleteLivemodeValue deletes livemode value of given key in keyring
+func (p *Profile) deleteLivemodeValue(key string) error {
+	return p.DeleteConfigField(key)
+}
+
+// redactAllLivemodeValues redacts all livemode values in the local config file
+func (p *Profile) redactAllLivemodeValues() {
+	color := ansi.Color(os.Stdout)
+	fmt.Println(color.Yellow(`(!) ON ARM64. DO NOTHING`))
+}
+
+// RedactAPIKey returns a redacted version of API keys. The first 8 and last 4
+// characters are not redacted, everything else is replaced by "*" characters.
+//
+// It panics if the provided string has less than 12 characters.
+func RedactAPIKey(apiKey string) string {
+	return apiKey
+}
+
+// isRedactedAPIKey checks if the input string is a refacted api key
+func isRedactedAPIKey(apiKey string) bool {
+	return false
+}

--- a/pkg/config/profile_livemode_arm64.go
+++ b/pkg/config/profile_livemode_arm64.go
@@ -23,7 +23,8 @@ const (
 )
 
 // saveLivemodeValue saves livemode value of given key in keyring
-func (p *Profile) saveLivemodeValue(field, value, description string) {
+func (p *Profile) saveLivemodeValue(key, value, description string) {
+	fieldID := p.GetConfigField(key)
 	value = encodingPrefix + hex.EncodeToString([]byte(value))
 
 	cmd := exec.Command(execPathKeychain, "-i")
@@ -32,7 +33,7 @@ func (p *Profile) saveLivemodeValue(field, value, description string) {
 
 	command := fmt.Sprintf(
 		"add-generic-password -U -s %s -a %s -w %s\n",
-		shellescape.Quote(field),
+		shellescape.Quote(fieldID),
 		shellescape.Quote(KeyManagementService),
 		shellescape.Quote(value),
 	)

--- a/pkg/config/profile_livemode_arm64.go
+++ b/pkg/config/profile_livemode_arm64.go
@@ -4,33 +4,97 @@
 package config
 
 import (
+	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/99designs/keyring"
+	"github.com/alessio/shellescape"
 	"github.com/spf13/viper"
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/validators"
+	exec "golang.org/x/sys/execabs"
 )
 
-// DateStringFormat ...
-const DateStringFormat = "2006-01-02"
+const (
+	// DateStringFormat ...
+	DateStringFormat = "2006-01-02"
 
-// KeyValidInDays ...
-const KeyValidInDays = 90
+	// KeyValidInDays ...
+	KeyValidInDays = 90
+
+	execPathKeychain = "/usr/bin/security"
+
+	// encodingPrefix is a well-known prefix added to strings encoded by Set.
+	encodingPrefix = "go-keyring-encoded:"
+)
 
 // KeyRing ...
 var KeyRing keyring.Keyring
 
+var User = "Stripe CLI"
+
 // saveLivemodeValue saves livemode value of given key in keyring
 func (p *Profile) saveLivemodeValue(field, value, description string) {
-	p.WriteConfigField(field, value)
+	// p.WriteConfigField(field, value)
+
+	color := ansi.Color(os.Stdout)
+	fmt.Println(color.Yellow(`(!) ON ARM64. WRITING TO GOKEYRING`))
+
+	// err := goKeyring.Set(p.GetConfigField(field), User, value)
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+
+	value = encodingPrefix + hex.EncodeToString([]byte(value))
+
+	cmd := exec.Command(execPathKeychain, "-i")
+	stdIn, _ := cmd.StdinPipe()
+
+	// save value
+	cmd.Start()
+
+	command := fmt.Sprintf("add-generic-password -U -s %s -a %s -w %s\n", shellescape.Quote(field), shellescape.Quote(User), shellescape.Quote(value))
+	io.WriteString(stdIn, command)
+	stdIn.Close()
+	cmd.Wait()
 }
 
 // retrieveLivemodeValue retrieves livemode value of given key in keyring
 func (p *Profile) retrieveLivemodeValue(key string) (string, error) {
 	fieldID := p.GetConfigField(key)
-	value := viper.GetString(fieldID)
+
+	color := ansi.Color(os.Stdout)
+	fmt.Println(color.Yellow(`(!) ON ARM64. READING FROM GOKEYRING`))
+
+	// value, err := goKeyring.Get(fieldID, User)
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+
+	// value := viper.GetString(fieldID)
+
+	out, err := exec.Command(
+		execPathKeychain,
+		"find-generic-password",
+		"-s", fieldID,
+		"-wa", User).CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(out), "could not be found") {
+			err = fmt.Errorf("KEY NOT FOUND")
+		}
+		return "", err
+	}
+
+	value := strings.TrimSpace(string(out[:]))
+	// if the string has the well-known prefix, assume it's encoded
+	if strings.HasPrefix(value, encodingPrefix) {
+		dec, err := hex.DecodeString(value[len(encodingPrefix):])
+		return string(dec), err
+	}
+
 	if value != "" {
 		return value, nil
 	}
@@ -46,7 +110,20 @@ func (p *Profile) deleteLivemodeValue(key string) error {
 // redactAllLivemodeValues redacts all livemode values in the local config file
 func (p *Profile) redactAllLivemodeValues() {
 	color := ansi.Color(os.Stdout)
-	fmt.Println(color.Yellow(`(!) ON ARM64. DO NOTHING`))
+
+	if err := viper.ReadInConfig(); err == nil {
+		// if the config file has expires at date, then it is using the new livemode key storage
+		if viper.IsSet(p.GetConfigField(LiveModeAPIKeyName)) {
+			key := viper.GetString(p.GetConfigField(LiveModeAPIKeyName))
+			if !isRedactedAPIKey(key) {
+				fmt.Println(color.Yellow(`
+(!) Livemode value found for the field '` + LiveModeAPIKeyName + `' in your config file.
+Livemode values from the config file will be redacted and will not be used.`))
+
+				p.WriteConfigField(LiveModeAPIKeyName, RedactAPIKey(key))
+			}
+		}
+	}
 }
 
 // RedactAPIKey returns a redacted version of API keys. The first 8 and last 4
@@ -54,10 +131,29 @@ func (p *Profile) redactAllLivemodeValues() {
 //
 // It panics if the provided string has less than 12 characters.
 func RedactAPIKey(apiKey string) string {
-	return apiKey
+	var b strings.Builder
+
+	b.WriteString(apiKey[0:8])                         // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
+	b.WriteString(strings.Repeat("*", len(apiKey)-12)) // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
+	b.WriteString(apiKey[len(apiKey)-4:])              // #nosec G104 (gosec bug: https://github.com/securego/gosec/issues/267)
+
+	return b.String()
 }
 
 // isRedactedAPIKey checks if the input string is a refacted api key
 func isRedactedAPIKey(apiKey string) bool {
-	return false
+	keyParts := strings.Split(apiKey, "_")
+	if len(keyParts) < 3 {
+		return false
+	}
+
+	if keyParts[0] != "sk" && keyParts[0] != "rk" {
+		return false
+	}
+
+	if RedactAPIKey(apiKey) != apiKey {
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

- restore storing livmode api keys by OS default credential management app
- store livemode api keys by `add-generic-password` for macOS arm64, due to CGO incompatibility with keying library
