### PR TITLE
cmd/listen: Exit when stdin is closed

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"net/url"
@@ -130,6 +131,8 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
+	ctx = withStdinCloseCancel(ctx)
+
 	client := &stripe.Client{
 		APIKey:  key,
 		BaseURL: apiBase,
@@ -194,6 +197,20 @@ func withSIGTERMCancel(ctx context.Context, onCancel func()) context.Context {
 		<-interruptCh
 		onCancel()
 		cancel()
+	}()
+	return ctx
+}
+
+func withStdinCloseCancel(ctx context.Context) context.Context {
+	ctx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+		}
+		if scanner.Err() == nil {
+			cancel()
+		}
 	}()
 	return ctx
 }


### PR DESCRIPTION
### Reviewers

r? @
cc @stripe/developer-products

### Summary

Besides exiting programs on SIGTERM/ctrl+c, it's common to exit on closing stdin/ctrl+d.