### PR TITLE
Add support for STRIPE_API_KEY in .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ default_cassette.yaml
 .vscode/*.log
 stripe-completion.bash
 stripe-completion.zsh
+.env


### PR DESCRIPTION
 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
Add support for using a .env file in the current directory that contains the STRIPE_API_KEY key/value.

Addresses #653 
