### PR TITLE
Implement suggested fix from #1013

### DIFF
--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -52,7 +52,7 @@ const (
 	KeyValidInDays = 90
 
 	// KeyManagementService is the key management service name
-	KeyManagementService = "Stripe CLI"
+	KeyManagementService = "StripeCLI"
 )
 
 // KeyRing ...


### PR DESCRIPTION
Fixes auth-loop on Linux/Gnome systems.

Thanks @ksullivan

See also
https://github.com/GNOME/gnome-keyring/blob/f24e374/daemon/dbus/gkd-secret-util.c#L111 for root-cause

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
- Previously, users on Linux/Gnome were stuck in an auth loop and unable to use the Stripe CLI _at all_ for anything live mode related. This is because of a bug in the upstream 99designs keyring module (which I think https://github.com/99designs/keyring/pull/90 would've fixed if it was pulled). We work around Gnome's encoding logic and 99designs' handling logic by using a simpler keychain name, without spaces.
- If pulled, this is likely to require some users who already have credentials in the previously-named keychain to need to re-authenticate.