### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ scoop bucket add stripe https://github.com/stripe/scoop-stripe-cli.git
 scoop install stripe
 ```
 
+Stripe CLI is also available on windows via windows package manager(winget):
+
+```sh
+winget install "Stripe Cli"
+```
 ### Docker
 
 The CLI is also available as a Docker image: [`stripe/stripe-cli`](https://hub.docker.com/r/stripe/stripe-cli).


### PR DESCRIPTION
Adding support for installing stripe cli via winget

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

As windows winget is default tool for installing application via command line in windows now a days adding support for installing stripe cli via windows package manager(winget).  I have create the manifest files and uploaded the latest version of the stipe cli to winget repository. Below I have attached few screenshot which I have taken while testing.

Validating the manifest
![winget_validate](https://github.com/stripe/stripe-cli/assets/24490660/b1eb6173-d33d-4a9d-a496-b447e19ef2a0)

Testing the installation 
![winget_testing_sandbox](https://github.com/stripe/stripe-cli/assets/24490660/3c5f1f8b-e761-47d9-9684-b3d3aa79d07f)
![winget_testing_sandbox_env](https://github.com/stripe/stripe-cli/assets/24490660/7b33460d-eb80-46e9-aeee-5e91d77a8a57)
