### PR TITLE
Add `preview v2` command support

### DIFF
--- a/pkg/gen/resources_cmds.go.tpl
+++ b/pkg/gen/resources_cmds.go.tpl
@@ -11,9 +11,11 @@ import (
 )
 
 func addAllResourcesCmds(rootCmd *cobra.Command) {
-	{{ range $specVersion, $vData := .Versions }}{{ if eq $specVersion "v1" }}v1root := rootCmd{{ else }}
+	{{ range $specVersion, $vData := .Versions }}{{ if eq $specVersion "v1" }}v1root := rootCmd{{ else if eq $specVersion "v2-preview" }}
+	previewRoot := resource.NewNamespaceCmd(rootCmd, "preview").Cmd
+	previewV2Root := resource.NewNamespaceCmd(previewRoot, "v2").Cmd{{ else }}
 	{{ $specVersion }}root := resource.NewNamespaceCmd(rootCmd, "{{ $specVersion }}").Cmd{{ end }}
-	add{{ $specVersion | ToCamel }}ResourcesCmds({{ $specVersion }}root){{ end }}
+	add{{ $specVersion | ToCamel }}ResourcesCmds({{ if eq $specVersion "v2-preview" }}previewV2Root{{ else }}{{ $specVersion }}root{{ end }}){{ end }}
 }
 
 {{ range $specVersion, $vData := .Versions }}

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -288,7 +288,7 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 	body, err := io.ReadAll(resp.Body)
 
 	if resp.StatusCode == 401 || (errOnStatus && resp.StatusCode >= 300) {
-		requestError := compileRequestError(body, resp.StatusCode, stripe.IsV2Path(path))
+		requestError := compileRequestError(body, resp.StatusCode)
 		return []byte{}, requestError
 	}
 
@@ -304,7 +304,7 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 	return body, nil
 }
 
-func compileRequestError(body []byte, statusCode int, isV2 bool) RequestError {
+func compileRequestError(body []byte, statusCode int) RequestError {
 	type requestErrorContent struct {
 		Code string `json:"code"`
 		Type string `json:"type"`
@@ -318,10 +318,6 @@ func compileRequestError(body []byte, statusCode int, isV2 bool) RequestError {
 	json.Unmarshal(body, &errorBody)
 
 	msg := "Request failed"
-	if statusCode == 401 && isV2 {
-		msg = "V2 commands must be run with a secret API key (starts with 'sk_')"
-	}
-
 	return RequestError{
 		msg:        msg,
 		StatusCode: statusCode,


### PR DESCRIPTION
 ### Reviewers
r? @etsai2-stripe 
cc @stripe/developer-products

 ### Summary
Adds support for `preview` APIs in the CLI:
```
➜ ./stripe preview v2 --help
Usage:
  stripe preview v2 <resource> <operation> [parameters...]

Available Resources:
  ...
  billing
  core
  test_helpers
  ...
  ```