### PR TITLE
cmd: add whoami environment output + tests (1360)

### DIFF
--- a/pkg/cmd/resource/events_resend_test.go
+++ b/pkg/cmd/resource/events_resend_test.go
@@ -16,6 +16,11 @@ import (
 )
 
 func TestRunEventsResendCmd(t *testing.T) {
+	// Ensure the test is hermetic: Profile.GetAPIKey() prefers STRIPE_API_KEY.
+	// If it is set in the developer environment, it can cause this test to send
+	// an unexpected Authorization header.
+	t.Setenv("STRIPE_API_KEY", "")
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		body, err := io.ReadAll(r.Body)
@@ -47,6 +52,9 @@ func TestRunEventsResendCmd(t *testing.T) {
 }
 
 func TestRunEventsResendCmd_WithWebhookEndpoint(t *testing.T) {
+	// Ensure the test is hermetic: Profile.GetAPIKey() prefers STRIPE_API_KEY.
+	t.Setenv("STRIPE_API_KEY", "")
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		body, err := io.ReadAll(r.Body)

--- a/pkg/cmd/resource/operation_test.go
+++ b/pkg/cmd/resource/operation_test.go
@@ -62,6 +62,9 @@ func TestNewOperationCmd_NumberType(t *testing.T) {
 }
 
 func TestRunOperationCmd(t *testing.T) {
+	// Ensure the test is hermetic: Profile.GetAPIKey() prefers STRIPE_API_KEY.
+	t.Setenv("STRIPE_API_KEY", "")
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		body, err := io.ReadAll(r.Body)
@@ -112,6 +115,9 @@ func TestRunOperationCmd(t *testing.T) {
 }
 
 func TestRunOperationCmd_ExtraParams(t *testing.T) {
+	// Ensure the test is hermetic: Profile.GetAPIKey() prefers STRIPE_API_KEY.
+	t.Setenv("STRIPE_API_KEY", "")
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		body, err := io.ReadAll(r.Body)
@@ -152,6 +158,9 @@ func TestRunOperationCmd_ExtraParams(t *testing.T) {
 }
 
 func TestRunOperationCmd_NoAPIKey(t *testing.T) {
+	// Ensure a developer's STRIPE_API_KEY doesn't accidentally satisfy this test.
+	t.Setenv("STRIPE_API_KEY", "")
+
 	viper.Reset()
 
 	parentCmd := &cobra.Command{Annotations: make(map[string]string)}

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	stripecfg "github.com/stripe/stripe-cli/pkg/config"
+)
+
+func init() {
+	rootCmd.AddCommand(newWhoamiCmd())
+}
+
+type whoamiOutput struct {
+	ProjectName string `json:"project_name"`
+
+	AccountID    string `json:"account_id,omitempty"`
+	DisplayName  string `json:"display_name,omitempty"`
+	DeviceName   string `json:"device_name,omitempty"`
+	Color        string `json:"color,omitempty"`
+	HasTestKey   bool   `json:"has_test_mode_api_key"`
+	HasLiveKey   bool   `json:"has_live_mode_api_key"`
+	TestKeyExp   string `json:"test_mode_key_expires_at,omitempty"`
+	LiveKeyExp   string `json:"live_mode_key_expires_at,omitempty"`
+	TestAPIKey   string `json:"test_mode_api_key,omitempty"`
+	LiveAPIKey   string `json:"live_mode_api_key,omitempty"`
+	ProfilesFile string `json:"profiles_file,omitempty"`
+}
+
+func newWhoamiCmd() *cobra.Command {
+	var asJSON bool
+	var showKeys bool
+
+	cmd := &cobra.Command{
+		Use:   "whoami",
+		Short: "Show the currently selected Stripe CLI profile/environment",
+		Long:  "Prints which Stripe CLI profile/environment you are currently operating against (project, account, display name, device, and key expiry).",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Config is the global CLI configuration in this package:
+			// var Config config.Config (documented on pkg.go.dev)
+			p := Config.GetProfile()
+			if p == nil {
+				return fmt.Errorf("no active profile found (try `stripe login` or check your config)")
+			}
+
+			out := whoamiOutput{
+				ProjectName: cmd.Flag("project-name").Value.String(),
+				DisplayName: p.GetDisplayName(),
+				ProfilesFile: func() string {
+					// Helpful for debugging which file you're reading from.
+					// Safe even if empty.
+					return Config.ProfilesFile
+				}(),
+			}
+
+			if v, err := p.GetAccountID(); err == nil {
+				out.AccountID = v
+			}
+			if v, err := p.GetDeviceName(); err == nil {
+				out.DeviceName = v
+			}
+			if v, err := p.GetColor(); err == nil {
+				out.Color = v
+			}
+
+			// Keys and expirations
+			testKey, testKeyErr := p.GetAPIKey(false)
+			liveKey, liveKeyErr := p.GetAPIKey(true)
+
+			out.HasTestKey = testKeyErr == nil && testKey != ""
+			out.HasLiveKey = liveKeyErr == nil && liveKey != ""
+
+			if t, err := p.GetExpiresAt(false); err == nil && !t.IsZero() {
+				out.TestKeyExp = t.Format(stripecfg.DateStringFormat)
+			}
+
+			if t, err := p.GetExpiresAt(true); err == nil && !t.IsZero() {
+				out.LiveKeyExp = t.Format(stripecfg.DateStringFormat)
+			}
+
+			if showKeys {
+				// Redact rather than dumping secrets.
+				if out.HasTestKey {
+					out.TestAPIKey = stripecfg.RedactAPIKey(testKey)
+				}
+				if out.HasLiveKey {
+					out.LiveAPIKey = stripecfg.RedactAPIKey(liveKey)
+				}
+			}
+
+			if asJSON {
+				b, err := json.MarshalIndent(out, "", "")
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), string(b))
+				return nil
+			}
+
+			// Human output (boring, clear, and grep-friendly).
+			fmt.Fprintf(cmd.OutOrStdout(), "project-name: %s\n", out.ProjectName)
+
+			if out.DisplayName != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "display_name: %s\n", out.DisplayName)
+			}
+
+			if out.AccountID != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "account_id: %s\n", out.AccountID)
+			}
+			if out.DeviceName != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "device_name: %s\n", out.DeviceName)
+			}
+			if out.Color != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "color: %s\n", out.Color)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "has_test_mode_api_key: %t\n", out.HasTestKey)
+			if out.TestKeyExp != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "test_mode_key_expires_at: %s\n", out.TestKeyExp)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "has_live_mode_api_key: %t\n", out.HasLiveKey)
+			if out.LiveKeyExp != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "live_mode_key_expires_at: %s\n", out.LiveKeyExp)
+			}
+
+			if showKeys {
+				if out.HasTestKey {
+					fmt.Fprintf(cmd.OutOrStdout(), "test_mode_api_key: %s\n", out.TestAPIKey)
+				}
+				if out.HasLiveKey {
+					fmt.Fprintf(cmd.OutOrStdout(), "live_mode_api_key: %s\n", out.LiveAPIKey)
+				}
+			}
+
+			// Tiny extra clue: if the test key is expired, say it loudly.
+			if out.TestKeyExp != "" {
+				if exp, err := time.Parse(stripecfg.DateStringFormat, out.TestKeyExp); err == nil {
+					if time.Now().After(exp.Add(24 * time.Hour)) {
+						fmt.Fprintln(cmd.OutOrStdout(), "warning: test_mode_api_key appears expired (re-login may be required)")
+					}
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&showKeys, "show-keys", false, "Include redacted API keys in output")
+	return cmd
+}

