### PR TITLE
Support automatically updating plugins

### DIFF
--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -186,13 +186,13 @@ func StrikeThrough(text string) string {
 // Private functions
 //
 
+type fder interface{ Fd() uintptr }
+
 func isTerminal(w io.Writer) bool {
-	switch v := w.(type) {
-	case *os.File:
-		return term.IsTerminal(int(v.Fd()))
-	default:
-		return false
+	if f, ok := w.(fder); ok {
+		return term.IsTerminal(int(f.Fd()))
 	}
+	return false
 }
 
 func isPlugin() bool {

--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/plugins"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
@@ -19,6 +20,7 @@ type pluginTemplateCmd struct {
 	cfg        *config.Config
 	cmd        *cobra.Command
 	fs         afero.Fs
+	baseURL    string
 	ParsedArgs []string
 }
 
@@ -28,6 +30,7 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 	ptc := &pluginTemplateCmd{}
 	ptc.fs = afero.NewOsFs()
 	ptc.cfg = config
+	ptc.baseURL = stripe.DefaultAPIBaseURL
 
 	ptc.cmd = &cobra.Command{
 		Use:   plugin.Shortname,
@@ -110,8 +113,9 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 		"prefix": "cmd.pluginCmd.runPluginCmd",
 	}).Debug("Running plugin...")
 
-	err = plugin.Run(ctx, ptc.cfg, fs, ptc.ParsedArgs)
-	plugins.CleanupAllClients()
+	err = plugins.WithBackgroundUpdate(ctx, ptc.cfg, fs, ptc.baseURL, &plugin, os.Stderr, func() error {
+		return plugin.Run(ctx, ptc.cfg, fs, ptc.ParsedArgs)
+	})
 
 	if err != nil {
 		if err == validators.ErrAPIKeyNotConfigured {

--- a/pkg/cmd/plugin_cmds_test.go
+++ b/pkg/cmd/plugin_cmds_test.go
@@ -1,18 +1,24 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/plugins"
 )
 
-func createPluginCmd() *pluginTemplateCmd {
+func createPluginCmd(cfg *config.Config) *pluginTemplateCmd {
 	plugin := plugins.Plugin{
 		Shortname:        "test",
 		Shortdesc:        "test your stuff",
@@ -26,7 +32,7 @@ func createPluginCmd() *pluginTemplateCmd {
 		}},
 	}
 
-	pluginCmd := newPluginTemplateCmd(&Config, &plugin)
+	pluginCmd := newPluginTemplateCmd(cfg, &plugin)
 
 	return pluginCmd
 }
@@ -35,7 +41,8 @@ func createPluginCmd() *pluginTemplateCmd {
 // This is a complex dance between the CLI itself and the plugin, so the flags come from
 // two different sources as a result. This test is here to catch any non-obvious regressions
 func TestFlagsArePassedAsArgs(t *testing.T) {
-	pluginCmd := createPluginCmd()
+	cfg := &config.Config{}
+	pluginCmd := createPluginCmd(cfg)
 	rootCmd.AddCommand(pluginCmd.cmd)
 
 	Execute(context.Background())
@@ -132,6 +139,105 @@ func TestAddPluginSubcommandStubsSkipsEmptyName(t *testing.T) {
 	assert.Equal(t, "also-valid", cmds[0].Name())
 	assert.Equal(t, "valid", cmds[1].Name())
 }
+
+// TestWithBackgroundUpdate_FnRuns verifies that fn is invoked and completes.
+func TestWithBackgroundUpdate_FnRuns(t *testing.T) {
+	cfg := &config.Config{}
+	fs := afero.NewMemMapFs()
+	plugin := plugins.Plugin{Shortname: "test"}
+
+	called := false
+	err := plugins.WithBackgroundUpdate(context.Background(), cfg, fs, "", &plugin, io.Discard, func() error {
+		called = true
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, called)
+}
+
+// TestWithBackgroundUpdate_PropagatesError verifies that an error returned by fn
+// is returned by WithBackgroundUpdate.
+func TestWithBackgroundUpdate_PropagatesError(t *testing.T) {
+	cfg := &config.Config{}
+	fs := afero.NewMemMapFs()
+	plugin := plugins.Plugin{Shortname: "test"}
+
+	want := errors.New("plugin failed")
+	err := plugins.WithBackgroundUpdate(context.Background(), cfg, fs, "", &plugin, io.Discard, func() error {
+		return want
+	})
+
+	assert.Equal(t, want, err)
+}
+
+// TestWithBackgroundUpdate_UpdateOutputAppearsAfterFn verifies that any output
+// written by the background update goroutine is only flushed to the underlying
+// writer after fn returns — never interleaved with fn's execution.
+func TestWithBackgroundUpdate_UpdateOutputAppearsAfterFn(t *testing.T) {
+	cfg := &config.Config{}
+	fs := afero.NewMemMapFs()
+	plugin := plugins.Plugin{Shortname: "test"}
+
+	var mu sync.Mutex
+	var events []string
+
+	// recordWriter appends each Write as an event.
+	out := &funcWriter{fn: func(p []byte) (int, error) {
+		mu.Lock()
+		events = append(events, "write:"+string(p))
+		mu.Unlock()
+		return len(p), nil
+	}}
+
+	err := plugins.WithBackgroundUpdate(context.Background(), cfg, fs, "", &plugin, out, func() error {
+		mu.Lock()
+		events = append(events, "fn:done")
+		mu.Unlock()
+		return nil
+	})
+
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	// If there were any writes (update output), they must come after fn:done.
+	fnIdx := -1
+	for i, e := range events {
+		if e == "fn:done" {
+			fnIdx = i
+		}
+	}
+	// fn must have run
+	require.GreaterOrEqual(t, fnIdx, 0, "fn:done not recorded")
+	for i, e := range events {
+		if strings.HasPrefix(e, "write:") {
+			assert.Greater(t, i, fnIdx, "update write at index %d appeared before fn:done at index %d", i, fnIdx)
+		}
+	}
+}
+
+// TestWithBackgroundUpdate_NilErrorOnSuccess verifies a nil error on clean fn exit.
+func TestWithBackgroundUpdate_NilErrorOnSuccess(t *testing.T) {
+	cfg := &config.Config{}
+	fs := afero.NewMemMapFs()
+	plugin := plugins.Plugin{Shortname: "test"}
+
+	// Provide a non-nil out to ensure the writer path is exercised.
+	var buf bytes.Buffer
+	err := plugins.WithBackgroundUpdate(context.Background(), cfg, fs, "", &plugin, &buf, func() error {
+		return nil
+	})
+
+	assert.NoError(t, err)
+}
+
+// funcWriter is a minimal io.Writer backed by a function, used in tests.
+type funcWriter struct {
+	fn func([]byte) (int, error)
+}
+
+func (f *funcWriter) Write(p []byte) (int, error) { return f.fn(p) }
 
 func TestSubsliceAfter(t *testing.T) {
 	tests := []struct {

--- a/pkg/gatedwriter/gatedwriter.go
+++ b/pkg/gatedwriter/gatedwriter.go
@@ -1,0 +1,97 @@
+// Package gatedwriter provides a buffered writer that can be opened and closed
+// to control the flow of data to the underlying writer.
+package gatedwriter
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
+)
+
+// GatedWriter is an io.Writer that buffers writes until opened. Once Open is
+// called, buffered data is flushed and subsequent writes go directly to the
+// underlying writer. Closing the gate resumes buffering. Safe for concurrent use.
+type GatedWriter struct {
+	mu        sync.Mutex
+	out       io.Writer    // underlying destination (must be non-nil)
+	buf       bytes.Buffer // buffered data while closed
+	open      bool         // when true, writes go directly to out
+	maxBuffer int64        // maximum number of bytes to buffer; 0 = defaultMaxBuffer
+}
+
+var _ io.Writer = (*GatedWriter)(nil)
+
+// defaultMaxBuffer is the maximum bytes to buffer while the gate is closed (100 KB).
+// Writes that would exceed this limit are dropped silently.
+const defaultMaxBuffer = 100 * 1024
+
+// NewGatedWriter creates a closed GatedWriter that writes to out once opened.
+// maxBuffer caps the in-memory buffer in bytes; 0 uses defaultMaxBuffer.
+// If out is nil, io.Discard is used.
+func NewGatedWriter(out io.Writer, maxBuffer int64) *GatedWriter {
+	if out == nil {
+		out = io.Discard
+	}
+	if maxBuffer == 0 {
+		maxBuffer = defaultMaxBuffer
+	}
+	return &GatedWriter{out: out, maxBuffer: maxBuffer}
+}
+
+// Write buffers p while the gate is closed. Once open, it writes directly to
+// the underlying writer. Writes that would push the buffer past maxBuffer are
+// dropped silently.
+func (g *GatedWriter) Write(p []byte) (int, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.open {
+		return g.out.Write(p)
+	}
+	if g.maxBuffer > 0 && int64(g.buf.Len()+len(p)) > g.maxBuffer {
+		return len(p), nil // drop silently
+	}
+	n, _ := g.buf.Write(p) // bytes.Buffer.Write never returns error
+	return n, nil
+}
+
+// Open flushes any buffered data to the underlying writer and opens the gate
+// so future writes go directly to out. Calling Open on an already-open writer
+// is a no-op.
+func (g *GatedWriter) Open() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.open {
+		return nil
+	}
+	data := g.buf.Bytes()
+	g.buf.Reset()
+	g.open = true
+	if len(data) > 0 {
+		_, err := g.out.Write(data)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close closes the gate, causing subsequent writes to be buffered again.
+func (g *GatedWriter) Close() {
+	g.mu.Lock()
+	g.open = false
+	g.mu.Unlock()
+}
+
+// Fd returns the file descriptor of the underlying writer if it is an *os.File,
+// allowing callers to check whether the destination is a terminal. Returns
+// ^uintptr(0) if the underlying writer is not an *os.File.
+func (g *GatedWriter) Fd() uintptr {
+	g.mu.Lock()
+	out := g.out
+	g.mu.Unlock()
+	if f, ok := out.(*os.File); ok {
+		return f.Fd()
+	}
+	return ^uintptr(0) // invalid fd
+}

--- a/pkg/gatedwriter/gatedwriter_test.go
+++ b/pkg/gatedwriter/gatedwriter_test.go
@@ -1,0 +1,151 @@
+package gatedwriter
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuffersWhileClosed(t *testing.T) {
+	var out bytes.Buffer
+	w := NewGatedWriter(&out, 0)
+
+	n, err := w.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Empty(t, out.String(), "nothing should reach out while closed")
+}
+
+func TestFlushesOnOpen(t *testing.T) {
+	var out bytes.Buffer
+	w := NewGatedWriter(&out, 0)
+
+	w.Write([]byte("hello "))
+	w.Write([]byte("world"))
+
+	require.NoError(t, w.Open())
+	assert.Equal(t, "hello world", out.String())
+}
+
+func TestWritesDirectlyWhenOpen(t *testing.T) {
+	var out bytes.Buffer
+	w := NewGatedWriter(&out, 0)
+
+	require.NoError(t, w.Open())
+	w.Write([]byte("direct"))
+	assert.Equal(t, "direct", out.String())
+}
+
+func TestOpenIsIdempotent(t *testing.T) {
+	var out bytes.Buffer
+	w := NewGatedWriter(&out, 0)
+
+	w.Write([]byte("once"))
+	require.NoError(t, w.Open())
+	require.NoError(t, w.Open()) // second Open should not re-flush
+	assert.Equal(t, "once", out.String())
+}
+
+func TestCloseRebuffers(t *testing.T) {
+	var out bytes.Buffer
+	w := NewGatedWriter(&out, 0)
+
+	require.NoError(t, w.Open())
+	w.Close()
+	w.Write([]byte("rebuffered"))
+	assert.Equal(t, "", out.String(), "closed again, should not reach out")
+
+	require.NoError(t, w.Open())
+	assert.Equal(t, "rebuffered", out.String())
+}
+
+func TestMaxBufferDropsOverflow(t *testing.T) {
+	var out bytes.Buffer
+	w := NewGatedWriter(&out, 5)
+
+	w.Write([]byte("hello")) // exactly 5 bytes — fits
+	w.Write([]byte("X"))     // would exceed cap — dropped
+
+	require.NoError(t, w.Open())
+	assert.Equal(t, "hello", out.String())
+}
+
+func TestMaxBufferZeroDefaultsToDefaultMaxBuffer(t *testing.T) {
+	var out bytes.Buffer
+	w := NewGatedWriter(&out, 0)
+
+	big := strings.Repeat("a", defaultMaxBuffer)
+	w.Write([]byte(big))
+
+	require.NoError(t, w.Open())
+	assert.Equal(t, big, out.String())
+}
+
+func TestNilOutDefaultsToDiscard(t *testing.T) {
+	w := NewGatedWriter(nil, 0)
+	w.Write([]byte("discarded"))
+	// should not panic; Open flushes to io.Discard
+	require.NoError(t, w.Open())
+}
+
+func TestFdWithFile(t *testing.T) {
+	w := NewGatedWriter(os.Stderr, 0)
+	assert.Equal(t, os.Stderr.Fd(), w.Fd())
+}
+
+func TestFdWithNonFile(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewGatedWriter(&buf, 0)
+	assert.Equal(t, ^uintptr(0), w.Fd())
+}
+
+func TestConcurrentWrites(t *testing.T) {
+	var out bytes.Buffer
+	w := NewGatedWriter(&out, 0)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w.Write([]byte("x"))
+		}()
+	}
+	wg.Wait()
+
+	require.NoError(t, w.Open())
+	assert.Equal(t, 100, len(out.String()))
+}
+
+func TestConcurrentWritesDuringOpen(t *testing.T) {
+	var out bytes.Buffer
+	w := NewGatedWriter(&out, 0)
+
+	// pre-buffer some data
+	for i := 0; i < 50; i++ {
+		w.Write([]byte("x"))
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		w.Open()
+	}()
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w.Write([]byte("x"))
+		}()
+	}
+	wg.Wait()
+
+	// all 100 writes should reach out (either flushed or direct)
+	assert.Equal(t, 100, len(out.String()))
+}

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -25,6 +25,7 @@ import (
 
 	hclog "github.com/hashicorp/go-hclog"
 	hcplugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
@@ -173,6 +174,28 @@ func (p *Plugin) LookUpLatestVersion() string {
 	return version
 }
 
+// LookupLatestVersionForMajor finds the latest version for a given major version
+// If no version is found, returns an empty string
+func (p *Plugin) LookupLatestVersionForMajor(major int) string {
+	opsystem := runtime.GOOS
+	arch := runtime.GOARCH
+
+	var v string
+	for _, pkg := range p.Releases {
+		if pkg.OS == opsystem && pkg.Arch == arch {
+			parsedVersion, err := version.NewVersion(pkg.Version)
+			if err != nil {
+				continue
+			}
+			if parsedVersion.Segments()[0] == major {
+				v = pkg.Version
+			}
+		}
+	}
+
+	return v
+}
+
 // getReleaseForVersion finds the release object for a specific version on the current platform
 func (p *Plugin) getReleaseForVersion(version string) *Release {
 	opsystem := runtime.GOOS
@@ -189,14 +212,18 @@ func (p *Plugin) getReleaseForVersion(version string) *Release {
 
 // Install installs the plugin of the given version
 func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, baseURL string) error {
-	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)
+	return p.install(ctx, cfg, fs, version, baseURL, os.Stdout, true)
+}
+
+func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, baseURL string, out io.Writer, doCleanup bool) error {
+	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), out)
 
 	apiKey, _ := cfg.GetProfile().GetAPIKey(false)
 
 	pluginData, err := requests.GetPluginData(ctx, baseURL, stripe.APIVersion, apiKey, cfg.GetProfile())
 
 	if err != nil {
-		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), out)
 
 		log.WithFields(log.Fields{
 			"prefix": "plugins.plugin.Install",
@@ -209,11 +236,11 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	release := p.getReleaseForVersion(version)
 	if release != nil {
 		if nodeVersion, requiresNode := GetRuntimeRequirement(*release); requiresNode {
-			ansi.StopSpinner(spinner, "", os.Stdout)
+			ansi.StopSpinner(spinner, "", out)
 			if err := InstallNodeRuntime(ctx, cfg, fs, nodeVersion); err != nil {
 				return fmt.Errorf("failed to install required Node.js runtime: %w", err)
 			}
-			spinner = ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)
+			spinner = ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), out)
 		}
 	}
 
@@ -223,7 +250,7 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	err = p.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version)
 
 	if err != nil {
-		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), os.Stdout)
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), out)
 		return err
 	}
 
@@ -244,10 +271,11 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	// sync list of installed plugins to file
 	cfg.WriteConfigField("installed_plugins", installedList)
 
-	// Once the plugin is successfully downloaded, clean up other versions
-	p.cleanUpPluginPath(cfg, fs, version)
-
-	ansi.StopSpinner(spinner, "", os.Stdout)
+	if doCleanup {
+		// Once the plugin is successfully downloaded, clean up other versions
+		p.cleanUpPluginPath(cfg, fs, version)
+	}
+	ansi.StopSpinner(spinner, "", out)
 
 	return nil
 }

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -22,6 +22,21 @@ func TestLookUpLatestVersion(t *testing.T) {
 	require.Equal(t, "2.0.1", version)
 }
 
+func TestLookupLatestVersionForMajor(t *testing.T) {
+	fs := setUpFS()
+	config := &TestConfig{}
+
+	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
+	version := plugin.LookupLatestVersionForMajor(1)
+	require.Equal(t, "1.0.1", version)
+
+	version = plugin.LookupLatestVersionForMajor(2)
+	require.Equal(t, "2.0.1", version)
+
+	version = plugin.LookupLatestVersionForMajor(3)
+	require.Equal(t, "", version)
+}
+
 func TestInstall(t *testing.T) {
 	fs := setUpFS()
 	config := &TestConfig{}

--- a/pkg/plugins/updater.go
+++ b/pkg/plugins/updater.go
@@ -1,0 +1,152 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/hashicorp/go-version"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/gatedwriter"
+)
+
+// WithBackgroundUpdate runs fn (typically plugin.Run) while concurrently
+// checking for and applying a plugin update. Update output is buffered until
+// fn returns, then flushed to stderr so it never interleaves with plugin output.
+func WithBackgroundUpdate(ctx context.Context, cfg config.IConfig, fs afero.Fs, baseURL string, plugin *Plugin, out io.Writer, fn func() error) error {
+	w := gatedwriter.NewGatedWriter(out, 0)
+	cleanupReady := make(chan struct{})
+	updateDone := make(chan struct{})
+
+	go func() {
+		checkAndUpdate(ctx, cfg, fs, plugin, w, baseURL, cleanupReady)
+		close(updateDone)
+	}()
+
+	err := fn()
+
+	w.Open()
+	CleanupAllClients()
+	close(cleanupReady)
+	<-updateDone
+
+	return err
+}
+
+// checkAndUpdate refreshes the plugin manifest and, if a newer version is
+// available, downloads and installs it.
+func checkAndUpdate(ctx context.Context, cfg config.IConfig, fs afero.Fs, plugin *Plugin, out io.Writer, baseURL string, cleanupReady chan struct{}) {
+	logger := log.WithFields(log.Fields{"prefix": "plugins.updater"})
+
+	if !updatesEnabled(plugin.Shortname) {
+		logger.Debugf("Automatic updates disabled")
+		return
+	}
+	logger.Debugf("Automatic updates enabled")
+
+	currentVersion, err := installedPluginVersion(cfg, fs, plugin)
+	if err != nil {
+		logger.Debugf("Error getting installed plugin version: %s", err)
+		return
+	}
+	if currentVersion == "" {
+		logger.Debugf("No installed plugin version found")
+		return
+	}
+	if currentVersion == "local.build.dev" {
+		logger.Debugf("Local build dev version found, skipping update check")
+		return
+	}
+
+	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("checking for '%s' updates...", plugin.Shortname)), out)
+
+	if err := RefreshPluginManifest(ctx, cfg, fs, baseURL); err != nil {
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("'%s' update failed: couldn't find the plugins list", plugin.Shortname)), out)
+		return
+	}
+
+	// Re-look up the plugin so we have the freshest release list.
+	fresh, err := LookUpPlugin(ctx, cfg, fs, plugin.Shortname)
+	if err != nil {
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("'%s' update failed: couldn't find the plugin", plugin.Shortname)), out)
+		return
+	}
+
+	current, err := version.NewVersion(currentVersion)
+	if err != nil {
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("'%s' update failed: couldn't parse current version", plugin.Shortname)), out)
+		return
+	}
+
+	latestVersion := fresh.LookupLatestVersionForMajor(current.Segments()[0])
+	if latestVersion == "" {
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("'%s' update failed: couldn't find latest release for major version %d", plugin.Shortname, current.Segments()[0])), out)
+		return
+	}
+
+	latest, err := version.NewVersion(latestVersion)
+	if err != nil {
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("'%s' update failed: couldn't parse latest version", plugin.Shortname)), out)
+		return
+	}
+
+	if latest.Segments()[0] != current.Segments()[0] {
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("Skipping update for '%s' because you're on the latest major version", plugin.Shortname)), out)
+		return
+	}
+
+	if !latest.GreaterThan(current) {
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("'%s' is already up to date", plugin.Shortname)), out)
+		return
+	}
+
+	ansi.StartSpinner(spinner, ansi.Faint(fmt.Sprintf("updating '%s' to v%s...", plugin.Shortname, latestVersion)), out)
+
+	if err := fresh.install(ctx, cfg, fs, latestVersion, baseURL, io.Discard, false); err != nil {
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("'%s' update to v%s failed", plugin.Shortname, latestVersion)), out)
+		return
+	}
+
+	// Wait for cleanup to be ready because you can't delete a running executable on Windows.
+	<-cleanupReady
+	fresh.cleanUpPluginPath(cfg, fs, latestVersion)
+	ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("'%s' updated to v%s — this version will be used next time", plugin.Shortname, latestVersion)), out)
+}
+
+// installedPluginVersion returns the version string of the locally installed
+// plugin binary, or an empty string if no installation is found.
+func installedPluginVersion(cfg config.IConfig, fs afero.Fs, p *Plugin) (string, error) {
+	pluginDir := filepath.Join(getPluginsDir(cfg), p.Shortname)
+	entries, err := afero.ReadDir(fs, pluginDir)
+	if err != nil {
+		// Directory doesn't exist means nothing is installed.
+		return "", nil
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			return e.Name(), nil
+		}
+	}
+	return "", nil
+}
+
+// updatesEnabled reports whether automatic updates are enabled for the given
+// plugin. It checks the plugin-specific config first, then the global config.
+// The default when neither is set is false (updates off).
+func updatesEnabled(pluginName string) bool {
+	logger := log.WithFields(log.Fields{"prefix": "plugins.updater"})
+	pluginVal := viper.GetString(config.PluginConfigKey(pluginName, config.PluginConfigUpdatesField))
+	if pluginVal != "" {
+		logger.Debugf("Automatic updates for plugin '%s' enabled: %t", pluginName, pluginVal == "on")
+		return pluginVal == "on"
+	}
+	globalVal := viper.GetString(config.PluginConfigKey(config.PluginConfigGlobalScope, config.PluginConfigUpdatesField))
+	logger.Debugf("Automatic updates for plugins globally enabled: %t", globalVal == "on")
+	return globalVal == "on"
+}

--- a/pkg/plugins/updater_test.go
+++ b/pkg/plugins/updater_test.go
@@ -1,0 +1,269 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+func TestUpdatesEnabled(t *testing.T) {
+	tests := []struct {
+		name       string
+		pluginVal  string
+		globalVal  string
+		pluginName string
+		want       bool
+	}{
+		{
+			name: "no config set defaults to off",
+			want: false,
+		},
+		{
+			name:      "global on enables updates",
+			globalVal: "on",
+			want:      true,
+		},
+		{
+			name:      "global off disables updates",
+			globalVal: "off",
+			want:      false,
+		},
+		{
+			name:       "plugin-specific on overrides global off",
+			pluginVal:  "on",
+			globalVal:  "off",
+			pluginName: "apps",
+			want:       true,
+		},
+		{
+			name:       "plugin-specific off overrides global on",
+			pluginVal:  "off",
+			globalVal:  "on",
+			pluginName: "apps",
+			want:       false,
+		},
+		{
+			name:       "plugin-specific on with no global",
+			pluginVal:  "on",
+			pluginName: "apps",
+			want:       true,
+		},
+		{
+			name:       "plugin-specific off with no global",
+			pluginVal:  "off",
+			pluginName: "apps",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+
+			pluginName := tt.pluginName
+			if pluginName == "" {
+				pluginName = "apps"
+			}
+
+			if tt.pluginVal != "" {
+				viper.Set(config.PluginConfigKey(pluginName, config.PluginConfigUpdatesField), tt.pluginVal)
+			}
+			if tt.globalVal != "" {
+				viper.Set(config.PluginConfigKey(config.PluginConfigGlobalScope, config.PluginConfigUpdatesField), tt.globalVal)
+			}
+
+			assert.Equal(t, tt.want, updatesEnabled(pluginName))
+		})
+	}
+}
+
+// setUpFSWithInstalledVersion creates a memmap FS with the standard manifest
+// and an already-installed binary at the given version (empty = none installed).
+func setUpFSWithInstalledVersion(installedVersion string) afero.Fs {
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	fs := afero.NewMemMapFs()
+	afero.WriteFile(fs, "/plugins.toml", manifestContent, os.ModePerm)
+	if installedVersion != "" {
+		binaryPath := fmt.Sprintf("/plugins/appA/%s/stripe-cli-app-a%s", installedVersion, GetBinaryExtension())
+		afero.WriteFile(fs, binaryPath, []byte("fake binary"), os.ModePerm)
+	}
+	return fs
+}
+
+func setViperUpdates(t *testing.T, pluginName, value string) {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set(config.PluginConfigKey(pluginName, config.PluginConfigUpdatesField), value)
+}
+
+func setViperUpdatesGlobal(t *testing.T, value string) {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set(config.PluginConfigKey(config.PluginConfigGlobalScope, config.PluginConfigUpdatesField), value)
+}
+
+func TestCheckAndUpdateSkipsWhenUpdatesDisabled(t *testing.T) {
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	// updates off (default) — no viper set
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	fs := setUpFSWithInstalledVersion("1.0.1")
+	plugin, _ := LookUpPlugin(context.Background(), cfg, fs, "appA")
+	cleanupReady := make(chan struct{})
+	close(cleanupReady)
+	checkAndUpdate(context.Background(), cfg, fs, &plugin, io.Discard, testServers.StripeServer.URL, cleanupReady)
+
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
+	exists, _ := afero.Exists(fs, file)
+	require.False(t, exists)
+}
+
+func TestCheckAndUpdateSkipsWhenNoInstalledVersion(t *testing.T) {
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	setViperUpdates(t, "appA", "on")
+
+	fs := setUpFSWithInstalledVersion("") // nothing installed
+	plugin, _ := LookUpPlugin(context.Background(), cfg, fs, "appA")
+	cleanupReady := make(chan struct{})
+	close(cleanupReady)
+	checkAndUpdate(context.Background(), cfg, fs, &plugin, io.Discard, testServers.StripeServer.URL, cleanupReady)
+
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
+	exists, _ := afero.Exists(fs, file)
+	require.False(t, exists)
+}
+
+func TestCheckAndUpdateSkipsLocalDevBuild(t *testing.T) {
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	setViperUpdates(t, "appA", "on")
+
+	fs := setUpFSWithInstalledVersion("local.build.dev")
+	plugin, _ := LookUpPlugin(context.Background(), cfg, fs, "appA")
+	cleanupReady := make(chan struct{})
+	close(cleanupReady)
+	checkAndUpdate(context.Background(), cfg, fs, &plugin, io.Discard, testServers.StripeServer.URL, cleanupReady)
+
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
+	exists, _ := afero.Exists(fs, file)
+	require.False(t, exists)
+}
+
+func TestCheckAndUpdateInstallsNewerMinorVersion(t *testing.T) {
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	setViperUpdates(t, "appA", "on")
+
+	// Installed 2.0.0 (not in manifest, but on disk); latest same-major is 2.0.1.
+	fs := setUpFSWithInstalledVersion("2.0.0")
+	cfg.InstalledPlugins = []string{"appA"}
+
+	plugin, _ := LookUpPlugin(context.Background(), cfg, fs, "appA")
+	cleanupReady := make(chan struct{})
+	close(cleanupReady)
+	checkAndUpdate(context.Background(), cfg, fs, &plugin, io.Discard, testServers.StripeServer.URL, cleanupReady)
+
+	newFile := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
+	exists, err := afero.Exists(fs, newFile)
+	require.Nil(t, err)
+	require.True(t, exists, "expected 2.0.1 to be installed after update")
+}
+
+func TestCheckAndUpdateSkipsWhenAlreadyLatest(t *testing.T) {
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	setViperUpdates(t, "appA", "on")
+
+	fs := setUpFSWithInstalledVersion("2.0.1")
+	plugin, _ := LookUpPlugin(context.Background(), cfg, fs, "appA")
+	cleanupReady := make(chan struct{})
+	close(cleanupReady)
+	checkAndUpdate(context.Background(), cfg, fs, &plugin, io.Discard, testServers.StripeServer.URL, cleanupReady)
+
+	// Only 2.0.1 should exist — no spurious re-install or removal.
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
+	exists, _ := afero.Exists(fs, file)
+	require.True(t, exists)
+}
+
+func TestCheckAndUpdateSkipsDifferentMajorVersion(t *testing.T) {
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	setViperUpdates(t, "appA", "on")
+
+	// Installed 1.0.1; LookupLatestVersionForMajor(1) returns 1.0.1 (already latest),
+	// so no update should happen and the 2.x binary must not be installed.
+	fs := setUpFSWithInstalledVersion("1.0.1")
+	plugin, _ := LookUpPlugin(context.Background(), cfg, fs, "appA")
+	cleanupReady := make(chan struct{})
+	close(cleanupReady)
+	checkAndUpdate(context.Background(), cfg, fs, &plugin, io.Discard, testServers.StripeServer.URL, cleanupReady)
+
+	v2File := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
+	exists, _ := afero.Exists(fs, v2File)
+	require.False(t, exists, "expected no cross-major update")
+}
+
+func TestCheckAndUpdateUsesGlobalEnableSetting(t *testing.T) {
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	// Enable via global config (no per-plugin key set).
+	setViperUpdatesGlobal(t, "on")
+
+	fs := setUpFSWithInstalledVersion("2.0.0")
+	cfg.InstalledPlugins = []string{"appA"}
+
+	plugin, _ := LookUpPlugin(context.Background(), cfg, fs, "appA")
+
+	cleanupReady := make(chan struct{})
+	close(cleanupReady)
+	checkAndUpdate(context.Background(), cfg, fs, &plugin, io.Discard, testServers.StripeServer.URL, cleanupReady)
+
+	newFile := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
+	exists, err := afero.Exists(fs, newFile)
+	require.Nil(t, err)
+	require.True(t, exists, "expected update via global enable setting")
+}


### PR DESCRIPTION
### Summary

When running a plugin command, check if there's a new version and install it in the background while the current command is running. We read the config added in https://github.com/stripe/stripe-cli/pull/1518 to decide if we should do this or not (default off).

How it works:
- The user runs a plugin command, e.g. `stripe projects`.
- We run a goroutine to refresh the plugin manifest, check for a new version within the same major, and install it if there is one.
  - At the same time, we write progress messages to a buffer.
- The command proceeds as normal in the main routine.
- When the command finishes, we'll print the progress messages that we saved in the buffer.

To test this, try installing an old version of the projects plugin and then invoking it:
```
go run cmd/stripe/main.go plugin install projects@0.0.58
go run cmd/stripe/main.go projects --version
```

TODO:
- [ ] Check for updates on an interval instead of every invocation (once per day)?
- [ ] Don't check again if the user requested a specific version (maybe wait 1-7 days)?
- [ ] How should we handle compatibility? (maybe plugin defines a min CLI version?)