### PR TITLE
[actions] fail package manager action if paging

### DIFF
--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -72,6 +72,7 @@ then
                 if ! run_install
                 then
                 trigger_pagerduty_alert
+                exit 1
                 fi
             fi
         fi


### PR DESCRIPTION
 ### Reviewers
r? @ianjabour-stripe 

 ### Summary

if we fail to install multiple times and trigger an alert, we should also set the status of the GH action to 'failed' by exiting with code 1
