### PR TITLE
Add support for number-based flags

### DIFF
--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -180,6 +180,8 @@ func NewOperationCmd(parentCmd *cobra.Command, name, path, httpVerb string,
 			operationCmd.arrayFlags[flagName] = cmd.Flags().StringArray(flagName, []string{}, description)
 		case "string":
 			operationCmd.stringFlags[flagName] = cmd.Flags().String(flagName, "", description)
+		case "number":
+			operationCmd.stringFlags[flagName] = cmd.Flags().String(flagName, "", description)
 		case "integer":
 			operationCmd.integerFlags[flagName] = cmd.Flags().Int(flagName, -1, description)
 		case "boolean":

--- a/pkg/cmd/resource/operation_test.go
+++ b/pkg/cmd/resource/operation_test.go
@@ -32,6 +32,35 @@ func TestNewOperationCmd(t *testing.T) {
 	require.Contains(t, oc.Cmd.UsageTemplate(), "<id>")
 }
 
+func TestNewOperationCmd_NumberType(t *testing.T) {
+	parentCmd := &cobra.Command{Annotations: make(map[string]string)}
+
+	oc := NewOperationCmd(parentCmd, "create", "/v1/test", http.MethodPost, map[string]string{
+		"percentage":   "number",
+		"percent_off":  "number",
+		"string_param": "string",
+		"int_param":    "integer",
+		"bool_param":   "boolean",
+	}, map[string][]spec.StripeEnumValue{}, &config.Config{}, false)
+
+	// Check that number type parameters create string flags
+	_, err := oc.Cmd.Flags().GetString("percentage")
+	require.NoError(t, err, "percentage flag should exist as string flag")
+
+	_, err = oc.Cmd.Flags().GetString("percent-off")
+	require.NoError(t, err, "percent-off flag should exist as string flag")
+
+	// Verify other types still work correctly
+	_, err = oc.Cmd.Flags().GetString("string-param")
+	require.NoError(t, err)
+
+	_, err = oc.Cmd.Flags().GetInt("int-param")
+	require.NoError(t, err)
+
+	_, err = oc.Cmd.Flags().GetBool("bool-param")
+	require.NoError(t, err)
+}
+
 func TestRunOperationCmd(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
Fixes #1351 

We were missing a base case for `number` which meant that some flags weren't getting generated. Will look like this now:

```
➜ ./stripe tax_rates create --help
Usage:
  stripe tax_rates create [--param=value] [-d "nested[param]=value"]

Request Parameters:
      --active
      --country
      --description
      --display-name
      --inclusive
      --jurisdiction
      --percentage
      --state
      --tax-type

➜ ./stripe coupons create --help
Usage:
  stripe coupons create [--param=value] [-d "nested[param]=value"]

Request Parameters:
      --amount-off
      --applies-to.products
      --currency
      --duration
      --duration-in-months
      --id
      --max-redemptions
      --name
      --percent-off
      --redeem-by
```