### PR TITLE
Fix typo in CDN path for OpenAPI artifacts

### DIFF
--- a/.github/workflows/sync-openapi-artifacts.yml
+++ b/.github/workflows/sync-openapi-artifacts.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Download Preview CLI spec
         run: |
-          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/public-preview/cli.json" \
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/public_preview/cli.json" \
             -o ./api/openapi-spec/spec3.cli.preview.json
 
       - name: Check for changes


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Fixes the bug that failed this run: https://github.com/stripe/stripe-cli/actions/runs/21304973240/job/61330796704

The _ link resolves: https://b.stripecdn.com/api-artifacts/assets/openapi/2026-01-28.clover/public_preview/cli.json