### PR TITLE
Look for more codex env vars

### DIFF
--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -37,7 +37,7 @@ func DetectAIAgent(getEnv func(string) string) string {
 	if getEnv("CLINE_ACTIVE") != "" {
 		return "cline"
 	}
-	if getEnv("CODEX_SANDBOX") != "" {
+	if getEnv("CODEX_SANDBOX") != "" || getEnv("CODEX_THREAD_ID") != "" || getEnv("CODEX_SANDBOX_NETWORK_DISABLED") != "" || getEnv("CODEX_CI") != "" {
 		return "codex_cli"
 	}
 	if getEnv("CURSOR_AGENT") != "" {


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
I noticed we were detecting any Codex usage which seems suspicious and can misrepresent the data we show users. Codex doesn't seem to set one specific env var like others do but potentially a few different ones depending on the situation:

`CODEX_SANDBOX_NETWORK_DISABLED` =>https://github.com/openai/codex/blob/main/codex-rs/core/src/spawn.rs#L19
`CODEX_THREAD_ID` => https://github.com/openai/codex/blob/main/codex-rs/core/src/exec_env.rs#L8
`CODEX_CI` => https://github.com/openai/codex/blob/main/codex-rs/core/src/unified_exec/process_manager.rs#L65