### PR TITLE
Update script to use mint-path-resolver

### DIFF
--- a/scripts/sync-openapi-v2.sh
+++ b/scripts/sync-openapi-v2.sh
@@ -11,8 +11,6 @@ fi
 
 pushd "$zoolander_path"
 
-pushd "$(mint-path-resolver -repo zoolander)"
-
 # Pull master.
 echo "Bringing $branch up to date."
 git checkout "$branch" && git pull


### PR DESCRIPTION
 ### Reviewers
r? 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
This replaces hardcoded laptop paths with the mint-path-resolver. We will be migrating to the monorepo (mint), where zoolander will be at `~/stripe/mint/zoolander`. The mint-path-resolver is a deployed binary on laptops that returns the correct path depending on whether the user is using mint. The mint repo will have master but not master-passing-tests, so I replaced the branch with master if mint is being used. 

[DEVE-6175](https://jira.corp.stripe.com/browse/DEVE-6175)
