### PR TITLE
fix: duplicate config initialization

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -219,9 +219,6 @@ func init() {
 		log.Fatal(err)
 	}
 
-	// config is not initialized by cobra at this point, so we need to temporarily initialize it
-	Config.InitConfig()
-
 	// get a list of installed plugins, validate against the manifest
 	// and finally add each validated plugin as a command
 	nfs := afero.NewOsFs()

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -79,7 +79,7 @@ func (a *Authenticator) Login(ctx context.Context, links *Links) error {
 
 			message, err := SuccessMessage(ctx, res.Account, stripe.DefaultAPIBaseURL, res.TestModeAPIKey)
 			if err != nil {
-				fmt.Printf("> Error verifying the CLI was set up successfully: %s\n", err)
+				fmt.Printf("> Error verifying if the CLI was set up successfully: %s\n", err)
 				return err
 			}
 

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -76,7 +76,7 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 		return nil, err
 	}
 
-	// if path starts with v1
+	// if path starts with v2
 	if IsV2Path(path) {
 		req.Header.Set("Content-Type", V2ContentType)
 	} else {


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
The config was being initialized twice which was unnecessary (see below redundant calls to `Config.InitConfig()`)
First in Cobra OnInitialize
```go
cobra.OnInitialize(Config.InitConfig, ReBindKeys)
```

then again, later in the `init()` function in `cmd/pkg/root.go` - which is redundant as cobra has already initialized it
```go
// config is not initialized by cobra at this point, so we need to temporarily initialize it
Config.InitConfig()
```


