### PR TITLE
[Stacked: 1465] Add customer.tax_id.created and customer.tax_id.deleted triggers

### DIFF
--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -55,6 +55,8 @@ var Events = map[string]string{
 	"customer.subscription.updated":                        "triggers/customer.subscription.updated.json",
 	"customer.subscription.paused":                         "triggers/customer.subscription.paused.json",
 	"customer.subscription.trial_will_end":                 "triggers/customer.subscription.trial_will_end.json",
+	"customer.tax_id.created":                              "triggers/customer.tax_id.created.json",
+	"customer.tax_id.deleted":                              "triggers/customer.tax_id.deleted.json",
 	"identity.verification_session.canceled":               "triggers/identity.verification_session.canceled.json",
 	"identity.verification_session.created":                "triggers/identity.verification_session.created.json",
 	"identity.verification_session.redacted":               "triggers/identity.verification_session.redacted.json",

--- a/pkg/fixtures/triggers/customer.tax_id.created.json
+++ b/pkg/fixtures/triggers/customer.tax_id.created.json
@@ -1,0 +1,24 @@
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "customer",
+      "path": "/v1/customers",
+      "method": "post",
+      "params": {
+        "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "tax_id",
+      "path": "/v1/customers/${customer:id}/tax_ids",
+      "method": "post",
+      "params": {
+        "type": "us_ein",
+        "value": "000000000"
+      }
+    }
+  ]
+}

--- a/pkg/fixtures/triggers/customer.tax_id.deleted.json
+++ b/pkg/fixtures/triggers/customer.tax_id.deleted.json
@@ -1,0 +1,30 @@
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "customer",
+      "path": "/v1/customers",
+      "method": "post",
+      "params": {
+        "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "tax_id",
+      "path": "/v1/customers/${customer:id}/tax_ids",
+      "method": "post",
+      "params": {
+        "type": "us_ein",
+        "value": "000000000"
+      }
+    },
+    {
+      "name": "deleted_tax_id",
+      "path": "/v1/customers/${customer:id}/tax_ids/${tax_id:id}",
+      "method": "delete",
+      "params": {}
+    }
+  ]
+}


### PR DESCRIPTION
### Reviewers
r? @
cc @stripe/developer-products

### Summary

Adds 2 new trigger events for customer tax IDs:
- `customer.tax_id.created` -- creates a customer and adds a tax ID (`eu_vat`)
- `customer.tax_id.deleted` -- creates a customer, adds a tax ID, then deletes it

### `stripe trigger --help`: Event list

Two new customer tax ID events appear in the event list:

```diff
   customer.subscription.created
   customer.subscription.deleted
   customer.subscription.paused
   customer.subscription.trial_will_end
   customer.subscription.updated
+  customer.tax_id.created
+  customer.tax_id.deleted
   customer.updated
   customer_cash_balance_transaction.created
   identity.verification_session.canceled
```

#### Test plan

- [x] `stripe trigger customer.tax_id.created` succeeds
- [x] `stripe trigger customer.tax_id.deleted` succeeds
