### PR TITLE
fix: link to thin event in local listener view

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -67,7 +67,8 @@ func (f FailedToReadResponseError) Error() string {
 // Config provides the configuration of a Proxy
 type Config struct {
 	// DeviceName is the name of the device sent to Stripe to help identify the device
-	DeviceName string
+	DeviceName  string
+	DeviceToken *string
 
 	// Client is a configured stripe client used to execute authenticated calls to the Stripe API.
 	Client stripe.RequestPerformer
@@ -156,7 +157,7 @@ func (p *Proxy) Run(ctx context.Context) error {
 
 	for nAttempts < maxConnectAttempts {
 		session, err := p.createSession(ctx)
-
+		*p.cfg.DeviceToken = session.DeviceToken
 		if err != nil {
 			p.cfg.OutCh <- websocket.ErrorElement{
 				Error: fmt.Errorf("Error while authenticating with Stripe: %v", err),

--- a/pkg/proxy/v2_stripe_event.go
+++ b/pkg/proxy/v2_stripe_event.go
@@ -23,11 +23,6 @@ type primaryRelatedObject struct {
 }
 
 // URLForEventID builds a full URL from a V2StripeEvent ID.
-func (e *V2EventPayload) URLForEventID() string {
-	return fmt.Sprintf("https://dashboard.stripe.com/events/%s", e.ID)
-}
-
-// URLForEventType builds a full URL from a V2StripeEvent Type.
-func (e *V2EventPayload) URLForEventType() string {
-	return fmt.Sprintf("https://dashboard.stripe.com/events?type=%s", e.Type)
+func (e *V2EventPayload) URLForEventID(cliEndpointId string) string {
+	return fmt.Sprintf("https://dashboard.stripe.com/workbench/webhooks/%s?event=%s", cliEndpointId, e.ID)
 }

--- a/pkg/proxy/v2_stripe_event.go
+++ b/pkg/proxy/v2_stripe_event.go
@@ -23,6 +23,6 @@ type primaryRelatedObject struct {
 }
 
 // URLForEventID builds a full URL from a V2StripeEvent ID.
-func (e *V2EventPayload) URLForEventID(cliEndpointId string) string {
-	return fmt.Sprintf("https://dashboard.stripe.com/workbench/webhooks/%s?event=%s", cliEndpointId, e.ID)
+func (e *V2EventPayload) URLForEventID(cliEndpointID string) string {
+	return fmt.Sprintf("https://dashboard.stripe.com/workbench/webhooks/%s?event=%s", cliEndpointID, e.ID)
 }

--- a/pkg/stripeauth/messages.go
+++ b/pkg/stripeauth/messages.go
@@ -11,4 +11,5 @@ type StripeCLISession struct {
 	WebSocketURL                string `json:"websocket_url"`
 	DefaultVersion              string `json:"default_version"`
 	LatestVersion               string `json:"latest_version"`
+	DeviceToken                 string `json:"device_token"`
 }


### PR DESCRIPTION
 ### Reviewers
r? @tomas-stripe 
cc @stripe/developer-products

 ### Summary

This adds support for linking directly to an event delivery attempt in the local listener view in workbench. We pass back the `DeviceToken` now, and use that to construct the URL. Tested this locally and confirmed the URL works as expected

