### PR TITLE
[actions] use pagerduty CLI to create alert

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -71,8 +71,7 @@ jobs:
   pagerduty:
     needs: [docker, scoop, yum, apt, homebrew]
     runs-on: ubuntu-latest
-    if: ${{ always() }}
-    # if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
       - shell: bash
         env:
@@ -80,9 +79,7 @@ jobs:
         run: |
           sh -c "$(curl -sL https://raw.githubusercontent.com/martindstone/pagerduty-cli/master/install.sh)"
           pd event alert --routing_key "$PAGERDUTY_INTEGRATION_KEY" \
-            --summary "Failed to install Stripe CLI on one or more operating systems." \
+            --summary "Failed to install Stripe CLI on one or more operating systems. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml" \
             --timestamp "\"$(date)\"" \
             --source "Stripe CLI GitHub Actions" \
-            --severity critical \
-            --keys run_details --values "https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml"
-
+            --severity critical

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -81,7 +81,7 @@ jobs:
           sh -c "$(curl -sL https://raw.githubusercontent.com/martindstone/pagerduty-cli/master/install.sh)"
           pd event alert --routing_key "$PAGERDUTY_INTEGRATION_KEY" \
             --summary "Failed to install Stripe CLI on one or more operating systems." \
-            --timestamp date \
+            --timestamp $(date) \
             --source "Stripe CLI GitHub Actions" \
             --severity critical \
             --keys run_details --values "https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml"

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -84,5 +84,5 @@ jobs:
             --timestamp date \
             --source "Stripe CLI GitHub Actions" \
             --severity critical \
-            --key run_details --value "https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml"
+            --keys run_details --values "https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml"
 

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -79,7 +79,7 @@ jobs:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
         run: |
           sh -c "$(curl -sL https://raw.githubusercontent.com/martindstone/pagerduty-cli/master/install.sh)"
-          pd auth:set "$PAGERDUTY_INTEGRATION_KEY"
+          pd auth:set -t "$PAGERDUTY_INTEGRATION_KEY" -d
           pd event alert --summary "Failed to install Stripe CLI on one or more operating systems." \\
             --timestamp date \\
             --source "Stripe CLI GitHub Actions" \\

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -79,8 +79,8 @@ jobs:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
         run: |
           sh -c "$(curl -sL https://raw.githubusercontent.com/martindstone/pagerduty-cli/master/install.sh)"
-          pd auth:set -t "$PAGERDUTY_INTEGRATION_KEY" -d
-          pd event alert --summary "Failed to install Stripe CLI on one or more operating systems." \\
+          pd event alert --routing_key "$PAGERDUTY_INTEGRATION_KEY" \\
+            --summary "Failed to install Stripe CLI on one or more operating systems." \\
             --timestamp date \\
             --source "Stripe CLI GitHub Actions" \\
             --severity critical \\

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -71,7 +71,8 @@ jobs:
   pagerduty:
     needs: [docker, scoop, yum, apt, homebrew]
     runs-on: ubuntu-latest
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ always() }}
+    # if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
       - shell: bash
         env:

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -73,8 +73,15 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
-      - name: Send PagerDuty alert on failure
-        uses: Entle/action-pagerduty-alert@0.2.0
-        with:
-          pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
-          pagerduty-dedup-key: package_manager_install_workflow_failed
+      - shell: bash
+        env:
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+        run: |
+          sh -c "$(curl -sL https://raw.githubusercontent.com/martindstone/pagerduty-cli/master/install.sh)"
+          pd auth:set "$PAGERDUTY_INTEGRATION_KEY"
+          pd event alert --summary "Failed to install Stripe CLI on one or more operating systems." \\
+            --timestamp date \\
+            --source "Stripe CLI GitHub Actions" \\
+            --severity critical \\
+            --key run_details --value "https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml"
+

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -81,7 +81,7 @@ jobs:
           sh -c "$(curl -sL https://raw.githubusercontent.com/martindstone/pagerduty-cli/master/install.sh)"
           pd event alert --routing_key "$PAGERDUTY_INTEGRATION_KEY" \
             --summary "Failed to install Stripe CLI on one or more operating systems." \
-            --timestamp $(date) \
+            --timestamp "\"$(date)\"" \
             --source "Stripe CLI GitHub Actions" \
             --severity critical \
             --keys run_details --values "https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml"

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -79,10 +79,10 @@ jobs:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
         run: |
           sh -c "$(curl -sL https://raw.githubusercontent.com/martindstone/pagerduty-cli/master/install.sh)"
-          pd event alert --routing_key "$PAGERDUTY_INTEGRATION_KEY" \\
-            --summary "Failed to install Stripe CLI on one or more operating systems." \\
-            --timestamp date \\
-            --source "Stripe CLI GitHub Actions" \\
-            --severity critical \\
+          pd event alert --routing_key "$PAGERDUTY_INTEGRATION_KEY" \
+            --summary "Failed to install Stripe CLI on one or more operating systems." \
+            --timestamp date \
+            --source "Stripe CLI GitHub Actions" \
+            --severity critical \
             --key run_details --value "https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml"
 


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary

The github action isn't maintained and doesn't have a lot of features, let's just use Pager Duty CLI instead. This makes it so that the title of the pagerduty alert isn't a very long and confusing string plus url (plus my name, which im not a super big fan of 😄 ). Hopefully this will make this page a lot clearer to the runner

