### PR TITLE
Add docker manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,10 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-latest
+    env:
+      # https://goreleaser.com/customization/docker_manifest/
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+
     steps:
       - name: Code checkout
         uses: actions/checkout@v2

--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -81,6 +81,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=repository=https://github.com/stripe/stripe-cli"
       - "--label=homepage=https://stripe.com"
+      - "--platform=linux/amd64"
   - goos: linux
     goarch: arm64
     ids:
@@ -97,6 +98,17 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=repository=https://github.com/stripe/stripe-cli"
       - "--label=homepage=https://stripe.com"
+      - "--platform=linux/arm64"
+docker_manifests:
+  - name_template: "stripe/stripe-cli:latest"
+    image_templates:
+      - "stripe/stripe-cli:latest-amd64"
+      - "stripe/stripe-cli:latest-arm64"
+  - name_template: "stripe/stripe-cli:{{ .Tag }}"
+    image_templates:
+      - "stripe/stripe-cli:{{ .Tag }}-amd64"
+      - "stripe/stripe-cli:{{ .Tag }}-arm64"
+
 publishers:
   - name: deb
     ids:


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
In this [PR](https://github.com/stripe/stripe-cli/pull/999), I included the arch in the image template. This lets us pull the correct version when specifying the image with the arch like so:
```
➜  stripe-cli git:(gracegoo-docker-manifest) ✗ docker images
REPOSITORY          TAG             IMAGE ID       CREATED          SIZE
stripe/stripe-cli   latest-amd64    3bdd1fd31953   11 seconds ago   29.1MB
stripe/stripe-cli   v1.13.1-amd64   3bdd1fd31953   11 seconds ago   29.1MB
stripe/stripe-cli   latest-arm64    42447b0cbc8a   14 seconds ago   28.2MB
stripe/stripe-cli   v1.13.1-arm64   42447b0cbc8a   14 seconds ago   28.2MB

➜  stripe-cli git:(gracegoo-docker-manifest) ✗ docker image inspect 3bdd1fd31953 | jq '.[].Architecture '
"amd64"
➜  stripe-cli git:(gracegoo-docker-manifest) ✗ docker image inspect 42447b0cbc8a | jq '.[].Architecture '
"arm64"

```

However, we were no longer publishing to the old image names (ex. `stripe/stripe-cli:latest`) so they still returned an image with an stripe v1.13.0 with only the ARM64 build.

This change adds a docker_manifests step to the goreleaser, which will allow us to publish a manifest list to the previous image names. In other words, `stripe/stripe-cli:latest` will now become a manifest list that contains multi-arch images, and docker will figure out what specific image to pull down.

About docker manifests: https://docs.docker.com/engine/reference/commandline/manifest/
Following guide [here](https://goreleaser.com/customization/docker_manifest/).


# Testing
I was not able to find a way to test this locally. I could run a snapshot version of the releaser but it bypasses the publishing step which also happens to bypass manifest builds:
```
 goreleaser release -f .goreleaser/linux.yml --rm-dist --snapshot
```
Warning from the [goreleaser docs](https://goreleaser.com/customization/docker_manifest/#how-it-works):
"Unfortunately, the manifest tool needs the images to be pushed to create the manifest, that's why we both create and push it in the publishing phase."
