### PR TITLE
Add websocket.UnknownMessage

### DIFF
--- a/pkg/websocket/messages_test.go
+++ b/pkg/websocket/messages_test.go
@@ -13,7 +13,9 @@ func TestUnmarshalUnknownIncomingMsg(t *testing.T) {
 
 	var msg IncomingMessage
 	err := json.Unmarshal([]byte(data), &msg)
-	require.EqualError(t, err, "Unexpected message type: unknown_type")
+	require.NoError(t, err)
+	require.Equal(t, "unknown_type", msg.Unknown.Type)
+	require.Equal(t, data, string(msg.Unknown.Data))
 }
 
 func TestMarshalWebhookEventAck(t *testing.T) {


### PR DESCRIPTION

 ### Reviewers
r?
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Instead of always skipping structured messages of an unknonw type with a generic log message, the websocket client will provide them to the configured handler in the Unknown field of the IncomingMessage type.

Existing message handlers already defensively handle unexpected message types by explicitly checking for msg.WebhookEvent or msg.RequestLogEvent.