### PR TITLE
use localhost for serve command

### DIFF
--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -42,7 +42,7 @@ func newServeCmd() *serveCmd {
 
 			fmt.Println("Starting static file server at address", fmt.Sprintf("http://localhost:%s", port))
 			http.Handle("/", http.FileServer(http.Dir(absoluteDir)))
-			return http.ListenAndServe(fmt.Sprintf(":%s", port), handlers.LoggingHandler(os.Stdout, http.DefaultServeMux))
+			return http.ListenAndServe(fmt.Sprintf("localhost:%s", port), handlers.LoggingHandler(os.Stdout, http.DefaultServeMux))
 		},
 	}
 


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

`http.ListenAndServe` doesn't use specifically localhost unless you set it in the address. I verified this with `netstat -an | grep 4242`.