### PR TITLE
Fix trigger checkout.session.async_payment_succeeded to use SEPA Debit

### DIFF
--- a/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
+++ b/pkg/fixtures/triggers/checkout.session.async_payment_succeeded.json
@@ -62,12 +62,20 @@
       "path": "/v1/payment_methods",
       "method": "post",
       "params": {
-        "type": "card",
-        "card": {
-          "token": "tok_visa"
+        "type": "sepa_debit",
+        "sepa_debit": {
+          "iban": "AT611904300234573201"
         },
         "billing_details": {
-          "email": "stripe@example.com"
+          "email": "stripe@example.com",
+          "name": "Jenny Rosen",
+          "phone": "1234567890",
+          "address": {
+            "line1": "71 Crown Street",
+            "city": "London",
+            "postal_code": "W10 2WB",
+            "country": "GB"
+          }
         }
       }
     },


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
Fix trigger checkout.session.async_payment_succeeded to use SEPA Debit

Fixes https://github.com/stripe/stripe-cli/issues/1104

The trigger was changed a few months ago in https://github.com/stripe/stripe-cli/pull/929 but this was done incorrectly. It uses a card to confirm the Checkout Session which would never cause that Event to be triggered. We switched away from BACS Debit that is not supported in most countries but we still broke the trigger. I'm switching to SEPA Debit which is supported in a lot of countries (though not all) making the trigger work again.

Note that a future improvement would be for the CLI to dynamically pick the right currency and payment method type to trigger that Event but this would be a substantial redesign of triggers.
