### PR TITLE
Add required payment_method_types for multiple triggers to work with the latest API version

### DIFF
--- a/pkg/fixtures/triggers/charge.disputed.created.json
+++ b/pkg/fixtures/triggers/charge.disputed.created.json
@@ -10,6 +10,7 @@
       "params": {
         "amount": 100,
         "currency": "usd",
+        "payment_method_types": ["card"],
         "payment_method": "pm_card_createDisputeInquiry",
         "confirm": true,
         "description": "(created by Stripe CLI)"

--- a/pkg/fixtures/triggers/charge.failed.json
+++ b/pkg/fixtures/triggers/charge.failed.json
@@ -11,6 +11,7 @@
       "params": {
         "amount": 100,
         "currency": "usd",
+        "payment_method_types": ["card"],
         "payment_method": "pm_card_visa_chargeDeclined",
         "confirm": true,
         "description": "(created by Stripe CLI)"

--- a/pkg/fixtures/triggers/charge.refund.updated.json
+++ b/pkg/fixtures/triggers/charge.refund.updated.json
@@ -10,6 +10,7 @@
       "params": {
         "amount": 100,
         "currency": "usd",
+        "payment_method_types": ["card"],
         "payment_method": "pm_card_visa",
         "confirm": true,
         "description": "(created by Stripe CLI)"

--- a/pkg/fixtures/triggers/charge.refunded.json
+++ b/pkg/fixtures/triggers/charge.refunded.json
@@ -10,6 +10,7 @@
       "params": {
         "amount": 100,
         "currency": "usd",
+        "payment_method_types": ["card"],
         "payment_method": "pm_card_visa",
         "confirm": true,
         "description": "(created by Stripe CLI)"

--- a/pkg/fixtures/triggers/charge.succeeded.json
+++ b/pkg/fixtures/triggers/charge.succeeded.json
@@ -10,6 +10,7 @@
       "params": {
         "amount": 100,
         "currency": "usd",
+        "payment_method_types": ["card"],
         "payment_method": "pm_card_visa",
         "confirm": true,
         "description": "(created by Stripe CLI)"

--- a/pkg/fixtures/triggers/payment_intent.amount_capturable_updated.json
+++ b/pkg/fixtures/triggers/payment_intent.amount_capturable_updated.json
@@ -14,6 +14,7 @@
         "confirmation_method": "manual",
         "currency": "usd",
         "description": "(created by Stripe CLI)",
+        "payment_method_types": ["card"],
         "payment_method": "pm_card_visa",
         "return_url": "https://stripe.com"
       }


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
Add required `payment_method_types` for multiple triggers to work with the latest API version
Without it, the latest API version enables "Dynamic Payment Methods" which expects a `return_url` by default for hosted UIs. Forcing `payment_method_types` is simpler here as we hardcode a `payment_method` id.
