### PR TITLE
Fix assorted CLI UX issues from issue triage

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -238,10 +238,16 @@ func (lc *listenCmd) createVisitor(logger *log.Logger, format string, printJSON 
 				color := ansi.Color(os.Stdout)
 				localTime := time.Now().Format(timeLayout)
 
-				errStr := fmt.Sprintf("%s            [%s] Failed to POST: %v\n",
+				postErr := ee.Error.(proxy.FailedToPostError)
+				errMsg := fmt.Sprintf("Failed to POST: %v", postErr)
+				if strings.Contains(postErr.Error(), "connection refused") {
+					errMsg = fmt.Sprintf("Failed to POST: Connection to %s was refused. Is your local server running?", postErr.URL)
+				}
+
+				errStr := fmt.Sprintf("%s            [%s] %s\n",
 					color.Faint(localTime),
 					color.Red("ERROR"),
-					ee.Error,
+					errMsg,
 				)
 				fmt.Println(errStr)
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -116,7 +116,7 @@ func Execute(ctx context.Context) {
 		case requests.IsAPIKeyExpiredError(err):
 			fmt.Fprintln(os.Stderr, "The API key provided has expired. Obtain a new key from the Dashboard or run `stripe login` and try again.")
 		case isLoginRequiredError && projectNameFlag != "default":
-			fmt.Printf("You provided the project name \"%[1]s\" (either via the \"--project-name\" flag or the \"STRIPE_PROJECT_NAME\" environment variable), but no config for that project was found.\nPlease run `stripe login --project-name=%[1]s` to enable commands for this project.\n", projectNameFlag)
+			fmt.Fprintf(os.Stderr, "You provided the project name \"%[1]s\" (either via the \"--project-name\" flag or the \"STRIPE_PROJECT_NAME\" environment variable), but no config for that project was found.\nPlease run `stripe login --project-name=\"%[1]s\"` to enable commands for this project.\n", projectNameFlag)
 		case isLoginRequiredError:
 			// capitalize first letter of error because linter
 			errRunes := []rune(errString)
@@ -134,7 +134,7 @@ func Execute(ctx context.Context) {
 			showSuggestion()
 
 		default:
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 		}
 
 		os.Exit(1)

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -144,7 +144,7 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 	if envKey != "" {
 		err := validators.APIKey(envKey)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("the STRIPE_API_KEY environment variable is set but invalid: %w", err)
 		}
 
 		return envKey, nil

--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -99,6 +99,7 @@ var Events = map[string]string{
 	"plan.deleted":                              "triggers/plan.deleted.json",
 	"plan.updated":                              "triggers/plan.updated.json",
 	"price.created":                             "triggers/price.created.json",
+	"price.deleted":                             "triggers/price.deleted.json",
 	"price.updated":                             "triggers/price.updated.json",
 	"product.created":                           "triggers/product.created.json",
 	"product.deleted":                           "triggers/product.deleted.json",

--- a/pkg/fixtures/triggers/price.deleted.json
+++ b/pkg/fixtures/triggers/price.deleted.json
@@ -1,0 +1,31 @@
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "product",
+      "path": "/v1/products",
+      "method": "post",
+      "params": {
+          "name": "myproduct",
+          "description": "(created by Stripe CLI)"
+      }
+    },
+    {
+      "name": "price",
+      "path": "/v1/prices",
+      "method": "post",
+      "params": {
+        "product": "${product:id}",
+        "unit_amount": "1500",
+        "currency": "usd"
+      }
+    },
+    {
+      "name": "product_deleted",
+      "path": "/v1/products/${product:id}",
+      "method": "delete"
+    }
+  ]
+}

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -11,7 +11,8 @@ import (
 
 // Login is the main entrypoint for logging in to the CLI.
 func Login(ctx context.Context, baseURL string, config *config.Config) error {
-	links, err := GetLinks(ctx, baseURL, config.Profile.DeviceName)
+	deviceName, _ := config.Profile.GetDeviceName()
+	links, err := GetLinks(ctx, baseURL, deviceName)
 	if err != nil {
 		return err
 	}

--- a/pkg/proxy/endpoint.go
+++ b/pkg/proxy/endpoint.go
@@ -48,6 +48,7 @@ func (f EndpointResponseHandlerFunc) ProcessResponse(evtCtx eventContext, forwar
 // FailedToPostError describes a failure to send a POST request to an endpoint
 type FailedToPostError struct {
 	Err error
+	URL string
 }
 
 func (f FailedToPostError) Error() string {
@@ -123,7 +124,7 @@ func (c *EndpointClient) Post(evtCtx eventContext) error {
 	resp, err := c.cfg.HTTPClient.Do(req)
 	if err != nil {
 		c.cfg.OutCh <- websocket.ErrorElement{
-			Error: FailedToPostError{Err: err},
+			Error: FailedToPostError{Err: err, URL: c.URL},
 		}
 		return err
 	}
@@ -158,7 +159,7 @@ func (c *EndpointClient) PostV2(evtCtx eventContext) error {
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		c.cfg.OutCh <- websocket.ErrorElement{
-			Error: FailedToPostError{Err: err},
+			Error: FailedToPostError{Err: err, URL: c.URL},
 		}
 		return err
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -187,7 +187,7 @@ func (p *Proxy) Run(ctx context.Context) error {
 			displayedAPIVersion := ""
 			if p.cfg.UseLatestAPIVersion && session.LatestVersion != "" {
 				displayedAPIVersion = "You are using Stripe API Version [" + session.LatestVersion + "]. "
-			} else if !p.cfg.UseLatestAPIVersion && session.DefaultVersion != "" {
+			} else if session.DefaultVersion != "" {
 				displayedAPIVersion = "You are using Stripe API Version [" + session.DefaultVersion + "]. "
 			}
 


### PR DESCRIPTION
## Summary

- **Quote project name** in `--project-name=` login suggestion to handle names with spaces (#1061)
- **Print errors to stderr** instead of stdout in the root error handler (#872)
- **Better STRIPE_API_KEY error**: wrap validation errors with context that the env var is set but invalid (#1316)
- **Add `price.deleted` trigger** fixture so `stripe trigger price.deleted` works (#1128)
- **Improve connection refused errors**: show "Is your local server running?" with the target URL when forwarding fails (#273)
- **Honor `STRIPE_DEVICE_NAME` env var** in the login flow by using `GetDeviceName()` instead of reading `DeviceName` directly (#1063)
- **Always display API version** in `stripe listen` output, not only when `--latest` is used (#401)

## Test plan

- [x] All existing tests pass (`go test ./pkg/cmd/... ./pkg/proxy/... ./pkg/config/... ./pkg/fixtures/... ./pkg/login/...`)
- [ ] Manual: `stripe trigger price.deleted` creates a product+price then deletes the product
- [ ] Manual: `stripe listen --forward-to http://localhost:9999` with no server running shows improved error
- [ ] Manual: Set invalid `STRIPE_API_KEY` env var and verify error mentions the env var
- [ ] Manual: Set `STRIPE_DEVICE_NAME` env var and run `stripe login` to verify it's used

🤖 Generated with [Claude Code](https://claude.com/claude-code)