### PR TITLE
refactor: improve stripecli package naming conventions

### DIFF
--- a/scripts/publish-to-artifactory.sh
+++ b/scripts/publish-to-artifactory.sh
@@ -13,6 +13,7 @@ REPO="stripe-cli-$FORMAT"
 PACKAGE="stripe"
 DISTRIBUTIONS="stable"
 COMPONENTS="main"
+FILENAME_BASENAME=$(basename "$FILENAME")
 
 if [ -z "$ARTIFACTORY_SECRET" ]; then
   echo "ARTIFACTORY_SECRET is not set"
@@ -31,11 +32,11 @@ artifactoryUpload () {
       fi
 
       echo "setting deployment to debian repo"
-      UPLOAD_URL="https://stripe.jfrog.io/artifactory/$REPO-local/pool/$PACKAGE/$VERSION/$ARCH/$PACKAGE.deb;deb.distribution=$DISTRIBUTIONS;deb.component=$COMPONENTS;deb.architecture=$ARCH"
+      UPLOAD_URL="https://stripe.jfrog.io/artifactory/$REPO-local/pool/$PACKAGE/$VERSION/$ARCH/$FILENAME_BASENAME;deb.distribution=$DISTRIBUTIONS;deb.component=$COMPONENTS;deb.architecture=$ARCH"
   elif [[ $FORMAT == "rpm" ]]
   then
       echo "setting deployment to rpm repo"
-      UPLOAD_URL="https://stripe.jfrog.io/artifactory/$REPO-local/$PACKAGE/$VERSION/$ARCH/$PACKAGE.rpm"
+      UPLOAD_URL="https://stripe.jfrog.io/artifactory/$REPO-local/$PACKAGE/$VERSION/$ARCH/$FILENAME_BASENAME"
   else
       echo "unrecognised package format"
       exit 1


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Updates the Artifactory publish script to use goreleaser's conventional package filenames instead of hardcoded generic names. 

Users installing via apt install stripe or yum install stripe are unaffected.