### PR TITLE
fix: use meter-events.stripe.com instead of events.stripe.com

### DIFF
--- a/pkg/fixtures/triggers/v1.billing.meter.error_report_triggered.json
+++ b/pkg/fixtures/triggers/v1.billing.meter.error_report_triggered.json
@@ -48,7 +48,7 @@
       "name": "create_billing_meter_event_stream",
       "path": "/v2/billing/meter_event_stream",
       "method": "post",
-      "api_base": "https://events.stripe.com",
+      "api_base": "https://meter-events.stripe.com",
       "headers": {
         "Content-Type": "application/json",
         "Stripe-Version": "unsafe-development",

--- a/pkg/fixtures/triggers/v1.billing.meter.no_meter_found.json
+++ b/pkg/fixtures/triggers/v1.billing.meter.no_meter_found.json
@@ -17,7 +17,7 @@
       "name": "create_billing_meter_event_stream",
       "path": "/v2/billing/meter_event_stream",
       "method": "post",
-      "api_base": "https://events.stripe.com",
+      "api_base": "https://meter-events.stripe.com",
       "headers": {
         "Content-Type": "application/json",
         "Stripe-Version": "unsafe-development",


### PR DESCRIPTION
 ### Reviewers
cc @stripe/developer-products

 ### Summary

https://docs.google.com/document/d/1wznFRwI90rgKjzW6IyYzYFK91Ms5sjMX3434AQ2hdOI/edit#heading=h.hze9u5lv7gvp
