### PR TITLE
Set permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+permissions:
+  actions: write
+  contents: write
+
 jobs:
   build-mac:
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - "v*"
 
 permissions:
-  actions: write
   contents: write
 
 jobs:


### PR DESCRIPTION
 ### Reviewers
r? @charliecruzan-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
The `release` workflow recently started failing to publish releases [0] due to a lack of permissions. We need to explicitly define the permissions needed in the YAML file -- other permissions that are not included are implicitly set to `none` [1].

[0] https://github.com/stripe/stripe-cli/actions/runs/10712343543/job/29744080418
[1] https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions