### PR TITLE
fix: restrict WriteConfigField to atomic writes

### DIFF
--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -276,6 +276,7 @@ func (p *Profile) RegisterAlias(alias, key string) {
 // WriteConfigField updates a configuration field and writes the updated
 // configuration to disk.
 func (p *Profile) WriteConfigField(field, value string) error {
+	viper.ReadInConfig()
 	viper.Set(p.GetConfigField(field), value)
 	return viper.WriteConfig()
 }


### PR DESCRIPTION
 ### Reviewers
cc @stripe/developer-products

 ### Summary

It's possible to get into a state where the values stored in the config file do not equal the values that viper has in memory. When this happens, if we call `.WriteConfigField`, viper will write _other_ values besides the one we are explicitly passing in, causing unforeseen behavior and very difficult to track down bugs. This change makes it so that viper reads from the current config file, then sets the key we are explicitly trying to override, then writes to the file.
