### PR TITLE
Fix path filter typo in test-snapshot PR trigger

### DIFF
--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -10,7 +10,7 @@ on:
     - '.goreleaser/**'
   pull_request:
     paths:
-    - 'goreleaser/**'
+    - '.goreleaser/**'
 
 jobs:
   build-linux:


### PR DESCRIPTION
## Summary
- The `pull_request` trigger in `test-snapshot.yml` used `goreleaser/**` instead of `.goreleaser/**` (missing leading dot)
- This meant the GoReleaser snapshot validation never ran on PRs — only on pushes
- Matches the path filter already used by the `push` trigger

## Test plan
- [x] Verify the `push` and `pull_request` path filters now match (`.goreleaser/**`)
- [x] Confirm the workflow triggers on a PR that modifies files under `.goreleaser/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)