### PR TITLE
Add fixture for llama.created event trigger

### DIFF
--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -80,6 +80,7 @@ var Events = map[string]string{
 	"issuing_cardholder.created":                "triggers/issuing_cardholder.created.json",
 	"issuing_cardholder.created.eu":             "triggers/issuing_cardholder.created.eu.json",
 	"issuing_cardholder.created.gb":             "triggers/issuing_cardholder.created.gb.json",
+	"llama.created":                             "triggers/llama.created.json",
 	"payment_intent.amount_capturable_updated":  "triggers/payment_intent.amount_capturable_updated.json",
 	"payment_intent.created":                    "triggers/payment_intent.created.json",
 	"payment_intent.payment_failed":             "triggers/payment_intent.payment_failed.json",

--- a/pkg/fixtures/triggers/llama.created.json
+++ b/pkg/fixtures/triggers/llama.created.json
@@ -1,0 +1,16 @@
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "llama",
+      "path": "/v2/llamas",
+      "method": "post",
+      "params": {
+        "name": "Stripe CLI Test Llama",
+        "description": "A llama created by Stripe CLI trigger"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds support for triggering llama.created events via the CLI by creating a fixture that makes a POST request to /v2/llamas with basic parameters.


 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
