### PR TITLE
stripe samples: show 7 server options, not 5

### DIFF
--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -178,6 +178,7 @@ func selectOptions(template, label string, options []string) (string, error) {
 		Label:     label,
 		Items:     options,
 		Templates: templates,
+		Size: 7,
 	}
 
 	_, result, err := prompt.Run()

--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -178,7 +178,7 @@ func selectOptions(template, label string, options []string) (string, error) {
 		Label:     label,
 		Items:     options,
 		Templates: templates,
-		Size: 7,
+		Size:      7,
 	}
 
 	_, result, err := prompt.Run()


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

When you do "stripe samples create" it uses `promptui.Select` which [defaults](https://pkg.go.dev/github.com/manifoldco/promptui#Select) to only showing 5 options. We have 7 official SDKs, so many of the stripe samples have 7 options. Why not just show all of them? It's sometimes hard to spot that little arrow that indicates that you're able to scroll, so at first I didn't think the stripe sample had support for go or .NET, but it does:
![image](https://github.com/stripe/stripe-cli/assets/52928443/570edeb8-b835-4334-b95f-af0008f19076)

Tested locally:
![image](https://github.com/stripe/stripe-cli/assets/52928443/dcdb14f6-f92a-4167-b222-1ddec54e9a9e)

Some samples have more than 7 it's true (this one has a "node-typescript" option) but let's put at least the basic versions of the 7 official libraries above the fold.
