### PR TITLE
Fixes shutdown deadlock in websocket client

### DIFF
--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -537,7 +537,7 @@ func NewClient(url string, webSocketID string, websocketAuthorizedFeature string
 		WebSocketAuthorizedFeature: websocketAuthorizedFeature,
 		cfg:                        cfg,
 		done:                       make(chan struct{}),
-		send:                       make(chan *OutgoingMessage),
+		send:                       make(chan *OutgoingMessage, 10),
 		NotifyExpired:              make(chan struct{}),
 	}
 }

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -79,16 +79,30 @@ type Client struct {
 	// Optional configuration parameters
 	cfg *Config
 
-	conn        *ws.Conn
-	done        chan struct{}
-	isConnected bool
+	conn             *ws.Conn
+	done             chan struct{}
+	isConnected      bool
+	isConnectedMutex sync.RWMutex
 
-	NotifyExpired chan struct{}
-	notifyClose   chan error
-	send          chan *OutgoingMessage
-	stopReadPump  chan struct{}
-	stopWritePump chan struct{}
-	wg            *sync.WaitGroup
+	NotifyExpired     chan struct{}
+	notifyClose       chan error
+	send              chan *OutgoingMessage
+	stopReadPumpMutex sync.RWMutex
+	stopReadPump      chan struct{}
+	stopWritePump     chan struct{}
+	wg                *sync.WaitGroup
+}
+
+func (c *Client) setIsConnected(newValue bool) {
+	c.isConnectedMutex.Lock()
+	defer c.isConnectedMutex.Unlock()
+	c.isConnected = newValue
+}
+
+func (c *Client) getIsConnected() bool {
+	c.isConnectedMutex.RLock()
+	defer c.isConnectedMutex.RUnlock()
+	return c.isConnected
 }
 
 // Connected returns a channel that's closed when the client has finished
@@ -97,7 +111,7 @@ func (c *Client) Connected() <-chan struct{} {
 	d := make(chan struct{})
 
 	go func() {
-		for !c.isConnected {
+		for !c.getIsConnected() {
 			time.Sleep(100 * time.Millisecond)
 		}
 		close(d)
@@ -109,7 +123,7 @@ func (c *Client) Connected() <-chan struct{} {
 // Run starts listening for incoming webhook requests from Stripe.
 func (c *Client) Run(ctx context.Context) {
 	for {
-		c.isConnected = false
+		c.setIsConnected(false)
 		c.cfg.Log.WithFields(log.Fields{
 			"prefix": "websocket.client.Run",
 		}).Debug("Attempting to connect to Stripe")
@@ -171,6 +185,8 @@ func (c *Client) Run(ctx context.Context) {
 // Close executes a proper closure handshake then closes the connection
 // list of close codes: https://datatracker.ietf.org/doc/html/rfc6455#section-7.4
 func (c *Client) Close(closeCode int, text string) {
+	c.stopReadPumpMutex.Lock()
+	defer c.stopReadPumpMutex.Unlock()
 	close(c.stopReadPump)
 	close(c.stopWritePump)
 	if c.conn != nil {
@@ -271,7 +287,7 @@ func (c *Client) connect(ctx context.Context) error {
 	defer resp.Body.Close()
 
 	c.changeConnection(conn)
-	c.isConnected = true
+	c.setIsConnected(true)
 
 	c.wg = &sync.WaitGroup{}
 	c.wg.Add(2)
@@ -289,6 +305,8 @@ func (c *Client) connect(ctx context.Context) error {
 
 // changeConnection takes a new connection and recreates the channels.
 func (c *Client) changeConnection(conn *ws.Conn) {
+	c.stopReadPumpMutex.Lock()
+	defer c.stopReadPumpMutex.Unlock()
 	c.conn = conn
 	c.notifyClose = make(chan error)
 	c.stopReadPump = make(chan struct{})
@@ -459,6 +477,12 @@ func (c *Client) writePump() {
 			return
 		}
 	}
+}
+
+func (c *Client) terminateReadPump() {
+	c.stopReadPumpMutex.Lock()
+	defer c.stopReadPumpMutex.Unlock()
+	c.stopReadPump <- struct{}{}
 }
 
 //

--- a/pkg/websocket/client_test.go
+++ b/pkg/websocket/client_test.go
@@ -240,7 +240,7 @@ func TestWritePumpInterruptionRequeued(t *testing.T) {
 	actualMessages := []string{}
 	connectedChan := client.Connected()
 	<-connectedChan
-	go func() { client.stopReadPump <- struct{}{} }()
+	go func() { client.terminateReadPump() }()
 
 	for i := 0; i < 2; i++ {
 		client.SendMessage(NewEventAck(fmt.Sprintf("event_%d", i), fmt.Sprintf("event_%d", i)))


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products

 ### Summary
This change solves a deadlock that can happen in `stripe listen` when the underlying websocket connection closes or is reconnecting while the websocket client is attempting to send a message. The deadlock happens when the `writePump` has a message to send:

```go
	for {
		select {
		case outMsg, ok := <-c.send:
```

runs into an error trying to send the message because the connection has been closed for one reason or another:

```go
			err = c.conn.WriteJSON(outMsg)
			if err != nil {
```

and attempts to re-queue the message it was going to process:

```go
				// Requeue the message to be processed when writePump restarts
				c.send <- outMsg
```

`c.send` is unbuffered, and only read from in this select. Sending messages to `c.send` in the same block that processes reads from `c.send` will always deadlock, as message sending to unbuffered channels blocks until the message is read.

This PR fixes that deadlock by making `c.send` a buffered channel, allowing the re-queueing behavior we're looking for.

This condition is not all that common, but given `stripe listen` tries to reconnect every once in a while this could happen more often than you'd think in a busy `stripe listen` session.

This change comes with a unit test meant to provoke the regression to verify it remains fixed. That test was a little challenging to write (I'm still learning how to do these well), and to support the new test case I added some synchronization primitives in the websocket client to make it easier to monkey with the client from the test case.