### PR TITLE
Use human-friendly display name in plugin install messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
-	golang.org/x/text v0.34.0 // indirect
+	golang.org/x/text v0.34.0
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -15,6 +15,8 @@ import (
 	"runtime"
 	"time"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"golang.org/x/term"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
@@ -64,6 +66,12 @@ type Release struct {
 	Version string            `toml:"Version"`
 	Sum     string            `toml:"Sum"`
 	Runtime map[string]string `toml:"Runtime,omitempty"`
+}
+
+// GetDisplayName returns a human-friendly display name derived from the plugin's Shortname,
+// e.g. "projects" → "Stripe Projects".
+func (p *Plugin) GetDisplayName() string {
+	return "Stripe " + cases.Title(language.English).String(p.Shortname)
 }
 
 // getPluginInterface computes the correct metadata needed for starting the hcplugin client
@@ -189,14 +197,14 @@ func (p *Plugin) getReleaseForVersion(version string) *Release {
 
 // Install installs the plugin of the given version
 func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, baseURL string) error {
-	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)
+	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing \"%s\" v%s...", p.GetDisplayName(), version)), os.Stdout)
 
 	apiKey, _ := cfg.GetProfile().GetAPIKey(false)
 
 	pluginData, err := requests.GetPluginData(ctx, baseURL, stripe.APIVersion, apiKey, cfg.GetProfile())
 
 	if err != nil {
-		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin \"%s\"", p.GetDisplayName())), os.Stdout)
 
 		log.WithFields(log.Fields{
 			"prefix": "plugins.plugin.Install",
@@ -213,7 +221,7 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 			if err := InstallNodeRuntime(ctx, cfg, fs, nodeVersion); err != nil {
 				return fmt.Errorf("failed to install required Node.js runtime: %w", err)
 			}
-			spinner = ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)
+			spinner = ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing \"%s\" v%s...", p.GetDisplayName(), version)), os.Stdout)
 		}
 	}
 
@@ -223,7 +231,7 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	err = p.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version)
 
 	if err != nil {
-		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), os.Stdout)
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin \"%s\": %s", p.GetDisplayName(), err)), os.Stdout)
 		return err
 	}
 

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -15,9 +15,9 @@ import (
 	"runtime"
 	"time"
 
+	"golang.org/x/term"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"golang.org/x/term"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"


### PR DESCRIPTION
Transforms the plugin Shortname (e.g. "projects") into a display name (e.g. "Stripe Projects") for install spinner and error messages. This change was requested by the Projects team.

Examples:

Projects

<img width="712" height="44" alt="Screenshot 2026-04-14 at 2 19 03 PM" src="https://github.com/user-attachments/assets/861d9c16-2347-45d1-9abb-545f2cb0cb5d" />

Apps

<img width="698" height="42" alt="Screenshot 2026-04-14 at 2 19 14 PM" src="https://github.com/user-attachments/assets/d610221b-d7fd-4153-8d3f-d1d5b5e683a9" />