### PR TITLE
fix: remove extra character typo in product.deleted fixture trigger json description

### DIFF
--- a/pkg/fixtures/triggers/product.deleted.json
+++ b/pkg/fixtures/triggers/product.deleted.json
@@ -9,7 +9,7 @@
       "method": "post",
       "params": {
         "name": "myproduct",
-        "description": "(created by Stripe CLI)t"
+        "description": "(created by Stripe CLI)"
       }
     },
     {


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
I noticed a very minor extra character typo in the `product.deleted` fixture json description.

I am unsure if it was worth adding as an issue before such a small change - apologies in advance if I should have.