### PR TITLE
Refactor `samples.go` to be more configurable

### DIFF
--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -64,7 +64,13 @@ func (cc *CreateCmd) runCreateCmd(cmd *cobra.Command, args []string) error {
 	color := ansi.Color(os.Stdout)
 	spinner := ansi.StartNewSpinner(fmt.Sprintf("Downloading %s", selectedSample), os.Stdout)
 
-	sampleConfig, err := samples.GetSampleConfig(selectedSample, cc.forceRefresh)
+	sampleManager, err := samples.NewSampleManager(cc.cfg)
+	if err != nil {
+		ansi.StopSpinner(spinner, "", os.Stdout)
+		return err
+	}
+
+	sampleConfig, err := sampleManager.GetSampleConfig(selectedSample, cc.forceRefresh)
 	if err != nil {
 		ansi.StopSpinner(spinner, "", os.Stdout)
 		return err
@@ -83,9 +89,8 @@ func (cc *CreateCmd) runCreateCmd(cmd *cobra.Command, args []string) error {
 
 	resultChan := make(chan samples.CreationResult)
 
-	go samples.Create(
+	go sampleManager.Create(
 		cmd.Context(),
-		cc.cfg,
 		selectedSample,
 		selectedConfig,
 		destination,

--- a/pkg/rpcservice/sample_configs.go
+++ b/pkg/rpcservice/sample_configs.go
@@ -3,26 +3,24 @@ package rpcservice
 import (
 	"context"
 
-	"github.com/spf13/afero"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	gitpkg "github.com/stripe/stripe-cli/pkg/git"
 	"github.com/stripe/stripe-cli/pkg/samples"
 	"github.com/stripe/stripe-cli/rpc"
 )
 
 // Make overridable for tests
 var fetchRawSampleIntegrations = func(req *rpc.SampleConfigsRequest) ([]samples.SampleConfigIntegration, error) {
-	sample := samples.Samples{
-		Fs:  afero.NewOsFs(),
-		Git: gitpkg.Operations{},
-	}
-	err := sample.Initialize(req.SampleName)
+	sampleManager, err := samples.NewSampleManager(nil)
 	if err != nil {
 		return nil, err
 	}
-	return sample.SampleConfig.Integrations, nil
+	err = sampleManager.Initialize(req.SampleName)
+	if err != nil {
+		return nil, err
+	}
+	return sampleManager.SampleConfig.Integrations, nil
 }
 
 // SampleConfigs returns a list of available configs for a given Stripe sample.

--- a/pkg/rpcservice/sample_create.go
+++ b/pkg/rpcservice/sample_create.go
@@ -33,7 +33,6 @@ var createSample = func(sample *samples.SampleManager) createSampleFunc {
 
 // SampleCreate creates a sample at a given path with the selected integration, client language, and server language.
 func (srv *RPCService) SampleCreate(ctx context.Context, req *rpc.SampleCreateRequest) (*rpc.SampleCreateResponse, error) {
-
 	sampleManager, err := samples.NewSampleManager(srv.cfg.UserCfg)
 	if err != nil {
 		return nil, err

--- a/pkg/rpcservice/sample_create.go
+++ b/pkg/rpcservice/sample_create.go
@@ -10,20 +10,43 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var getSampleConfig = samples.GetSampleConfig
-var createSample = samples.Create
+// We declare these functions here insteoad of calling `sample.GetSampleConfig` or `sample.Create` directly
+// so that they can be overridden during tests
+
+type getSampleConfigFunc = func(sampleName string, forceRefresh bool) (*samples.SampleConfig, error)
+
+var getSampleConfig = func(sample *samples.SampleManager) getSampleConfigFunc {
+	return sample.GetSampleConfig
+}
+
+type createSampleFunc = func(
+	ctx context.Context,
+	sampleName string,
+	selectedConfig *samples.SelectedConfig,
+	destination string,
+	forceRefresh bool,
+	resultChan chan<- samples.CreationResult)
+
+var createSample = func(sample *samples.SampleManager) createSampleFunc {
+	return sample.Create
+}
 
 // SampleCreate creates a sample at a given path with the selected integration, client language, and server language.
 func (srv *RPCService) SampleCreate(ctx context.Context, req *rpc.SampleCreateRequest) (*rpc.SampleCreateResponse, error) {
+
+	sampleManager, err := samples.NewSampleManager(srv.cfg.UserCfg)
+	if err != nil {
+		return nil, err
+	}
+
 	selectedConfig, err := getSelectedConfig(req)
 	if err != nil {
 		return nil, err
 	}
 
 	resultChan := make(chan samples.CreationResult)
-	go createSample(
+	go createSample(sampleManager)(
 		ctx,
-		srv.cfg.UserCfg,
 		req.SampleName,
 		selectedConfig,
 		req.Path,
@@ -47,8 +70,12 @@ func (srv *RPCService) SampleCreate(ctx context.Context, req *rpc.SampleCreateRe
 }
 
 func getSelectedConfig(req *rpc.SampleCreateRequest) (*samples.SelectedConfig, error) {
+	sampleManager, err := samples.NewSampleManager(nil)
+	if err != nil {
+		return nil, err
+	}
 	// Validate the selected integration exists
-	sampleConfig, err := getSampleConfig(req.SampleName, req.ForceRefresh)
+	sampleConfig, err := getSampleConfig(sampleManager)(req.SampleName, req.ForceRefresh)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/samples/os.go
+++ b/pkg/samples/os.go
@@ -10,7 +10,7 @@ import (
 )
 
 // cacheFolder is the local directory where we place local copies of samples
-func (s *Samples) cacheFolder() (string, error) {
+func (s *SampleManager) cacheFolder() (string, error) {
 	configPath := s.Config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
 	cachePath := filepath.Join(configPath, "samples-cache")
 
@@ -25,7 +25,7 @@ func (s *Samples) cacheFolder() (string, error) {
 }
 
 // appCacheFolder returns the full path of the local cache with the recipe name
-func (s *Samples) appCacheFolder(app string) (string, error) {
+func (s *SampleManager) appCacheFolder(app string) (string, error) {
 	path, err := s.cacheFolder()
 	if err != nil {
 		return "", err
@@ -37,7 +37,7 @@ func (s *Samples) appCacheFolder(app string) (string, error) {
 }
 
 // MakeFolder creates the folder that'll contain the Stripe app the user is creating
-func (s *Samples) MakeFolder(name string) (string, error) {
+func (s *SampleManager) MakeFolder(name string) (string, error) {
 	appFolder, err := filepath.Abs(name)
 	if err != nil {
 		return "", err
@@ -55,7 +55,7 @@ func (s *Samples) MakeFolder(name string) (string, error) {
 }
 
 // GetFolders returns a list of all folders for a given path
-func (s *Samples) GetFolders(path string) ([]string, error) {
+func (s *SampleManager) GetFolders(path string) ([]string, error) {
 	var dir []string
 
 	files, err := afero.ReadDir(s.Fs, path)
@@ -74,7 +74,7 @@ func (s *Samples) GetFolders(path string) ([]string, error) {
 }
 
 // GetFiles returns a list of files for a given path
-func (s *Samples) GetFiles(path string) ([]string, error) {
+func (s *SampleManager) GetFiles(path string) ([]string, error) {
 	var file []string
 
 	files, err := afero.ReadDir(s.Fs, path)
@@ -92,7 +92,7 @@ func (s *Samples) GetFiles(path string) ([]string, error) {
 	return file, nil
 }
 
-func (s *Samples) delete(name string) error {
+func (s *SampleManager) delete(name string) error {
 	dir, err := os.Getwd()
 	if err != nil {
 		return err

--- a/pkg/samples/os_test.go
+++ b/pkg/samples/os_test.go
@@ -31,13 +31,13 @@ func TestCacheFolder(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	viper.SetFs(fs)
 
-	sample := Samples{
+	sampleManager := SampleManager{
 		Fs: fs,
 	}
 
 	expectedPath := filepath.Join(home(), ".config", "stripe", "samples-cache")
 
-	path, _ := sample.cacheFolder()
+	path, _ := sampleManager.cacheFolder()
 	pathExists, err := afero.Exists(fs, path)
 
 	assert.Equal(t, expectedPath, path)
@@ -49,13 +49,13 @@ func TestAppCacheFolder(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	viper.SetFs(fs)
 
-	sample := Samples{
+	sampleManager := SampleManager{
 		Fs: fs,
 	}
 
 	expectedPath := filepath.Join(home(), ".config", "stripe", "samples-cache", "bender")
 
-	path, err := sample.appCacheFolder("bender")
+	path, err := sampleManager.appCacheFolder("bender")
 
 	assert.Equal(t, expectedPath, path)
 	assert.Nil(t, err)
@@ -65,14 +65,14 @@ func TestMakeFolder(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	viper.SetFs(fs)
 
-	sample := Samples{
+	sampleManager := SampleManager{
 		Fs: fs,
 	}
 
 	wd, _ := os.Getwd()
 	expectedPath := filepath.Join(wd, "bender")
 
-	path, err := sample.MakeFolder("bender")
+	path, err := sampleManager.MakeFolder("bender")
 	exists, _ := afero.Exists(fs, path)
 
 	assert.Equal(t, expectedPath, path)
@@ -80,7 +80,7 @@ func TestMakeFolder(t *testing.T) {
 	assert.Nil(t, err)
 
 	absolutePath := filepath.Join(wd, "absolute/path/indeed")
-	path, err = sample.MakeFolder(absolutePath)
+	path, err = sampleManager.MakeFolder(absolutePath)
 	exists, _ = afero.Exists(fs, path)
 	assert.Equal(t, absolutePath, path)
 	assert.True(t, exists)
@@ -91,7 +91,7 @@ func TestMakeFolderExists(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	viper.SetFs(fs)
 
-	sample := Samples{
+	sampleManager := SampleManager{
 		Fs: fs,
 	}
 
@@ -99,7 +99,7 @@ func TestMakeFolderExists(t *testing.T) {
 	preExistingPath := filepath.Join(wd, "bender")
 	fs.MkdirAll(preExistingPath, os.ModePerm)
 
-	path, err := sample.MakeFolder("bender")
+	path, err := sampleManager.MakeFolder("bender")
 
 	assert.Equal(t, "", path)
 	assert.EqualError(t, err, fmt.Sprintf("Path already exists, aborting: %s", preExistingPath))
@@ -113,10 +113,10 @@ func TestGetFolders(t *testing.T) {
 	fs.Mkdir("leela", os.ModePerm)
 	fs.Create("zoidberg")
 
-	sample := Samples{
+	sampleManager := SampleManager{
 		Fs: fs,
 	}
-	folders, err := sample.GetFolders("/")
+	folders, err := sampleManager.GetFolders("/")
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"bender", "fry", "leela"}, folders)
@@ -130,10 +130,10 @@ func TestGetFiles(t *testing.T) {
 	fs.Create("leela")
 	fs.Mkdir("zoidberg", os.ModePerm)
 
-	sample := Samples{
+	sampleManager := SampleManager{
 		Fs: fs,
 	}
-	files, err := sample.GetFiles("/")
+	files, err := sampleManager.GetFiles("/")
 
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"bender", "fry", "leela"}, files)

--- a/rpc/commands_grpc.pb.go
+++ b/rpc/commands_grpc.pb.go
@@ -8,6 +8,7 @@ package rpc
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"


### PR DESCRIPTION
### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
Refactors the `samples` command so that the code can be re-used/configured via plugin.

Specifically
* I renamed the `Samples` struct to `SampleManager` as identifier `samples` was referring both to the package and to an instance of `Samples` which I found confusing.
* I gave `SampleManager` a constructor helper, `NewSampleManager` with a default initialization, rather than having it initialized directly everywhere.
* I changed the `Create` and `GetSampleConfig` functions to be methods with a `SampleManager` receiver, so that they are more configurable.
* I refactored `ConfigureDotEnv` into `SampleManager.ConfigureDotEnv` (which can be given a custom implementation, now that it's on the struct), and `WriteDotEnv`.
* I introduced a `SampleLister` interface to replace `getSamples`, so that this can be customized (e.g., an implementation that returns a hardcoded list instead of fetching and caching from a specific github repository) and refactored the existing implementation into `cachedGithubSampleLister`.

### Testing
As a basic sanity check, I manually ran `stripe samples list` and `stripe samples create` and they appear still to work.
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
