### PR TITLE
feat: Add .env file support with auto-loading #653

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ default_cassette.yaml
 .vscode/*.log
 stripe-completion.bash
 stripe-completion.zsh
+.env
+.env.*
+!.env.example

--- a/pkg/cmd/dotenv.go
+++ b/pkg/cmd/dotenv.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/joho/godotenv"
+	log "github.com/sirupsen/logrus"
+)
+
+// loadDotenvFromFlags is called by cobra.OnInitialize
+func loadDotenvFromFlags() {
+	// Decide which file to use
+	path := ""
+	explicitlyRequested := false
+
+	switch {
+	case envFile != "":
+		path = envFile
+		explicitlyRequested = true
+	case dotenv:
+		path = ".env"
+		explicitlyRequested = true
+	default:
+		// Auto-load .env from current directory if it exists
+		path = ".env"
+	}
+
+	// Check if file exists
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// If explicitly requested via flag, this is an error
+			if explicitlyRequested {
+				panic(fmt.Errorf("failed to load %s: file not found", path))
+			}
+			return // missing file is fine when auto-loading
+		}
+		if explicitlyRequested {
+			panic(fmt.Errorf("failed to stat %s: %w", path, err))
+		}
+		return
+	}
+
+	// Security check: ensure file is not world-readable (especially important for auto-loading)
+	mode := fileInfo.Mode()
+	if mode&0004 != 0 { // Check if world-readable bit is set
+		log.WithFields(log.Fields{
+			"prefix": "cmd.loadDotenvFromFlags",
+			"path":   path,
+			"mode":   fmt.Sprintf("%#o", mode.Perm()),
+		}).Warn("Skipping .env file: file permissions are too permissive (world-readable). Run 'chmod 600 .env' to fix this.")
+
+		// Only fail if explicitly requested
+		if explicitlyRequested {
+			panic(fmt.Errorf(".env file has insecure permissions (world-readable): %s. Run 'chmod 600 %s' to fix this", path, path))
+		}
+		return
+	}
+
+	env, err := godotenv.Read(path)
+	if err != nil {
+		// Cobra will print this and exit
+		panic(fmt.Errorf("failed to load %s: %w", path, err))
+	}
+
+	log.WithFields(log.Fields{
+		"prefix": "cmd.loadDotenvFromFlags",
+		"path":   path,
+	}).Debug("Loaded environment variables from .env file")
+
+	// Print message when explicitly using --dotenv flag
+	if dotenv {
+		fmt.Printf("Loaded environment variables from %s\n", path)
+	}
+
+	// allowlist — adjust later if needed
+	allowlist := []string{
+		"STRIPE_SECRET_KEY",
+		"STRIPE_DEVICE_NAME",
+	}
+
+	for _, k := range allowlist {
+		if v, ok := env[k]; ok {
+			// Don't override existing environment
+			if _, exists := os.LookupEnv(k); !exists {
+				_ = os.Setenv(k, v)
+			}
+		}
+	}
+}

--- a/pkg/cmd/dotenv_test.go
+++ b/pkg/cmd/dotenv_test.go
@@ -1,0 +1,222 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadDotenvAutoLoad(t *testing.T) {
+	// Save and restore global state
+	oldDotenv := dotenv
+	oldEnvFile := envFile
+	defer func() {
+		dotenv = oldDotenv
+		envFile = oldEnvFile
+	}()
+
+	// Create a temp directory
+	tmpDir := t.TempDir()
+	prevDir, _ := os.Getwd()
+	defer os.Chdir(prevDir)
+	os.Chdir(tmpDir)
+
+	// Create a .env file with secure permissions
+	envContent := "STRIPE_SECRET_KEY=sk_test_123\nSTRIPE_DEVICE_NAME=test_device\n"
+	envPath := filepath.Join(tmpDir, ".env")
+	err := os.WriteFile(envPath, []byte(envContent), 0600)
+	require.NoError(t, err)
+
+	// Clear any existing env vars
+	os.Unsetenv("STRIPE_SECRET_KEY")
+	os.Unsetenv("STRIPE_DEVICE_NAME")
+
+	// Test auto-loading
+	dotenv = false
+	envFile = ""
+	loadDotenvFromFlags()
+
+	// Verify env vars were loaded
+	require.Equal(t, "sk_test_123", os.Getenv("STRIPE_SECRET_KEY"))
+	require.Equal(t, "test_device", os.Getenv("STRIPE_DEVICE_NAME"))
+}
+
+func TestLoadDotenvExplicitFlag(t *testing.T) {
+	// Save and restore global state
+	oldDotenv := dotenv
+	oldEnvFile := envFile
+	defer func() {
+		dotenv = oldDotenv
+		envFile = oldEnvFile
+	}()
+
+	tmpDir := t.TempDir()
+	prevDir, _ := os.Getwd()
+	defer os.Chdir(prevDir)
+	os.Chdir(tmpDir)
+
+	envContent := "STRIPE_SECRET_KEY=sk_test_explicit\n"
+	envPath := filepath.Join(tmpDir, ".env")
+	err := os.WriteFile(envPath, []byte(envContent), 0600)
+	require.NoError(t, err)
+
+	os.Unsetenv("STRIPE_SECRET_KEY")
+
+	// Test explicit --dotenv flag
+	dotenv = true
+	envFile = ""
+	loadDotenvFromFlags()
+
+	require.Equal(t, "sk_test_explicit", os.Getenv("STRIPE_SECRET_KEY"))
+}
+
+func TestLoadDotenvCustomFile(t *testing.T) {
+	// Save and restore global state
+	oldDotenv := dotenv
+	oldEnvFile := envFile
+	defer func() {
+		dotenv = oldDotenv
+		envFile = oldEnvFile
+	}()
+
+	tmpDir := t.TempDir()
+
+	envContent := "STRIPE_SECRET_KEY=sk_test_custom\n"
+	customPath := filepath.Join(tmpDir, "custom.env")
+	err := os.WriteFile(customPath, []byte(envContent), 0600)
+	require.NoError(t, err)
+
+	os.Unsetenv("STRIPE_SECRET_KEY")
+
+	// Test custom --env-file
+	dotenv = false
+	envFile = customPath
+	loadDotenvFromFlags()
+
+	require.Equal(t, "sk_test_custom", os.Getenv("STRIPE_SECRET_KEY"))
+}
+
+func TestLoadDotenvInsecurePermissions(t *testing.T) {
+	// Save and restore global state
+	oldDotenv := dotenv
+	oldEnvFile := envFile
+	defer func() {
+		dotenv = oldDotenv
+		envFile = oldEnvFile
+	}()
+
+	tmpDir := t.TempDir()
+	prevDir, _ := os.Getwd()
+	defer os.Chdir(prevDir)
+	os.Chdir(tmpDir)
+
+	// Create a world-readable .env file
+	envContent := "STRIPE_SECRET_KEY=sk_test_insecure\n"
+	envPath := filepath.Join(tmpDir, ".env")
+	err := os.WriteFile(envPath, []byte(envContent), 0644)
+	require.NoError(t, err)
+
+	os.Unsetenv("STRIPE_SECRET_KEY")
+
+	// Auto-load should skip insecure file
+	dotenv = false
+	envFile = ""
+	loadDotenvFromFlags()
+
+	// Env var should NOT be set
+	require.Equal(t, "", os.Getenv("STRIPE_SECRET_KEY"))
+}
+
+func TestLoadDotenvInsecurePermissionsExplicit(t *testing.T) {
+	// Save and restore global state
+	oldDotenv := dotenv
+	oldEnvFile := envFile
+	defer func() {
+		dotenv = oldDotenv
+		envFile = oldEnvFile
+	}()
+
+	tmpDir := t.TempDir()
+
+	// Create a world-readable file
+	envContent := "STRIPE_SECRET_KEY=sk_test_insecure\n"
+	envPath := filepath.Join(tmpDir, "insecure.env")
+	err := os.WriteFile(envPath, []byte(envContent), 0644)
+	require.NoError(t, err)
+
+	// Explicit request should panic
+	dotenv = false
+	envFile = envPath
+
+	require.Panics(t, func() {
+		loadDotenvFromFlags()
+	}, "Should panic on insecure permissions when explicitly requested")
+}
+
+func TestLoadDotenvMissingFile(t *testing.T) {
+	// Save and restore global state
+	oldDotenv := dotenv
+	oldEnvFile := envFile
+	defer func() {
+		dotenv = oldDotenv
+		envFile = oldEnvFile
+	}()
+
+	tmpDir := t.TempDir()
+	prevDir, _ := os.Getwd()
+	defer os.Chdir(prevDir)
+	os.Chdir(tmpDir)
+
+	// Auto-load with missing file should not panic
+	dotenv = false
+	envFile = ""
+	require.NotPanics(t, func() {
+		loadDotenvFromFlags()
+	})
+}
+
+func TestLoadDotenvMissingFileExplicit(t *testing.T) {
+	// Save and restore global state
+	oldDotenv := dotenv
+	oldEnvFile := envFile
+	defer func() {
+		dotenv = oldDotenv
+		envFile = oldEnvFile
+	}()
+
+	dotenv = false
+	envFile = "/nonexistent/file.env"
+
+	require.Panics(t, func() {
+		loadDotenvFromFlags()
+	}, "Should panic when explicitly requested file is missing")
+}
+
+func TestLoadDotenvNoOverride(t *testing.T) {
+	// Save and restore global state
+	oldDotenv := dotenv
+	oldEnvFile := envFile
+	defer func() {
+		dotenv = oldDotenv
+		envFile = oldEnvFile
+	}()
+
+	tmpDir := t.TempDir()
+
+	envContent := "STRIPE_SECRET_KEY=sk_test_from_file\n"
+	envPath := filepath.Join(tmpDir, "test.env")
+	err := os.WriteFile(envPath, []byte(envContent), 0600)
+	require.NoError(t, err)
+
+	// Set env var before loading
+	os.Setenv("STRIPE_SECRET_KEY", "sk_test_existing")
+
+	dotenv = false
+	envFile = envPath
+	loadDotenvFromFlags()
+
+	// Should NOT override existing env var
+	require.Equal(t, "sk_test_existing", os.Getenv("STRIPE_SECRET_KEY"))
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -30,6 +30,11 @@ import (
 // Config is the cli configuration for the user
 var Config config.Config
 
+var (
+	dotenv  bool
+	envFile string
+)
+
 var fs = afero.NewOsFs()
 
 // rootCmd represents the base command when called without any subcommands
@@ -170,8 +175,10 @@ func bindEnv(key, envKey string) {
 }
 
 func init() {
-	cobra.OnInitialize(Config.InitConfig, ReBindKeys)
+	cobra.OnInitialize(loadDotenvFromFlags, Config.InitConfig, ReBindKeys)
 
+	rootCmd.PersistentFlags().BoolVar(&dotenv, "dotenv", false, "explicitly load environment variables from a .env file (auto-loaded by default with secure permissions)")
+	rootCmd.PersistentFlags().StringVar(&envFile, "env-file", "", "path to a custom .env file (overrides auto-loading)")
 	rootCmd.PersistentFlags().StringVar(&Config.Profile.APIKey, "api-key", "", "Your API key to use for the command")
 	rootCmd.PersistentFlags().StringVar(&Config.Color, "color", "", "turn on/off color output (on, off, auto)")
 	rootCmd.PersistentFlags().StringVar(&Config.ProfilesFile, "config", "", "config file (default is $HOME/.config/stripe/config.toml)")


### PR DESCRIPTION
Adds support for loading environment variables from .env files with secure defaults and flexible configuration options.

Features:
- Auto-loads .env from current directory by default
- --dotenv flag to explicitly load .env file
- --env-file flag for custom file paths
- Security check: rejects world-readable files (0644+)
- Allowlist: only loads STRIPE_SECRET_KEY and STRIPE_DEVICE_NAME
- Never overrides existing environment variables

Changes:
- Add pkg/cmd/dotenv.go with loadDotenvFromFlags()
- Add comprehensive unit tests in pkg/cmd/dotenv_test.go
- Add --dotenv and --env-file flags to root command
- Update .gitignore to exclude .env files

Testing:
- 8 unit tests covering all scenarios
- Security checks validated
- All existing tests pass

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

https://github.com/stripe/stripe-cli/issues/653
