### PR TITLE
Add --api-base flag suport to fixtures cmd

### DIFF
--- a/pkg/cmd/fixtures.go
+++ b/pkg/cmd/fixtures.go
@@ -19,6 +19,7 @@ type FixturesCmd struct {
 
 	stripeAccount string
 	apiVersion    string
+	apiBaseURL    string
 	skip          []string
 	override      []string
 	add           []string
@@ -45,6 +46,10 @@ func newFixturesCmd(cfg *config.Config) *FixturesCmd {
 	fixturesCmd.Cmd.Flags().StringArrayVar(&fixturesCmd.remove, "remove", []string{}, "Remove parameters from the fixture")
 	fixturesCmd.Cmd.Flags().StringVar(&fixturesCmd.apiVersion, "api-version", "", "Specify API version in the fixture")
 
+	// Hidden configuration flags, useful for dev/debugging
+	fixturesCmd.Cmd.Flags().StringVar(&fixturesCmd.apiBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
+	fixturesCmd.Cmd.Flags().MarkHidden("api-base") // #nosec G104
+
 	return fixturesCmd
 }
 
@@ -64,7 +69,7 @@ func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
 		afero.NewOsFs(),
 		apiKey,
 		fc.stripeAccount,
-		stripe.DefaultAPIBaseURL,
+		fc.apiBaseURL,
 		args[0],
 		fc.skip,
 		fc.override,


### PR DESCRIPTION
 ### Reviewers
r?
cc @stripe/developer-products

 ### Summary
Most CLI commands support the (hidden) `--api-base` flag to override the base URL used for constructing API requests, which is useful during development and debugging.

The fixtures command did not include this, though, so it was possible to send individual requests to an alternate API endpoint but not a batch of fixture requests.
