### PR TITLE
Send client version on login

### DIFF
--- a/pkg/login/links.go
+++ b/pkg/login/links.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/stripe/stripe-cli/pkg/stripe"
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 // Links provides the URLs for the CLI to continue the login flow
@@ -30,6 +31,7 @@ func GetLinks(ctx context.Context, baseURL string, deviceName string) (*Links, e
 	}
 
 	data := url.Values{}
+	data.Set("client_version", version.Version)
 	data.Set("device_name", deviceName)
 
 	res, err := client.PerformRequest(ctx, http.MethodPost, stripeCLIAuthPath, data.Encode(), nil)


### PR DESCRIPTION
 ### Reviewers
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Posts the `client_version` of the Stripe CLI to the backend on login. This allows us to more easily verify if the client is supported before continuing the login flow. This value will be:
- semver for future versions of the CLI (whenever this is released so probably >=1.20.1)
- nothing for current and previous versions (<1.20.1)
- `"master"` when the source code is run directly with `go run` or the binary is built from source