### PR TITLE
Fix goreleaser docker config

### DIFF
--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -71,7 +71,6 @@ dockers:
     goos: linux
     goarch: amd64
     ids:
-      - stripe
       - stripe-linux
     image_templates:
       - "stripe/stripe-cli:latest-amd64"
@@ -89,7 +88,6 @@ dockers:
     goos: linux
     goarch: arm64
     ids:
-      - stripe
       - stripe-linux-arm
     image_templates:
       - "stripe/stripe-cli:latest-arm64"


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Fix error releasing to docker: https://github.com/stripe/stripe-cli/actions/runs/12919228652/job/36029305762

When run locally, I now get this:
```
goreleaser release --skip=publish --clean --config ./.goreleaser/linux.yml --snapshot
  • skipping announce, publish and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=059befeb3a80ae37e63c84a64a8be9dde0f221c4 branch=master current_tag=v1.23.7 previous_tag=v1.23.6 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=1.23.7-next
  • running before hooks
    • running                                        hook=go mod download
    • running                                        hook=go generate ./...
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/stripe-linux-arm_linux_arm64_v8.0/stripe
    • building                                       binary=dist/stripe-linux_linux_amd64_v1/stripe
  • archives
    • archiving                                      name=dist/stripe_1.23.7-next_linux_x86_64.tar.gz
    • archiving                                      name=dist/stripe_1.23.7-next_linux_arm64.tar.gz
    • no files matched                               glob=none*
    • no files matched                               glob=none*
  • linux packages
    • creating                                       package=stripe format=deb arch=amd64v1 file=dist/stripe_1.23.7-next_linux_amd64.deb
    • creating                                       package=stripe format=deb arch=arm64v8.0 file=dist/stripe_1.23.7-next_linux_arm64.deb
    • creating                                       package=stripe format=rpm arch=amd64v1 file=dist/stripe_1.23.7-next_linux_amd64.rpm
    • creating                                       package=stripe format=rpm arch=arm64v8.0 file=dist/stripe_1.23.7-next_linux_arm64.rpm
  • calculating checksums
  • docker images
    • building docker image                          image=stripe/stripe-cli:latest-arm64
    • building docker image                          image=stripe/stripe-cli:latest-amd64
  • writing artifacts metadata
  • release succeeded after 15s
  • thanks for using GoReleaser!
```