--- a/pkg/cmd/whoami_test.go
+++ b/pkg/cmd/whoami_test.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/99designs/keyring"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	stripecfg "github.com/stripe/stripe-cli/pkg/config"
+)
+
+func writeTempConfig(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	err := os.WriteFile(path, []byte(contents), 0o600)
+	require.NoError(t, err)
+	return path
+}
+
+func setupWhoamiConfig(t *testing.T) (profilesFile string) {
+	t.Helper()
+
+	viper.Reset()
+	// Ensure tests are hermetic; Profile.GetAPIKey() prefers STRIPE_API_KEY.
+	t.Setenv("STRIPE_API_KEY", "")
+	t.Setenv("STRIPE_DEVICE_NAME", "device-from-env")
+
+	profilesFile = writeTempConfig(t, `[test]
+account_id = "acct_123"
+display_name = "Alice"
+test_mode_api_key = "sk_test_1234abcd"
+test_mode_key_expires_at = "2099-01-02"
+live_mode_key_expires_at = "2099-02-03"
+`)
+
+	// Configure the CLI to read from our temp config.
+	Config.ProfilesFile = profilesFile
+	Config.Profile.ProfileName = "test"
+	// Ensure no leftover state from other tests/environment overrides config/keyring.
+	Config.Profile.APIKey = ""
+	Config.Profile.AccountID = ""
+	Config.Profile.DisplayName = ""
+	Config.Profile.DeviceName = ""
+
+	// Load config into viper (GetAPIKey(false) requires ReadInConfig() to succeed).
+	viper.SetConfigFile(profilesFile)
+	viper.SetConfigType("toml")
+	require.NoError(t, viper.ReadInConfig())
+
+	// Use an in-memory keyring to simulate a stored live key.
+	stripecfg.KeyRing = keyring.NewArrayKeyring([]keyring.Item{{
+		Key:  "test.live_mode_api_key",
+		Data: []byte("rk_live_0000000001"),
+	}})
+
+	return profilesFile
+}
+
+func runWhoami(t *testing.T, profilesFile string, asJSON bool, showKeys bool) (string, error) {
+	t.Helper()
+
+	c := newWhoamiCmd()
+	// In production this flag is a persistent flag on the root command. The
+	// implementation reads it from the command, so add it here for unit tests.
+	c.Flags().String("project-name", "test", "the project name to read from for config")
+
+	require.NoError(t, c.Flags().Set("project-name", "test"))
+	require.NoError(t, c.Flags().Set("json", map[bool]string{true: "true", false: "false"}[asJSON]))
+	require.NoError(t, c.Flags().Set("show-keys", map[bool]string{true: "true", false: "false"}[showKeys]))
+
+	buf := new(bytes.Buffer)
+	c.SetOut(buf)
+
+	err := c.RunE(c, []string{})
+	return buf.String(), err
+}
+
+func TestWhoami_JSON_NoKeys(t *testing.T) {
+	profilesFile := setupWhoamiConfig(t)
+	out, err := runWhoami(t, profilesFile, true, false)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &m))
+
+	require.Equal(t, "test", m["project_name"])
+	require.Equal(t, "acct_123", m["account_id"])
+	require.Equal(t, "Alice", m["display_name"])
+	require.Equal(t, "device-from-env", m["device_name"])
+	require.Equal(t, "auto", m["color"])
+	require.Equal(t, true, m["has_test_mode_api_key"])
+	require.Equal(t, true, m["has_live_mode_api_key"])
+	require.Equal(t, "2099-01-02", m["test_mode_key_expires_at"])
+	require.Equal(t, "2099-02-03", m["live_mode_key_expires_at"])
+	require.Equal(t, profilesFile, m["profiles_file"])
+
+	_, hasTestKey := m["test_mode_api_key"]
+	_, hasLiveKey := m["live_mode_api_key"]
+	require.False(t, hasTestKey)
+	require.False(t, hasLiveKey)
+}
+
+func TestWhoami_JSON_ShowKeys_Redacted(t *testing.T) {
+	profilesFile := setupWhoamiConfig(t)
+	out, err := runWhoami(t, profilesFile, true, true)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &m))
+
+	require.Equal(t, stripecfg.RedactAPIKey("sk_test_1234abcd"), m["test_mode_api_key"])
+	require.Equal(t, stripecfg.RedactAPIKey("rk_live_0000000001"), m["live_mode_api_key"])
+}
+
+func TestWhoami_HumanOutput(t *testing.T) {
+	profilesFile := setupWhoamiConfig(t)
+	out, err := runWhoami(t, profilesFile, false, false)
+	require.NoError(t, err)
+
+	require.Contains(t, out, "project-name: test\n")
+	require.Contains(t, out, "display_name: Alice\n")
+	require.Contains(t, out, "account_id: acct_123\n")
+	require.Contains(t, out, "device_name: device-from-env\n")
+	require.Contains(t, out, "color: auto\n")
+	require.Contains(t, out, "has_test_mode_api_key: true\n")
+	require.Contains(t, out, "test_mode_key_expires_at: 2099-01-02\n")
+	require.Contains(t, out, "has_live_mode_api_key: true\n")
+	require.Contains(t, out, "live_mode_key_expires_at: 2099-02-03\n")
+	require.NotContains(t, out, "\ntest_mode_api_key: ")
+	require.NotContains(t, out, "\nlive_mode_api_key: ")
+}
+
+func TestWhoami_HumanOutput_ShowKeys(t *testing.T) {
+	profilesFile := setupWhoamiConfig(t)
+	out, err := runWhoami(t, profilesFile, false, true)
+	require.NoError(t, err)
+
+	require.Contains(t, out, "test_mode_api_key: "+stripecfg.RedactAPIKey("sk_test_1234abcd")+"\n")
+	require.Contains(t, out, "live_mode_api_key: "+stripecfg.RedactAPIKey("rk_live_0000000001")+"\n")
+}


### PR DESCRIPTION
 ### Reviewers
r @tomer-stripe
cc @stripe/developer-products

Title
Add [stripe whoami](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) + tests (issue #1360)

PR Description
This PR adds a [stripe whoami](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) command to make it easy to confirm which Stripe CLI profile/environment a terminal is currently using (requested in #1360). This helps when running multiple terminals against different sandboxes/accounts and you need to verify you’re listening/triggering in the right place.

Changes:

[stripe whoami](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) outputs current profile/project name, account_id, display_name, device_name, color, and API key presence.
Adds JSON output ([--json](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) for easy diffing across terminals.
Adds optional redacted key output ([--show-keys](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) to confirm which key is in use without exposing secrets.
Fix: populate live_mode_key_expires_at (previously printed/serialized but never set).
UX: JSON output now ends with a newline (avoids zsh showing a trailing %).
Tests:

Added unit tests covering JSON + human output and [--show-keys](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) redaction.
Made [resource](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) tests hermetic by clearing STRIPE_API_KEY to avoid developer env leakage.
How to test:

go test [repos](http://_vscodecontentref_/7).
go test ./pkg/cmd -run TestWhoami
Fixes #1360 