### PR TITLE
[Bug] Fixes #1158 bad invoice items URL

### DIFF
--- a/pkg/requests/ids.go
+++ b/pkg/requests/ids.go
@@ -16,7 +16,7 @@ var idURLMap = map[string]string{
 	"ic":        "/v1/issuing/cards/",
 	"ich":       "/v1/issuing/cardholders/",
 	"idp":       "/v1/issuing/disputes/",
-	"ii":        "/v1/invoice_items/",
+	"ii":        "/v1/invoiceitems/",
 	"in":        "/v1/invoices/",
 	"ipi":       "/v1/issuing/transactions/",
 	"issfr":     "/v1/radar/early_fraud_warnings/",


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Hi Stripe!

When I was using the CLI to retrieve an invoice item by ID, I tried the following:
```
stripe get ii_im_an_invoice_item_id
```

This resulted in the following error:
```
{
  "error": {
    "message": "Unrecognized request URL (GET: /v1/invoice_items/ii_im_an_invoice_item_id). Please see https://stripe.com/docs or we can help at https://support.stripe.com/.",
    "type": "invalid_request_error"
  }
}
```

Looking at the documentation for invoice items it seems the URL has a typo as it should be `invoiceitems` instead of `invoice_items`: https://docs.stripe.com/api/invoiceitems. I changed the `ids.go` file that maps each ID to the corresponding URL as I effectively found it was mapping to `invoice_items`. Now, running the command shown above effectively renders the invoice item.

Thanks! 🎉 