### PR TITLE
Fix stripe trigger payment_method.detached

### DIFF
--- a/pkg/fixtures/triggers/payment_method.detached.json
+++ b/pkg/fixtures/triggers/payment_method.detached.json
@@ -21,11 +21,8 @@
     },
     {
       "name": "payment_method_detach",
-      "path": "/v1/payment_methods/${payment_method_attach.id}/detach",
-      "method": "post",
-      "params": {
-        "customer": "${customer:id}"
-      }
+      "path": "/v1/payment_methods/${payment_method_attach:id}/detach",
+      "method": "post"
     }
   ]
 }


### PR DESCRIPTION
 ### Reviewers
r? @charliecruzan-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Fixes a typo in the fixture to detach a PaymentMethod, and also removes the `customer` parameter because it's not needed [0].

Built and tested locally:

```
$ ./stripe trigger payment_method.detached
Setting up fixture for: customer
Running fixture for: customer
Setting up fixture for: payment_method_attach
Running fixture for: payment_method_attach
Setting up fixture for: payment_method_detach
Running fixture for: payment_method_detach
Trigger succeeded! Check dashboard for event details.
```

[0] https://docs.stripe.com/api/payment_methods/detach