### PR TITLE
fix(proxy): enable HTTP/2 support for forwarding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/net v0.38.0
 	golang.org/x/sys v0.31.0
 	golang.org/x/term v0.30.0
 	google.golang.org/grpc v1.71.1

--- a/pkg/proxy/webhook_event_processor_h2_test.go
+++ b/pkg/proxy/webhook_event_processor_h2_test.go
@@ -1,0 +1,36 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-cli/pkg/websocket"
+)
+
+func TestNewWebhookEventProcessor_HTTP2Configured(t *testing.T) {
+	sendMessage := func(msg *websocket.OutgoingMessage) {}
+	routes := []EndpointRoute{
+		{
+			URL: "https://localhost:4242",
+		},
+	}
+	cfg := &WebhookEventProcessorConfig{
+		SkipVerify: true,
+		Timeout:    30,
+	}
+
+	p := NewWebhookEventProcessor(sendMessage, routes, cfg)
+
+	require.Equal(t, 1, len(p.endpointClients))
+	client := p.endpointClients[0]
+	
+	// Assert that the transport is an *http.Transport
+	transport, ok := client.cfg.HTTPClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	
+	// http2.ConfigureTransport adds "h2" to TLSNextProto
+	require.NotNil(t, transport.TLSNextProto)
+	_, hasH2 := transport.TLSNextProto["h2"]
+	require.True(t, hasH2, "Transport should have h2 configured in TLSNextProto")
+}


### PR DESCRIPTION
Fixes #1406. Explicitly enables HTTP/2 transport when skipping verification, resolving the fallback to HTTP/1.1.