### PR TITLE
fix: do not overwrite local plugin manifest if fetched manifest is invalid

### DIFF
--- a/pkg/cmd/plugin/upgrade.go
+++ b/pkg/cmd/plugin/upgrade.go
@@ -53,7 +53,10 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	})
 
 	// Refresh the plugin info before proceeding
-	plugins.RefreshPluginManifest(cmd.Context(), uc.cfg, uc.fs, uc.apiBaseURL)
+	if err := plugins.RefreshPluginManifest(cmd.Context(), uc.cfg, uc.fs, uc.apiBaseURL); err != nil {
+		log.Debug(err)
+		fmt.Println("Unable to refresh plugin manifest, continuing with cached manifest...")
+	}
 
 	plugin, err := plugins.LookUpPlugin(cmd.Context(), uc.cfg, uc.fs, args[0])
 

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -119,6 +119,10 @@ func RefreshPluginManifest(ctx context.Context, config config.IConfig, fs afero.
 		return err
 	}
 
+	if err := validatePluginManifest(body); err != nil {
+		return err
+	}
+
 	configPath := config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
 	pluginManifestPath := filepath.Join(configPath, "plugins.toml")
 
@@ -128,6 +132,18 @@ func RefreshPluginManifest(ctx context.Context, config config.IConfig, fs afero.
 		return err
 	}
 
+	return nil
+}
+
+func validatePluginManifest(body []byte) error {
+	var manifestBody PluginList
+
+	if err := toml.Unmarshal(body, &manifestBody); err != nil {
+		return fmt.Errorf("Received an invalid plugin manifest. Error: %s", err)
+	}
+	if len(manifestBody.Plugins) == 0 {
+		return fmt.Errorf("Received an empty plugin manifest")
+	}
 	return nil
 }
 


### PR DESCRIPTION


 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary

Previously, we'd fetch the remote plugin manifest and write it the local config. this caused issues if the remote manifest was invalid (for example, if it was empty), since the install step would fail, but it would break the `stripe plugin upgrade` and `stripe plugin install` commands from then on. 
This PR changes it so that:
- when running `install`, it will fail fast with a useful error
- when running `upgrade`, it will log that we couldn't fetch the remote manifest, so we'll upgrade based off of the local `plugins.toml`

<img width="657" alt="Screen Shot 2022-11-11 at 3 49 04 PM" src="https://user-images.githubusercontent.com/97612659/201445316-d2fa6e06-ff8d-41e0-9800-d151eab12f77.png">

