### PR TITLE
[Stacked: 1465] Add price.deleted trigger

### DIFF
--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -102,6 +102,7 @@ var Events = map[string]string{
 	"plan.deleted":                                         "triggers/plan.deleted.json",
 	"plan.updated":                                         "triggers/plan.updated.json",
 	"price.created":                                        "triggers/price.created.json",
+	"price.deleted":                                        "triggers/price.deleted.json",
 	"price.updated":                                        "triggers/price.updated.json",
 	"product.created":                                      "triggers/product.created.json",
 	"product.deleted":                                      "triggers/product.deleted.json",

--- a/pkg/fixtures/triggers/price.deleted.json
+++ b/pkg/fixtures/triggers/price.deleted.json
@@ -1,0 +1,35 @@
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "product",
+      "path": "/v1/products",
+      "method": "post",
+      "params": {
+          "name": "myproduct",
+          "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "price",
+      "path": "/v1/prices",
+      "method": "post",
+      "params": {
+        "product": "${product:id}",
+        "unit_amount": "1500",
+        "currency": "usd",
+        "recurring[interval]": "month"
+      }
+    },
+    {
+      "name": "price_deleted",
+      "path": "/v1/prices/${price:id}",
+      "method": "post",
+      "params": {
+        "active": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Reviewers
r? @
cc @stripe/developer-products

### Summary

Adds the `price.deleted` trigger event. The fixture creates a product, creates a price on it, then archives the price via `active: false`.

Note: Stripe prices cannot be truly deleted, only deactivated. The `price.deleted` event fires when a price is archived.

### `stripe trigger --help`: Event list

One new price event appears in the event list:

```diff
   payout.updated
   plan.created
   plan.deleted
   plan.updated
   price.created
+  price.deleted
   price.updated
   product.created
   product.deleted
```

#### Test plan

- [x] `stripe trigger price.deleted` succeeds
