### PR TITLE
Add keyring dependencies to Debian package

### DIFF
--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -57,7 +57,7 @@ nfpms:
     license: Apache 2.0
     formats:
       - deb
-    depends:
+    dependencies:
       - libsecret-1-0
       - gnome-keyring
       - libsecret-tools


### PR DESCRIPTION
Includes libsecret, gnome-keyring, libsecret-tools, and dbus-x11 as package dependencies for the Debian package to support secure credential storage.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
