### PR TITLE
Fix arg passing to plugin processes

### DIFF
--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -96,6 +96,7 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 	return nil
 }
 
+// Return a copy of sl strictly after the first occurrence of str, or empty slice if not found.
 func subsliceAfter(sl []string, str string) []string {
 	for i, s := range sl {
 		if s == str {

--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -32,7 +32,9 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 		Use:   plugin.Shortname,
 		Short: plugin.Shortdesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ptc.runPluginCmd(cmd, os.Args[2:])
+			// "stripe [host_flags...] plugin_name [plugin_subcommands...] [plugin_flags...]" => "[plugin_subcommands...] [plugin_flags...]"
+			pluginArgs := subsliceAfter(os.Args, cmd.Name())
+			return ptc.runPluginCmd(cmd, pluginArgs)
 		},
 		Annotations: map[string]string{"scope": "plugin"},
 		FParseErrWhitelist: cobra.FParseErrWhitelist{
@@ -42,7 +44,16 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 
 	// override the CLI's help command and let the plugin supply the help text instead
 	ptc.cmd.SetHelpFunc(func(c *cobra.Command, s []string) {
-		ptc.runPluginCmd(c, s[1:])
+		var args []string
+		if len(s) == 0 {
+			// "stripe help plugin_name [plugin_subcommands...]" => "[plugin_subcommands...] --help"
+			args = subsliceAfter(os.Args, c.Name())
+			args = append(args, "--help")
+		} else {
+			// "stripe plugin_name [plugin_subcommands...] --help" => "[plugin_subcommands...] --help"
+			args = subsliceAfter(s, c.Name())
+		}
+		ptc.runPluginCmd(c, args)
 	})
 
 	return ptc
@@ -50,16 +61,12 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 
 // runPluginCmd hands off to the plugin itself to take over
 func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) error {
-	ctx := withSIGTERMCancel(cmd.Context(), func() {
-		log.WithFields(log.Fields{
-			"prefix": "cmd.pluginCmd.runPluginCmd",
-		}).Debug("Ctrl+C received, cleaning up...")
-	})
+	ctx := cmd.Context()
 
 	ptc.ParsedArgs = args
 
 	fs := afero.NewOsFs()
-	plugin, err := plugins.LookUpPlugin(ctx, ptc.cfg, fs, cmd.CalledAs())
+	plugin, err := plugins.LookUpPlugin(ctx, ptc.cfg, fs, ptc.cmd.Name())
 
 	if err != nil {
 		return err
@@ -87,4 +94,16 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 	}
 
 	return nil
+}
+
+func subsliceAfter(sl []string, str string) []string {
+	for i, s := range sl {
+		if s == str {
+			subsl := sl[i+1:]
+			res := make([]string, len(subsl))
+			copy(res, subsl)
+			return res
+		}
+	}
+	return make([]string, 0)
 }

--- a/pkg/cmd/plugin_cmds_test.go
+++ b/pkg/cmd/plugin_cmds_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/plugins"
@@ -49,4 +50,26 @@ func TestFlagsArePassedAsArgs(t *testing.T) {
 
 	require.Equal(t, 2, len(pluginCmd.ParsedArgs))
 	require.Equal(t, "testarg --log-level=info", strings.Join(pluginCmd.ParsedArgs, " "))
+}
+
+func TestSubsliceAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected []string
+		sl       []string
+		str      string
+	}{
+		{"empty slice", []string{}, []string{}, "foo"},
+		{"empty string", []string{}, []string{""}, ""},
+		{"not found", []string{}, []string{"bar"}, "foo"},
+		{"found at beginning", []string{"bar"}, []string{"foo", "bar"}, "foo"},
+		{"found at middle", []string{"baz", "qux"}, []string{"foo", "bar", "baz", "qux"}, "bar"},
+		{"found at end", []string{}, []string{"foo", "bar"}, "bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, subsliceAfter(tt.sl, tt.str))
+		})
+	}
 }


### PR DESCRIPTION
 ### Reviewers
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Fixes an issue where the host passes the wrong args to plugins. This issue affected commands like:
- `stripe help plugin_name`: would panic
- `stripe --log-level trace plugin_name`: would exit with unknown command
