### PR TITLE
Revert "cmd/listen: Exit when stdin is closed (#1155)"

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"net/url"
@@ -131,8 +130,6 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
-	ctx = withStdinCloseCancel(ctx)
-
 	client := &stripe.Client{
 		APIKey:  key,
 		BaseURL: apiBase,
@@ -197,20 +194,6 @@ func withSIGTERMCancel(ctx context.Context, onCancel func()) context.Context {
 		<-interruptCh
 		onCancel()
 		cancel()
-	}()
-	return ctx
-}
-
-func withStdinCloseCancel(ctx context.Context) context.Context {
-	ctx, cancel := context.WithCancel(ctx)
-
-	go func() {
-		scanner := bufio.NewScanner(os.Stdin)
-		for scanner.Scan() {
-		}
-		if scanner.Err() == nil {
-			cancel()
-		}
 	}()
 	return ctx
 }


### PR DESCRIPTION
This reverts commit 531ccfb14c0c3442a20f15fe53dd36c4e60636a0.

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
Fixes https://github.com/stripe/stripe-cli/issues/1159
