### PR TITLE
fix: preserve trailing path segments in ParsePath for multiple dynamic IDs

### DIFF
--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -78,7 +78,7 @@ func ParsePath(httpPath string, queryRespMap map[string]gjson.Result) (string, e
 			newPath = append(newPath, value)
 		}
 
-		if len(pathParts)%2 == 0 {
+		if pathParts[len(pathParts)-1] != "" {
 			newPath = append(newPath, pathParts[len(pathParts)-1])
 		}
 


### PR DESCRIPTION
Fixes #1340

When parsing paths with multiple dynamic ID placeholders, the trailing segment was being dropped due to an incorrect modulo condition. Changed to check if the final pathPart is non-empty instead.