### PR TITLE
Adds sanitization of request log data on output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 )
 
 require (
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-plugin v1.4.4
@@ -55,7 +56,6 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
-	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/logs/tail_test.go
+++ b/pkg/cmd/logs/tail_test.go
@@ -1,0 +1,122 @@
+package logs
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-cli/pkg/logtailing"
+)
+
+func hasZeroValueString(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if hasZeroValueString(v.Field(i)) {
+				return true
+			}
+		}
+		return false
+	case reflect.String:
+		return v.IsZero()
+	default:
+		return false
+	}
+}
+
+func containsZeroValueStrings(x interface{}) bool {
+	v := reflect.ValueOf(x)
+
+	// If it's a pointer, dereference it
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	if !v.IsValid() {
+		return true
+	}
+
+	return hasZeroValueString(v)
+}
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "does not change basic strings",
+			input:    "GET",
+			expected: "GET",
+		},
+		{
+			name:     "removes ansi escape codes",
+			input:    "\x0d\x0a\x1b[90mvery cool\x0d\x0a\x1b[32m and very legal",
+			expected: "very cool and very legal",
+		},
+		{
+			name:     "removes newlines",
+			input:    "\x0d\x0a\x1b[90mvery cool",
+			expected: "very cool",
+		},
+		{
+			name:     "removes both ansi escape codes and newlines",
+			input:    "\x0d\x0a\x1b[90ma horse\r\n a dog\n a cat\x0d\x0a\x1b[32m and a bird",
+			expected: "a horse a dog a cat and a bird",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := sanitize(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestSanitizePayload(t *testing.T) {
+	withAnsi := func(s string) string {
+		return fmt.Sprintf("\x1b[90m%s\x1b[0m", s)
+	}
+
+	payload := logtailing.EventPayload{
+		Error: logtailing.RedactedError{
+			Charge:       withAnsi("ch_123"),
+			Code:         withAnsi("invlaid_argument"),
+			DeclineCode:  withAnsi("card_declined"),
+			ErrorInsight: withAnsi("make fewer errors"),
+			Message:      withAnsi("an error occurred"),
+			Param:        withAnsi("card"),
+			Type:         withAnsi("invalid_request"),
+		},
+		Method:    withAnsi("POST"),
+		RequestID: withAnsi("req_123"),
+		URL:       withAnsi("https://example.com"),
+	}
+
+	expected := logtailing.EventPayload{
+		Error: logtailing.RedactedError{
+			Charge:       "ch_123",
+			Code:         "invlaid_argument",
+			DeclineCode:  "card_declined",
+			ErrorInsight: "make fewer errors",
+			Message:      "an error occurred",
+			Param:        "card",
+			Type:         "invalid_request",
+		},
+		Method:    "POST",
+		RequestID: "req_123",
+		URL:       "https://example.com",
+	}
+
+	// Ensures that we're testing/covering the entire payload in case
+	// any new fields are added
+	require.Equal(t, containsZeroValueStrings(payload), false)
+
+	sanitizePayload(&payload)
+
+	assert.Equal(t, expected, payload)
+}

--- a/pkg/cmd/logs/tail_test.go
+++ b/pkg/cmd/logs/tail_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/stripe/stripe-cli/pkg/logtailing"
 )
 


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products

 ### Summary
This PR adds some basic sanitization of the output of `stripe logs tail`, as elements of this output can be influenced by user input. Also adds a few tests for the behavior added.
