### PR TITLE
Add completion auto-install and uninstall

### DIFF
--- a/pkg/ansi/diff.go
+++ b/pkg/ansi/diff.go
@@ -1,0 +1,233 @@
+package ansi
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/logrusorgru/aurora"
+)
+
+// RenderDiff prints a colorized, line-numbered unified diff to w.
+// path is shown as a header. oldContent/newContent are full file contents.
+// Colors respect --color flag, CLICOLOR, and TTY detection via Color(w).
+func RenderDiff(w io.Writer, path, oldContent, newContent string) {
+	if oldContent == newContent {
+		return
+	}
+
+	color := Color(w)
+
+	oldLines := splitLines(oldContent)
+	newLines := splitLines(newContent)
+
+	// Print header
+	if oldContent == "" && newContent != "" {
+		fmt.Fprintf(w, "\n%s %s:\n\n", path, color.Sprintf(color.Faint("(new file)")))
+	} else {
+		fmt.Fprintf(w, "\n%s:\n\n", path)
+	}
+
+	// Find common prefix (identical lines from start)
+	prefixLen := 0
+	for prefixLen < len(oldLines) && prefixLen < len(newLines) && oldLines[prefixLen] == newLines[prefixLen] {
+		prefixLen++
+	}
+
+	// Find common suffix (identical lines from end, not overlapping prefix)
+	suffixLen := 0
+	for suffixLen < len(oldLines)-prefixLen && suffixLen < len(newLines)-prefixLen &&
+		oldLines[len(oldLines)-1-suffixLen] == newLines[len(newLines)-1-suffixLen] {
+		suffixLen++
+	}
+
+	oldMiddleStart := prefixLen
+	oldMiddleEnd := len(oldLines) - suffixLen
+	newMiddleStart := prefixLen
+	newMiddleEnd := len(newLines) - suffixLen
+
+	hunks := buildHunks(oldLines, newLines, oldMiddleStart, oldMiddleEnd, newMiddleStart, newMiddleEnd)
+
+	useColors := shouldUseColors(w)
+
+	for i, h := range hunks {
+		if i > 0 {
+			fmt.Fprintf(w, "%s\n", color.Sprintf(color.Faint("        ···")))
+		}
+		renderHunk(w, color, useColors, oldLines, newLines, h, 3)
+	}
+
+	fmt.Fprintln(w)
+}
+
+// diffHunk represents a contiguous changed region.
+type diffHunk struct {
+	oldStart int // index into oldLines where removed lines start
+	oldEnd   int // exclusive end
+	newStart int // index into newLines where added lines start
+	newEnd   int // exclusive end
+}
+
+// buildHunks identifies individual hunks within the middle changed region.
+// When the middle contains runs of 7+ identical lines, the region is split
+// into separate hunks so the output shows ··· between distant changes.
+func buildHunks(oldLines, newLines []string, oldStart, oldEnd, newStart, newEnd int) []diffHunk {
+	oldMiddle := oldLines[oldStart:oldEnd]
+	newMiddle := newLines[newStart:newEnd]
+
+	if len(oldMiddle) == 0 && len(newMiddle) == 0 {
+		return nil
+	}
+
+	// For purely added or purely removed, there are no common inner lines to split on.
+	if len(oldMiddle) == 0 || len(newMiddle) == 0 {
+		return []diffHunk{{oldStart: oldStart, oldEnd: oldEnd, newStart: newStart, newEnd: newEnd}}
+	}
+
+	// Look for runs of common lines within the middle region that are long
+	// enough (7+) to justify splitting into separate hunks.
+	// Use a simple LCS-like scan: match identical lines at the same offset.
+	type matchRun struct {
+		oldIdx, newIdx, length int
+	}
+
+	var runs []matchRun
+	oi, ni := 0, 0
+	for oi < len(oldMiddle) && ni < len(newMiddle) {
+		if oldMiddle[oi] == newMiddle[ni] {
+			start := oi
+			nStart := ni
+			for oi < len(oldMiddle) && ni < len(newMiddle) && oldMiddle[oi] == newMiddle[ni] {
+				oi++
+				ni++
+			}
+			if oi-start >= 7 {
+				runs = append(runs, matchRun{oldIdx: start, newIdx: nStart, length: oi - start})
+			}
+		} else {
+			// Advance whichever side is "behind"
+			if oi < ni {
+				oi++
+			} else {
+				ni++
+			}
+		}
+	}
+
+	if len(runs) == 0 {
+		return []diffHunk{{oldStart: oldStart, oldEnd: oldEnd, newStart: newStart, newEnd: newEnd}}
+	}
+
+	// Split the middle region around the runs
+	var hunks []diffHunk
+	curOldStart, curNewStart := 0, 0
+
+	for _, run := range runs {
+		// Everything before this run is a hunk
+		if curOldStart < run.oldIdx || curNewStart < run.newIdx {
+			hunks = append(hunks, diffHunk{
+				oldStart: oldStart + curOldStart,
+				oldEnd:   oldStart + run.oldIdx,
+				newStart: newStart + curNewStart,
+				newEnd:   newStart + run.newIdx,
+			})
+		}
+		curOldStart = run.oldIdx + run.length
+		curNewStart = run.newIdx + run.length
+	}
+
+	// Remaining after last run
+	if curOldStart < len(oldMiddle) || curNewStart < len(newMiddle) {
+		hunks = append(hunks, diffHunk{
+			oldStart: oldStart + curOldStart,
+			oldEnd:   oldEnd,
+			newStart: newStart + curNewStart,
+			newEnd:   newEnd,
+		})
+	}
+
+	return hunks
+}
+
+// renderHunk renders a single hunk with surrounding context lines.
+func renderHunk(w io.Writer, color aurora.Aurora, useColors bool, oldLines, newLines []string, h diffHunk, contextSize int) {
+	// Leading context: use lines from whichever side has them at the common prefix position
+	contextStart := max(0, min(h.oldStart, h.newStart)-contextSize)
+
+	// Use newLines for context when available (they represent the final state),
+	// falling back to oldLines for the leading context region.
+	contextSource := newLines
+	if len(newLines) == 0 {
+		contextSource = oldLines
+	}
+
+	// Format: left-aligned number in a fixed-width gutter, then prefix+text.
+	// The +/- prefix replaces the second space in context lines, keeping
+	// the text aligned while visually marking the change.
+	// Context:  "  123  line text"
+	// Removed:  "  123 -line text"   (dark red background)
+	// Added:    "  123 +line text"   (dark green background)
+
+	changeStart := min(h.oldStart, h.newStart)
+	for i := contextStart; i < changeStart && i < len(contextSource); i++ {
+		fmt.Fprintf(w, "%5d  %s\n", i+1, contextSource[i])
+	}
+
+	// Removed lines — very dark red background covering full line including gutter,
+	// desaturated red line number (index 131: #af5f5f)
+	for i := h.oldStart; i < h.oldEnd; i++ {
+		renderColoredLine(w, useColors, i+1, "-", oldLines[i], diffColorRemoved, 131)
+	}
+
+	// Added lines — very dark green background covering full line including gutter,
+	// bright green line number (index 34: #00af00)
+	for i := h.newStart; i < h.newEnd; i++ {
+		renderColoredLine(w, useColors, i+1, "+", newLines[i], diffColorAdded, 34)
+	}
+
+	// Trailing context (use new file lines and line numbers)
+	trailStart := h.newEnd
+	trailEnd := min(len(newLines), trailStart+contextSize)
+	for i := trailStart; i < trailEnd; i++ {
+		fmt.Fprintf(w, "%5d  %s\n", i+1, newLines[i])
+	}
+}
+
+// diffColor holds the true-color RGB for a diff line background.
+type diffColor struct {
+	r, g, b uint8
+}
+
+var (
+	// Very dark green (#002200) and very dark red (#220000) for diff backgrounds.
+	// True-color (24-bit) ANSI escapes, darker than the 256-color palette allows.
+	diffColorAdded   = diffColor{0x00, 0x22, 0x00}
+	diffColorRemoved = diffColor{0x22, 0x00, 0x00}
+)
+
+// renderColoredLine writes a full-width background-colored diff line using
+// raw ANSI escapes. The background covers the entire line including the gutter.
+// The line number foreground is set without resetting, so the background persists.
+func renderColoredLine(w io.Writer, useColors bool, lineNum int, prefix, text string, bg diffColor, fgIndex uint8) {
+	if useColors {
+		// Set background (24-bit), then foreground (256-color) for line number,
+		// print number, reset foreground to default, print prefix+text, then full reset.
+		fmt.Fprintf(w, "\x1b[48;2;%d;%d;%dm\x1b[38;5;%dm%5d %s\x1b[39m%s\x1b[0m\n",
+			bg.r, bg.g, bg.b, fgIndex, lineNum, prefix, text)
+	} else {
+		fmt.Fprintf(w, "%5d %s%s\n", lineNum, prefix, text)
+	}
+}
+
+// splitLines splits a string into lines, removing a trailing empty element
+// caused by a final newline.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}

