### PR TITLE
Run scripts on master-passing-tests instead of master

### DIFF
--- a/scripts/sync-openapi-v2.sh
+++ b/scripts/sync-openapi-v2.sh
@@ -4,8 +4,8 @@ set -eu -o pipefail
 pushd "$HOME/stripe/zoolander"
 
 # Pull master.
-echo "Bringing master up to date."
-git checkout master && git pull
+echo "Bringing master-passing-tests up to date."
+git checkout master-passing-tests && git pull
 
 # Grab SHA so we can save this to a file for some kind of "paper trail".
 SHA=$(git rev-parse HEAD)


### PR DESCRIPTION
 ### Reviewers
r? 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Update OpenAPI sync script to checkout master-passing-tests instead of master to avoid temporary build failures on master.