### PR TITLE
Move all charge.* triggers to use the PaymentIntents API

### DIFF
--- a/pkg/fixtures/triggers/charge.disputed.created.json
+++ b/pkg/fixtures/triggers/charge.disputed.created.json
@@ -4,13 +4,14 @@
   },
   "fixtures": [
     {
-      "name": "charge",
-      "path": "/v1/charges",
+      "name": "payment_intent",
+      "path": "/v1/payment_intents",
       "method": "post",
       "params": {
-        "source": "tok_createDisputeInquiry",
         "amount": 100,
         "currency": "usd",
+        "payment_method": "pm_card_createDisputeInquiry",
+        "confirm": true,
         "description": "(created by Stripe CLI)"
       }
     }

--- a/pkg/fixtures/triggers/charge.failed.json
+++ b/pkg/fixtures/triggers/charge.failed.json
@@ -4,14 +4,15 @@
   },
   "fixtures": [
     {
-      "name": "charge",
+      "name": "payment_intent",
       "expected_error_type": "card_error",
-      "path": "/v1/charges",
+      "path": "/v1/payment_intents",
       "method": "post",
       "params": {
-        "source": "tok_chargeDeclined",
         "amount": 100,
         "currency": "usd",
+        "payment_method": "pm_card_visa_chargeDeclined",
+        "confirm": true,
         "description": "(created by Stripe CLI)"
       }
     }

--- a/pkg/fixtures/triggers/charge.refund.updated.json
+++ b/pkg/fixtures/triggers/charge.refund.updated.json
@@ -4,13 +4,14 @@
   },
   "fixtures": [
     {
-      "name": "charge",
-      "path": "/v1/charges",
+      "name": "payment_intent",
+      "path": "/v1/payment_intents",
       "method": "post",
       "params": {
-        "source": "tok_visa",
         "amount": 100,
         "currency": "usd",
+        "payment_method": "pm_card_visa",
+        "confirm": true,
         "description": "(created by Stripe CLI)"
       }
     },
@@ -19,7 +20,7 @@
       "path": "/v1/refunds",
       "method": "post",
       "params": {
-        "charge": "${charge:id}"
+        "payment_intent": "${payment_intent:id}"
       }
     },
     {

--- a/pkg/fixtures/triggers/charge.refunded.json
+++ b/pkg/fixtures/triggers/charge.refunded.json
@@ -4,13 +4,14 @@
   },
   "fixtures": [
     {
-      "name": "charge",
-      "path": "/v1/charges",
+      "name": "payment_intent",
+      "path": "/v1/payment_intents",
       "method": "post",
       "params": {
-        "source": "tok_visa",
         "amount": 100,
         "currency": "usd",
+        "payment_method": "pm_card_visa",
+        "confirm": true,
         "description": "(created by Stripe CLI)"
       }
     },
@@ -19,7 +20,7 @@
       "path": "/v1/refunds",
       "method": "post",
       "params": {
-        "charge": "${charge:id}"
+        "payment_intent": "${payment_intent:id}"
       }
     }
   ]

--- a/pkg/fixtures/triggers/charge.succeeded.json
+++ b/pkg/fixtures/triggers/charge.succeeded.json
@@ -4,13 +4,14 @@
   },
   "fixtures": [
     {
-      "name": "charge",
-      "path": "/v1/charges",
+      "name": "payment_intent",
+      "path": "/v1/payment_intents",
       "method": "post",
       "params": {
-        "source": "tok_visa",
         "amount": 100,
         "currency": "usd",
+        "payment_method": "pm_card_visa",
+        "confirm": true,
         "description": "(created by Stripe CLI)"
       }
     }


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
Move all charge.* triggers to use the PaymentIntents API so that it's clearer that this is the canonical integration path overall.

The one small downside is that you can't use the CLI anymore to get a Charge object without a PaymentIntent and with a legacy Card object. I think that trade-off is worth it since you can always make your own triggers if you need a legacy behavior.
