### PR TITLE
Add an error if a user tries to run listen in an org

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -135,6 +135,12 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if strings.Contains(key, "sk_org") {
+		log.Errorf("The listen command is not supported in an organization sandbox at this time.")
+		return nil
+	}
+
 	apiBase, err := url.Parse(lc.apiBaseURL)
 	if err != nil {
 		return fmt.Errorf("failed to parse API base url: %w", err)


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
The CLI listen command isn't supported by orgs so add a more explicit error when a user tries to run it with an org API key.

```
➜ ./stripe listen
[Mon, 28 Apr 2025 09:32:23 PDT] ERROR The listen command does not support organizations at this time.
```