### PR TITLE
update go version for goreleaser to 1.22.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22.0
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.22.0
       - name: Run GoReleaser Snapshot
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Followup to https://github.com/stripe/stripe-cli/pull/1287
Goreleaser fails during the release action because it can't read the go.mod file: https://github.com/stripe/stripe-cli/actions/runs/12898751838/job/35966371903
I'm hoping updating this to 1.22.0 will fix this