### PR TITLE
Init config in login tests

### DIFF
--- a/pkg/login/client_login_test.go
+++ b/pkg/login/client_login_test.go
@@ -56,6 +56,7 @@ func TestLogin(t *testing.T) {
 		Profile:      p,
 		ProfilesFile: profilesFile,
 	}
+	c.InitConfig()
 
 	var pollURL string
 
@@ -134,6 +135,7 @@ func TestLoginNoInput(t *testing.T) {
 		Profile:      p,
 		ProfilesFile: profilesFile,
 	}
+	c.InitConfig()
 
 	var pollURL string
 


### PR DESCRIPTION
 ### Reviewers
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Fix tests that fail locally on running `make test`. In https://github.com/stripe/stripe-cli/pull/1198, we need the keyring library on login, whereas we didn't before. The `InitConfig()` function initializes the keyring object.
