### PR TITLE
Removing the platform tag

### DIFF
--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -81,7 +81,6 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=repository=https://github.com/stripe/stripe-cli"
       - "--label=homepage=https://stripe.com"
-      - "--platform=linux/amd64"
   - goos: linux
     goarch: arm64
     ids:
@@ -98,7 +97,6 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=repository=https://github.com/stripe/stripe-cli"
       - "--label=homepage=https://stripe.com"
-      - "--platform=linux/arm64"
 docker_manifests:
   - name_template: "stripe/stripe-cli:latest"
     image_templates:


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
The last update causes the release step to fail while building the docker image: https://github.com/stripe/stripe-cli/actions/runs/3465880982

Not entirely sure why... but there may be a mismatch in the specific ARM version we are requesting vs. the one that we actually create. The posts below suggest omitting it: 
https://github.com/moby/moby/issues/42158 
https://github.com/docker/for-linux/issues/1170

### Testing
Local building of the images seem to work on my local machine so I am unable to verify: 
```
stripe-cli git:(gracegoo-remove-platform-tag) goreleaser release -f .goreleaser/linux.yml --rm-dist --snapshot
  • starting release...
  • loading config file                              file=.goreleaser/linux.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=1a174e021225b2ceec268768c52ddaedc02d7acb latest tag=v1.13.2
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod download
    • running                                        hook=go generate ./...
    • took: 13s
  • snapshotting
    • building snapshot...                           version=v1.13.2-next
  • checking distribution directory
    • --rm-dist is set, cleaning it up
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/stripe-linux-arm_linux_arm64/stripe
    • building                                       binary=dist/stripe-linux_linux_amd64_v1/stripe
    • took: 2s
  • archives
    • creating                                       archive=dist/stripe_v1.13.2-next_linux_arm64.tar.gz
    • creating                                       archive=dist/stripe_v1.13.2-next_linux_x86_64.tar.gz
    • took: 2s
  • linux packages
    • creating                                       arch=amd64v1 file=dist/stripe_v1.13.2-next_linux_amd64.deb format=deb package=stripe
    • creating                                       arch=arm64 file=dist/stripe_v1.13.2-next_linux_arm64.deb format=deb package=stripe
    • creating                                       arch=arm64 file=dist/stripe_v1.13.2-next_linux_arm64.rpm format=rpm package=stripe
    • creating                                       arch=amd64v1 file=dist/stripe_v1.13.2-next_linux_amd64.rpm format=rpm package=stripe
  • calculating checksums
  • docker images
    • building docker image                          image=stripe/stripe-cli:latest-arm64
    • building docker image                          image=stripe/stripe-cli:latest-amd64
    • took: 3s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 19s
```
