### PR TITLE
fix triggers

### DIFF
--- a/pkg/fixtures/triggers/checkout.session.async_payment_failed.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_failed.json
@@ -19,7 +19,7 @@
       "params": {
         "product": "${product:id}",
         "unit_amount": "1500",
-        "currency": "gbp"
+        "currency": "eur"
       }
     },
     {
@@ -30,7 +30,7 @@
       "params": {
         "success_url": "https://httpbin.org/post",
         "cancel_url": "https://httpbin.org/post",
-        "payment_method_types": ["bacs_debit"],
+        "payment_method_types": ["sepa_debit"],
         "mode": "payment",
         "line_items": [
           {
@@ -65,10 +65,9 @@
       "path": "/v1/payment_methods",
       "method": "post",
       "params": {
-        "type": "bacs_debit",
-        "bacs_debit": {
-          "account_number": "33333335",
-          "sort_code": "108800"
+        "type": "sepa_debit",
+        "sepa_debit": {
+          "iban": "IT60X0542811101000000123456"
         },
         "billing_details": {
           "email": "stripe@example.com",

--- a/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
@@ -19,7 +19,7 @@
       "params": {
         "product": "${product:id}",
         "unit_amount": "1500",
-        "currency": "gbp"
+        "currency": "eur"
       }
     },
     {
@@ -29,7 +29,7 @@
       "params": {
         "success_url": "https://httpbin.org/post",
         "cancel_url": "https://httpbin.org/post",
-        "payment_method_types": ["bacs_debit"],
+        "payment_method_types": ["sepa_debit"],
         "mode": "payment",
         "line_items": [
           {


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Updates the checkout.session.async_payment_failed.json and checkout.session.async_payment_succeeded.json fixtures so that it works for a larger set of our merchants who are either in US or Europe instead of just UK merchants.


### Motivation
<!-- Why are you making this change? This can be a link to a Jira task. -->
https://admin.corp.stripe.com/team-run/boards/RUN_DX/preview/RUN_DX-1652

### Test plan
<!-- How did you test this change? What were you unable to test? Please include additional context, e.g. were you able to cover failures and edge cases? Reference automated tests or describe a manual test plan and confirm the outcome. Please keep the frontpage test, our auditors (who review a random sample of our PRs), and your reviewer in mind. In cases where you are unable to test your changes, or it is not appropriate, please leave both boxes unchecked. -->
<img width="1427" alt="Screen Shot 2023-02-17 at 10 59 05 AM" src="https://user-images.githubusercontent.com/85950589/219790924-aaaa3316-2733-462e-b9a7-ef69f4f58247.png">

- [ ] All changes in PR are covered by tests
- [ ] Failures and edge cases tested

### Rollout/monitoring/revert plan
<!--
  What services will you deploy? Include all services which could be impacted by the change. Hint: CIBot can tag a PR with services using the `s: service` syntax.

  Are there any post-deploy steps (e.g. run migration or enable feature flag)? If this change requires special attention to rollout, what will you monitor to make sure the deployment is proceeding as expected? If the change needs to be rolled back or reverted, are there any additional steps that need to be taken? If this change needs to be manually deployed or deployed with unusual tooling, please list the specific steps required to deploy — and if it becomes necessary — roll back this change.

Changes in the critical payments path must be decoupled from the deploy and have a monitoring plan. This can usually be achieved with a feature flag or gate. See go/code-reviewer-guide and go/safe-payflows-rollouts for details.
-->
Safe to revert unless specified otherwise
