### PR TITLE
Downgrade to alpine:3.22 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.22
 RUN apk update && apk upgrade && \
   apk add --no-cache ca-certificates
 COPY stripe /bin/stripe


### PR DESCRIPTION
 ### Reviewers
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

We're trying to release 1.33.1 but it's [failing](https://github.com/stripe/stripe-cli/actions/runs/20240829793/job/58108199908) to build the Docker image:
```
ERROR: lib/apk/exec/busybox-1.37.0-r29.trigger: exited with error 127
```

There's a [known issue](https://gitlab.alpinelinux.org/alpine/aports/-/issues/17775?__goaway_challenge=cookie&__goaway_id=3e691f8ca73ad376f169b7ddde8da460&__goaway_referer=https%3A%2F%2Fwww.google.com%2F) when using alpine 3.23, so this PR updates the Dockerfile to use 3.22. We can switch back to latest when there's a fix upstream.
