### PR TITLE
fix: bail out of experimental request signing early if api key is overridden

### DIFF
--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -498,8 +498,9 @@ const (
 )
 
 // GetExperimentalFields returns a struct of the profile's experimental fields. These fields are only ever additive in functionality.
+// If the API key is being overriden, via the --api-key flag or STRIPE_API_KEY env variable, this returns an empty struct.
 func (p *Profile) GetExperimentalFields() ExperimentalFields {
-	if err := viper.ReadInConfig(); err == nil {
+	if err := viper.ReadInConfig(); err == nil && os.Getenv("STRIPE_API_KEY") == "" && p.APIKey == "" {
 		name := viper.GetString(p.GetConfigField(experimentalContextualName))
 		privKey := viper.GetString(p.GetConfigField(experimentalPrivateKey))
 		headers := viper.GetString(p.GetConfigField(experimentalStripeHeaders))

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -498,7 +498,7 @@ const (
 )
 
 // GetExperimentalFields returns a struct of the profile's experimental fields. These fields are only ever additive in functionality.
-// If the API key is being overriden, via the --api-key flag or STRIPE_API_KEY env variable, this returns an empty struct.
+// If the API key is being overridden, via the --api-key flag or STRIPE_API_KEY env variable, this returns an empty struct.
 func (p *Profile) GetExperimentalFields() ExperimentalFields {
 	if err := viper.ReadInConfig(); err == nil && os.Getenv("STRIPE_API_KEY") == "" && p.APIKey == "" {
 		name := viper.GetString(p.GetConfigField(experimentalContextualName))


### PR DESCRIPTION
### Reviewers
r? @etsai-stripe 
cc @stripe/developer-products

https://jira.corp.stripe.com/browse/RUN_DX-2185

 ### Summary

if a merchant manually overrides the authorization by passing the api-key flag or has the api key env var set, we can't be sure the experimental headers are correct so we should ignore them