--- a/pkg/ansi/diff_test.go
+++ b/pkg/ansi/diff_test.go
@@ -1,0 +1,284 @@
+package ansi_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+)
+
+func disableColors(t *testing.T) {
+	t.Helper()
+	ansi.DisableColors = true
+	t.Cleanup(func() { ansi.DisableColors = false })
+}
+
+func TestRenderDiff_NewFile(t *testing.T) {
+	disableColors(t)
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "~/.zshrc", "", "line one\nline two\nline three\n")
+
+	output := buf.String()
+	assert.Contains(t, output, "~/.zshrc (new file):")
+	assert.Contains(t, output, "    1 +line one")
+	assert.Contains(t, output, "    2 +line two")
+	assert.Contains(t, output, "    3 +line three")
+	assert.True(t, strings.HasSuffix(output, "\n"), "output should end with newline")
+}
+
+func TestRenderDiff_LinesAddedAtEnd(t *testing.T) {
+	disableColors(t)
+
+	oldContent := "line 1\nline 2\nline 3\nline 4\nline 5\n"
+	newContent := "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\n"
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", oldContent, newContent)
+
+	output := buf.String()
+	assert.Contains(t, output, "file.txt:")
+	assert.NotContains(t, output, "(new file)")
+	// Should show 3 lines of context before the additions
+	assert.Contains(t, output, "    3  line 3")
+	assert.Contains(t, output, "    4  line 4")
+	assert.Contains(t, output, "    5  line 5")
+	// Then the added lines (number, space, +, text)
+	assert.Contains(t, output, "    6 +line 6")
+	assert.Contains(t, output, "    7 +line 7")
+}
+
+func TestRenderDiff_LinesRemoved(t *testing.T) {
+	disableColors(t)
+
+	oldContent := "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\n"
+	newContent := "line 1\nline 2\nline 3\n"
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", oldContent, newContent)
+
+	output := buf.String()
+	assert.Contains(t, output, "file.txt:")
+	// Should show context before removed lines
+	assert.Contains(t, output, "    1  line 1")
+	assert.Contains(t, output, "    2  line 2")
+	assert.Contains(t, output, "    3  line 3")
+	// Then the removed lines (number, space, -, text)
+	assert.Contains(t, output, "    4 -line 4")
+	assert.Contains(t, output, "    5 -line 5")
+	assert.Contains(t, output, "    6 -line 6")
+}
+
+func TestRenderDiff_LinesRemovedFromMiddle(t *testing.T) {
+	disableColors(t)
+
+	oldContent := "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\n"
+	newContent := "line 1\nline 2\nline 3\nline 6\nline 7\nline 8\n"
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", oldContent, newContent)
+
+	output := buf.String()
+	// Should show 3 lines of context before
+	assert.Contains(t, output, "    1  line 1")
+	assert.Contains(t, output, "    2  line 2")
+	assert.Contains(t, output, "    3  line 3")
+	// Then removed lines
+	assert.Contains(t, output, "    4 -line 4")
+	assert.Contains(t, output, "    5 -line 5")
+	// Then 3 lines of context after (new-file line numbers)
+	assert.Contains(t, output, "    4  line 6")
+	assert.Contains(t, output, "    5  line 7")
+	assert.Contains(t, output, "    6  line 8")
+}
+
+func TestRenderDiff_Replacement(t *testing.T) {
+	disableColors(t)
+
+	oldContent := "line 1\nline 2\nold line 3\nold line 4\nline 5\nline 6\n"
+	newContent := "line 1\nline 2\nnew line 3\nnew line 4\nline 5\nline 6\n"
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", oldContent, newContent)
+
+	output := buf.String()
+	// Should show removal of old lines
+	assert.Contains(t, output, "    3 -old line 3")
+	assert.Contains(t, output, "    4 -old line 4")
+	// And addition of new lines
+	assert.Contains(t, output, "    3 +new line 3")
+	assert.Contains(t, output, "    4 +new line 4")
+	// With proper context
+	assert.Contains(t, output, "    2  line 2")
+	assert.Contains(t, output, "    5  line 5")
+}
+
+func TestRenderDiff_MultipleHunks(t *testing.T) {
+	disableColors(t)
+
+	// Create content with changes at start and end, separated by 7+ unchanged lines
+	oldContent := "old line 1\nold line 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10\nold line 11\nold line 12\n"
+	newContent := "new line 1\nnew line 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10\nnew line 11\nnew line 12\n"
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", oldContent, newContent)
+
+	output := buf.String()
+	// Should show first hunk
+	assert.Contains(t, output, "    1 -old line 1")
+	assert.Contains(t, output, "    2 -old line 2")
+	assert.Contains(t, output, "    1 +new line 1")
+	assert.Contains(t, output, "    2 +new line 2")
+	// Should show separator
+	assert.Contains(t, output, "        ···")
+	// Should show second hunk
+	assert.Contains(t, output, "   11 -old line 11")
+	assert.Contains(t, output, "   12 -old line 12")
+	assert.Contains(t, output, "   11 +new line 11")
+	assert.Contains(t, output, "   12 +new line 12")
+}
+
+func TestRenderDiff_NoChange(t *testing.T) {
+	disableColors(t)
+
+	content := "line 1\nline 2\nline 3\n"
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", content, content)
+
+	output := buf.String()
+	// When there's no change, should output nothing
+	assert.Empty(t, output)
+}
+
+func TestRenderDiff_EmptyToEmpty(t *testing.T) {
+	disableColors(t)
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", "", "")
+
+	output := buf.String()
+	// Both empty means no change
+	assert.Empty(t, output)
+}
+
+func TestRenderDiff_ContextCappingAtStart(t *testing.T) {
+	disableColors(t)
+
+	// Change on line 1 - should show only available context (none before)
+	oldContent := "old line 1\nline 2\nline 3\nline 4\nline 5\n"
+	newContent := "new line 1\nline 2\nline 3\nline 4\nline 5\n"
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", oldContent, newContent)
+
+	output := buf.String()
+	// Should show the change immediately without 3 lines of context before
+	assert.Contains(t, output, "    1 -old line 1")
+	assert.Contains(t, output, "    1 +new line 1")
+	// Should show 3 lines of context after
+	assert.Contains(t, output, "    2  line 2")
+	assert.Contains(t, output, "    3  line 3")
+	assert.Contains(t, output, "    4  line 4")
+}
+
+func TestRenderDiff_ContextCappingAtStartWithTwoLines(t *testing.T) {
+	disableColors(t)
+
+	// Change on line 3 - should show only 2 lines of context before
+	oldContent := "line 1\nline 2\nold line 3\nline 4\nline 5\nline 6\n"
+	newContent := "line 1\nline 2\nnew line 3\nline 4\nline 5\nline 6\n"
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", oldContent, newContent)
+
+	output := buf.String()
+	// Should show 2 lines of context before (not 3, because we're at line 3)
+	assert.Contains(t, output, "    1  line 1")
+	assert.Contains(t, output, "    2  line 2")
+	assert.Contains(t, output, "    3 -old line 3")
+	assert.Contains(t, output, "    3 +new line 3")
+	// Should show 3 lines of context after
+	assert.Contains(t, output, "    4  line 4")
+	assert.Contains(t, output, "    5  line 5")
+	assert.Contains(t, output, "    6  line 6")
+}
+
+func TestRenderDiff_ContextCappingAtEnd(t *testing.T) {
+	disableColors(t)
+
+	// Change on last line - should show only available context (none after)
+	oldContent := "line 1\nline 2\nline 3\nline 4\nold line 5\n"
+	newContent := "line 1\nline 2\nline 3\nline 4\nnew line 5\n"
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", oldContent, newContent)
+
+	output := buf.String()
+	// Should show 3 lines of context before
+	assert.Contains(t, output, "    2  line 2")
+	assert.Contains(t, output, "    3  line 3")
+	assert.Contains(t, output, "    4  line 4")
+	// Then the change
+	assert.Contains(t, output, "    5 -old line 5")
+	assert.Contains(t, output, "    5 +new line 5")
+	// No context after (it's the last line)
+}
+
+func TestRenderDiff_LineNumberAlignment(t *testing.T) {
+	disableColors(t)
+
+	// Test that line numbers are right-aligned in a 5-char gutter
+	oldContent := "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10\n"
+	newContent := "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10\nline 11\n"
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", oldContent, newContent)
+
+	output := buf.String()
+	// Single-digit line numbers should be right-aligned
+	assert.Contains(t, output, "    8  line 8")
+	assert.Contains(t, output, "    9  line 9")
+	// Double-digit line numbers should be right-aligned
+	assert.Contains(t, output, "   10  line 10")
+	assert.Contains(t, output, "   11 +line 11")
+}
+
+func TestRenderDiff_TrailingNewline(t *testing.T) {
+	disableColors(t)
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", "", "line 1\n")
+
+	output := buf.String()
+	// Should end with trailing newline
+	assert.True(t, strings.HasSuffix(output, "\n\n"), "output should end with two newlines (one from last line, one trailing)")
+}
+
+func TestRenderDiff_ComplexReplacement(t *testing.T) {
+	disableColors(t)
+
+	// Replace multiple lines with different number of lines
+	oldContent := "line 1\nline 2\nold line 3\nold line 4\nold line 5\nline 6\nline 7\n"
+	newContent := "line 1\nline 2\nnew line 3\nnew line 4\nline 6\nline 7\n"
+
+	var buf bytes.Buffer
+	ansi.RenderDiff(&buf, "file.txt", oldContent, newContent)
+
+	output := buf.String()
+	// Should show context
+	assert.Contains(t, output, "    2  line 2")
+	// Should show all removed lines
+	assert.Contains(t, output, "    3 -old line 3")
+	assert.Contains(t, output, "    4 -old line 4")
+	assert.Contains(t, output, "    5 -old line 5")
+	// Should show all added lines
+	assert.Contains(t, output, "    3 +new line 3")
+	assert.Contains(t, output, "    4 +new line 4")
+	// Should show context after (new-file line numbers: line 6 is now at position 5)
+	assert.Contains(t, output, "    5  line 6")
+	assert.Contains(t, output, "    6  line 7")
+}

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
@@ -37,7 +39,19 @@ func newCompletionCmd() *completionCmd {
 	cc.cmd = &cobra.Command{
 		Use:   "completion",
 		Short: "Generate bash, zsh, and fish completion scripts",
-		Args:  validators.NoArgs,
+		Long:  "Generate shell completion scripts. Use --install to automatically configure your shell profile, or run without flags to generate a script file manually.",
+		Example: `  # Auto-install completions (detects your shell)
+  stripe completion --install
+
+  # Install for a specific shell
+  stripe completion --install --shell zsh
+
+  # Remove installed completions
+  stripe completion --uninstall
+
+  # Generate completion script to stdout
+  stripe completion --shell bash --write-to-stdout`,
+		Args: validators.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			shell := cc.shell
 			if shell == "" {
@@ -47,6 +61,9 @@ func newCompletionCmd() *completionCmd {
 			if cc.install || cc.uninstall {
 				if shell == "" {
 					return fmt.Errorf("could not automatically detect your shell. Please run the command with the `--shell` flag for bash, zsh, or fish")
+				}
+				if shell != "bash" && shell != "zsh" && shell != "fish" {
+					return fmt.Errorf("unsupported shell %q. Supported shells: bash, zsh, fish", shell)
 				}
 				if cc.install {
 					return installCompletion(shell, os.UserHomeDir)
@@ -293,7 +310,7 @@ func generateCompletionScript(shell string, buf *bytes.Buffer) error {
 func sourceLine(shell, scriptPath string) string {
 	switch shell {
 	case "bash", "zsh":
-		return fmt.Sprintf("source %s", scriptPath)
+		return fmt.Sprintf("source \"%s\"", scriptPath)
 	default:
 		return ""
 	}
@@ -334,21 +351,34 @@ func installCompletion(shell string, getHomeDir homeDirFunc) error {
 		return fmt.Errorf("could not write completion script to %s: %w", scriptPath, err)
 	}
 
-	// For bash/zsh, add source line to shell config (with user confirmation)
+	// For bash/zsh, add source line to shell config (with diff preview + confirmation)
 	if shell != "fish" {
 		configPath := getShellConfigFile(shell, homeDir)
 		line := sourceLine(shell, scriptPath)
 
-		if !confirmFunc(fmt.Sprintf("This will add shell completion configuration to %s. Proceed?", configPath)) {
-			// Script file was already written, but user declined config modification
-			fmt.Printf("Aborted. Completion script was written to %s but your shell config was not modified.\nTo activate manually, add this line to %s:\n  %s\n", scriptPath, configPath, line)
-			return nil
+		oldContent, perm, err := readConfigFile(configPath)
+		if err != nil {
+			return fmt.Errorf("could not read %s: %w", configPath, err)
 		}
 
-		if err := addSentinelBlock(configPath, line); err != nil {
-			return fmt.Errorf("could not update %s: %w", configPath, err)
+		newContent := computeAddSentinel(oldContent, line)
+
+		if newContent != oldContent {
+			ansi.RenderDiff(os.Stdout, configPath, oldContent, newContent)
+
+			if !confirm(installConfirmFn, "Apply changes?") {
+				fmt.Printf("Aborted. Completion script was written to %s but your shell config was not modified.\nTo activate manually, add this line to %s:\n  %s\n", scriptPath, configPath, line)
+				return nil
+			}
+
+			if err := os.WriteFile(configPath, []byte(newContent), perm); err != nil {
+				return fmt.Errorf("could not update %s: %w", configPath, err)
+			}
+
+			fmt.Printf("Completion installed for %s.\nScript written to: %s\nShell config updated: %s\nRestart your shell or run: %s\n", shell, scriptPath, configPath, line)
+		} else {
+			fmt.Printf("Completion already configured in %s.\nScript updated: %s\n", configPath, scriptPath)
 		}
-		fmt.Printf("Completion installed for %s.\nScript written to: %s\nShell config updated: %s\nRestart your shell or run: %s\n", shell, scriptPath, configPath, line)
 
 		// Warn about manually-added lines outside our sentinel block
 		remnants := findManualRemnants(configPath, completionScriptFilename(shell))
@@ -379,17 +409,28 @@ func uninstallCompletion(shell string, getHomeDir homeDirFunc) error {
 		return fmt.Errorf("could not remove completion script %s: %w", scriptPath, err)
 	}
 
-	// For bash/zsh, remove sentinel block from shell config (with user confirmation)
+	// For bash/zsh, remove sentinel block from shell config (with diff preview + confirmation)
 	if shell != "fish" {
 		configPath := getShellConfigFile(shell, homeDir)
 
-		if !confirmFunc(fmt.Sprintf("This will remove shell completion configuration from %s. Proceed?", configPath)) {
-			fmt.Printf("Aborted. Completion script was removed but your shell config was not modified.\nTo clean up manually, remove the block between \"%s\" and \"%s\" in %s.\n", sentinelBegin, sentinelEnd, configPath)
-			return nil
+		oldContent, perm, err := readConfigFile(configPath)
+		if err != nil {
+			return fmt.Errorf("could not read %s: %w", configPath, err)
 		}
 
-		if err := removeSentinelBlock(configPath); err != nil {
-			return fmt.Errorf("could not update %s: %w", configPath, err)
+		newContent, found := computeRemoveSentinel(oldContent)
+
+		if found {
+			ansi.RenderDiff(os.Stdout, configPath, oldContent, newContent)
+
+			if !confirm(uninstallConfirmFn, "Apply changes?") {
+				fmt.Printf("Aborted. Completion script was removed but your shell config was not modified.\nTo clean up manually, remove the block between \"%s\" and \"%s\" in %s.\n", sentinelBegin, sentinelEnd, configPath)
+				return nil
+			}
+
+			if err := os.WriteFile(configPath, []byte(newContent), perm); err != nil {
+				return fmt.Errorf("could not update %s: %w", configPath, err)
+			}
 		}
 
 		fmt.Printf("Completion uninstalled for %s.\n", shell)
@@ -410,92 +451,72 @@ func uninstallCompletion(shell string, getHomeDir homeDirFunc) error {
 	return nil
 }
 
-// addSentinelBlock adds or replaces a sentinel-delimited block in the given
-// config file. If the file does not exist, it is created with mode 0644.
-// Existing file permissions are preserved. The operation is idempotent:
-// calling it twice with the same line produces the same result as calling
-// it once. If the file contains orphaned or reversed markers, a new block
-// is appended rather than attempting to repair the malformed state.
-func addSentinelBlock(configPath, line string) error {
-	block := fmt.Sprintf("%s\n%s\n%s", sentinelBegin, line, sentinelEnd)
-
-	data, err := os.ReadFile(configPath)
+// readConfigFile reads a shell config file and returns its content and
+// permissions. If the file does not exist, returns ("", 0644, nil).
+// Uses Open+Fstat to read content and permissions atomically from the
+// same file descriptor.
+func readConfigFile(path string) (string, os.FileMode, error) {
+	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// Create new file with just the sentinel block
-			return os.WriteFile(configPath, []byte(block+"\n"), 0644)
+			return "", 0644, nil
 		}
-		return err
+		return "", 0, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return "", 0, err
 	}
 
-	// Preserve existing file permissions
-	perm := os.FileMode(0644)
-	if info, statErr := os.Stat(configPath); statErr == nil {
-		perm = info.Mode().Perm()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return "", 0, err
 	}
 
-	content := string(data)
+	return string(data), info.Mode().Perm(), nil
+}
 
-	// Replace existing block if both markers are present in the correct order.
-	// Orphaned or reversed markers are left untouched — we append instead.
+// computeAddSentinel returns the content with a sentinel block added or
+// replaced. Pure function — no I/O. If the file contains orphaned or reversed
+// markers, a new block is appended rather than attempting to repair.
+func computeAddSentinel(content, line string) string {
+	block := fmt.Sprintf("%s\n%s\n%s", sentinelBegin, line, sentinelEnd)
+
 	beginIdx := strings.Index(content, sentinelBegin)
 	endIdx := strings.Index(content, sentinelEnd)
 	if beginIdx >= 0 && endIdx >= 0 && endIdx > beginIdx {
 		endIdx += len(sentinelEnd)
-		// Include trailing newline if present
 		if endIdx < len(content) && content[endIdx] == '\n' {
 			endIdx++
 		}
-		content = content[:beginIdx] + block + "\n" + content[endIdx:]
-		return os.WriteFile(configPath, []byte(content), perm)
+		return content[:beginIdx] + block + "\n" + content[endIdx:]
 	}
 
-	// Append sentinel block
 	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
 		content += "\n"
 	}
-	content += block + "\n"
 
-	return os.WriteFile(configPath, []byte(content), perm)
+	return content + block + "\n"
 }
 
-// removeSentinelBlock removes the sentinel-delimited block from the given
-// config file. If the file does not exist, this is a no-op. If the markers
-// are orphaned or reversed, the file is left unchanged. Existing file
-// permissions are preserved.
-func removeSentinelBlock(configPath string) error {
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	content := string(data)
-
+// computeRemoveSentinel returns the content with the sentinel block removed.
+// Pure function — no I/O. Returns (result, true) if a block was found and
+// removed, or ("", false) if no valid block exists.
+func computeRemoveSentinel(content string) (string, bool) {
 	beginIdx := strings.Index(content, sentinelBegin)
 	endIdx := strings.Index(content, sentinelEnd)
 	if beginIdx < 0 || endIdx < 0 || endIdx <= beginIdx {
-		// No valid sentinel block found, nothing to do
-		return nil
-	}
-
-	// Preserve existing file permissions
-	perm := os.FileMode(0644)
-	if info, statErr := os.Stat(configPath); statErr == nil {
-		perm = info.Mode().Perm()
+		return "", false
 	}
 
 	endIdx += len(sentinelEnd)
-	// Include trailing newline if present
 	if endIdx < len(content) && content[endIdx] == '\n' {
 		endIdx++
 	}
 
-	content = content[:beginIdx] + content[endIdx:]
-
-	return os.WriteFile(configPath, []byte(content), perm)
+	return content[:beginIdx] + content[endIdx:], true
 }
 
 // manualRemnant represents a line in a shell config file that references the
@@ -567,12 +588,23 @@ func warnManualRemnants(configPath string, remnants []manualRemnant) {
 	fmt.Printf("You may want to remove %s manually to avoid loading completions twice.\n", pluralize(len(remnants), "this line", "these lines"))
 }
 
-// confirmFunc is the function used to prompt the user for confirmation.
+// installConfirmFn and uninstallConfirmFn override the confirm prompt used
+// during install/uninstall. nil means use the default stdin prompt.
 // Override in tests to avoid blocking on stdin.
-var confirmFunc = defaultConfirm
+var (
+	installConfirmFn   func(string) bool
+	uninstallConfirmFn func(string) bool
+)
 
-// defaultConfirm asks the user a yes/no question via stdin and returns true
-// if they answer y or yes. Defaults to no on empty input or read failure.
+// confirm calls fn if non-nil, otherwise falls back to defaultConfirm.
+func confirm(fn func(string) bool, question string) bool {
+	if fn != nil {
+		return fn(question)
+	}
+	return defaultConfirm(question)
+}
+
+// defaultConfirm asks a yes/no question on stdout/stdin.
 func defaultConfirm(question string) bool {
 	fmt.Printf("%s [y/N] ", question)
 

--- a/pkg/cmd/completion_test.go
+++ b/pkg/cmd/completion_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
 )
 
 // ---------------------------------------------------------------------------
@@ -172,298 +174,155 @@ func TestGenShellCreatesFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Sentinel block tests (from sentinel-block-management branch, preserved)
+// computeAddSentinel (pure function — no I/O)
 // ---------------------------------------------------------------------------
 
-func TestAddSentinelBlockToNewFile(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-
-	err := addSentinelBlock(configPath, "source /home/user/.stripe/stripe-completion.zsh")
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	content := string(data)
-	assert.Contains(t, content, sentinelBegin)
-	assert.Contains(t, content, "source /home/user/.stripe/stripe-completion.zsh")
-	assert.Contains(t, content, sentinelEnd)
+func TestComputeAddSentinelToEmptyContent(t *testing.T) {
+	result := computeAddSentinel("", "source /home/user/.stripe/stripe-completion.zsh")
+	assert.Contains(t, result, sentinelBegin)
+	assert.Contains(t, result, "source /home/user/.stripe/stripe-completion.zsh")
+	assert.Contains(t, result, sentinelEnd)
 }
 
-func TestAddSentinelBlockPreservesExistingContent(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-
+func TestComputeAddSentinelPreservesExistingContent(t *testing.T) {
 	existing := "export PATH=/usr/local/bin:$PATH\nalias ll='ls -la'\n"
-	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0644))
-
-	err := addSentinelBlock(configPath, "source /home/user/.stripe/stripe-completion.zsh")
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	content := string(data)
-	assert.True(t, strings.HasPrefix(content, existing), "existing content should be preserved at the start")
-	assert.Contains(t, content, sentinelBegin)
-	assert.Contains(t, content, sentinelEnd)
+	result := computeAddSentinel(existing, "source /home/user/.stripe/stripe-completion.zsh")
+	assert.True(t, strings.HasPrefix(result, existing), "existing content should be preserved at the start")
+	assert.Contains(t, result, sentinelBegin)
+	assert.Contains(t, result, sentinelEnd)
 }
 
-func TestAddSentinelBlockReplaceExisting(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-
-	initial := fmt.Sprintf("before\n%s\nold source line\n%s\nafter\n", sentinelBegin, sentinelEnd)
-	require.NoError(t, os.WriteFile(configPath, []byte(initial), 0644))
-
-	err := addSentinelBlock(configPath, "new source line")
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	content := string(data)
-	assert.Contains(t, content, "before\n")
-	assert.Contains(t, content, "new source line")
-	assert.NotContains(t, content, "old source line")
-	assert.Contains(t, content, "after\n")
-	assert.Equal(t, 1, strings.Count(content, sentinelBegin))
-	assert.Equal(t, 1, strings.Count(content, sentinelEnd))
+func TestComputeAddSentinelReplacesExisting(t *testing.T) {
+	content := fmt.Sprintf("before\n%s\nold source line\n%s\nafter\n", sentinelBegin, sentinelEnd)
+	result := computeAddSentinel(content, "new source line")
+	assert.Contains(t, result, "before\n")
+	assert.Contains(t, result, "new source line")
+	assert.NotContains(t, result, "old source line")
+	assert.Contains(t, result, "after\n")
+	assert.Equal(t, 1, strings.Count(result, sentinelBegin))
+	assert.Equal(t, 1, strings.Count(result, sentinelEnd))
 }
 
-func TestAddSentinelBlockAppendsNewlineIfMissing(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-	require.NoError(t, os.WriteFile(configPath, []byte("no trailing newline"), 0644))
-
-	err := addSentinelBlock(configPath, "source line")
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), "no trailing newline\n"+sentinelBegin)
+func TestComputeAddSentinelAppendsNewlineIfMissing(t *testing.T) {
+	result := computeAddSentinel("no trailing newline", "source line")
+	assert.Contains(t, result, "no trailing newline\n"+sentinelBegin)
 }
 
-func TestAddSentinelBlockOrphanedBeginOnly(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
+func TestComputeAddSentinelOrphanedBeginOnly(t *testing.T) {
 	content := fmt.Sprintf("before\n%s\norphaned source line\nafter\n", sentinelBegin)
-	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
-
-	err := addSentinelBlock(configPath, "new source line")
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	result := string(data)
+	result := computeAddSentinel(content, "new source line")
 	assert.Contains(t, result, "new source line")
 	assert.Contains(t, result, sentinelEnd)
 }
 
-func TestAddSentinelBlockOrphanedEndOnly(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
+func TestComputeAddSentinelOrphanedEndOnly(t *testing.T) {
 	content := fmt.Sprintf("before\n%s\nafter\n", sentinelEnd)
-	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
-
-	err := addSentinelBlock(configPath, "new source line")
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	result := string(data)
+	result := computeAddSentinel(content, "new source line")
 	assert.Contains(t, result, "new source line")
 	assert.Equal(t, 1, strings.Count(result, sentinelBegin))
 }
 
-func TestAddSentinelBlockReversedMarkers(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
+func TestComputeAddSentinelReversedMarkers(t *testing.T) {
 	content := fmt.Sprintf("before\n%s\norphaned\n%s\nafter\n", sentinelEnd, sentinelBegin)
-	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
-
-	err := addSentinelBlock(configPath, "new source line")
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), "new source line")
+	result := computeAddSentinel(content, "new source line")
+	assert.Contains(t, result, "new source line")
 }
 
-func TestRemoveSentinelBlockPreservesOtherContent(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
+func TestComputeAddSentinelIdempotent(t *testing.T) {
+	line := "source /home/user/.stripe/stripe-completion.zsh"
+	once := computeAddSentinel("", line)
+	twice := computeAddSentinel(once, line)
+	assert.Equal(t, once, twice, "applying computeAddSentinel twice should produce the same result")
+}
+
+// ---------------------------------------------------------------------------
+// computeRemoveSentinel (pure function — no I/O)
+// ---------------------------------------------------------------------------
+
+func TestComputeRemoveSentinelOnlyBlock(t *testing.T) {
+	content := fmt.Sprintf("%s\nsource line\n%s\n", sentinelBegin, sentinelEnd)
+	result, found := computeRemoveSentinel(content)
+	require.True(t, found)
+	assert.Equal(t, "", result, "removing the only content should yield empty string")
+}
+
+func TestComputeRemoveSentinelPreservesOtherContent(t *testing.T) {
 	content := fmt.Sprintf("before\n%s\nsource line\n%s\nafter\n", sentinelBegin, sentinelEnd)
-	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
-
-	err := removeSentinelBlock(configPath)
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	result := string(data)
+	result, found := computeRemoveSentinel(content)
+	require.True(t, found)
 	assert.Contains(t, result, "before\n")
 	assert.Contains(t, result, "after\n")
 	assert.NotContains(t, result, sentinelBegin)
 	assert.NotContains(t, result, "source line")
 }
 
-func TestRemoveSentinelBlockNoBlockPresent(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-	original := "export FOO=bar\n"
-	require.NoError(t, os.WriteFile(configPath, []byte(original), 0644))
-
-	err := removeSentinelBlock(configPath)
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	assert.Equal(t, original, string(data))
+func TestComputeRemoveSentinelNoBlockPresent(t *testing.T) {
+	_, found := computeRemoveSentinel("export FOO=bar\n")
+	assert.False(t, found)
 }
 
-func TestRemoveSentinelBlockFileMissing(t *testing.T) {
-	err := removeSentinelBlock(filepath.Join(t.TempDir(), "nonexistent"))
-	assert.NoError(t, err)
+func TestComputeRemoveSentinelEmptyContent(t *testing.T) {
+	_, found := computeRemoveSentinel("")
+	assert.False(t, found)
 }
 
-func TestRemoveSentinelBlockOrphanedBeginOnly(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
+func TestComputeRemoveSentinelOrphanedBeginOnly(t *testing.T) {
 	content := fmt.Sprintf("before\n%s\norphaned\nafter\n", sentinelBegin)
-	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
-
-	err := removeSentinelBlock(configPath)
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	assert.Equal(t, content, string(data))
+	_, found := computeRemoveSentinel(content)
+	assert.False(t, found)
 }
 
-func TestRemoveSentinelBlockOrphanedEndOnly(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
+func TestComputeRemoveSentinelOrphanedEndOnly(t *testing.T) {
 	content := fmt.Sprintf("before\n%s\nafter\n", sentinelEnd)
-	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
-
-	err := removeSentinelBlock(configPath)
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	assert.Equal(t, content, string(data))
+	_, found := computeRemoveSentinel(content)
+	assert.False(t, found)
 }
 
-func TestRemoveSentinelBlockReversedMarkers(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-
-	// End marker appears before begin — should be a no-op
+func TestComputeRemoveSentinelReversedMarkers(t *testing.T) {
 	content := fmt.Sprintf("before\n%s\norphaned\n%s\nafter\n", sentinelEnd, sentinelBegin)
-	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
-
-	err := removeSentinelBlock(configPath)
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(configPath)
-	require.NoError(t, err)
-	assert.Equal(t, content, string(data), "reversed markers should be left untouched")
+	_, found := computeRemoveSentinel(content)
+	assert.False(t, found, "reversed markers should not be treated as a valid block")
 }
 
-func TestAddSentinelBlockReadPermissionDenied(t *testing.T) {
+// ---------------------------------------------------------------------------
+// readConfigFile
+// ---------------------------------------------------------------------------
+
+func TestReadConfigFileMissing(t *testing.T) {
+	content, perm, err := readConfigFile(filepath.Join(t.TempDir(), "nonexistent"))
+	require.NoError(t, err)
+	assert.Equal(t, "", content)
+	assert.Equal(t, os.FileMode(0644), perm)
+}
+
+func TestReadConfigFilePreservesPermissions(t *testing.T) {
 	if runtime.GOOS == "windows" || os.Getuid() == 0 {
 		t.Skip("Cannot test Unix file permissions on Windows or as root")
 	}
 
 	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-	require.NoError(t, os.WriteFile(configPath, []byte("content"), 0644))
-	require.NoError(t, os.Chmod(configPath, 0000))
-	t.Cleanup(func() { os.Chmod(configPath, 0644) })
+	path := filepath.Join(dir, ".zshrc")
+	require.NoError(t, os.WriteFile(path, []byte("content\n"), 0600))
 
-	err := addSentinelBlock(configPath, "source line")
+	content, perm, err := readConfigFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "content\n", content)
+	assert.Equal(t, os.FileMode(0600), perm)
+}
+
+func TestReadConfigFilePermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Getuid() == 0 {
+		t.Skip("Cannot test Unix file permissions on Windows or as root")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".zshrc")
+	require.NoError(t, os.WriteFile(path, []byte("content"), 0644))
+	require.NoError(t, os.Chmod(path, 0000))
+	t.Cleanup(func() { os.Chmod(path, 0644) })
+
+	_, _, err := readConfigFile(path)
 	assert.Error(t, err)
-}
-
-func TestAddSentinelBlockWritePermissionDenied(t *testing.T) {
-	if runtime.GOOS == "windows" || os.Getuid() == 0 {
-		t.Skip("Cannot test Unix file permissions on Windows or as root")
-	}
-
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-	require.NoError(t, os.WriteFile(configPath, []byte("existing\n"), 0644))
-	require.NoError(t, os.Chmod(configPath, 0444))
-	t.Cleanup(func() { os.Chmod(configPath, 0644) })
-
-	err := addSentinelBlock(configPath, "source line")
-	assert.Error(t, err)
-}
-
-func TestRemoveSentinelBlockReadPermissionDenied(t *testing.T) {
-	if runtime.GOOS == "windows" || os.Getuid() == 0 {
-		t.Skip("Cannot test Unix file permissions on Windows or as root")
-	}
-
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-	content := fmt.Sprintf("%s\nline\n%s\n", sentinelBegin, sentinelEnd)
-	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
-	require.NoError(t, os.Chmod(configPath, 0000))
-	t.Cleanup(func() { os.Chmod(configPath, 0644) })
-
-	err := removeSentinelBlock(configPath)
-	assert.Error(t, err)
-}
-
-func TestRemoveSentinelBlockWritePermissionDenied(t *testing.T) {
-	if runtime.GOOS == "windows" || os.Getuid() == 0 {
-		t.Skip("Cannot test Unix file permissions on Windows or as root")
-	}
-
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-	content := fmt.Sprintf("%s\nline\n%s\n", sentinelBegin, sentinelEnd)
-	require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
-	require.NoError(t, os.Chmod(configPath, 0444))
-	t.Cleanup(func() { os.Chmod(configPath, 0644) })
-
-	err := removeSentinelBlock(configPath)
-	assert.Error(t, err)
-}
-
-func TestAddSentinelBlockPreservesFilePermissions(t *testing.T) {
-	if runtime.GOOS == "windows" || os.Getuid() == 0 {
-		t.Skip("Cannot test Unix file permissions on Windows or as root")
-	}
-
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-	require.NoError(t, os.WriteFile(configPath, []byte("existing\n"), 0600))
-
-	err := addSentinelBlock(configPath, "source line")
-	require.NoError(t, err)
-
-	info, err := os.Stat(configPath)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "file permissions should be preserved")
-}
-
-func TestRemoveSentinelBlockPreservesFilePermissions(t *testing.T) {
-	if runtime.GOOS == "windows" || os.Getuid() == 0 {
-		t.Skip("Cannot test Unix file permissions on Windows or as root")
-	}
-
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, ".zshrc")
-	content := fmt.Sprintf("before\n%s\nline\n%s\nafter\n", sentinelBegin, sentinelEnd)
-	require.NoError(t, os.WriteFile(configPath, []byte(content), 0600))
-
-	err := removeSentinelBlock(configPath)
-	require.NoError(t, err)
-
-	info, err := os.Stat(configPath)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "file permissions should be preserved")
 }
 
 // ---------------------------------------------------------------------------
@@ -588,21 +447,43 @@ func failingHomeDir() homeDirFunc {
 	return func() (string, error) { return "", fmt.Errorf("no home directory") }
 }
 
-// alwaysConfirm overrides confirmFunc to always return true (auto-accept).
-// Returns a cleanup function that restores the original.
-func alwaysConfirm(t *testing.T) {
+// disableColors suppresses ANSI color output during tests.
+func disableColors(t *testing.T) {
 	t.Helper()
-	original := confirmFunc
-	confirmFunc = func(_ string) bool { return true }
-	t.Cleanup(func() { confirmFunc = original })
+	ansi.DisableColors = true
+	t.Cleanup(func() { ansi.DisableColors = false })
 }
 
-// neverConfirm overrides confirmFunc to always return false (auto-decline).
+// alwaysConfirm overrides installConfirmFn and uninstallConfirmFn to always
+// return true (auto-accept). Restores originals on cleanup.
+func alwaysConfirm(t *testing.T) {
+	t.Helper()
+	disableColors(t)
+	origInstall := installConfirmFn
+	origUninstall := uninstallConfirmFn
+	accept := func(_ string) bool { return true }
+	installConfirmFn = accept
+	uninstallConfirmFn = accept
+	t.Cleanup(func() {
+		installConfirmFn = origInstall
+		uninstallConfirmFn = origUninstall
+	})
+}
+
+// neverConfirm overrides installConfirmFn and uninstallConfirmFn to always
+// return false (auto-decline).
 func neverConfirm(t *testing.T) {
 	t.Helper()
-	original := confirmFunc
-	confirmFunc = func(_ string) bool { return false }
-	t.Cleanup(func() { confirmFunc = original })
+	disableColors(t)
+	origInstall := installConfirmFn
+	origUninstall := uninstallConfirmFn
+	decline := func(_ string) bool { return false }
+	installConfirmFn = decline
+	uninstallConfirmFn = decline
+	t.Cleanup(func() {
+		installConfirmFn = origInstall
+		uninstallConfirmFn = origUninstall
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -657,7 +538,7 @@ func TestInstallCompletionZsh(t *testing.T) {
 	require.NoError(t, err)
 	content := string(configData)
 	assert.Contains(t, content, sentinelBegin)
-	assert.Contains(t, content, "source "+scriptPath)
+	assert.Contains(t, content, fmt.Sprintf("source \"%s\"", scriptPath))
 	assert.Contains(t, content, sentinelEnd)
 }
 
@@ -681,7 +562,7 @@ func TestInstallCompletionBash(t *testing.T) {
 	configData, err := os.ReadFile(configPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(configData), sentinelBegin)
-	assert.Contains(t, string(configData), "source "+scriptPath)
+	assert.Contains(t, string(configData), fmt.Sprintf("source \"%s\"", scriptPath))
 }
 
 func TestInstallCompletionFish(t *testing.T) {
@@ -735,6 +616,16 @@ func TestInstallCompletionWritePermissionDenied(t *testing.T) {
 	err := installCompletion("zsh", fakeHomeDir(home))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "could not write completion script")
+}
+
+func TestInstallUnsupportedShell(t *testing.T) {
+	cc := newCompletionCmd()
+	cc.cmd.SetArgs([]string{"--install", "--shell", "powershell"})
+
+	err := cc.cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported shell")
+	assert.Contains(t, err.Error(), "powershell")
 }
 
 func TestInstallMutuallyExclusiveFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

Add a colorized diff preview when `stripe completion --install` or `--uninstall` modifies shell config files. Users see the exact changes before approving.

- Colorized diff renderer (`pkg/ansi/diff.go`) with line numbers, context lines, multi-hunk support, and dark green/red true-color backgrounds
- Pure `computeAddSentinel`/`computeRemoveSentinel` functions (no I/O) for sentinel block manipulation
- Inline read → compute → diff → confirm → write flow — no wrapper abstractions
- Early shell name validation, `Long`/`Example` help text, quoted source paths
- 256-color line number foreground (bright green for adds, desaturated red for removes)
- True-color (24-bit) line backgrounds that span the full line including gutter

### `stripe completion --install` (new file)

```diff
 ~/.zshrc (new file):
 
+    1 +# begin stripe-completion
+    2 +source "/Users/jane/.stripe/stripe-completion.zsh"
+    3 +# end stripe-completion
 
 Apply changes? [y/N]
```

### `stripe completion --uninstall` (lines removed)

```diff
 ~/.zshrc:
 
     1  export PATH=/usr/local/bin:$PATH
     2  alias ll='ls -la'
-    3 -# begin stripe-completion
-    4 -source "/Users/jane/.stripe/stripe-completion.zsh"
-    5 -# end stripe-completion
 
 Apply changes? [y/N]
```

### `stripe completion --help`

```diff
   Short: "Generate bash, zsh, and fish completion scripts",
+  Long:  "Generate shell completion scripts. Use --install to automatically
+          configure your shell profile, or run without flags to generate a
+          script file manually.",
+  Example: `  # Auto-install completions (detects your shell)
+  stripe completion --install
+
+  # Install for a specific shell
+  stripe completion --install --shell zsh
+
+  # Remove installed completions
+  stripe completion --uninstall
+
+  # Generate completion script to stdout
+  stripe completion --shell bash --write-to-stdout`,
```

## Test plan

- [x] `go test ./pkg/ansi/...` — 15 diff renderer tests (new file, add/remove/replace, multi-hunk, context capping, line alignment)
- [x] `go test ./pkg/cmd/...` — pure function tests for `computeAddSentinel`/`computeRemoveSentinel`, `readConfigFile`, install/uninstall integration tests, confirmation accept/decline, manual remnant warnings
- [x] `golangci-lint` passes
- [x] Colors respect `--color off`, `CLICOLOR=0`, non-TTY piping (via `ansi.Color(w)`)