### PR TITLE
Adding buildx to docker image building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/test-gorelease.yml
+++ b/.github/workflows/test-gorelease.yml
@@ -1,0 +1,48 @@
+# Running goreleaser with the snapshot flag allows us to run some custom validations
+# on our build without publishing: https://goreleaser.com/customization/snapshots/
+# TODO -- verify docker builds
+# TODO -- add so it only runs when we update the goreleaser directory.
+
+name: test-gorelease
+
+on:
+  push:
+    paths:
+    - '.goreleaser/**'
+  pull_request:
+    paths:
+    - 'goreleaser/**'
+
+# TODO -- it would be nice if we could verify pulling the docker images from other machines
+# by actually publishing the docker image to a test namespace
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    env:
+      # https://goreleaser.com/customization/docker_manifest/
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Docker Login
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+      - name: Run GoReleaser Snapshot
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: v0.184.0
+          args: release -f .goreleaser/linux.yml --rm-dist --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACTORY_SECRET: ${{ secrets.ARTIFACTORY_SECRET }}

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -38,7 +38,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: v0.184.0
-          args: release -f .goreleaser/linux.yml --rm-dist --snapshot
+          args: release -f .goreleaser/linux.yml --rm-dist --snapshot --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACTORY_SECRET: ${{ secrets.ARTIFACTORY_SECRET }}

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -1,9 +1,7 @@
 # Running goreleaser with the snapshot flag allows us to run some custom validations
 # on our build without publishing: https://goreleaser.com/customization/snapshots/
-# TODO -- verify docker builds
-# TODO -- add so it only runs when we update the goreleaser directory.
 
-name: test-gorelease
+name: test-snapshot
 
 on:
   push:
@@ -13,8 +11,6 @@ on:
     paths:
     - 'goreleaser/**'
 
-# TODO -- it would be nice if we could verify pulling the docker images from other machines
-# by actually publishing the docker image to a test namespace
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -3,13 +3,15 @@
 
 name: test-snapshot
 
-on:
-  push:
-    paths:
-    - '.goreleaser/**'
-  pull_request:
-    paths:
-    - 'goreleaser/**'
+on: [push, pull_request]
+
+# on:
+#   push:
+#     paths:
+#     - '.goreleaser/**'
+#   pull_request:
+#     paths:
+#     - 'goreleaser/**'
 
 jobs:
   build-linux:

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -32,6 +32,8 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -3,15 +3,13 @@
 
 name: test-snapshot
 
-on: [push, pull_request]
-
-# on:
-#   push:
-#     paths:
-#     - '.goreleaser/**'
-#   pull_request:
-#     paths:
-#     - 'goreleaser/**'
+on:
+  push:
+    paths:
+    - '.goreleaser/**'
+  pull_request:
+    paths:
+    - 'goreleaser/**'
 
 jobs:
   build-linux:
@@ -42,7 +40,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: v0.184.0
-          args: release -f .goreleaser/linux.yml --rm-dist --snapshot --debug
+          args: release -f .goreleaser/linux.yml --rm-dist --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACTORY_SECRET: ${{ secrets.ARTIFACTORY_SECRET }}

--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -65,7 +65,8 @@ nfpms:
     formats:
       - rpm
 dockers:
-  - goos: linux
+  - use: buildx
+    goos: linux
     goarch: amd64
     ids:
       - stripe
@@ -82,7 +83,8 @@ dockers:
       - "--label=repository=https://github.com/stripe/stripe-cli"
       - "--label=homepage=https://stripe.com"
       - "--platform=linux/amd64"
-  - goos: linux
+  - use: buildx
+    goos: linux
     goarch: arm64
     ids:
       - stripe

--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -81,6 +81,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=repository=https://github.com/stripe/stripe-cli"
       - "--label=homepage=https://stripe.com"
+      - "--platform=linux/amd64"
   - goos: linux
     goarch: arm64
     ids:
@@ -97,6 +98,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=repository=https://github.com/stripe/stripe-cli"
       - "--label=homepage=https://stripe.com"
+      - "--platform=linux/arm64"
 docker_manifests:
   - name_template: "stripe/stripe-cli:latest"
     image_templates:

--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -98,7 +98,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=repository=https://github.com/stripe/stripe-cli"
       - "--label=homepage=https://stripe.com"
-      - "--platform=linux/arm64"
+      - "--platform=linux/arm64/v8"
 docker_manifests:
   - name_template: "stripe/stripe-cli:latest"
     image_templates:


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
Using docker's [buildx](https://docs.docker.com/build/buildx/install/) builder so we can set the platform images. 
Also added a test-snapshot workflow that will only trigger for updates to the goreleaser. 

