### PR TITLE
Update subscription triggers to use test tokens

### DIFF
--- a/pkg/fixtures/triggers/subscription.payment_failed.json
+++ b/pkg/fixtures/triggers/subscription.payment_failed.json
@@ -10,10 +10,7 @@
       "params": {
         "type": "card",
         "card": {
-          "number": "4000000000000341",
-          "exp_month": 10,
-          "exp_year": 2026,
-          "cvc": 314
+          "token": "tok_chargeCustomerFail"
         }
       }
     },

--- a/pkg/fixtures/triggers/subscription.payment_succeeded.json
+++ b/pkg/fixtures/triggers/subscription.payment_succeeded.json
@@ -10,11 +10,8 @@
       "params": {
         "type": "card",
         "card": {
-          "number": "4242424242424242",
-          "exp_month": 10,
-          "exp_year": 2026,
-          "cvc": 314
-        }
+          "token": "tok_visa"
+       }
       }
     },
     {


### PR DESCRIPTION
 ### Reviewers
r? @charliecruzan-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

`stripe trigger subscription.payment_succeeded` and `stripe trigger subscription.payment_failed` currently fail:
```
Setting up fixture for: payment_method
Running fixture for: payment_method
Trigger failed: Request failed, status=402, body={
  "error": {
    "message": "Sending credit card numbers directly to the Stripe API is generally unsafe. We suggest you use test tokens that map to the test card you are using, see https://stripe.com/docs/testing. To enable raw card data APIs in test mode, see https://support.stripe.com/questions/enabling-access-to-raw-card-data-apis.",
    "request_log_url": "https://dashboard.stripe.com/test/logs/req_QMYi1CK0ecpLRX?t=1694021882",
    "type": "invalid_request_error"
  }
}
```

We fix this by using test tokens instead of passing raw card data to the API: https://stripe.com/docs/testing
