### PR TITLE
fix: only trigger pager duty alert if install actually fails

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -18,6 +18,8 @@ jobs:
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
       - run: bash scripts/install-test.sh homebrew
+        env:
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
   apt:
     runs-on: ubuntu-latest
     steps:
@@ -27,6 +29,8 @@ jobs:
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
       - run: bash scripts/install-test.sh apt
+        env:
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
   yum:
     runs-on: ubuntu-latest
     container: fedora:latest
@@ -47,6 +51,8 @@ jobs:
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
       - run: bash scripts/install-test.sh yum
+        env:
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
   scoop:
     runs-on: windows-latest
     steps:
@@ -58,6 +64,8 @@ jobs:
     - uses: MinoruSekine/setup-scoop@v4
     - shell: powershell
       run: bash scripts/install-test.sh scoop
+      env:
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
   docker:
     runs-on: ubuntu-latest
     container: stripe/stripe-cli:latest
@@ -68,18 +76,5 @@ jobs:
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
       - run: sh scripts/install-test.sh docker
-  pagerduty:
-    needs: [docker, scoop, yum, apt, homebrew]
-    runs-on: ubuntu-latest
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
-    steps:
-      - shell: bash
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
-        run: |
-          sh -c "$(curl -sL https://raw.githubusercontent.com/martindstone/pagerduty-cli/master/install.sh)"
-          pd event alert --routing_key "$PAGERDUTY_INTEGRATION_KEY" \
-            --summary "Failed to install Stripe CLI on one or more operating systems. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml" \
-            --timestamp "\"$(date)\"" \
-            --source "Stripe CLI GitHub Actions" \
-            --severity critical

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -69,7 +69,7 @@ then
                 echo "Install failed again. Retrying for the last time in 180 seconds..."
                 sleep 180
                 run_install
-                if ! run_install
+                if [ "$PACKAGE_MANAGER" = "homebrew" ]
                 then
                 trigger_pagerduty_alert
                 fi

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -77,8 +77,3 @@ then
         fi
     fi
 fi
-
-if [ "$PACKAGE_MANAGER" = "homebrew" ]
-then
-    trigger_pagerduty_alert
-fi

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -69,11 +69,16 @@ then
                 echo "Install failed again. Retrying for the last time in 180 seconds..."
                 sleep 180
                 run_install
-                if [ "$PACKAGE_MANAGER" = "homebrew" ]
+                if ! run_install
                 then
                 trigger_pagerduty_alert
                 fi
             fi
         fi
     fi
+fi
+
+if [ "$PACKAGE_MANAGER" = "homebrew" ]
+then
+    trigger_pagerduty_alert
 fi


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary

This can flake occasionally due to network flakiness or something else that **isn't** the actual install command failing, so I say we just fully ignore any failures that aren't due to the actual install step. We rerun this every hour so if we miss one hour every few days due to a network outage, idt that's a huge deal for this test specifically.

To make this clear:
before, if any action failed (which could be due to any reason- the install failing or any setup steps for the job failing) we would page

after this PR: we only trigger the alert after the install test fails 5 times for a platform. If we fail in the setup, the job will fail silently and we'll test again in an hour.

tested this manually and made sure i got paged
