### PR TITLE
fix: add FileDir to keyring config for WSL 2 compatibility

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -166,9 +166,16 @@ func (c *Config) InitConfig() {
 	}
 
 	// initialize key ring
-	KeyRing, _ = keyring.Open(keyring.Config{
+	KeyRing, err = keyring.Open(keyring.Config{
 		ServiceName: KeyManagementService,
+		FileDir:     "~/.stripe/keys",
 	})
+	if err != nil {
+		log.WithFields(log.Fields{
+			"prefix": "config.Config.InitConfig",
+			"error":  err,
+		}).Warn("Failed to initialize keyring")
+	}
 
 	// redact livemode values for existing configs
 	c.Profile.redactAllLivemodeValues()

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -499,6 +499,7 @@ func (p *Profile) GetSessionCredentials() (*SessionCredentials, error) {
 	ring, err := keyring.Open(keyring.Config{
 		KeychainTrustApplication: true,
 		ServiceName:              KeyManagementService,
+		FileDir:                  "~/.stripe/keys",
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #1419

When running on WSL 2 or Linux without Secret Service available, the keyring library falls back to the file backend, which requires a FileDir to be specified. This was causing 'No directory provided for file keyring' errors on WSL 2.

Added FileDir: ~/.stripe/keys following the pattern used by aws-vault (the creators of the keyring library). Also added proper error handling.