### PR TITLE
[Plugin manifest] append plugin manifest matched by shortname instead of magic cookie

### DIFF
--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -296,7 +296,7 @@ func addPluginToList(pluginList *PluginList, pl Plugin) {
 
 func findPluginIndex(list *PluginList, p Plugin) int {
 	for i, pp := range list.Plugins {
-		if pp.MagicCookieValue == p.MagicCookieValue {
+		if pp.Shortname == p.Shortname {
 			return i
 		}
 	}


### PR DESCRIPTION
 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

  **Bug:**

 When multiple additional plugin manifests are fetched (e.g. plugins-generate.toml and plugins-docs.toml), plugins from later manifests could silently get merged into an earlier plugin instead of 
  being added as a new entry.                                                                                                                                                                             
                                                                                                                                                                                                          
  **Root cause:** 

findPluginIndex matched plugins by MagicCookieValue. If two distinct plugins (e.g. generate and docs) share the same MagicCookieValue — which is valid since the HashiCorp go-plugin handshake cookie isn't required to be unique across plugins — the second plugin would be treated as a duplicate of the first. Its releases would be merged into the first plugin's entry rather than creating a new entry, effectively making the second plugin invisible.                                                                                                                                   
                                                            
`Fix:` Match by Shortname instead. Shortname is the unique user-facing identifier for a plugin and is the correct key for deduplication when merging manifests.  

Install success after the fix:
<img width="1121" height="188" alt="Screenshot 2026-04-14 at 1 43 00 PM" src="https://github.com/user-attachments/assets/cd9af3fc-c007-49b7-9633-7dc5e2ae0f82" />
