### PR TITLE
Relax URL regexes for debugging/development

### DIFF
--- a/pkg/stripe/url.go
+++ b/pkg/stripe/url.go
@@ -10,7 +10,7 @@ const (
 	DefaultAPIBaseURL   = "https://api.stripe.com"
 	APIBaseURLRegexp    = `^https:\/\/api\.stripe\.com\/v\d+$`
 	qaAPIBaseURL        = "https://qa-api.stripe.com"
-	devAPIBaseURLRegexp = `http(s)?:\/\/[A-Za-z0-9\-]+api-mydev.dev.stripe.me`
+	devAPIBaseURLRegexp = `http(s)?:\/\/[A-Za-z0-9\-]+.dev.stripe.me`
 
 	// DefaultFilesAPIBaseURL is the default base URL for Files API requsts
 	DefaultFilesAPIBaseURL = "https://files.stripe.com"
@@ -18,7 +18,7 @@ const (
 	// DefaultDashboardBaseURL is the default base URL for dashboard requests
 	DefaultDashboardBaseURL   = "https://dashboard.stripe.com"
 	qaDashboardBaseURL        = "https://qa-dashboard.stripe.com"
-	devDashboardBaseURLRegexp = `http(s)?:\/\/[A-Za-z0-9\-]+manage-mydev\.dev\.stripe\.me`
+	devDashboardBaseURLRegexp = `http(s)?:\/\/[A-Za-z0-9\-]+\.dev\.stripe\.me`
 
 	// localhostURLRegexp is used in tests
 	localhostURLRegexp = `http:\/\/127\.0\.0\.1(:[0-9]+)?`

--- a/pkg/stripe/url_test.go
+++ b/pkg/stripe/url_test.go
@@ -14,6 +14,7 @@ func TestValidateAPIBaseURLWorks(t *testing.T) {
 	assert.Nil(t, ValidateAPIBaseURL("https://qa-api.stripe.com"))
 	assert.Nil(t, ValidateAPIBaseURL("http://foo-api-mydev.dev.stripe.me"))
 	assert.Nil(t, ValidateAPIBaseURL("https://foo-lv5r9y--api-mydev.dev.stripe.me/"))
+	assert.Nil(t, ValidateAPIBaseURL("https://foo-lv5r9y--api-iso.dev.stripe.me"))
 	assert.Nil(t, ValidateAPIBaseURL("http://127.0.0.1"))
 	assert.Nil(t, ValidateAPIBaseURL("http://127.0.0.1:1337"))
 
@@ -29,6 +30,7 @@ func TestValidateDashboardBaseURLWorks(t *testing.T) {
 	assert.Nil(t, ValidateDashboardBaseURL("https://qa-dashboard.stripe.com"))
 	assert.Nil(t, ValidateDashboardBaseURL("http://foo-manage-mydev.dev.stripe.me"))
 	assert.Nil(t, ValidateDashboardBaseURL("https://foo-lv5r9y--manage-mydev.dev.stripe.me/"))
+	assert.Nil(t, ValidateDashboardBaseURL("https://foo-0-lv5r9y--manage-dashboard-proxy-mydev.dev.stripe.me/"))
 	assert.Nil(t, ValidateDashboardBaseURL("http://127.0.0.1"))
 	assert.Nil(t, ValidateDashboardBaseURL("http://127.0.0.1:1337"))
 


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
The URLs we use for development change pretty often, so this makes the regexes for validating the `--api-base` and `--dashboard-base` values less strict. This helps improve the DX, especially for other teams who may have their own specialized workflows.