### PR TITLE
Better error handling for plugins

### DIFF
--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -38,7 +38,6 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 		FParseErrWhitelist: cobra.FParseErrWhitelist{
 			UnknownFlags: true,
 		},
-		SilenceErrors: true,
 	}
 
 	// override the CLI's help command and let the plugin supply the help text instead

--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -38,6 +38,7 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 		FParseErrWhitelist: cobra.FParseErrWhitelist{
 			UnknownFlags: true,
 		},
+		SilenceErrors: true,
 	}
 
 	// override the CLI's help command and let the plugin supply the help text instead
@@ -80,6 +81,10 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 		log.WithFields(log.Fields{
 			"prefix": "pluginTemplateCmd.runPluginCmd",
 		}).Debug(fmt.Sprintf("Plugin command '%s' exited with error: %s", plugin.Shortname, err))
+
+		// We can't return err because the plugin will have already printed the error message at
+		// this point, and we can't return nil because the host will exit with code 0.
+		os.Exit(1)
 	}
 
 	return nil

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -51,7 +51,7 @@ type Client struct {
 }
 
 // PerformRequest sends a request to Stripe and returns the response.
-func (c *Client) PerformRequest(ctx context.Context, method, path string, params string, configure func(*http.Request)) (*http.Response, error) {
+func (c *Client) PerformRequest(ctx context.Context, method, path string, params string, configure func(*http.Request) error) (*http.Response, error) {
 	url, err := url.Parse(path)
 	if err != nil {
 		return nil, err
@@ -81,7 +81,9 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 	}
 
 	if configure != nil {
-		configure(req)
+		if err := configure(req); err != nil {
+			return nil, err
+		}
 	}
 
 	if c.httpClient == nil {

--- a/pkg/stripe/client_test.go
+++ b/pkg/stripe/client_test.go
@@ -135,8 +135,9 @@ func TestPerformRequest_ConfigureFunc(t *testing.T) {
 		BaseURL: baseURL,
 	}
 
-	resp, err := client.PerformRequest(context.Background(), http.MethodGet, "/get", "", func(r *http.Request) {
+	resp, err := client.PerformRequest(context.Background(), http.MethodGet, "/get", "", func(r *http.Request) error {
 		r.Header.Add("Stripe-Version", "2019-07-10")
+		return nil
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
 ### Reviewers
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Before:
- Plugin commands would exit with code 0 even on error. This makes plugin commands hard to write scripts for.
- The `configure` function for the Stripe client did not return error, allowing requests to pass through even if the configuring the request fails.

After:
- Exit non-zero when the plugin process returns an error.
- Return an error in the Stripe client's `configure` function so errors can be handled properly.
