### PR TITLE
Introduce Stripe client interface for proxy

### DIFF
--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/stripeauth"
 	"github.com/stripe/stripe-cli/pkg/websocket"
 )
@@ -30,16 +31,13 @@ type LogFilters struct {
 
 // Config provides the configuration of a log tailer
 type Config struct {
-	APIBaseURL string
+	Client stripe.RequestPerformer
 
 	// DeviceName is the name of the device sent to Stripe to help identify the device
 	DeviceName string
 
 	// Filters for API request logs
 	Filters *LogFilters
-
-	// Key is the API key used to authenticate with Stripe
-	Key string
 
 	// Info, error, etc. logger. Unrelated to API request logs.
 	Log *log.Logger
@@ -91,10 +89,9 @@ func New(cfg *Config) *Tailer {
 
 	return &Tailer{
 		cfg: cfg,
-		// stripeAuthClient: stripeauth.NewClient(cfg.Key, &stripeauth.Config{
-		// 	Log:        cfg.Log,
-		// 	APIBaseURL: cfg.APIBaseURL,
-		// }),
+		stripeAuthClient: stripeauth.NewClient(cfg.Client, &stripeauth.Config{
+			Log: cfg.Log,
+		}),
 		interruptCh: make(chan os.Signal, 1),
 	}
 }

--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -91,10 +91,10 @@ func New(cfg *Config) *Tailer {
 
 	return &Tailer{
 		cfg: cfg,
-		stripeAuthClient: stripeauth.NewClient(cfg.Key, &stripeauth.Config{
-			Log:        cfg.Log,
-			APIBaseURL: cfg.APIBaseURL,
-		}),
+		// stripeAuthClient: stripeauth.NewClient(cfg.Key, &stripeauth.Config{
+		// 	Log:        cfg.Log,
+		// 	APIBaseURL: cfg.APIBaseURL,
+		// }),
 		interruptCh: make(chan os.Signal, 1),
 	}
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -66,7 +66,7 @@ type Config struct {
 	// DeviceName is the name of the device sent to Stripe to help identify the device
 	DeviceName string
 
-	// TODO: document
+	// Client is a configured stripe client used to execute authenticated calls to the Stripe API.
 	Client stripe.RequestPerformer
 
 	// URL to which events are forwarded to

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -189,20 +189,6 @@ func (rb *Base) MakeMultiPartRequest(ctx context.Context, apiKey, path string, p
 		return nil
 	}
 
-	return rb.performRequest(ctx, apiKey, path, params, reqBody.String(), errOnStatus, configure)
-}
-
-// MakeRequest will make a request to the Stripe API with the specific variables given to it
-func (rb *Base) MakeRequest(ctx context.Context, apiKey, path string, params *RequestParameters, errOnStatus bool) ([]byte, error) {
-	data, err := rb.BuildDataForRequest(params)
-	if err != nil {
-		return []byte{}, err
-	}
-
-	return rb.performRequest(ctx, apiKey, path, params, data, errOnStatus, nil)
-}
-
-func (rb *Base) performRequest(ctx context.Context, apiKey, path string, params *RequestParameters, data string, errOnStatus bool, additionalConfigure func(req *http.Request) error) ([]byte, error) {
 	parsedBaseURL, err := url.Parse(rb.APIBaseURL)
 	if err != nil {
 		return []byte{}, err
@@ -214,6 +200,35 @@ func (rb *Base) performRequest(ctx context.Context, apiKey, path string, params 
 		Verbose: rb.showHeaders,
 	}
 
+	return rb.performRequest(ctx, client, path, params, reqBody.String(), errOnStatus, configure)
+}
+
+// MakeRequest will make a request to the Stripe API with the specific variables given to it
+func (rb *Base) MakeRequest(ctx context.Context, apiKey, path string, params *RequestParameters, errOnStatus bool) ([]byte, error) {
+	parsedBaseURL, err := url.Parse(rb.APIBaseURL)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	client := &stripe.Client{
+		BaseURL: parsedBaseURL,
+		APIKey:  apiKey,
+		Verbose: rb.showHeaders,
+	}
+
+	return rb.MakeRequestWithClient(ctx, client, path, params, errOnStatus)
+}
+
+func (rb *Base) MakeRequestWithClient(ctx context.Context, client stripe.RequestPerformer, path string, params *RequestParameters, errOnStatus bool) ([]byte, error) {
+	data, err := rb.BuildDataForRequest(params)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return rb.performRequest(ctx, client, path, params, data, errOnStatus, nil)
+}
+
+func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerformer, path string, params *RequestParameters, data string, errOnStatus bool, additionalConfigure func(req *http.Request) error) ([]byte, error) {
 	configure := func(req *http.Request) error {
 		rb.setIdempotencyHeader(req, params)
 		rb.setStripeAccountHeader(req, params)

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -219,6 +219,8 @@ func (rb *Base) MakeRequest(ctx context.Context, apiKey, path string, params *Re
 	return rb.MakeRequestWithClient(ctx, client, path, params, errOnStatus)
 }
 
+// MakeRequestWithClient will make a request to the Stripe API with the specific
+// variables given to it using the provided client.
 func (rb *Base) MakeRequestWithClient(ctx context.Context, client stripe.RequestPerformer, path string, params *RequestParameters, errOnStatus bool) ([]byte, error) {
 	data, err := rb.BuildDataForRequest(params)
 	if err != nil {

--- a/pkg/requests/webhook_endpoints.go
+++ b/pkg/requests/webhook_endpoints.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 // WebhookEndpointList contains the list of webhook endpoints for the account
@@ -37,6 +38,25 @@ func WebhookEndpointsList(ctx context.Context, baseURL, apiVersion, apiKey strin
 		APIBaseURL:     baseURL,
 	}
 	resp, _ := base.MakeRequest(ctx, apiKey, "/v1/webhook_endpoints", params, true)
+	data := WebhookEndpointList{}
+	json.Unmarshal(resp, &data)
+
+	return data
+}
+
+// WebhookEndpointsListWithClient returns all the webhook endpoints on a users' account
+func WebhookEndpointsListWithClient(ctx context.Context, client stripe.RequestPerformer, apiVersion string, profile *config.Profile) WebhookEndpointList {
+	params := &RequestParameters{
+		data:    []string{"limit=30"},
+		version: apiVersion,
+	}
+
+	base := &Base{
+		Profile:        profile,
+		Method:         http.MethodGet,
+		SuppressOutput: true,
+	}
+	resp, _ := base.MakeRequestWithClient(ctx, client, "/v1/webhook_endpoints", params, true)
 	data := WebhookEndpointList{}
 	json.Unmarshal(resp, &data)
 

--- a/pkg/rpcservice/listen.go
+++ b/pkg/rpcservice/listen.go
@@ -39,10 +39,10 @@ func (srv *RPCService) Listen(req *rpc.ListenRequest, stream rpc.StripeCLI_Liste
 		return status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	key, err := srv.cfg.UserCfg.Profile.GetAPIKey(req.Live)
-	if err != nil {
-		return status.Error(codes.Unauthenticated, err.Error())
-	}
+	// key, err := srv.cfg.UserCfg.Profile.GetAPIKey(req.Live)
+	// if err != nil {
+	// 	return status.Error(codes.Unauthenticated, err.Error())
+	// }
 
 	logger := log.StandardLogger()
 	proxyVisitor := createProxyVisitor(&stream)
@@ -52,8 +52,8 @@ func (srv *RPCService) Listen(req *rpc.ListenRequest, stream rpc.StripeCLI_Liste
 	defer cancel()
 
 	p, err := createProxy(ctx, &proxy.Config{
-		DeviceName:            deviceName,
-		Key:                   key,
+		DeviceName: deviceName,
+		// Key:                   key,
 		ForwardURL:            req.ForwardTo,
 		ForwardHeaders:        req.Headers,
 		ForwardConnectURL:     req.ForwardConnectTo,
@@ -67,8 +67,8 @@ func (srv *RPCService) Listen(req *rpc.ListenRequest, stream rpc.StripeCLI_Liste
 		OutCh:                 proxyOutCh,
 
 		// Hidden for debugging
-		APIBaseURL: "",
-		NoWSS:      false,
+		// APIBaseURL: "",
+		NoWSS: false,
 	})
 
 	if err != nil {

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -316,7 +316,7 @@ func ConfigureDotEnv(ctx context.Context, config *config.Config) (map[string]str
 		return nil, err
 	}
 
-	authClient := stripeauth.NewClient(apiKey, nil)
+	authClient := &stripeauth.Client{} //stripeauth.NewClient(apiKey, nil)
 
 	authSession, err := authClient.Authorize(ctx, deviceName, "webhooks", nil, nil)
 	if err != nil {

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/config"
 	g "github.com/stripe/stripe-cli/pkg/git"
 	gitpkg "github.com/stripe/stripe-cli/pkg/git"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/stripeauth"
 )
 
@@ -316,7 +318,13 @@ func ConfigureDotEnv(ctx context.Context, config *config.Config) (map[string]str
 		return nil, err
 	}
 
-	authClient := &stripeauth.Client{} //stripeauth.NewClient(apiKey, nil)
+	apiBase, _ := url.Parse(stripe.DefaultAPIBaseURL)
+
+	stripeClient := &stripe.Client{
+		APIKey:  apiKey,
+		BaseURL: apiBase,
+	}
+	authClient := stripeauth.NewClient(stripeClient, nil)
 
 	authSession, err := authClient.Authorize(ctx, deviceName, "webhooks", nil, nil)
 	if err != nil {

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -50,6 +50,8 @@ type Client struct {
 	httpClient *http.Client
 }
 
+// RequestPerformer is an interface for executing requests against the Stripe
+// API, usually satisfied by providing a stripe.Client.
 type RequestPerformer interface {
 	PerformRequest(ctx context.Context, method, path string, params string, configure func(*http.Request) error) (*http.Response, error)
 }

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -50,6 +50,10 @@ type Client struct {
 	httpClient *http.Client
 }
 
+type RequestPerformer interface {
+	PerformRequest(ctx context.Context, method, path string, params string, configure func(*http.Request) error) (*http.Response, error)
+}
+
 // PerformRequest sends a request to Stripe and returns the response.
 func (c *Client) PerformRequest(ctx context.Context, method, path string, params string, configure func(*http.Request) error) (*http.Response, error) {
 	url, err := url.Parse(path)

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -6,10 +6,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 func TestAuthorize(t *testing.T) {
@@ -36,10 +38,9 @@ func TestAuthorize(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := &Client{}
-	// client := NewClient("sk_test_123", &Config{
-	// 	APIBaseURL: ts.URL,
-	// })
+	baseURL, _ := url.Parse(ts.URL)
+	client := NewClient(&stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL}, nil)
+
 	session, err := client.Authorize(context.Background(), "my-device", "webhooks", nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, "some-id", session.WebSocketID)
@@ -57,10 +58,9 @@ func TestUserAgent(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := &Client{}
-	// client := NewClient("sk_test_123", &Config{
-	// 	APIBaseURL: ts.URL,
-	// })
+	baseURL, _ := url.Parse(ts.URL)
+	client := NewClient(&stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL}, nil)
+
 	client.Authorize(context.Background(), "my-device", "webhooks", nil, nil)
 }
 
@@ -81,10 +81,9 @@ func TestStripeClientUserAgent(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := &Client{}
-	// client := NewClient("sk_test_123", &Config{
-	// 	APIBaseURL: ts.URL,
-	// })
+	baseURL, _ := url.Parse(ts.URL)
+	client := NewClient(&stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL}, nil)
+
 	client.Authorize(context.Background(), "my-device", "webhooks", nil, nil)
 }
 
@@ -99,10 +98,8 @@ func TestAuthorizeWithURLDeviceMap(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := &Client{}
-	// client := NewClient("sk_test_123", &Config{
-	// 	APIBaseURL: ts.URL,
-	// })
+	baseURL, _ := url.Parse(ts.URL)
+	client := NewClient(&stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL}, nil)
 
 	devURLMap := DeviceURLMap{
 		ForwardURL:        "http://localhost:3000/events",

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -36,9 +36,10 @@ func TestAuthorize(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := NewClient("sk_test_123", &Config{
-		APIBaseURL: ts.URL,
-	})
+	client := &Client{}
+	// client := NewClient("sk_test_123", &Config{
+	// 	APIBaseURL: ts.URL,
+	// })
 	session, err := client.Authorize(context.Background(), "my-device", "webhooks", nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, "some-id", session.WebSocketID)
@@ -56,9 +57,10 @@ func TestUserAgent(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := NewClient("sk_test_123", &Config{
-		APIBaseURL: ts.URL,
-	})
+	client := &Client{}
+	// client := NewClient("sk_test_123", &Config{
+	// 	APIBaseURL: ts.URL,
+	// })
 	client.Authorize(context.Background(), "my-device", "webhooks", nil, nil)
 }
 
@@ -79,9 +81,10 @@ func TestStripeClientUserAgent(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := NewClient("sk_test_123", &Config{
-		APIBaseURL: ts.URL,
-	})
+	client := &Client{}
+	// client := NewClient("sk_test_123", &Config{
+	// 	APIBaseURL: ts.URL,
+	// })
 	client.Authorize(context.Background(), "my-device", "webhooks", nil, nil)
 }
 
@@ -96,9 +99,10 @@ func TestAuthorizeWithURLDeviceMap(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := NewClient("sk_test_123", &Config{
-		APIBaseURL: ts.URL,
-	})
+	client := &Client{}
+	// client := NewClient("sk_test_123", &Config{
+	// 	APIBaseURL: ts.URL,
+	// })
 
 	devURLMap := DeviceURLMap{
 		ForwardURL:        "http://localhost:3000/events",

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 


### PR DESCRIPTION
 ### Reviewers
r?
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

This is the initial phase of a refactor to update CLI packages to depend on a client interface instead of accepting keys, URLs, etc. and constructing their own clients.

* Introduces `stripe.RequestPerformer` interface, implemented by `*stripe.Client`
* Updates `proxy` to accept `stripe.RequestPerformer` instead of directly accepting a key and base URL
* `listen` and `logs` commands construct a client to provide to the proxy
* Add `MakeRequestWithClient` to `requests.Base` to support usage with an already-constructed client