### PR TITLE
Create .env file with pub key placeholder

### DIFF
--- a/pkg/cmd/samples/create.go
+++ b/pkg/cmd/samples/create.go
@@ -117,6 +117,9 @@ func (cc *CreateCmd) runCreateCmd(cmd *cobra.Command, args []string) error {
 		case samples.DidConfigure:
 			ansi.StopSpinner(spinner, "", os.Stdout)
 			fmt.Printf("%s %s\n", color.Green("✔"), ansi.Faint("Project configured"))
+		case samples.DidConfigureWithoutTestPubKey:
+			ansi.StopSpinner(spinner, "", os.Stdout)
+			fmt.Printf("%s %s\n", color.Green("⚠️"), ansi.Faint("Project configured without testmode publishable key. Please update your pk_test... key in the .env file in the server folder"))
 		case samples.Done:
 			fmt.Println("You're all set. To get started: cd", destination)
 			if res.PostInstall != "" {

--- a/pkg/samples/create.go
+++ b/pkg/samples/create.go
@@ -35,6 +35,7 @@ const (
 	// DidConfigure means the .env of the sample has finished being configured with the user's Stripe account details
 	DidConfigure
 
+	// DidConfigureWithoutTestPubKey means the .env of the sample has finished being configured without the publishable key
 	DidConfigureWithoutTestPubKey
 
 	// Done means sample creation is complete

--- a/pkg/samples/create.go
+++ b/pkg/samples/create.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 
 	log "github.com/sirupsen/logrus"
+
 	"github.com/spf13/afero"
 	"github.com/stripe/stripe-cli/pkg/validators"
 

--- a/pkg/samples/create.go
+++ b/pkg/samples/create.go
@@ -8,8 +8,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/spf13/afero"
 	"github.com/stripe/stripe-cli/pkg/validators"
+
+	"github.com/spf13/afero"
 
 	"github.com/go-git/go-git/v5"
 )

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -33,6 +33,7 @@ type SampleConfig struct {
 	Integrations    []SampleConfigIntegration `json:"integrations"`
 }
 
+// TestPublishableKeyPlaceholder is the placeholder for empty publishable key in the .env file
 const TestPublishableKeyPlaceholder = "pk_test..."
 
 // HasIntegrations returns true if the sample has multiple integrations

--- a/pkg/validators/validate.go
+++ b/pkg/validators/validate.go
@@ -15,6 +15,8 @@ type ArgValidator func(string) error
 var (
 	// ErrAPIKeyNotConfigured is the error returned when the loaded profile is missing the api key property
 	ErrAPIKeyNotConfigured = errors.New("you have not configured API keys yet")
+	// ErrPubKeyNotConfigured is the error returned when the loaded profile is missing the publishable key property
+	ErrPubKeyNotConfigured = errors.New("you have not configured publishable keys yet")
 	// ErrDeviceNameNotConfigured is the error returned when the loaded profile is missing the device name property
 	ErrDeviceNameNotConfigured = errors.New("you have not configured your device name yet")
 	// ErrAccountIDNotConfigured is the error returned when the loaded profile is missing the account_id property


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Samples were downloaded without .env file configured if the user is not logged in. The instruction to set up the .env file was not clear. We will configure .env file with test pub key placeholder and ask user to update it manually after.

## Download sample with test mode pub key
```
$ stripe samples create starter
✔ Finished downloading
✔ Selected server: node
✔ Files copied
✔ Project configured
You're all set. To get started: cd starter
$ more starter/server/.env
STATIC_DIR="../client"
STRIPE_PUBLISHABLE_KEY="pk_test_51Of62wKYULnmyk0cBSrGl1xAx5l8tgArWiuu7vyXwapv6raNDE3ZWAb2cmKLEHJZxCnEMABHHXAyw04kuxXsqTWr00wOe2XCGG"
STRIPE_SECRET_KEY="rk_test_[redacted]"
STRIPE_WEBHOOK_SECRET="whsec_[redacted]"
```
## Download sample without test mode pub key
```
$ stripe samples create starter
✔ Finished downloading
✔ Selected server: node
✔ Files copied
⚠️ Project configured without testmode publishable key. Please update your pk_test... key in the .env file in the server folder
You're all set. To get started: cd starter
$ more starter/server/.env
STATIC_DIR="../client"
STRIPE_PUBLISHABLE_KEY="pk_test..."
STRIPE_SECRET_KEY="rk_test_[redacted]"
STRIPE_WEBHOOK_SECRET="whsec_[redacted]"
```