### PR TITLE
On `stripe login`, fail open when interacting with the keyring

### DIFF
--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -63,9 +63,8 @@ func (p *Profile) CreateProfile() error {
 	// Remove all keys under existing profile first
 	v := p.deleteProfile(viper.GetViper())
 
-	if err := p.deleteLivemodeValue(LiveModeAPIKeyName); err != nil {
-		return err
-	}
+	// Fail open to avoid blocking login
+	p.deleteLivemodeValue(LiveModeAPIKeyName)
 
 	writeErr := p.writeProfile(v)
 	if writeErr != nil {


### PR DESCRIPTION
 ### Reviewers
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
This fixes the `No directory provided for file keyring` issue when trying to run `stripe login` on WSL. On that system, there may not be a keyring backend, so we fail open to avoid blocking the login flow from completing.

I verified this on Ubuntu 22.04.4 LTS. Our unit tests actually catch this when running `make test` on this platform, so I also made sure those pass. We should consider ways to handle catching errors like this before they make it into a release.