### PR TITLE
remove unnecessary reconnect logic

### DIFF
--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -134,10 +134,9 @@ func (t *Tailer) Run(ctx context.Context) error {
 			session.WebSocketID,
 			session.WebSocketAuthorizedFeature,
 			&websocket.Config{
-				EventHandler:      websocket.EventHandlerFunc(t.processRequestLogEvent),
-				Log:               t.cfg.Log,
-				NoWSS:             t.cfg.NoWSS,
-				ReconnectInterval: time.Duration(session.ReconnectDelay) * time.Second,
+				EventHandler: websocket.EventHandlerFunc(t.processRequestLogEvent),
+				Log:          t.cfg.Log,
+				NoWSS:        t.cfg.NoWSS,
 			},
 		)
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -173,10 +173,9 @@ func (p *Proxy) Run(ctx context.Context) error {
 			session.WebSocketID,
 			session.WebSocketAuthorizedFeature,
 			&websocket.Config{
-				Log:               p.cfg.Log,
-				NoWSS:             p.cfg.NoWSS,
-				ReconnectInterval: time.Duration(session.ReconnectDelay) * time.Second,
-				EventHandler:      p.webhookEventProcessor,
+				Log:          p.cfg.Log,
+				NoWSS:        p.cfg.NoWSS,
+				EventHandler: p.webhookEventProcessor,
 			},
 		)
 

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -37,9 +37,6 @@ type Config struct {
 
 	PongWait time.Duration
 
-	// Interval at which the websocket client should reset the connection
-	ReconnectInterval time.Duration
-
 	// Duration to wait before closing connection
 	CloseDelayPeriod time.Duration
 
@@ -172,20 +169,6 @@ func (c *Client) Run(ctx context.Context) {
 			}).Debug("Disconnected from Stripe")
 			c.Close(ws.CloseGoingAway, "Server closed the connection")
 			c.wg.Wait()
-		case <-time.After(c.cfg.ReconnectInterval):
-			c.cfg.Log.WithFields(log.Fields{
-				"prefix": "websocket.Client.Run",
-			}).Debug("Resetting the connection")
-			c.Close(ws.CloseNormalClosure, "Resetting the connection")
-
-			c.cfg.Log.WithFields(log.Fields{
-				"prefix": "websocket.Client.Run",
-			}).Debug("Waiting on client wg")
-			c.wg.Wait()
-
-			c.cfg.Log.WithFields(log.Fields{
-				"prefix": "websocket.Client.Run",
-			}).Debug("Client wg is done")
 		}
 	}
 }
@@ -581,10 +564,6 @@ func NewClient(url string, webSocketID string, websocketAuthorizedFeature string
 		cfg.PingPeriod = (cfg.PongWait * 2) / 10
 	}
 
-	if cfg.ReconnectInterval == 0 {
-		cfg.ReconnectInterval = defaultReconnectInterval
-	}
-
 	if cfg.CloseDelayPeriod == 0 {
 		cfg.CloseDelayPeriod = defaultCloseDelayPeriod
 	}
@@ -616,8 +595,6 @@ const (
 	defaultConnectAttemptWait = 10 * time.Second
 
 	defaultPongWait = 10 * time.Second
-
-	defaultReconnectInterval = 60 * time.Second
 
 	defaultCloseDelayPeriod = 1 * time.Second
 


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
This code change removes forced periodic websocket reconnect (ReconnectInterval) since the existing ping/pong keepalive and error-driven reconnection already maintain connection health, making the timed teardown unnecessary overhead.