### PR TITLE
Use golangci-lint github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.58
+        version: v1.48
     - name: Run Tests
       run: make ci
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,10 @@ jobs:
         go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
         go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
       shell: bash
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: v1.58
     - name: Run Tests
       run: make ci
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROTOC_FAILURE_MESSAGE="\nFailed to compile protobuf files: protoc exited with c
 export GO111MODULE := on
 export GOBIN := $(shell pwd)/bin
 export PATH := $(GOBIN):$(PATH)
-export GOLANGCI_LINT_VERSION := v1.59.0
+export GOLANGCI_LINT_VERSION := v1.48.0
 
 # Install all the build and lint dependencies
 setup:
@@ -51,7 +51,7 @@ go-mod-tidy:
 .PHONY: go-mod-tidy
 
 # Run all the tests and code checks
-ci: build-all-platforms test lint go-mod-tidy protoc-ci
+ci: build-all-platforms test go-mod-tidy protoc-ci
 .PHONY: ci
 
 # Build a beta version of stripe

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROTOC_FAILURE_MESSAGE="\nFailed to compile protobuf files: protoc exited with c
 export GO111MODULE := on
 export GOBIN := $(shell pwd)/bin
 export PATH := $(GOBIN):$(PATH)
-export GOLANGCI_LINT_VERSION := v1.48.0
+export GOLANGCI_LINT_VERSION := v1.59.0
 
 # Install all the build and lint dependencies
 setup:


### PR DESCRIPTION
 ### Reviewers
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Fix an issue where golangci-lint couldn't be installed on windows in CI. We use the golangci-lint github action as recommended by https://golangci-lint.run/welcome/install/#ci-installation.