### PR TITLE
Add x-stripeMostCommon

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -132,6 +132,7 @@ type Schema struct {
 	XExpansionResources *ExpansionResources `json:"x-expansionResources,omitempty"`
 	XResourceID         string              `json:"x-resourceId,omitempty"`
 	XStripeOperations   *[]StripeOperation  `json:"x-stripeOperations,omitempty"`
+	XStripeMostCommon   []string            `json:"x-stripeMostCommon,omitempty"`
 }
 
 func (s *Schema) String() string {


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
 Fixes failures in `openapi` CI that updates stripe-cli: https://github.com/stripe/openapi/actions/runs/10638892098/job/29495772839
 
We recently added a `x-stripeMostCommon` custom property to the OpenAPI spec, and apparently stripe-cli is very picky about unknown fields when unmarshalling the openapi spec.

<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
