### PR TITLE
fix: show connected account ID if deleting a connected account's resource

### DIFF
--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -112,6 +112,10 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 		if displayName != "" {
 			fmt.Printf("> Account Name: %s\n", displayName)
 		}
+		if strings.HasPrefix(path, "/v1/accounts/") {
+			connectedAccountID := strings.Split(path, "/")[3]
+			fmt.Printf("> Connected Account: %s\n", connectedAccountID)
+		}
 
 		// call the confirm command from base request
 		confirmation, err := oc.Confirm()


### PR DESCRIPTION

 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary

Gives clarity when operating on connected accounts. there are 3 APIs that will result in showing this:

- DELETE `/v1/accounts/:id`
- DELETE `/v1/accounts/:id/external_accounts/:id`
- DELETE `/v1/accounts/:id/persons/:id`

```
❯ stripe-dev accounts delete acct_123123123

This command will be executed on the account with the following details:
> Mode: Test
> Account Name: Merchant's Display Name
> Connected Account: acct_123123123
Are you sure you want to perform the command: DELETE?
Enter 'yes' to confirm: 
```