### PR TITLE
Skip plugin install and upgrade if the requested version is already installed

### DIFF
--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -98,6 +98,8 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	prevVersion := plugin.InstalledVersion(ic.cfg, ic.fs)
+
 	ctx := withSIGTERMCancel(cmd.Context(), func() {
 		log.WithFields(log.Fields{
 			"prefix": "cmd.installCmd.runInstallCmd",
@@ -108,7 +110,11 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Println(color.Green(fmt.Sprintf("✔ installation of v%s complete.", version)))
+	if prevVersion != "" {
+		fmt.Println(color.Green(fmt.Sprintf("✔ upgraded from v%s to v%s.", prevVersion, version)))
+	} else {
+		fmt.Println(color.Green(fmt.Sprintf("✔ installation of v%s complete.", version)))
+	}
 
 	return nil
 }

--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 
+	goversion "github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -111,12 +112,21 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if prevVersion != "" {
-		fmt.Println(color.Green(fmt.Sprintf("✔ upgraded from v%s to v%s.", prevVersion, version)))
+		fmt.Println(color.Green(fmt.Sprintf("✔ %s from v%s to v%s.", versionChangeVerb(prevVersion, version), prevVersion, version)))
 	} else {
 		fmt.Println(color.Green(fmt.Sprintf("✔ installation of v%s complete.", version)))
 	}
 
 	return nil
+}
+
+func versionChangeVerb(from, to string) string {
+	prev, prevErr := goversion.NewVersion(from)
+	next, nextErr := goversion.NewVersion(to)
+	if prevErr == nil && nextErr == nil && prev.GreaterThan(next) {
+		return "downgraded"
+	}
+	return "upgraded"
 }
 
 func withSIGTERMCancel(ctx context.Context, onCancel func()) context.Context {

--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -65,17 +65,22 @@ func parseInstallArg(arg string) (string, string) {
 	return plugin, version
 }
 
-func (ic *InstallCmd) installPluginByName(cmd *cobra.Command, arg string) (version string, err error) {
+func (ic *InstallCmd) installPluginByName(cmd *cobra.Command, arg string) (version string, skipped bool, isLatest bool, err error) {
 	pluginName, version := parseInstallArg(arg)
 
 	plugin, err := plugins.LookUpPlugin(cmd.Context(), ic.cfg, ic.fs, pluginName)
 
 	if err != nil {
-		return version, err
+		return version, false, false, err
 	}
 
 	if len(version) == 0 {
 		version = plugin.LookUpLatestVersion()
+		isLatest = true
+	}
+
+	if plugin.IsVersionInstalled(ic.cfg, ic.fs, version) {
+		return version, true, isLatest, nil
 	}
 
 	ctx := withSIGTERMCancel(cmd.Context(), func() {
@@ -86,7 +91,7 @@ func (ic *InstallCmd) installPluginByName(cmd *cobra.Command, arg string) (versi
 
 	err = plugin.Install(ctx, ic.cfg, ic.fs, version, ic.apiBaseURL)
 
-	return version, err
+	return version, false, isLatest, err
 }
 
 func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
@@ -104,12 +109,22 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	version, err = ic.installPluginByName(cmd, args[0])
+	var skipped bool
+	var isLatest bool
+	version, skipped, isLatest, err = ic.installPluginByName(cmd, args[0])
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(color.Green(fmt.Sprintf("✔ installation of v%s complete.", version)))
+	if skipped {
+		if isLatest {
+			fmt.Println(color.Green(fmt.Sprintf("✔ v%s is already installed (latest).", version)))
+		} else {
+			fmt.Println(color.Green(fmt.Sprintf("✔ v%s is already installed.", version)))
+		}
+	} else {
+		fmt.Println(color.Green(fmt.Sprintf("✔ installation of v%s complete.", version)))
+	}
 
 	return nil
 }

--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -65,22 +65,37 @@ func parseInstallArg(arg string) (string, string) {
 	return plugin, version
 }
 
-func (ic *InstallCmd) installPluginByName(cmd *cobra.Command, arg string) (version string, skipped bool, isLatest bool, err error) {
-	pluginName, version := parseInstallArg(arg)
-
-	plugin, err := plugins.LookUpPlugin(cmd.Context(), ic.cfg, ic.fs, pluginName)
-
-	if err != nil {
-		return version, false, false, err
+func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
+	if err := stripe.ValidateAPIBaseURL(ic.apiBaseURL); err != nil {
+		return err
 	}
 
-	if len(version) == 0 {
+	color := ansi.Color(os.Stdout)
+
+	// Refresh the plugin before proceeding
+	if err := plugins.RefreshPluginManifest(cmd.Context(), ic.cfg, ic.fs, ic.apiBaseURL); err != nil {
+		return err
+	}
+
+	pluginName, version := parseInstallArg(args[0])
+
+	plugin, err := plugins.LookUpPlugin(cmd.Context(), ic.cfg, ic.fs, pluginName)
+	if err != nil {
+		return err
+	}
+
+	isLatest := len(version) == 0
+	if isLatest {
 		version = plugin.LookUpLatestVersion()
-		isLatest = true
 	}
 
 	if plugin.IsVersionInstalled(ic.cfg, ic.fs, version) {
-		return version, true, isLatest, nil
+		if isLatest {
+			fmt.Println(color.Green(fmt.Sprintf("✔ v%s is already installed (latest).", version)))
+		} else {
+			fmt.Println(color.Green(fmt.Sprintf("✔ v%s is already installed.", version)))
+		}
+		return nil
 	}
 
 	ctx := withSIGTERMCancel(cmd.Context(), func() {
@@ -89,42 +104,11 @@ func (ic *InstallCmd) installPluginByName(cmd *cobra.Command, arg string) (versi
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
-	err = plugin.Install(ctx, ic.cfg, ic.fs, version, ic.apiBaseURL)
-
-	return version, false, isLatest, err
-}
-
-func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
-	if err := stripe.ValidateAPIBaseURL(ic.apiBaseURL); err != nil {
+	if err := plugin.Install(ctx, ic.cfg, ic.fs, version, ic.apiBaseURL); err != nil {
 		return err
 	}
 
-	var err error
-	var version string
-	color := ansi.Color(os.Stdout)
-
-	// Refresh the plugin before proceeding
-	err = plugins.RefreshPluginManifest(cmd.Context(), ic.cfg, ic.fs, ic.apiBaseURL)
-	if err != nil {
-		return err
-	}
-
-	var skipped bool
-	var isLatest bool
-	version, skipped, isLatest, err = ic.installPluginByName(cmd, args[0])
-	if err != nil {
-		return err
-	}
-
-	if skipped {
-		if isLatest {
-			fmt.Println(color.Green(fmt.Sprintf("✔ v%s is already installed (latest).", version)))
-		} else {
-			fmt.Println(color.Green(fmt.Sprintf("✔ v%s is already installed.", version)))
-		}
-	} else {
-		fmt.Println(color.Green(fmt.Sprintf("✔ installation of v%s complete.", version)))
-	}
+	fmt.Println(color.Green(fmt.Sprintf("✔ installation of v%s complete.", version)))
 
 	return nil
 }

--- a/pkg/cmd/plugin/upgrade.go
+++ b/pkg/cmd/plugin/upgrade.go
@@ -70,12 +70,17 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 
 	version := plugin.LookUpLatestVersion()
 
+	color := ansi.Color(os.Stdout)
+
+	if plugin.IsVersionInstalled(uc.cfg, uc.fs, version) {
+		fmt.Println(color.Green(fmt.Sprintf("✔ v%s is already installed (latest).", version)))
+		return nil
+	}
+
 	err = plugin.Install(ctx, uc.cfg, uc.fs, version, uc.apiBaseURL)
 
 	if err == nil {
-		color := ansi.Color(os.Stdout)
-		successMsg := fmt.Sprintf("✔ upgrade to v%s complete.", version)
-		fmt.Println(color.Green(successMsg))
+		fmt.Println(color.Green(fmt.Sprintf("✔ upgrade to v%s complete.", version)))
 	}
 
 	return err

--- a/pkg/cmd/plugin/upgrade.go
+++ b/pkg/cmd/plugin/upgrade.go
@@ -84,7 +84,7 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if prevVersion != "" {
-		fmt.Println(color.Green(fmt.Sprintf("✔ upgraded from v%s to v%s.", prevVersion, version)))
+		fmt.Println(color.Green(fmt.Sprintf("✔ %s from v%s to v%s.", versionChangeVerb(prevVersion, version), prevVersion, version)))
 	} else {
 		fmt.Println(color.Green(fmt.Sprintf("✔ upgrade to v%s complete.", version)))
 	}

--- a/pkg/cmd/plugin/upgrade.go
+++ b/pkg/cmd/plugin/upgrade.go
@@ -77,11 +77,17 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	err = plugin.Install(ctx, uc.cfg, uc.fs, version, uc.apiBaseURL)
+	prevVersion := plugin.InstalledVersion(uc.cfg, uc.fs)
 
-	if err == nil {
+	if err := plugin.Install(ctx, uc.cfg, uc.fs, version, uc.apiBaseURL); err != nil {
+		return err
+	}
+
+	if prevVersion != "" {
+		fmt.Println(color.Green(fmt.Sprintf("✔ upgraded from v%s to v%s.", prevVersion, version)))
+	} else {
 		fmt.Println(color.Green(fmt.Sprintf("✔ upgrade to v%s complete.", version)))
 	}
 
-	return err
+	return nil
 }

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -187,6 +187,14 @@ func (p *Plugin) getReleaseForVersion(version string) *Release {
 	return nil
 }
 
+// IsVersionInstalled returns true if the given version of the plugin is already installed on disk.
+func (p *Plugin) IsVersionInstalled(config config.IConfig, fs afero.Fs, version string) bool {
+	pluginDir := p.getPluginInstallPath(config, version)
+	pluginBinaryPath := filepath.Join(pluginDir, p.Binary) + GetBinaryExtension()
+	_, err := fs.Stat(pluginBinaryPath)
+	return err == nil
+}
+
 // Install installs the plugin of the given version
 func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, baseURL string) error {
 	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -195,6 +195,25 @@ func (p *Plugin) IsVersionInstalled(config config.IConfig, fs afero.Fs, version 
 	return err == nil
 }
 
+// InstalledVersion returns the currently installed version of the plugin, or empty string if none.
+func (p *Plugin) InstalledVersion(config config.IConfig, fs afero.Fs) string {
+	pluginsDir := getPluginsDir(config)
+	pluginDir := filepath.Join(pluginsDir, p.Shortname)
+
+	entries, err := afero.ReadDir(fs, pluginDir)
+	if err != nil {
+		return ""
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return entry.Name()
+		}
+	}
+
+	return ""
+}
+
 // Install installs the plugin of the given version
 func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, baseURL string) error {
 	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)


### PR DESCRIPTION
 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

What it says on the tin. I also updated these commands to output what version was previously installed, if there was one.

Manually tested a bunch of situations:

<img width="798" height="255" alt="Screenshot 2026-04-17 at 3 49 26 PM" src="https://github.com/user-attachments/assets/cfee8c5c-aa57-4266-bfc1-adf3ac0440dd" />
