### PR TITLE
update setup-protoc from v1 to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Run Setup
       run: make setup
     - name: Install protoc
-      uses: arduino/setup-protoc@v1.3.0
+      uses: arduino/setup-protoc@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install protoc deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Run Setup
       run: make setup
     - name: Install protoc
-      uses: arduino/setup-protoc@v2
+      uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install protoc deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Run Setup
       run: make setup
     - name: Install protoc
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install protoc deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
       uses: actions/checkout@v2
     - name: Run Setup
       run: make setup
+    - name: install diffutils
+      if: runner.os == 'macOS'
+      run: brew install diffutils
     - name: Install protoc
       uses: arduino/setup-protoc@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Run Setup
       run: make setup
     - name: Install protoc
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@v1.3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install protoc deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Run Setup
       run: make setup
     - name: Install protoc
-      uses: arduino/setup-protoc@v1.3
+      uses: arduino/setup-protoc@v1.3.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install protoc deps

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ lint: bin/golangci-lint
 .PHONY: lint
 
 bin/golangci-lint:
+	brew install diffutils
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 
 # Clean go.mod

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ lint: bin/golangci-lint
 .PHONY: lint
 
 bin/golangci-lint:
-	brew install diffutils
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 
 # Clean go.mod


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary

We were using an old version of arduino/setup-protoc that didnt support ARM architecture for macos, which I suppose the macos-latest runners just started using, so this began failing. After upgrading, we hit another error related to diffing, and https://github.com/golangci/golangci-lint/issues/3087 pointed me to installing diffutils which worked
