### PR TITLE
Fix: Stripe fixtures silently drops JSON null values

### DIFF
--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -151,6 +151,12 @@ func ParseMapForFormData(params map[string]interface{}, parent string, index int
 			keyname = key
 		}
 
+		// Handle null values by sending an empty string
+		if value == nil {
+			data = append(data, fmt.Sprintf("%s=", keyname))
+			continue
+		}
+
 		// Check the type of the value for this pair. If this is a
 		// terminal type, append the data with the key. For maps and
 		// arrays, keep parsing.
@@ -227,6 +233,12 @@ func ParseArrayForFormData(params []interface{}, parent string, queryRespMap map
 	// The index is only used for arrays of maps
 	index := -1
 	for _, value := range params {
+		// Handle null values by sending an empty string
+		if value == nil {
+			data = append(data, fmt.Sprintf("%s[]=", parent))
+			continue
+		}
+
 		switch v := reflect.ValueOf(value); v.Kind() {
 		case reflect.String:
 			// A string can be a regular value or one we need to look up first, ex: ${product.id}

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -278,6 +278,30 @@ func TestParseInterfaceToJSON(t *testing.T) {
 	require.Equal(t, "tax_id_data[1][value]=value_1", output[7])
 }
 
+func TestParseInterfaceWithNulls(t *testing.T) {
+	taxIDData := make([]interface{}, 2)
+	taxIDZero := make(map[string]interface{})
+	taxIDZero["type"] = "type_0"
+	taxIDZero["value"] = nil
+	taxIDData[0] = taxIDZero
+	taxIDData[1] = nil
+
+	data := make(map[string]interface{})
+	data["name"] = "Bender Bending Rodriguez"
+	data["description"] = nil
+	data["tax_id_data"] = taxIDData
+
+	output, _ := ParseToFormData(data, make(map[string]gjson.Result))
+	sort.Strings(output)
+
+	require.Equal(t, len(output), 5)
+	require.Equal(t, "description=", output[0])
+	require.Equal(t, "name=Bender Bending Rodriguez", output[1])
+	require.Equal(t, "tax_id_data[0][type]=type_0", output[2])
+	require.Equal(t, "tax_id_data[0][value]=", output[3])
+	require.Equal(t, "tax_id_data[]=", output[4])
+}
+
 func TestParseWithQueryIgnoreDefault(t *testing.T) {
 	queryRespMap := map[string]gjson.Result{
 		"cust_bender": gjson.Parse(`{"id": "cust_bend123456789", "currency": "eur"}`),


### PR DESCRIPTION
### Reviewers
r? @
cc @stripe/developer-products

### Summary
When a fixture JSON file contains `null` values (e.g., `"country": null`), the CLI silently dropped them during form data conversion instead of sending them as empty strings to the Stripe API. Due to this, explicit `null` fields were never transmitted, causing the API to use fallback defaults (like "US" for country) instead of actually clearing the fields.

This PR adds a `value == nil` check in [parsers.go](cci:7://file:///Users/chinmaybhatt/stripe-cli/pkg/parsers/parsers.go:0:0-0:0) for [ParseMapForFormData](cci:1://file:///Users/chinmaybhatt/stripe-cli/pkg/parsers/parsers.go:130:0-223:1) and [ParseArrayForFormData](cci:1://file:///Users/chinmaybhatt/stripe-cli/pkg/parsers/parsers.go:225:0-274:1) so that `null` JSON values are correctly serialized as empty strings in the payload (e.g. `shipping[address][country]=`). It also includes a [TestParseInterfaceWithNulls](cci:1://file:///Users/chinmaybhatt/stripe-cli/pkg/parsers/parsers_test.go:280:0-302:1) case in [parsers_test.go](cci:7://file:///Users/chinmaybhatt/stripe-cli/pkg/parsers/parsers_test.go:0:0-0:0) to assert this serialization.

Fixes #1447
