### PR TITLE
Refactor plugin version lookup to use afero and fix shadowing bug in Run

### DIFF
--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -35,6 +35,8 @@ var (
 	PluginsPath string
 )
 
+const localDevelopmentVersion = "local.build.dev"
+
 // CommandInfo describes a plugin subcommand for tree display (e.g. in --map).
 type CommandInfo struct {
 	Name     string        `toml:"Name" json:"name"`
@@ -97,6 +99,32 @@ func (p *Plugin) getPluginInstallPath(config config.IConfig, version string) str
 	cleanedPath := filepath.Clean(pluginPath)
 
 	return cleanedPath
+}
+
+func isLocalDevelopmentVersion(version string) bool {
+	return version == localDevelopmentVersion
+}
+
+func (p *Plugin) lookUpInstalledVersion(config config.IConfig, fs afero.Fs) (string, error) {
+	localDevPath := p.getPluginInstallPath(config, localDevelopmentVersion)
+	localDevExists, err := afero.DirExists(fs, localDevPath)
+	if err != nil {
+		return "", err
+	}
+	if localDevExists {
+		return localDevelopmentVersion, nil
+	}
+
+	localPluginDir := filepath.Join(getPluginsDir(config), p.Shortname, "*.*.*")
+	existingLocalPlugin, err := afero.Glob(fs, localPluginDir)
+	if err != nil {
+		return "", err
+	}
+	if len(existingLocalPlugin) == 0 {
+		return "", nil
+	}
+
+	return filepath.Base(existingLocalPlugin[0]), nil
 }
 
 // cleanUpPluginPath empties the plugin folder except for the version specified
@@ -335,6 +363,10 @@ func (p *Plugin) verifychecksumAndSavePlugin(pluginData []byte, config config.IC
 // verifyChecksum is to be used during installation only
 // hcplugins takes care of the boot time verification for us
 func (p *Plugin) verifyChecksum(binary io.Reader, version string) error {
+	if isLocalDevelopmentVersion(version) {
+		return nil
+	}
+
 	expectedSum, err := p.getChecksum(version)
 	if err != nil {
 		return err
@@ -391,24 +423,21 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 	var version string
 
 	if PluginsPath != "" {
-		version = "local.build.dev"
+		version = localDevelopmentVersion
 	} else {
-		// first perform a naive glob of the plugins/name dir for an existing version
-		localPluginDir := filepath.Join(getPluginsDir(config), p.Shortname, "*.*.*")
-		existingLocalPlugin, err := filepath.Glob(localPluginDir)
+		var err error
+		version, err = p.lookUpInstalledVersion(config, fs)
 		if err != nil {
 			return err
 		}
 
 		// if plugin is not installed locally, then we should install it first
-		if len(existingLocalPlugin) == 0 {
+		if version == "" {
 			version = p.LookUpLatestVersion()
 			err := p.Install(ctx, config, fs, version, stripe.DefaultAPIBaseURL)
 			if err != nil {
 				return err
 			}
-		} else {
-			version = filepath.Base(existingLocalPlugin[0])
 		}
 	}
 
@@ -465,7 +494,7 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 
 	// Only validate checksum for standalone binaries, not when using a runtime
 	// When using a runtime, cmd.Path points to the node binary, not the plugin
-	if !usesRuntime {
+	if !usesRuntime && !isLocalDevelopmentVersion(version) {
 		sum, err := p.getChecksum(version)
 		if err != nil {
 			return err

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -38,6 +39,13 @@ func TestInstall(t *testing.T) {
 	require.True(t, fileExists)
 
 	require.Equal(t, []string{"appA"}, config.GetInstalledPlugins())
+}
+
+func TestVerifyChecksumSkipsLocalDevelopmentVersion(t *testing.T) {
+	plugin := Plugin{Shortname: "appA"}
+
+	err := plugin.verifyChecksum(strings.NewReader("locally built binary"), localDevelopmentVersion)
+	require.NoError(t, err)
 }
 
 func TestInstallSucceedsIfNoAPIKey(t *testing.T) {
@@ -159,6 +167,34 @@ func TestInstallDoesNotCleanIfInstallFails(t *testing.T) {
 	// Require that we did not delete the initial version of the plugin
 	fileExists, _ = afero.Exists(fs, file)
 	require.True(t, fileExists, "Did not expect the original version of the plugin to be deleted.")
+}
+
+func TestLookUpInstalledVersionPrefersLocalDevelopmentVersion(t *testing.T) {
+	fs := setUpFS()
+	config := &TestConfig{}
+
+	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
+
+	require.NoError(t, fs.MkdirAll("/plugins/appA/local.build.dev", 0755))
+	require.NoError(t, fs.MkdirAll("/plugins/appA/2.0.1", 0755))
+
+	version, err := plugin.lookUpInstalledVersion(config, fs)
+	require.NoError(t, err)
+	require.Equal(t, localDevelopmentVersion, version)
+}
+
+func TestLookUpInstalledVersionFallsBackToInstalledRelease(t *testing.T) {
+	fs := setUpFS()
+	config := &TestConfig{}
+
+	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
+
+	require.NoError(t, fs.MkdirAll("/plugins/appA/1.0.1", 0755))
+	require.NoError(t, fs.MkdirAll("/plugins/appA/2.0.1", 0755))
+
+	version, err := plugin.lookUpInstalledVersion(config, fs)
+	require.NoError(t, err)
+	require.Equal(t, "1.0.1", version)
 }
 
 func TestCommandInfoParsedFromManifest(t *testing.T) {


### PR DESCRIPTION

It's annoying to run the local.build.dev version when developing a plugin, update the CLI version preference to always run the local version

## What                                                                                                                                                                                                 
                                                                                                                                                                                                          
  - Extracts `"local.build.dev"` into a `localDevelopmentVersion` constant                                                                                                                                
  - Introduces `lookUpInstalledVersion()` method that checks for a local dev build first, then falls back to a semver glob — using `afero.Fs` instead of `filepath.Glob` so it's testable                 
  - Adds `isLocalDevelopmentVersion()` predicate and uses it to skip checksum verification for local dev builds in both `verifyChecksum` and `Run`                                                        
  - Fixes a variable shadowing bug in `Run` where `:=` inside the `else` block created a new inner `version`, leaving the outer variable empty and causing `getPluginInstallPath` / `getChecksum` to      
  receive `""` for all non-dev plugin invocations                                                                                                                                                         
                                                                                                                                                                                                          
  ## No regression for production users                                                                                                                                                                   
                                                                  
  Regular users never have a `local.build.dev` directory, so `lookUpInstalledVersion` always falls through to the semver glob. `afero.OsFs` wraps the real filesystem, so behavior is identical to the    
  previous `filepath.Glob` call. The checksum skip only fires for the `local.build.dev` version string.
                                                                                                                                                                                                          
  ## Tests                                                        

  - `TestVerifyChecksumSkipsLocalDevelopmentVersion` — checksum is skipped for local dev builds                                                                                                           
  - `TestLookUpInstalledVersionPrefersLocalDevelopmentVersion` — local dev dir takes priority over an installed release
  - `TestLookUpInstalledVersionFallsBackToInstalledRelease` — falls back to semver glob when no local dev build exists  
