### PR TITLE
Downgrade release action ubuntu version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           GORELEASER_GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
 
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       # https://goreleaser.com/customization/docker_manifest/
       DOCKER_CLI_EXPERIMENTAL: "enabled"


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
The latest release action fails when trying to upload to artificatory: https://github.com/stripe/stripe-cli/actions/runs/12899742651. Checking the logs reveals the publish-to-artificatory.sh script never made any request to artifcatory.

There aren't any related changes in our repo between this release ([v1.23.5](https://github.com/stripe/stripe-cli/actions/runs/12899742651)) and the last successful one ([v1.23.3](https://github.com/stripe/stripe-cli/actions/runs/12420963875)). The only difference I could find between these two was that ubuntu-latest has been updated from 22.04 to 24.04, which I confirmed in the GitHub actions logs. This pins it to the older version to confirm if this is the cause of the failure.