### PR TITLE
hide status command

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -195,7 +195,8 @@ func init() {
 	rootCmd.AddCommand(newResourcesCmd().cmd)
 	rootCmd.AddCommand(newSamplesCmd().cmd)
 	rootCmd.AddCommand(newServeCmd().cmd)
-	rootCmd.AddCommand(newStatusCmd().cmd)
+	// hide status command until status site v2 is deployed
+	// rootCmd.AddCommand(newStatusCmd().cmd)
 	rootCmd.AddCommand(newTriggerCmd().cmd)
 	rootCmd.AddCommand(newVersionCmd().cmd)
 	rootCmd.AddCommand(newPostinstallCmd(&Config).cmd)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -195,7 +195,8 @@ func init() {
 	rootCmd.AddCommand(newResourcesCmd().cmd)
 	rootCmd.AddCommand(newSamplesCmd().cmd)
 	rootCmd.AddCommand(newServeCmd().cmd)
-	// hide status command until status site v2 is deployed
+	// current stripe status site is being deprecated
+	// hide status command until status site v2 is released
 	// rootCmd.AddCommand(newStatusCmd().cmd)
 	rootCmd.AddCommand(newTriggerCmd().cmd)
 	rootCmd.AddCommand(newVersionCmd().cmd)

--- a/pkg/cmd/status.go
+++ b/pkg/cmd/status.go
@@ -1,87 +1,87 @@
 package cmd
 
-import (
-	"fmt"
-	"os"
-	"time"
+// import (
+// 	"fmt"
+// 	"os"
+// 	"time"
 
-	"github.com/spf13/cobra"
+// 	"github.com/spf13/cobra"
 
-	"github.com/stripe/stripe-cli/pkg/ansi"
-	"github.com/stripe/stripe-cli/pkg/status"
-	"github.com/stripe/stripe-cli/pkg/validators"
-	"github.com/stripe/stripe-cli/pkg/version"
-)
+// 	"github.com/stripe/stripe-cli/pkg/ansi"
+// 	"github.com/stripe/stripe-cli/pkg/status"
+// 	"github.com/stripe/stripe-cli/pkg/validators"
+// 	"github.com/stripe/stripe-cli/pkg/version"
+// )
 
-type statusCmd struct {
-	cmd *cobra.Command
+// type statusCmd struct {
+// 	cmd *cobra.Command
 
-	format      string
-	hideSpinner bool
-	poll        bool
-	pollRate    int
-	verbose     bool
-}
+// 	format      string
+// 	hideSpinner bool
+// 	poll        bool
+// 	pollRate    int
+// 	verbose     bool
+// }
 
-func newStatusCmd() *statusCmd {
-	sc := &statusCmd{}
-	sc.cmd = &cobra.Command{
-		Use:   "status",
-		Args:  validators.NoArgs,
-		Short: "Check the status of the Stripe API",
-		Example: `stripe status
-  stripe status --poll
-  stripe status --poll --verbose`,
-		RunE: sc.runStatusCmd,
-	}
+// func newStatusCmd() *statusCmd {
+// 	sc := &statusCmd{}
+// 	sc.cmd = &cobra.Command{
+// 		Use:   "status",
+// 		Args:  validators.NoArgs,
+// 		Short: "Check the status of the Stripe API",
+// 		Example: `stripe status
+//   stripe status --poll
+//   stripe status --poll --verbose`,
+// 		RunE: sc.runStatusCmd,
+// 	}
 
-	sc.cmd.Flags().StringVar(&sc.format, "format", "default", "The format to print the status as (either 'default' or 'json')")
-	sc.cmd.Flags().BoolVar(&sc.verbose, "verbose", false, "Show status for all Stripe systems")
-	sc.cmd.Flags().BoolVar(&sc.poll, "poll", false, "Keep polling for status updates")
-	sc.cmd.Flags().IntVar(&sc.pollRate, "poll-rate", 60, "How many seconds to wait between status updates (minimum: 5)")
-	sc.cmd.Flags().BoolVar(&sc.hideSpinner, "hide-spinner", false, "Hide the loading spinner when polling")
+// 	sc.cmd.Flags().StringVar(&sc.format, "format", "default", "The format to print the status as (either 'default' or 'json')")
+// 	sc.cmd.Flags().BoolVar(&sc.verbose, "verbose", false, "Show status for all Stripe systems")
+// 	sc.cmd.Flags().BoolVar(&sc.poll, "poll", false, "Keep polling for status updates")
+// 	sc.cmd.Flags().IntVar(&sc.pollRate, "poll-rate", 60, "How many seconds to wait between status updates (minimum: 5)")
+// 	sc.cmd.Flags().BoolVar(&sc.hideSpinner, "hide-spinner", false, "Hide the loading spinner when polling")
 
-	return sc
-}
+// 	return sc
+// }
 
-func (sc *statusCmd) runStatusCmd(cmd *cobra.Command, args []string) error {
-	if sc.format != "json" {
-		version.CheckLatestVersion()
-	}
+// func (sc *statusCmd) runStatusCmd(cmd *cobra.Command, args []string) error {
+// 	if sc.format != "json" {
+// 		version.CheckLatestVersion()
+// 	}
 
-	if sc.pollRate < 5 {
-		return fmt.Errorf("poll-rate must be at least 5 seconds, received %d", sc.pollRate)
-	}
+// 	if sc.pollRate < 5 {
+// 		return fmt.Errorf("poll-rate must be at least 5 seconds, received %d", sc.pollRate)
+// 	}
 
-	if sc.format != "default" && sc.format != "json" {
-		return fmt.Errorf("invalid format, must be one of 'default' or 'json', received %s", sc.format)
-	}
+// 	if sc.format != "default" && sc.format != "json" {
+// 		return fmt.Errorf("invalid format, must be one of 'default' or 'json', received %s", sc.format)
+// 	}
 
-	for {
-		stripeStatus, err := status.GetStatus()
-		if err != nil {
-			return err
-		}
+// 	for {
+// 		stripeStatus, err := status.GetStatus()
+// 		if err != nil {
+// 			return err
+// 		}
 
-		formattedStatus, err := stripeStatus.FormattedMessage(sc.format, sc.verbose)
-		if err != nil {
-			return err
-		}
+// 		formattedStatus, err := stripeStatus.FormattedMessage(sc.format, sc.verbose)
+// 		if err != nil {
+// 			return err
+// 		}
 
-		fmt.Println(formattedStatus)
+// 		fmt.Println(formattedStatus)
 
-		if !sc.poll {
-			break
-		}
+// 		if !sc.poll {
+// 			break
+// 		}
 
-		if sc.hideSpinner {
-			time.Sleep(time.Duration(sc.pollRate) * time.Second)
-		} else {
-			spinner := ansi.StartNewSpinner("", os.Stderr)
-			time.Sleep(time.Duration(sc.pollRate) * time.Second)
-			ansi.StopSpinner(spinner, "", os.Stderr)
-		}
-	}
+// 		if sc.hideSpinner {
+// 			time.Sleep(time.Duration(sc.pollRate) * time.Second)
+// 		} else {
+// 			spinner := ansi.StartNewSpinner("", os.Stderr)
+// 			time.Sleep(time.Duration(sc.pollRate) * time.Second)
+// 			ansi.StopSpinner(spinner, "", os.Stderr)
+// 		}
+// 	}
 
-	return nil
-}
+// 	return nil
+// }


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

```
$ stripe-dev help
The official command-line tool to interact with Stripe.

Usage:
  stripe [command]

Webhook commands:
  listen                             Listen for webhook events
  trigger                            Trigger test webhook events

Stripe commands:
  logs                               Interact with Stripe API request logs
  
Resource commands:
  get                           Quickly retrieve resources from Stripe
  charges                       Make requests (capture, create, list, etc) on charges
  customers                     Make requests (create, delete, list, etc) on customers
  payment_intents               Make requests (cancel, capture, confirm, etc) on payment intents
  ...                           To see more resource commands, run `stripe resources help`

Other commands:
  community                          Chat with Stripe engineers and other developers
  completion                         Generate bash and zsh completion scripts
  config                             Manually change the config values for the CLI
  feedback                           Provide us with feedback on the CLI
  fixtures                           Run fixtures to populate your account with data
  help                               Help about any command
  login                              Login to your Stripe account
  logout                             Logout of your Stripe account
  open                               Quickly open Stripe pages
  preview
  samples                            Sample integrations built by Stripe
  serve                              Serve static files locally
  version                            Get the version of the Stripe CLI
```
