### PR TITLE
add action to test package manager installs

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
-      - run: sudo apt update
-      - run: sudo apt install yum
+      - run: apt update
+      - run: apt install yum
       - run: mkdir /etc/yum.repos.d
       - run: echo -e "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
       - run: yum install stripe

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -25,7 +25,7 @@ jobs:
       - run: apt-get update
       - run: apt-get -y install yum
       - run: mkdir /etc/yum.repos.d
-      - run: echo -e "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
+      - run: echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
       - run: yum install stripe
       - run: stripe --version
   scoop:

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -24,16 +24,22 @@ jobs:
     steps:
       - run: mkdir /etc/yum.repos.d
       - run: echo -e "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
-      - run: sudo yum install stripe
+      - run: yum install stripe
       - run: stripe --version
   scoop:
     runs-on: windows-latest
     steps:
-      - run: Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
-      - run: Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
-      - run: scoop bucket add stripe https://github.com/stripe/scoop-stripe-cli.git
-      - run: scoop install stripe
-      - run: stripe --version
+    - name: 'Setup scoop'
+      shell: powershell
+      run: |
+        Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+        Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+    - name: 'Test Stripe CLI'
+      shell: powershell
+      run: |
+        scoop bucket add stripe https://github.com/stripe/scoop-stripe-cli.git
+        scoop install stripe
+        stripe --version
   docker:
     runs-on: ubuntu-latest
     container: stripe/stripe-cli:latest

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -30,8 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
-      - uses: actions/setup-node@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3 # v4 does not support ubuntu 18
         with:
           sparse-checkout: |
             scripts/install-test.sh

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -11,19 +11,39 @@ jobs:
   homebrew:
     runs-on: macos-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/install-test.sh
+          sparse-checkout-cone-mode: false
       - run: bash scripts/install-test.sh homebrew
   apt:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/install-test.sh
+          sparse-checkout-cone-mode: false
       - run: bash scripts/install-test.sh apt
   yum:
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/install-test.sh
+          sparse-checkout-cone-mode: false
       - run: bash scripts/install-test.sh yum
   scoop:
     runs-on: windows-latest
     steps:
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          scripts/install-test.sh
+        sparse-checkout-cone-mode: false
     - uses: MinoruSekine/setup-scoop@v4
     - shell: powershell
       run: bash scripts/install-test.sh scoop
@@ -31,4 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     container: stripe/stripe-cli:latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/install-test.sh
+          sparse-checkout-cone-mode: false
       - run: bash scripts/install-test.sh docker

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
+      - run: sudo apt update
+      - run: sudo apt install yum
       - run: mkdir /etc/yum.repos.d
       - run: echo -e "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
       - run: yum install stripe
@@ -29,13 +31,8 @@ jobs:
   scoop:
     runs-on: windows-latest
     steps:
-    - name: 'Setup scoop'
-      shell: powershell
-      run: |
-        Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
-        Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
-    - name: 'Test Stripe CLI'
-      shell: powershell
+    - uses: MinoruSekine/setup-scoop@v4
+    - shell: powershell
       run: |
         scoop bucket add stripe https://github.com/stripe/scoop-stripe-cli.git
         scoop install stripe

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -56,4 +56,4 @@ jobs:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
-      - run: bash scripts/install-test.sh docker
+      - run: sh scripts/install-test.sh docker

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
     - '*'
+  pull_request:
+    types: [opened, edited]
 name: Package manager test
 jobs:
   homebrew:

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,8 +1,9 @@
 on:
   schedule:
     - cron: '0 0 * * *' # Every day at midnight
-  pull_request:
-    types: [opened, edited]
+  push:
+    tags:
+    - '*'
 name: Package manager test
 jobs:
   homebrew:

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -9,37 +9,24 @@ jobs:
   homebrew:
     runs-on: macos-latest
     steps:
-      - run: brew install stripe/stripe-cli/stripe
-      - run: stripe --version
+      - run: bash scripts/install-test.sh homebrew
   apt:
     runs-on: ubuntu-latest
     steps:
