### PR TITLE
Teach CLI to tolerate x-stripeEvent metadata

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -94,6 +94,7 @@ var supportedSchemaFields = []string{
 	// passed through our Spec and should be ignored
 	"x-stripeParam",
 	"x-stripeResource",
+	"x-stripeEvent",
 
 	// This is currently a hint for the server-side so I haven't included it in
 	// Schema yet. If we do start validating responses that come out of


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
We are documenting Webhook events in OpenAPI spec now. Without this annotation the generation (`go generate ./..`) fails. 
