### PR TITLE
Adds the capability to alias resource names and aliases line_items -> invoice_line_items

### DIFF
--- a/pkg/cmd/resource/alias.go
+++ b/pkg/cmd/resource/alias.go
@@ -11,6 +11,7 @@ var aliasedCmds = map[string]string{
 	"line_item": "invoice_line_item",
 }
 
+// GetCmdAlias retrieves the alias for a given resource, if one is present; otherwise returns ""
 func GetCmdAlias(principle string) string {
 	alias, ok := aliasedCmds[principle]
 	if !ok {
@@ -19,13 +20,16 @@ func GetCmdAlias(principle string) string {
 	return alias
 }
 
+// GetAliases retrieves the entire alias map, useful for testing
 func GetAliases() map[string]string {
 	return aliasedCmds
 }
 
+// HideAliasedCommands performs the post-processing on the command tree to hide
+// resources that have an alias
 func HideAliasedCommands(rootCmd *cobra.Command) {
 	for _, cmd := range rootCmd.Commands() {
-		for principle, _ := range aliasedCmds {
+		for principle := range aliasedCmds {
 			formattedPrinciple := GetResourceCmdName(principle)
 			if cmd.Use == formattedPrinciple {
 				cmd.Hidden = true

--- a/pkg/cmd/resource/alias.go
+++ b/pkg/cmd/resource/alias.go
@@ -1,0 +1,35 @@
+package resource
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Aliases are mapped from resource name in the OpenAPI spec -> friendly name in the CLI
+// Each alias causes a second resource command (the target / friendly name) to be generated, and uses post-processing
+// to hide the principle resource name (OpenAPI spec)
+var aliasedCmds = map[string]string{
+	"line_item": "invoice_line_item",
+}
+
+func GetCmdAlias(principle string) string {
+	alias, ok := aliasedCmds[principle]
+	if !ok {
+		return ""
+	}
+	return alias
+}
+
+func GetAliases() map[string]string {
+	return aliasedCmds
+}
+
+func HideAliasedCommands(rootCmd *cobra.Command) {
+	for _, cmd := range rootCmd.Commands() {
+		for principle, _ := range aliasedCmds {
+			formattedPrinciple := GetResourceCmdName(principle)
+			if cmd.Use == formattedPrinciple {
+				cmd.Hidden = true
+			}
+		}
+	}
+}

--- a/pkg/cmd/resource/resource.go
+++ b/pkg/cmd/resource/resource.go
@@ -133,5 +133,7 @@ func PostProcessResourceCommands(rootCmd *cobra.Command, cfg *config.Config) err
 		return err
 	}
 
+	HideAliasedCommands(rootCmd)
+
 	return nil
 }

--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -28,7 +28,7 @@ func newResourcesCmd() *resourcesCmd {
 
 func getResourcesHelpTemplate() string {
 	// This template uses `.Parent` to access subcommands on the root command.
-	return fmt.Sprintf(`%s{{range $index, $cmd := .Parent.Commands}}{{if (or (eq (index $.Parent.Annotations $cmd.Name) "resource") (eq (index $.Parent.Annotations $cmd.Name) "namespace"))}}
+	return fmt.Sprintf(`%s{{range $index, $cmd := .Parent.Commands}}{{if (and (not $cmd.Hidden) (or (eq (index $.Parent.Annotations $cmd.Name) "resource") (eq (index $.Parent.Annotations $cmd.Name) "namespace")))}}
   {{rpad $cmd.Name $cmd.NamePadding }} {{$cmd.Short}}{{end}}{{end}}
 
 Use "stripe [command] --help" for more information about a command.

--- a/pkg/cmd/resources_cmds.go
+++ b/pkg/cmd/resources_cmds.go
@@ -62,6 +62,7 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 	rFeeRefundsCmd := resource.NewResourceCmd(rootCmd, "fee_refunds")
 	rFileLinksCmd := resource.NewResourceCmd(rootCmd, "file_links")
 	rFilesCmd := resource.NewResourceCmd(rootCmd, "files")
+	rInvoiceLineItemsCmd := resource.NewResourceCmd(rootCmd, "invoice_line_items")
 	rInvoiceRenderingTemplatesCmd := resource.NewResourceCmd(rootCmd, "invoice_rendering_templates")
 	rInvoiceitemsCmd := resource.NewResourceCmd(rootCmd, "invoiceitems")
 	rInvoicesCmd := resource.NewResourceCmd(rootCmd, "invoices")
@@ -1189,6 +1190,30 @@ func addAllResourcesCmds(rootCmd *cobra.Command) {
 		"starting_after": "string",
 	}, &Config)
 	resource.NewOperationCmd(rFilesCmd.Cmd, "retrieve", "/v1/files/{file}", http.MethodGet, map[string]string{}, &Config)
+	resource.NewOperationCmd(rInvoiceLineItemsCmd.Cmd, "list", "/v1/invoices/{invoice}/lines", http.MethodGet, map[string]string{
+		"ending_before":  "string",
+		"limit":          "integer",
+		"starting_after": "string",
+	}, &Config)
+	resource.NewOperationCmd(rInvoiceLineItemsCmd.Cmd, "update", "/v1/invoices/{invoice}/lines/{line_item_id}", http.MethodPost, map[string]string{
+		"amount":                              "integer",
+		"description":                         "string",
+		"discountable":                        "boolean",
+		"period.end":                          "integer",
+		"period.start":                        "integer",
+		"price":                               "string",
+		"price_data.currency":                 "string",
+		"price_data.product":                  "string",
+		"price_data.product_data.description": "string",
+		"price_data.product_data.images":      "array",
+		"price_data.product_data.name":        "string",
+		"price_data.product_data.tax_code":    "string",
+		"price_data.tax_behavior":             "string",
+		"price_data.unit_amount":              "integer",
+		"price_data.unit_amount_decimal":      "string",
+		"quantity":                            "integer",
+		"tax_rates":                           "array",
+	}, &Config)
 	resource.NewOperationCmd(rInvoiceRenderingTemplatesCmd.Cmd, "archive", "/v1/invoice_rendering_templates/{template}/archive", http.MethodPost, map[string]string{}, &Config)
 	resource.NewOperationCmd(rInvoiceRenderingTemplatesCmd.Cmd, "list", "/v1/invoice_rendering_templates", http.MethodGet, map[string]string{
 		"ending_before":  "string",

--- a/pkg/cmd/resources_test.go
+++ b/pkg/cmd/resources_test.go
@@ -51,9 +51,11 @@ func TestAliasedResourcesCallPrincipleAPI(t *testing.T) {
 	defer ts.Close()
 
 	apiBase := fmt.Sprintf("--api-base=%s", ts.URL)
-	_, err := executeCommand(rootCmd, apiBase, "invoice_line_items", "list", "in_123")
+	apiKey := "--api-key=rk_test_1234567890"
+
+	_, err := executeCommand(rootCmd, apiBase, apiKey, "invoice_line_items", "list", "in_123")
 	require.NoError(t, err)
-	_, err = executeCommand(rootCmd, apiBase, "line_items", "list", "in_123")
+	_, err = executeCommand(rootCmd, apiBase, apiKey, "line_items", "list", "in_123")
 	require.NoError(t, err)
 }
 

--- a/pkg/cmd/resources_test.go
+++ b/pkg/cmd/resources_test.go
@@ -1,9 +1,16 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stripe/stripe-cli/pkg/cmd/resource"
 
 	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/require"
@@ -19,6 +26,34 @@ func TestResources(t *testing.T) {
 	output, err := executeCommand(rootCmd, "resources")
 
 	require.Contains(t, output, "Available commands:")
+	require.NoError(t, err)
+}
+
+func TestResourcesListAliasedName(t *testing.T) {
+	output, err := executeCommand(rootCmd, "resources")
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "Available commands:")
+
+	aliases := resource.GetAliases()
+	for principle, alias := range aliases {
+		aliasRegexp := fmt.Sprintf("\n\\s+%s(s?)\\s+\n", resource.GetResourceCmdName(alias))
+		principleRegexp := fmt.Sprintf("\n\\s+%s(s?)\\s+\n", resource.GetResourceCmdName(principle))
+		assert.Regexp(t, regexp.MustCompile(aliasRegexp), output)
+		assert.NotRegexp(t, regexp.MustCompile(principleRegexp), output)
+	}
+}
+
+func TestAliasedResourcesCallPrincipleAPI(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.URL.Path, "/v1/invoices/in_123/lines")
+	}))
+	defer ts.Close()
+
+	apiBase := fmt.Sprintf("--api-base=%s", ts.URL)
+	_, err := executeCommand(rootCmd, apiBase, "invoice_line_items", "list", "in_123")
+	require.NoError(t, err)
+	_, err = executeCommand(rootCmd, apiBase, "line_items", "list", "in_123")
 	require.NoError(t, err)
 }
 

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -25,6 +25,9 @@ func executeCommandC(root *cobra.Command, args ...string) (c *cobra.Command, out
 
 	c, err = root.ExecuteC()
 
+	// Resets args for the next test run to avoid arguments for flags being carried over
+	root.SetArgs([]string{})
+
 	return c, buf.String(), err
 }
 


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
This change adds the ability to alias resources so that they are renamed in the CLI's resource list. This allows resources to effectively be renamed, while preserving backwards compatibility by supporting the "principle" (e.g. OpenAPI spec) name but hiding that name from help text output.

The first consumer of this feature is invoice line items. Today, the CLI supports these under the name `line_items`, which differs from how the same resource is accessed in the Stripe Shell and Workbench (there it's `invoice_line_items`). It's also just not a very descriptive name -- there's the notion of line items in at least one other API (credit notes), and not having the `invoice_` prefix separates this resource from its other invoicing siblings in the help text output.

As of this PR, `line_items` does not show up in the resource list and `invoice_line_items` does:

![image](https://github.com/user-attachments/assets/f99d30c1-559f-4248-adf1-dac2e35cbe0d)

The CLI generates two resources in the case of an alias: one for the principle/original resource (from the openapi spec), and one for the alias name. The principle resource is then hidden using post-processing but still works for compatibility. They hit the same underlying API:

![image](https://github.com/user-attachments/assets/c36782a3-fc83-4f27-97a1-02d014e38a14)

I added a couple tests to ensure that aliased names show up and original names don't, and that original and aliased resources hit the same underlying API endpoint.