### PR TITLE
Fix trigger fixture for `payment_method.detached` event

### DIFF
--- a/pkg/fixtures/triggers/payment_method.detached.json
+++ b/pkg/fixtures/triggers/payment_method.detached.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "payment_method_detach",
-      "path": "/v1/payment_methods/${payment_method_attach.id}/detach",
+      "path": "/v1/payment_methods/${payment_method_attach:id}/detach",
       "method": "post",
       "params": {
         "customer": "${customer:id}"


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Triggering the `payment_method.detached` event using the CLI (`v1.20.0`) is failing with the following error:
```
Trigger failed: Request failed, status=404, body={
  "error": {
    "code": "resource_missing",
    "doc_url": " https://stripe.com/docs/error-codes/resource-misssing",
    "message" "No such PaymentMethod: '${payment_method_attach.id}'; It's possible this PaymentMethod exists on one of your connected accounts, in which case you should retry this request on that connected account. Learn more at https://stripe.com/docs/connect/authentication",
    "param": "payment_method",
    "request_log_url": <redacted>,
    "type": "invalid_request_error"
  }
}
```

This PR updates the fixture which should resolve this issue!
