### PR TITLE
Fix fixture param index bug

### DIFF
--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -187,7 +187,7 @@ func ParseMap(params map[string]interface{}, parent string, index int, queryResp
 		case reflect.Map:
 			m := value.(map[string]interface{})
 
-			result, err := ParseMap(m, keyname, index, queryRespMap)
+			result, err := ParseMap(m, keyname, -1, queryRespMap)
 
 			if err != nil {
 				return make([]string, 0), err

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -145,6 +145,28 @@ func TestParseInterfaceFromRaw(t *testing.T) {
 	require.Equal(t, output[1], "salary=1000000000")
 }
 
+func TestParseInterfaceDeeplyNested(t *testing.T) {
+	label := make(map[string]interface{})
+	label["custom"] = "First Name"
+	label["type"] = "custom"
+
+	customField := make(map[string]interface{})
+	customField["label"] = label
+
+	customFields := make([]interface{}, 1)
+	customFields[0] = customField
+
+	data := make(map[string]interface{})
+	data["custom_fields"] = customFields
+
+	output, _ := ParseInterface(data, make(map[string]gjson.Result))
+	sort.Strings(output)
+
+	require.Equal(t, 2, len(output))
+	require.Equal(t, "custom_fields[0][label][custom]=First Name", output[0])
+	require.Equal(t, "custom_fields[0][label][type]=custom", output[1])
+}
+
 func TestParseInterface(t *testing.T) {
 	address := make(map[string]interface{})
 	address["line1"] = "1 Planet Express St"


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Fix a bug in fixture param parsing. If a param in your fixture is an array of objects, and one of these objects itself has an object, then we were parsing it incorrectly.

For example, if you have
```
"custom_fields": [
  {
    "label": {
      "custom": "First Name",
      "type": "custom"
    }
  }
]
```

We would expect to get
```
custom_fields[0][label][custom]=First Name
custom_fields[0][label][type]=custom
```

But we were instead getting
```
custom_fields[0][label][0][custom]=First Name
custom_fields[0][label][0][type]=custom
```

The problem was we were passing down the root array's `index` into each recursive call to the parser when we only want to pass it down one level.