### PR TITLE
feat: add support for multiple fixture files in fixtures command

### DIFF
--- a/pkg/cmd/fixtures.go
+++ b/pkg/cmd/fixtures.go
@@ -34,7 +34,7 @@ func newFixturesCmd(cfg *config.Config) *FixturesCmd {
 
 	fixturesCmd.Cmd = &cobra.Command{
 		Use:   "fixtures",
-		Args:  validators.ExactArgs(1),
+		Args:  validators.MinimumNArgs(1),
 		Short: "Run fixtures to populate your account with data",
 		Long:  `Run fixtures to populate your account with data`,
 		RunE:  fixturesCmd.runFixturesCmd,
@@ -71,31 +71,34 @@ func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fixture, err := fixtures.NewFixtureFromFile(
-		afero.NewOsFs(),
-		apiKey,
-		fc.stripeAccount,
-		fc.apiBaseURL,
-		args[0],
-		fc.skip,
-		fc.override,
-		fc.add,
-		fc.remove,
-		fc.edit,
-	)
-	if err != nil {
-		return err
-	}
+	// Process each fixture file
+	for _, file := range args {
+		fixture, err := fixtures.NewFixtureFromFile(
+			afero.NewOsFs(),
+			apiKey,
+			fc.stripeAccount,
+			fc.apiBaseURL,
+			file,
+			fc.skip,
+			fc.override,
+			fc.add,
+			fc.remove,
+			fc.edit,
+		)
+		if err != nil {
+			return err
+		}
 
-	_, err = fixture.Execute(cmd.Context(), fc.apiVersion)
+		_, err = fixture.Execute(cmd.Context(), fc.apiVersion)
 
-	if err != nil {
-		return err
-	}
+		if err != nil {
+			return err
+		}
 
-	err = fixture.UpdateEnv()
-	if err != nil {
-		return err
+		err = fixture.UpdateEnv()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/validators/cmds.go
+++ b/pkg/validators/cmds.go
@@ -83,3 +83,28 @@ func MaximumNArgs(num int) cobra.PositionalArgs {
 		return nil
 	}
 }
+
+// MinimumNArgs is a validator for commands to print an error when the provided
+// args are less than the minimum amount
+func MinimumNArgs(num int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		commandPath := getCommandPath(cmd)
+		argument := "positional argument"
+		if num > 1 {
+			argument = "positional arguments"
+		}
+
+		errorMessage := fmt.Sprintf(
+			"`%s` requires at least %d %s. See `%s --help` for supported flags and usage",
+			commandPath,
+			num,
+			argument,
+			commandPath,
+		)
+
+		if len(args) < num {
+			return errors.New(errorMessage)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
- Adds support for multiple fixture files to the `fixtures` command
- Allows users to run multiple fixtures in a single command
- Processes fixture files sequentially in the order provided

## Rationale
Previously, users needed to chain multiple `stripe fixtures` commands using `&&`:
```bash
stripe fixtures ./subscription.created.json && stripe fixtures ./teardown.json
```

This change allows a simpler syntax:
```bash
stripe fixtures ./subscription.created.json ./teardown.json
```

This improves developer experience by reducing repetition and making it easier to run multiple fixtures together.

## Changes Made
- **pkg/cmd/fixtures.go**: 
  - Changed argument validator from `ExactArgs(1)` to `MinimumNArgs(1)` to accept one or more files
  - Added loop to process each fixture file sequentially
  - Each file is executed in order with proper error handling
  
- **pkg/validators/cmds.go**: 
  - Implemented `MinimumNArgs()` validator function
  - Follows the same pattern as existing `MaximumNArgs()` and `ExactArgs()` validators
  - Provides clear error messages when too few arguments are provided

## Test Plan
- Built the CLI successfully on Android/Linux (aarch64)
- Tested help output: `./stripe fixtures --help` displays correctly
- Tested error handling: `./stripe fixtures` shows appropriate error message
- Verified the binary compiles and runs correctly

The implementation maintains backward compatibility - single file usage continues to work as before.

Fixes #910