### PR TITLE
Update stripeauth to support multiple websocket features

### DIFF
--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -198,7 +198,11 @@ func (t *Tailer) createSession(ctx context.Context) (*stripeauth.StripeCLISessio
 		// Try to authorize at least 5 times before failing. Sometimes we have random
 		// transient errors that we just need to retry for.
 		for i := 0; i <= 5; i++ {
-			session, err = t.stripeAuthClient.Authorize(ctx, t.cfg.DeviceName, requestLogsWebSocketFeature, &filters, nil)
+			session, err = t.stripeAuthClient.Authorize(ctx, stripeauth.CreateSessionRequest{
+				DeviceName:        t.cfg.DeviceName,
+				WebSocketFeatures: []string{requestLogsWebSocketFeature},
+				Filters:           &filters,
+			})
 
 			if err == nil {
 				exitCh <- struct{}{}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -259,7 +259,11 @@ func (p *Proxy) createSession(ctx context.Context) (*stripeauth.StripeCLISession
 				ForwardConnectURL: p.cfg.ForwardConnectURL,
 			}
 
-			session, err = p.stripeAuthClient.Authorize(ctx, p.cfg.DeviceName, p.cfg.WebSocketFeature, nil, &devURLMap)
+			session, err = p.stripeAuthClient.Authorize(ctx, stripeauth.CreateSessionRequest{
+				DeviceName:        p.cfg.DeviceName,
+				WebSocketFeatures: []string{p.cfg.WebSocketFeature},
+				DeviceURLMap:      &devURLMap,
+			})
 
 			if err == nil {
 				exitCh <- struct{}{}

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -326,7 +326,10 @@ func ConfigureDotEnv(ctx context.Context, config *config.Config) (map[string]str
 	}
 	authClient := stripeauth.NewClient(stripeClient, nil)
 
-	authSession, err := authClient.Authorize(ctx, deviceName, "webhooks", nil, nil)
+	authSession, err := authClient.Authorize(ctx, stripeauth.CreateSessionRequest{
+		DeviceName:        deviceName,
+		WebSocketFeatures: []string{"webhooks"},
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
 ### Reviewers
r? @etsai-stripe @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

* Add `CreateSessionRequest` type that matches the latest version of the API
* Update stripeauth.Client's `Authorize` method to accept `CreateSessionRequest` instead of a list of arguments.