-      - run: curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg
-      - run: echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee -a /etc/apt/sources.list.d/stripe.list
-      - run: sudo apt update
-      - run: sudo apt install stripe
-      - run: stripe --version
+      - run: bash scripts/install-test.sh apt
   yum:
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
-      - run: apt-get update
-      - run: apt-get -y install yum
-      - run: mkdir /etc/yum.repos.d
-      - run: echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
-      - run: yum -y install stripe
-      - run: stripe --version
+      - run: bash scripts/install-test.sh yum
   scoop:
     runs-on: windows-latest
     steps:
     - uses: MinoruSekine/setup-scoop@v4
     - shell: powershell
-      run: |
-        scoop bucket add stripe https://github.com/stripe/scoop-stripe-cli.git
-        scoop install stripe
-        stripe --version
+      run: bash scripts/install-test.sh scoop
   docker:
     runs-on: ubuntu-latest
     container: stripe/stripe-cli:latest
     steps:
-      - run: stripe --version
+      - run: bash scripts/install-test.sh docker

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -30,6 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
+      - run: |
+          apt-get remove nodejs
+          nvm install 16.15.1
       - uses: actions/checkout@v4
         with:
           sparse-checkout: |

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -22,12 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
+      - run: mkdir /etc/yum.repos.d
       - run: echo -e "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
       - run: sudo yum install stripe
       - run: stripe --version
   scoop:
     runs-on: windows-latest
     steps:
+      - run: Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+      - run: Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
       - run: scoop bucket add stripe https://github.com/stripe/scoop-stripe-cli.git
       - run: scoop install stripe
       - run: stripe --version

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,0 +1,38 @@
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every day at midnight
+  pull_request:
+    types: [opened, edited]
+name: Package manager test
+jobs:
+  homebrew:
+    runs-on: macos-latest
+    steps:
+      - run: brew install stripe/stripe-cli/stripe
+      - run: stripe --version
+  apt:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg
+      - run: echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee -a /etc/apt/sources.list.d/stripe.list
+      - run: sudo apt update
+      - run: sudo apt install stripe
+      - run: stripe --version
+  yum:
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
+    steps:
+      - run: echo -e "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
+      - run: sudo yum install stripe
+      - run: stripe --version
+  scoop:
+    runs-on: windows-latest
+    steps:
+      - run: scoop bucket add stripe https://github.com/stripe/scoop-stripe-cli.git
+      - run: scoop install stripe
+      - run: stripe --version
+  docker:
+    runs-on: ubuntu-latest
+    container: stripe/stripe-cli:latest
+    steps:
+      - run: stripe --version

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
-      - run: apt update
-      - run: apt install yum
+      - run: apt-get update
+      - run: apt-get -y install yum
       - run: mkdir /etc/yum.repos.d
       - run: echo -e "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
       - run: yum install stripe

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -26,7 +26,7 @@ jobs:
       - run: apt-get -y install yum
       - run: mkdir /etc/yum.repos.d
       - run: echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
-      - run: yum install stripe
+      - run: yum -y install stripe
       - run: stripe --version
   scoop:
     runs-on: windows-latest

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -30,9 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
-      - run: |
-          apt-get remove nodejs
-          nvm install 16.15.1
+      - uses: actions/setup-node@v4
       - uses: actions/checkout@v4
         with:
           sparse-checkout: |

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '0 0 * * *' # Every day at midnight
+    - cron: '0 * * * *' # Every hour
   push:
     tags:
     - '*'

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -30,7 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
-      - run: mkdir /etc/yum.repos.d
+      - run: |
+          mkdir /etc/yum.repos.d
+          echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
       - uses: actions/checkout@v3 # v4 does not support ubuntu 18
         with:
           sparse-checkout: |

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
+      - run: mkdir /etc/yum.repos.d
       - uses: actions/checkout@v3 # v4 does not support ubuntu 18
         with:
           sparse-checkout: |

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -23,7 +23,6 @@ run_install() {
     yum)
         apt-get update
         apt-get -y install yum
