### PR TITLE
Pass CLI metadata to plugins via environment variables

### DIFF
--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stripe/stripe-cli/pkg/plugins/proto"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
+	"github.com/stripe/stripe-cli/pkg/useragent"
+	cliversion "github.com/stripe/stripe-cli/pkg/version"
 
 	hclog "github.com/hashicorp/go-hclog"
 	hcplugin "github.com/hashicorp/go-plugin"
@@ -399,6 +401,17 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 		// Couldn't find release info, assume it's a standalone binary
 		cmd = exec.Command(pluginBinaryPath)
 		usesRuntime = false
+	}
+
+	// Set environment variables for plugins to access CLI metadata
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("STRIPE_CLI_USER_AGENT=%s", useragent.GetEncodedUserAgent()),
+		fmt.Sprintf("STRIPE_CLI_VERSION=%s", cliversion.Version),
+	)
+
+	// Set account ID if available
+	if accountID, err := config.GetProfile().GetAccountID(); err == nil && accountID != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("STRIPE_ACCOUNT_ID=%s", accountID))
 	}
 
 	handshakeConfig, pluginSetMap := p.getPluginInterface()


### PR DESCRIPTION
 **Summary**                                                   

  When the CLI spawns plugin processes, it now sets environment variables containing CLI metadata that plugins need for telemetry and configuration. This enables plugins to report accurate telemetry
  data without requiring additional gRPC calls or hardcoded values.

  **Changes**

  New environment variables passed to all plugins:

  1. STRIPE_CLI_USER_AGENT - The CLI's user agent string (e.g., "Stripe/v1 stripe-cli/1.21.10")
    - Allows plugins to include parent CLI information in their telemetry
    - Maintains consistent user agent formatting across CLI and plugin requests
  2. STRIPE_CLI_VERSION - The CLI version (e.g., "1.21.10")
    - Enables plugins to report which CLI version invoked them
    - Useful for debugging version-specific issues
  3. STRIPE_ACCOUNT_ID - The active account/merchant ID (optional, only if available)
    - Allows plugins to associate telemetry with specific accounts
    - Only set when an account ID is available from the active profile

  **Why this matters**

  Before: Plugins had no way to know:
  - Which CLI version invoked them
  - The parent CLI's user agent string
  - The active account context

  This meant plugin telemetry was incomplete and couldn't be correlated with CLI telemetry.

  After: Plugins can:
  - Report accurate cli_version in telemetry
  - Build proper user_agent strings that include both CLI and plugin identity (e.g., "stripe-cli/1.21.10 plugin_generate/0.1.0")
  - Associate events with merchant accounts for better analytics


  **Compatibility**

  - Backward compatible: Existing plugins continue to work (they simply ignore the new env vars)
  - Forward compatible: New plugins can depend on these variables being set
  - No breaking changes: This is purely additive

`  Related work`

  - TypeScript plugin bootstrap library (stripe-cli-ts-plugin-bootstrap) already expects and uses these environment variables for telemetry: https://github.com/stripe/stripe-cli-ts-plugin-bootstrap/pull/18

  - Go plugin bootstrap library can be updated to use these as well
