### PR TITLE
Fail open when additional plugin manifests don't exist

### DIFF
--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -148,6 +149,11 @@ func fetchAndMergeManifests(pluginData requests.PluginData) (*PluginList, error)
 	for _, filename := range pluginData.AdditionalManifests {
 		additionalPluginList, err := fetchPluginList(pluginData.PluginBaseURL, filename)
 		if err != nil {
+			var remoteResourceNotFoundError *remoteResourceNotFoundError
+			if errors.As(err, &remoteResourceNotFoundError) {
+				log.Debugf("Additional plugin manifest not found, silently skipping: url=%s", remoteResourceNotFoundError.URL)
+				continue
+			}
 			return nil, err
 		}
 		additionalPluginLists = append(additionalPluginLists, additionalPluginList)
@@ -282,6 +288,14 @@ func findPluginIndex(list *PluginList, p Plugin) int {
 	return -1
 }
 
+type remoteResourceNotFoundError struct {
+	URL string
+}
+
+func (e *remoteResourceNotFoundError) Error() string {
+	return fmt.Sprintf("remote resource not found: url=%s", e.URL)
+}
+
 // FetchRemoteResource returns the remote resource body
 func FetchRemoteResource(url string) ([]byte, error) {
 	t := &requests.TracedTransport{}
@@ -311,7 +325,7 @@ func FetchRemoteResource(url string) ([]byte, error) {
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("remote resource not found: url=%s", url)
+		return nil, &remoteResourceNotFoundError{URL: url}
 	}
 
 	defer resp.Body.Close()

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -2,6 +2,9 @@ package plugins
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -9,6 +12,8 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/requests"
 )
 
 func TestGetPluginList(t *testing.T) {
@@ -209,6 +214,7 @@ func TestRefreshPluginManifestSucceedsIfNoAPIKey(t *testing.T) {
 	err := RefreshPluginManifest(context.Background(), config, fs, testServers.StripeServer.URL)
 	require.Nil(t, err)
 }
+
 func TestIsValidNodeLTSVersion(t *testing.T) {
 	validVersions := []string{"18", "20", "22", "24", "26"}
 	for _, version := range validVersions {
@@ -353,4 +359,43 @@ func TestValidatePluginManifestWithValidRuntime(t *testing.T) {
 	require.NotNil(t, pluginList)
 	require.Equal(t, 1, len(pluginList.Plugins))
 	require.Equal(t, "24", pluginList.Plugins[0].Releases[0].Runtime["node"])
+}
+
+func TestRefreshPluginSucceedsIfAdditionalManifestNotFound(t *testing.T) {
+	fs := setUpFS()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch url := req.URL.String(); {
+		case url == "/plugins.toml":
+			res.Write(manifestContent)
+		case url == "/plugins-nonexistent.toml":
+			res.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer func() { artifactoryServer.Close() }()
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch url := req.URL.String(); url {
+		case "/v1/stripecli/get-plugin-url":
+			pd := requests.PluginData{
+				PluginBaseURL:       artifactoryServer.URL,
+				AdditionalManifests: []string{"plugins-nonexistent.toml"},
+			}
+			body, err := json.Marshal(pd)
+			if err != nil {
+				t.Error(err)
+			}
+			res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+
+	err := RefreshPluginManifest(context.Background(), config, fs, stripeServer.URL)
+	require.Nil(t, err)
 }


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

We use additional plugin manifests to release WIP plugins or to incrementally roll out new ones. These files may sometimes not exist, but we shouldn't fail in that scenario since these plugins are not considered "GA" if they're in one of these additional manifests. So let's fail open to not block other plugins from being installed.

Tested manually by hacking in a request to a non-existent manifest (plugins-nonexist.toml) and found the expected debug log I introduced:

```
go run cmd/stripe/main.go plugin install apps --log-level debug

[Wed, 11 Mar 2026 14:59:18 PDT] DEBUG config.Config.InitConfig: Using profiles file path=/Users/vcheung/.config/stripe/config.toml
[Wed, 11 Mar 2026 14:59:18 PDT] DEBUG No API key available, using default plugin data
[Wed, 11 Mar 2026 14:59:20 PDT] DEBUG Additional plugin manifest not found, silently skipping: url=https://stripe.jfrog.io/artifactory/stripe-cli-plugins-local/plugins-nonexistent.toml
[Wed, 11 Mar 2026 14:59:20 PDT] DEBUG config.Config.GetProfilesFolder: Using profiles file path=/Users/vcheung/.config/stripe
[Wed, 11 Mar 2026 14:59:20 PDT] DEBUG config.Config.GetProfilesFolder: Using profiles file path=/Users/vcheung/.config/stripe
⣾ installing 'apps' v1.15.7...[Wed, 11 Mar 2026 14:59:20 PDT] DEBUG No API key available, using default plugin data
⡿ installing 'apps' v1.15.7...[Wed, 11 Mar 2026 14:59:21 PDT] DEBUG config.Config.GetProfilesFolder: Using profiles file path=/Users/vcheung/.config/stripe
[Wed, 11 Mar 2026 14:59:21 PDT] DEBUG plugins.plugin.Install: installing apps to /Users/vcheung/.config/stripe/plugins/apps/1.15.7/stripe-cli-apps...
[Wed, 11 Mar 2026 14:59:21 PDT] DEBUG plugins.plugin.cleanUpPluginPath: Cleaning up other plugin versions...
[Wed, 11 Mar 2026 14:59:21 PDT] DEBUG config.Config.GetProfilesFolder: Using profiles file path=/Users/vcheung/.config/stripe
[Wed, 11 Mar 2026 14:59:21 PDT] DEBUG plugins.plugin.cleanUpPluginPath: Skipping directory: /Users/vcheung/.config/stripe/plugins/apps
[Wed, 11 Mar 2026 14:59:21 PDT] DEBUG plugins.plugin.cleanUpPluginPath: Skipping directory: /Users/vcheung/.config/stripe/plugins/apps/1.15.7
✔ installation complete.
```