### PR TITLE
Add subscription schedule completion triggers

### DIFF
--- a/pkg/fixtures/triggers/subscription_schedule.aborted.json
+++ b/pkg/fixtures/triggers/subscription_schedule.aborted.json
@@ -1,0 +1,64 @@
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "customer",
+      "path": "/v1/customers",
+      "method": "post",
+      "params": {
+        "description": "(created by Stripe CLI)",
+        "source": "tok_visa"
+      }
+    },
+    {
+      "name": "product",
+      "path": "/v1/products",
+      "method": "post",
+      "params": {
+          "name": "myproduct",
+          "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "price",
+      "path": "/v1/prices",
+      "method": "post",
+      "params": {
+        "product": "${product:id}",
+        "unit_amount": "1500",
+        "currency": "usd",
+        "recurring[interval]": "month"
+      }
+    },
+    {
+      "name": "subscription_schedule",
+      "path": "/v1/subscription_schedules",
+      "method": "post",
+      "params": {
+        "customer": "${customer:id}",
+        "start_date": 1893456000,
+        "phases": {
+          "0": {
+            "items": [
+              {
+                "price": "${price:id}",
+                "quantity": 1
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "subscription_schedule_aborted",
+      "path": "/v1/subscription_schedules/${subscription_schedule:id}/cancel",
+      "method": "post",
+      "params": {
+        "prorate": "false",
+        "invoice_now": "false"
+      }
+    }
+  ]
+}

--- a/pkg/fixtures/triggers/subscription_schedule.completed.json
+++ b/pkg/fixtures/triggers/subscription_schedule.completed.json
@@ -1,0 +1,74 @@
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "test_clock",
+      "path": "/v1/test_helpers/test_clocks",
+      "method": "post",
+      "params": {
+        "frozen_time": 1577836800,
+        "name": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "customer",
+      "path": "/v1/customers",
+      "method": "post",
+      "params": {
+        "description": "(created by Stripe CLI)",
+        "test_clock": "${test_clock:id}"
+      }
+    },
+    {
+      "name": "product",
+      "path": "/v1/products",
+      "method": "post",
+      "params": {
+          "name": "myproduct",
+          "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "price",
+      "path": "/v1/prices",
+      "method": "post",
+      "params": {
+        "product": "${product:id}",
+        "unit_amount": "1500",
+        "currency": "usd",
+        "recurring[interval]": "month"
+      }
+    },
+    {
+      "name": "subscription_schedule",
+      "path": "/v1/subscription_schedules",
+      "method": "post",
+      "params": {
+        "customer": "${customer:id}",
+        "start_date": 1577836800,
+        "end_behavior": "release",
+        "phases": {
+          "0": {
+            "iterations": 1,
+            "items": [
+              {
+                "price": "${price:id}",
+                "quantity": 1
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "advance_test_clock",
+      "path": "/v1/test_helpers/test_clocks/${test_clock:id}/advance",
+      "method": "post",
+      "params": {
+        "frozen_time": 1580515200
+      }
+    }
+  ]
+}

--- a/pkg/fixtures/triggers/subscription_schedule.expiring.json
+++ b/pkg/fixtures/triggers/subscription_schedule.expiring.json
@@ -1,0 +1,74 @@
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "test_clock",
+      "path": "/v1/test_helpers/test_clocks",
+      "method": "post",
+      "params": {
+        "frozen_time": 1577836800,
+        "name": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "customer",
+      "path": "/v1/customers",
+      "method": "post",
+      "params": {
+        "description": "(created by Stripe CLI)",
+        "test_clock": "${test_clock:id}"
+      }
+    },
+    {
+      "name": "product",
+      "path": "/v1/products",
+      "method": "post",
+      "params": {
+          "name": "myproduct",
+          "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "price",
+      "path": "/v1/prices",
+      "method": "post",
+      "params": {
+        "product": "${product:id}",
+        "unit_amount": "1500",
+        "currency": "usd",
+        "recurring[interval]": "month"
+      }
+    },
+    {
+      "name": "subscription_schedule",
+      "path": "/v1/subscription_schedules",
+      "method": "post",
+      "params": {
+        "customer": "${customer:id}",
+        "start_date": 1577836800,
+        "end_behavior": "cancel",
+        "phases": {
+          "0": {
+            "items": [
+              {
+                "price": "${price:id}",
+                "quantity": 1
+              }
+            ],
+            "end_date": 1580256000
+          }
+        }
+      }
+    },
+    {
+      "name": "advance_test_clock",
+      "path": "/v1/test_helpers/test_clocks/${test_clock:id}/advance",
+      "method": "post",
+      "params": {
+        "frozen_time": 1579478400
+      }
+    }
+  ]
+}


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

## Summary

Adds trigger fixtures for subscription schedule lifecycle completion events:
- `subscription_schedule.aborted`
- `subscription_schedule.completed`
- `subscription_schedule.expiring`

## Context

Part of expanding Stripe CLI trigger coverage by 67 events (+49%). This PR adds 3 subscription schedule lifecycle events and can be reviewed independently.

## Changes

- **1 commit**, ~212 lines added
- **3 new events** mapped in `pkg/fixtures/triggers.go`
- **3 new fixture files** in `pkg/fixtures/triggers/`

## Test plan

- [x] All fixture JSON files validated
- [x] Go build successful
- [x] All tests passing
- [x] Manual: `stripe trigger subscription_schedule.aborted` ✅
- [x] Manual: `stripe trigger subscription_schedule.completed` ✅
- [x] Manual: `stripe trigger subscription_schedule.expiring` ✅
