### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -131,7 +131,7 @@ func ParseToFormData(params interface{}, queryRespMap map[string]gjson.Result) (
 // each leaf node has a terminal type (String, Int, etc) that can no
 // longer be recursively traversed.
 func ParseMapForFormData(params map[string]interface{}, parent string, index int, queryRespMap map[string]gjson.Result) ([]string, error) {
-	data := make([]string, len(params))
+	data := make([]string, 0, len(params))
 
 	var keyname string
 


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->


The intention here should be to initialize a slice with a capacity of   `len(params)`  rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW
