### PR TITLE
refactor: remove dead code and inline symlink checks in pkg/samples

### DIFF
--- a/pkg/samples/os.go
+++ b/pkg/samples/os.go
@@ -92,16 +92,16 @@ func (s *SampleManager) GetFiles(path string) ([]string, error) {
 	if err != nil {
 		return []string{}, err
 	}
-
 	for _, f := range files {
 		// We only want regular files, not directories or symlinks.
 		// Filtering symlinks prevents malicious sample repositories from
 		// using symlinks to escape the destination directory.
-		if !f.IsDir() && !isSymlink(filepath.Join(path, f.Name())) {
+		// Checking mode bits is efficient and avoids path based symlink checks.
+		mode := f.Mode()
+		if !mode.IsDir() && mode&os.ModeSymlink == 0 {
 			file = append(file, f.Name())
 		}
 	}
-
 	return file, nil
 }
 
@@ -117,14 +117,4 @@ func (s *SampleManager) delete(name string) error {
 	}
 
 	return nil
-}
-
-func folderSearch(folders []string, name string) bool {
-	for _, folder := range folders {
-		if folder == name {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/samples/os.go
+++ b/pkg/samples/os.go
@@ -9,17 +9,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-// isSymlink returns true if the file at path is a symbolic link.
-// Returns false if the path does not exist or cannot be stat'd.
-func isSymlink(path string) bool {
-	// os.Lstat inspects the link entry itself (rather than following it like os.Stat)
-	entry, err := os.Lstat(path)
-	if err != nil {
-		return false
-	}
-	return entry.Mode().Type() == os.ModeSymlink
-}
-
 // cacheFolder is the local directory where we place local copies of samples
 func (s *SampleManager) cacheFolder() (string, error) {
 	configPath := s.Config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))

--- a/pkg/samples/os_test.go
+++ b/pkg/samples/os_test.go
@@ -20,11 +20,8 @@ func home() string {
 func TestFolderSearch(t *testing.T) {
 	folders := []string{"foo", "bar", "baz"}
 
-	expectedFound := folderSearch(folders, "bar")
-	expectedNotFound := folderSearch(folders, "box")
-
-	assert.True(t, expectedFound)
-	assert.False(t, expectedNotFound)
+	assert.True(t, contains(folders, "bar"))
+	assert.False(t, contains(folders, "box"))
 }
 
 func TestCacheFolder(t *testing.T) {
@@ -141,6 +138,6 @@ func TestGetFiles(t *testing.T) {
 
 func TestFoldersSearch(t *testing.T) {
 	folders := []string{"bender", "fry", "leela"}
-	assert.True(t, folderSearch(folders, "leela"))
-	assert.False(t, folderSearch(folders, "zoidberg"))
+	assert.True(t, contains(folders, "leela"))
+	assert.False(t, contains(folders, "zoidberg"))
 }

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -388,7 +388,8 @@ func (s *SampleManager) WriteDotEnv(ctx context.Context, sampleLocation string) 
 
 		// We refuse to write through a symlink to prevent a malicious
 		// sample from overwriting files outside the destination directory.
-		if isSymlink(envFile) {
+		// Use Lstat so we inspect the link entry itself instead of following it.
+		if entry, err := os.Lstat(envFile); err == nil && entry.Mode().Type() == os.ModeSymlink {
 			return fmt.Errorf("refusing to write .env: %s is a symlink", envFile)
 		}
 


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

### Summary

Refactored `pkg/samples` to remove duplication and simplify symlink handling. This is my first contribution to the Stripe CLI, so I aimed to start with a small refactor to get familiar with the codebase.

### Changes

* Removed the duplicate `folderSearch` helper and updated tests to use the existing `contains` function, since `folderSearch` had identical behavior and added unnecessary duplication
* Replaced helper-based symlink checks with call-site logic in `GetFiles` and `WriteDotEnv`
* Removed the now unused `isSymlink` helper

### Notes

* No functional changes
* All tests pass
