### PR TITLE
Updating image template to include arch

### DIFF
--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -71,8 +71,8 @@ dockers:
       - stripe
       - stripe-linux
     image_templates:
-      - "stripe/stripe-cli:latest"
-      - "stripe/stripe-cli:{{ .Tag }}"
+      - "stripe/stripe-cli:latest-amd64"
+      - "stripe/stripe-cli:{{ .Tag }}-amd64"
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -87,8 +87,8 @@ dockers:
       - stripe
       - stripe-linux-arm
     image_templates:
-      - "stripe/stripe-cli:latest"
-      - "stripe/stripe-cli:{{ .Tag }}"
+      - "stripe/stripe-cli:latest-arm64"
+      - "stripe/stripe-cli:{{ .Tag }}-arm64"
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
Users reported not being able to run the stripe binary that comes in the docker image: https://github.com/stripe/stripe-cli/issues/993.
For some reason, I wasn't able to reproduce this with either version on my WSL2 setup, but I could verify that the 12.4.1 version would always pull the x86_64 and the 1.13.0 would always pull ARM. I think we just end up with whatever version we last pushed to the image since they share the same template. 
This adds the arch to the image template so we can have both instances. I would hope that grabbing just `stripe/stripe-cli` would grab the latest and correct arch automatically, but I'll have to test this after we run the release.
