### PR TITLE
fix: show pretty error when trying to create meter event stream or session

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ The CLI uses the [Cobra library](https://github.com/spf13/cobra) for command str
 
 In addition to the handwritten commands, the CLI also has many auto-generated resources that correspond to base [API resources](https://stripe.com/docs/api/charges). These commands are registered in `pkg/cmd/resources_cmds.go`, calling the generic `NewNamespaceCmd` function for each resource. These auto-generated commands hold no functionality on their own and mostly rely on [operation commands](#operation-commands) to do anything (see below).
 
-The big list of commands found in `resources_cmds.go` is _iself_ is an auto-generated file. It's built by running `pkg/gen/gen_resource_cmds.go`, which gets a big list of resources from OpenAPI via `api/openapi-spec/spec3.sdk.json` and generates the big command file via the `pkg/gen/resources_cmds.go.tpl` template. Generated commands can be manually overridden, as we do with `pkg/cmd/resource/events.go` taking precedence over the generated `events` command.
+The big list of commands found in `resources_cmds.go` is _itself_ an auto-generated file. It's built by running `pkg/gen/gen_resource_cmds.go`, which gets a big list of resources from OpenAPI via `api/openapi-spec/spec3.sdk.json` and generates the big command file via the `pkg/gen/resources_cmds.go.tpl` template. Generated commands can be manually overridden, as we do with `pkg/cmd/resource/events.go` taking precedence over the generated `events` command.
 
 ### Operation Commands
 

--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -3,11 +3,12 @@ package resource
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/requests"
@@ -143,7 +144,7 @@ func NewUnsupportedV2BillingOperationCmd(parentCmd *cobra.Command, name string, 
 * Hint: If you're trying to test webhook events, you can always use %s or %s.
 			`
 
-			fmt.Println(fmt.Sprintf(output, ansi.Bold(path), ansi.Linkify("Dashboard", "https://dashboard.stripe.com", log.StandardLogger().Out), parentCmd.Name(), ansi.Bold("stripe trigger v1.billing.meter.no_meter_found"), ansi.Bold("stripe trigger v1.billing.meter.error_report_triggered")))
+			fmt.Println(fmt.Sprintf(output, ansi.Bold(path), ansi.Linkify("Dashboard", "https://dashboard.stripe.com", os.Stdout), parentCmd.Name(), ansi.Bold("stripe trigger v1.billing.meter.no_meter_found"), ansi.Bold("stripe trigger v1.billing.meter.error_report_triggered")))
 		},
 	}
 	parentCmd.AddCommand(cmd)

--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/requests"
@@ -129,6 +129,26 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 //
 // Public functions
 //
+
+// NewUnsupportedV2BillingOperationCmd returns a new cobra command for an unsupported v2 billing command.
+// This is temporary until resource commands support the /v2/billing namespace.
+func NewUnsupportedV2BillingOperationCmd(parentCmd *cobra.Command, name string, path string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         name,
+		Annotations: make(map[string]string),
+		Run: func(cmd *cobra.Command, args []string) {
+			output := `
+%s is not supported by Stripe CLI yet. Please use the %s or cURL to create a %s, instead.
+
+* Hint: If you're trying to test webhook events, you can always use %s or %s.
+			`
+
+			fmt.Println(fmt.Sprintf(output, ansi.Bold(path), ansi.Linkify("Dashboard", "https://dashboard.stripe.com", log.StandardLogger().Out), parentCmd.Name(), ansi.Bold("stripe trigger v1.billing.meter.no_meter_found"), ansi.Bold("stripe trigger v1.billing.meter.error_report_triggered")))
+		},
+	}
+	parentCmd.AddCommand(cmd)
+	return cmd
+}
 
 // NewOperationCmd returns a new OperationCmd.
 func NewOperationCmd(parentCmd *cobra.Command, name, path, httpVerb string, propFlags map[string]string, cfg *config.Config) *OperationCmd {

--- a/pkg/cmd/resources_cmds.go
+++ b/pkg/cmd/resources_cmds.go
@@ -107,6 +107,8 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	rBillingMeterEventSummarysCmd := resource.NewResourceCmd(nsBillingCmd.Cmd, "meter_event_summarys")
 	rBillingMeterEventsCmd := resource.NewResourceCmd(nsBillingCmd.Cmd, "meter_events")
 	rBillingMetersCmd := resource.NewResourceCmd(nsBillingCmd.Cmd, "meters")
+	rBillingMeterEventSessionCmd := resource.NewResourceCmd(nsBillingCmd.Cmd, "meter_event_session")
+	rBillingMeterEventStreamCmd := resource.NewResourceCmd(nsBillingCmd.Cmd, "meter_event_stream")
 	rBillingPortalConfigurationsCmd := resource.NewResourceCmd(nsBillingPortalCmd.Cmd, "configurations")
 	rBillingPortalSessionsCmd := resource.NewResourceCmd(nsBillingPortalCmd.Cmd, "sessions")
 	rCheckoutSessionsCmd := resource.NewResourceCmd(nsCheckoutCmd.Cmd, "sessions")
@@ -3246,6 +3248,8 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rBillingMetersCmd.Cmd, "update", "/v1/billing/meters/{id}", http.MethodPost, map[string]string{
 		"display_name": "string",
 	}, &Config)
+	resource.NewUnsupportedV2BillingOperationCmd(rBillingMeterEventSessionCmd.Cmd, "create", "/v2/billing/meter_event_session")
+	resource.NewUnsupportedV2BillingOperationCmd(rBillingMeterEventStreamCmd.Cmd, "create", "/v2/billing/meter_event_stream")
 	resource.NewOperationCmd(rBillingPortalConfigurationsCmd.Cmd, "create", "/v1/billing_portal/configurations", http.MethodPost, map[string]string{
 		"business_profile.headline":                                "string",
 		"business_profile.privacy_policy_url":                      "string",

--- a/pkg/cmd/resources_cmds.go
+++ b/pkg/cmd/resources_cmds.go
@@ -107,8 +107,6 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	rBillingMeterEventSummarysCmd := resource.NewResourceCmd(nsBillingCmd.Cmd, "meter_event_summarys")
 	rBillingMeterEventsCmd := resource.NewResourceCmd(nsBillingCmd.Cmd, "meter_events")
 	rBillingMetersCmd := resource.NewResourceCmd(nsBillingCmd.Cmd, "meters")
-	rBillingMeterEventSessionCmd := resource.NewResourceCmd(nsBillingCmd.Cmd, "meter_event_session")
-	rBillingMeterEventStreamCmd := resource.NewResourceCmd(nsBillingCmd.Cmd, "meter_event_stream")
 	rBillingPortalConfigurationsCmd := resource.NewResourceCmd(nsBillingPortalCmd.Cmd, "configurations")
 	rBillingPortalSessionsCmd := resource.NewResourceCmd(nsBillingPortalCmd.Cmd, "sessions")
 	rCheckoutSessionsCmd := resource.NewResourceCmd(nsCheckoutCmd.Cmd, "sessions")
@@ -3248,8 +3246,6 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	resource.NewOperationCmd(rBillingMetersCmd.Cmd, "update", "/v1/billing/meters/{id}", http.MethodPost, map[string]string{
 		"display_name": "string",
 	}, &Config)
-	resource.NewUnsupportedV2BillingOperationCmd(rBillingMeterEventSessionCmd.Cmd, "create", "/v2/billing/meter_event_session")
-	resource.NewUnsupportedV2BillingOperationCmd(rBillingMeterEventStreamCmd.Cmd, "create", "/v2/billing/meter_event_stream")
 	resource.NewOperationCmd(rBillingPortalConfigurationsCmd.Cmd, "create", "/v1/billing_portal/configurations", http.MethodPost, map[string]string{
 		"business_profile.headline":                                "string",
 		"business_profile.privacy_policy_url":                      "string",

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -204,6 +204,7 @@ func init() {
 	rootCmd.AddCommand(newCommunityCmd().cmd)
 	rootCmd.AddCommand(newPluginCmd().cmd)
 	addAllResourcesCmds(rootCmd)
+	addV2BillingStubs(rootCmd)
 
 	err := resource.PostProcessResourceCommands(rootCmd, &Config)
 	if err != nil {
@@ -224,4 +225,16 @@ func init() {
 			rootCmd.AddCommand(newPluginTemplateCmd(&Config, &plugin).cmd)
 		}
 	}
+}
+
+func addV2BillingStubs(rootCmd *cobra.Command) {
+	cmd, _, err := rootCmd.Find([]string{"billing"})
+	if err != nil {
+		// silently fail
+		return
+	}
+	rBillingMeterEventSessionCmd := resource.NewResourceCmd(cmd, "meter_event_session")
+	rBillingMeterEventStreamCmd := resource.NewResourceCmd(cmd, "meter_event_stream")
+	resource.NewUnsupportedV2BillingOperationCmd(rBillingMeterEventSessionCmd.Cmd, "create", "/v2/billing/meter_event_session")
+	resource.NewUnsupportedV2BillingOperationCmd(rBillingMeterEventStreamCmd.Cmd, "create", "/v2/billing/meter_event_stream")
 }

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -110,3 +110,13 @@ func TestReadProjectFlagHasPrecedence(t *testing.T) {
 
 	require.Equal(t, Config.Profile.ProfileName, "from-flag")
 }
+
+func TestV2BillingOverrides(t *testing.T) {
+	Execute(context.Background())
+
+	output, err := executeCommand(rootCmd, "billing")
+
+	require.Contains(t, output, "meter_event_session")
+	require.Contains(t, output, "meter_event_stream")
+	require.NoError(t, err)
+}


### PR DESCRIPTION


 ### Reviewers
r? @stripe/developer-products 
cc @stripe/developer-products

 ### Summary

These paths aren't supported yet, but we want to throw a helpful error until they are

<img width="821" alt="Screenshot 2024-09-16 at 11 38 17 AM" src="https://github.com/user-attachments/assets/0e8f7fa5-8161-4920-8e5d-c5e821eeb6c7">

