### PR TITLE
fix: remove all profile keys when logging into a new account

### DIFF
--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -143,6 +143,54 @@ func TestExperimentalFields(t *testing.T) {
 	cleanUp(c.ProfilesFile)
 }
 
+func TestOldProfileDeleted(t *testing.T) {
+	profilesFile := filepath.Join(os.TempDir(), "stripe", "config.toml")
+	p := Profile{
+		ProfileName:    "test",
+		DeviceName:     "device-before-test",
+		TestModeAPIKey: "sk_test_123",
+		DisplayName:    "display-name-before-test",
+	}
+	c := &Config{
+		Color:        "auto",
+		LogLevel:     "info",
+		Profile:      p,
+		ProfilesFile: profilesFile,
+	}
+	c.InitConfig()
+
+	p.WriteConfigField("experimental.stripe_headers", "test-headers")
+
+	v := viper.New()
+
+	v.SetConfigFile(profilesFile)
+	err := p.writeProfile(v)
+	require.NoError(t, err)
+
+	require.FileExists(t, c.ProfilesFile)
+
+	p = Profile{
+		ProfileName:    "test",
+		DeviceName:     "device-after-test",
+		TestModeAPIKey: "sk_test_456",
+		DisplayName:    "",
+	}
+
+	v = p.deleteProfile(v)
+	err = p.writeProfile(v)
+	require.NoError(t, err)
+
+	require.FileExists(t, c.ProfilesFile)
+
+	require.False(t, v.IsSet(v.GetString(p.GetConfigField("experimental.stripe_headers"))))
+	require.False(t, v.IsSet(v.GetString(p.GetConfigField("experimental"))))
+	require.Equal(t, "device-after-test", v.GetString(p.GetConfigField(DeviceNameName)))
+	require.Equal(t, "sk_test_456", v.GetString(p.GetConfigField(TestModeAPIKeyName)))
+	require.Equal(t, "", v.GetString(p.GetConfigField(DisplayNameName)))
+
+	cleanUp(c.ProfilesFile)
+}
+
 func helperLoadBytes(t *testing.T, name string) []byte {
 	bytes, err := os.ReadFile(name)
 	if err != nil {


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
https://jira.corp.stripe.com/browse/DX-8171

We want to clear the profile before writing to it, otherwise stale profile data can linger around. For example, if you login to a new account that doesn't have a business name set, your display name in the Stripe CLI will be innaccurate.