-        echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
         yum -y install stripe
     ;;
 

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -22,8 +22,6 @@ run_install() {
 
     yum)
         apt-get update
-        apt-get remove nodejs
-        nvm install 16.15.1
         apt-get -y install yum
         mkdir /etc/yum.repos.d
         echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -23,8 +23,8 @@ run_install() {
     yum)
         apt-get update
         apt-get -y install yum
-        mkdir /etc/yum.repos.d
         echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
+        cat /etc/yum.repos.d/stripe.repo
         yum -y install stripe
     ;;
 

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -23,8 +23,7 @@ run_install() {
     yum)
         apt-get update
         apt-get -y install yum
-        touch /etc/yum.repos.d/stripe.repo
-        echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" | tee /etc/yum.repos.d/stripe.repo
+        echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
         yum -y install stripe
     ;;
 

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -23,8 +23,7 @@ run_install() {
     yum)
         apt-get update
         apt-get -y install yum
-        echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
-        cat /etc/yum.repos.d/stripe.repo
+        echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" | tee /etc/yum.repos.d/stripe.repo
         yum -y install stripe
     ;;
 

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -22,6 +22,8 @@ run_install() {
 
     yum)
         apt-get update
+        apt-get remove nodejs
+        nvm install 16.15.1
         apt-get -y install yum
         mkdir /etc/yum.repos.d
         echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -23,6 +23,7 @@ run_install() {
     yum)
         apt-get update
         apt-get -y install yum
+        touch /etc/yum.repos.d/stripe.repo
         echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" | tee /etc/yum.repos.d/stripe.repo
         yum -y install stripe
     ;;

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+PACKAGE_MANAGER=${1:-}
+
+if [ $# -eq 0 ]; then
+  echo "Error! Missing package manager argument"
+  exit 1
+fi
+
+run_install() {
+    case $PACKAGE_MANAGER in
+    homebrew)
+        brew install stripe/stripe-cli/stripe
+    ;;
+
+    apt)
+        curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg
+        echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee -a /etc/apt/sources.list.d/stripe.list
+        sudo apt update
+        sudo apt install stripe
+    ;;
+
+    yum)
+        apt-get update
+        apt-get -y install yum
+        mkdir /etc/yum.repos.d
+        echo "[Stripe]\nname=stripe\nbaseurl=https://packages.stripe.dev/stripe-cli-rpm-local/\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/stripe.repo
+        yum -y install stripe
+    ;;
+
+    scoop)
+        scoop bucket add stripe https://github.com/stripe/scoop-stripe-cli.git
+        scoop install stripe
+    ;;
+
+    docker)
+    ;;
+
+    *)
+        echo "Error! Invalid package manager supplied"
+        echo ""
+        echo_help
+        exit 1
+        ;;
+    esac
+
+    stripe --version
+}
+
+if ! run_install
+then
+    echo "Install failed. Retrying in 30 seconds..."
+    sleep 30
+    if ! run_install
+    then
+        echo "Install failed again. Retrying in 60 seconds..."
+        sleep 60
+        if ! run_install
+        then
+            echo "Install failed again. Retrying in 120 seconds..."
+            sleep 120
+            if ! run_install
+            then
+                echo "Install failed again. Retrying for the last time in 180 seconds..."
+                sleep 180
+                run_install
+            fi
+        fi
+    fi
+fi


### PR DESCRIPTION
 ### Reviewers

r? @vcheung-stripe 
or
r? @etsai-stripe 

 ### Summary

Adds a new Github Action that acts as a smoke test for all of our package manager install cases. This will install Stripe and run `stripe version` after:
- installing with homebrew
- installing with apt
- installing with scoop
- installing with yum
- running in the docker image

This will run once an hour, and also whenever a new tag is pushed. If it fails, this is a strong indicator that something broken in the installation flow and this should help us catch it early. To avoid noise, there's retry logic. 

