### PR TITLE
Have issuing fixtures pass individual names and terms acceptance

### DIFF
--- a/pkg/fixtures/triggers/issuing_authorization.request.json
+++ b/pkg/fixtures/triggers/issuing_authorization.request.json
@@ -8,8 +8,18 @@
       "path": "/v1/issuing/cardholders",
       "method": "post",
       "params": {
-        "name": "mycardholder",
+        "name": "My Cardholder",
         "type": "individual",
+        "individual": {
+          "first_name": "My",
+          "last_name": "Cardholder",
+          "card_issuing": {
+            "user_terms_acceptance": {
+              "date": 1470266163,
+              "ip": "91.121.146.224"
+            }
+          }
+        },
         "billing": {
           "address": {
             "line1": "1234 Main Street",

--- a/pkg/fixtures/triggers/issuing_card.created.json
+++ b/pkg/fixtures/triggers/issuing_card.created.json
@@ -8,8 +8,18 @@
       "path": "/v1/issuing/cardholders",
       "method": "post",
       "params": {
-        "name": "mycardholder",
+        "name": "My Cardholder",
         "type": "individual",
+        "individual": {
+          "first_name": "My",
+          "last_name": "Cardholder",
+          "card_issuing": {
+            "user_terms_acceptance": {
+              "date": 1470266163,
+              "ip": "91.121.146.224"
+            }
+          }
+        },
         "billing": {
           "address": {
             "line1": "1234 Main Street",

--- a/pkg/fixtures/triggers/issuing_cardholder.created.json
+++ b/pkg/fixtures/triggers/issuing_cardholder.created.json
@@ -8,8 +8,18 @@
       "path": "/v1/issuing/cardholders",
       "method": "post",
       "params": {
-        "name": "mycardholder",
+        "name": "My Cardholder",
         "type": "individual",
+        "individual": {
+          "first_name": "My",
+          "last_name": "Cardholder",
+          "card_issuing": {
+            "user_terms_acceptance": {
+              "date": 1470266163,
+              "ip": "91.121.146.224"
+            }
+          }
+        },
         "billing": {
           "address": {
             "line1": "1234 Main Street",


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary

With the release of tighter restriction on cardholder terms acceptance and first/last name requirements, this PR fixes issuing related fixtures so that issuing-related triggers will work again.