### PR TITLE
Add RunPeerPlugin helper to CoreCLIHelper

### DIFF
--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -110,7 +110,7 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 		"prefix": "cmd.pluginCmd.runPluginCmd",
 	}).Debug("Running plugin...")
 
-	err = plugin.Run(ctx, ptc.cfg, fs, ptc.ParsedArgs)
+	err = plugin.Run(ctx, ptc.cfg, fs, ptc.ParsedArgs, "")
 	plugins.CleanupAllClients()
 
 	if err != nil {

--- a/pkg/plugins/core_cli_helper.go
+++ b/pkg/plugins/core_cli_helper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/99designs/keyring"
+	"github.com/spf13/afero"
 
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/plugins/proto"
@@ -19,6 +20,7 @@ type CoreCLIHelper interface {
 	KeychainSetPassword(key string, value string) error
 	KeychainDeletePassword(key string) (bool, error)
 	KeychainFindCredentials() ([]string, error)
+	RunPeerPlugin(pluginName string, args []string, cwd string) error
 }
 
 type CoreCLIHelperClient struct {
@@ -71,6 +73,15 @@ func (c *CoreCLIHelperClient) KeychainFindCredentials() ([]string, error) {
 		return nil, err
 	}
 	return resp.Keys, nil
+}
+
+func (c *CoreCLIHelperClient) RunPeerPlugin(pluginName string, args []string, cwd string) error {
+	_, err := c.client.RunPeerPlugin(context.Background(), &proto.RunPeerPluginRequest{
+		PluginName: pluginName,
+		Args:       args,
+		Cwd:        cwd,
+	})
+	return err
 }
 
 type CoreCLIHelperServer struct {
@@ -126,16 +137,26 @@ func (s *CoreCLIHelperServer) KeychainFindCredentials(ctx context.Context, req *
 	return &proto.KeychainFindCredentialsResponse{Keys: keys}, nil
 }
 
+func (s *CoreCLIHelperServer) RunPeerPlugin(ctx context.Context, req *proto.RunPeerPluginRequest) (*proto.RunPeerPluginResponse, error) {
+	err := s.Impl.RunPeerPlugin(req.PluginName, req.Args, req.Cwd)
+	if err != nil {
+		return nil, err
+	}
+	return &proto.RunPeerPluginResponse{}, nil
+}
+
 // coreCLIHelper is the real implementation of the CoreCLIHelper interface.
 type coreCLIHelper struct {
-	ctx context.Context
+	ctx    context.Context
+	config config.IConfig
+	fs     afero.Fs
 }
 
 var _ CoreCLIHelper = &coreCLIHelper{}
 
-// NewCoreCLIHelper creates a new CoreCLIHelper with the given context.
-func NewCoreCLIHelper(ctx context.Context) CoreCLIHelper {
-	return &coreCLIHelper{ctx: ctx}
+// NewCoreCLIHelper creates a new CoreCLIHelper with the given context, config, and filesystem.
+func NewCoreCLIHelper(ctx context.Context, cfg config.IConfig, fs afero.Fs) CoreCLIHelper {
+	return &coreCLIHelper{ctx: ctx, config: cfg, fs: fs}
 }
 
 // Echo echoes the input string.
@@ -199,4 +220,18 @@ func (h *coreCLIHelper) KeychainDeletePassword(key string) (bool, error) {
 // KeychainFindCredentials lists all keys stored in the keychain for this service.
 func (h *coreCLIHelper) KeychainFindCredentials() ([]string, error) {
 	return config.KeyRing.Keys()
+}
+
+// RunPeerPlugin looks up and runs the named plugin with the given arguments.
+// cwd sets the working directory for the plugin process; an empty string uses the current directory.
+func (h *coreCLIHelper) RunPeerPlugin(pluginName string, args []string, cwd string) error {
+	plugin, err := LookUpPlugin(h.ctx, h.config, h.fs, pluginName)
+	if err != nil {
+		return fmt.Errorf("peer plugin %q not found: %w", pluginName, err)
+	}
+	cfg, ok := h.config.(*config.Config)
+	if !ok {
+		return fmt.Errorf("could not run peer plugin %q: config type mismatch", pluginName)
+	}
+	return plugin.Run(h.ctx, cfg, h.fs, args, cwd)
 }

--- a/pkg/plugins/core_cli_helper_test.go
+++ b/pkg/plugins/core_cli_helper_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/stripe"
@@ -11,7 +12,7 @@ import (
 
 func TestEcho(t *testing.T) {
 	ctx := context.Background()
-	coreCLIHelper := NewCoreCLIHelper(ctx)
+	coreCLIHelper := NewCoreCLIHelper(ctx, nil, afero.NewMemMapFs())
 	output, err := coreCLIHelper.Echo("test")
 	require.NoError(t, err)
 	require.Equal(t, "test", output)
@@ -20,7 +21,7 @@ func TestEcho(t *testing.T) {
 func TestSendAnalytics(t *testing.T) {
 	// Test with no telemetry client in context (should not error)
 	ctx := context.Background()
-	coreCLIHelper := NewCoreCLIHelper(ctx)
+	coreCLIHelper := NewCoreCLIHelper(ctx, nil, afero.NewMemMapFs())
 	err := coreCLIHelper.SendAnalytics("test_event", "test_value")
 	require.NoError(t, err)
 }
@@ -31,7 +32,7 @@ func TestSendAnalyticsWithTelemetryClient(t *testing.T) {
 	telemetryClient := &stripe.NoOpTelemetryClient{}
 	ctx = stripe.WithTelemetryClient(ctx, telemetryClient)
 
-	coreCLIHelper := NewCoreCLIHelper(ctx)
+	coreCLIHelper := NewCoreCLIHelper(ctx, nil, afero.NewMemMapFs())
 	err := coreCLIHelper.SendAnalytics("test_event", "test_value")
 	require.NoError(t, err)
 }

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -441,8 +441,9 @@ func buildAdditionalInfo(logger *log.Entry) *proto.AdditionalInfo {
 	}
 }
 
-// Run boots up the binary and then sends the command to it via RPC
-func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, args []string) error {
+// Run boots up the binary and then sends the command to it via RPC.
+// cwd sets the working directory for the plugin process; an empty string uses the current directory.
+func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, args []string, cwd string) error {
 	logger := log.WithFields(log.Fields{
 		"prefix": "plugins.plugin.Run",
 	})
@@ -495,6 +496,10 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 		// Couldn't find release info, assume it's a standalone binary
 		cmd = exec.Command(pluginBinaryPath)
 		usesRuntime = false
+	}
+
+	if cwd != "" {
+		cmd.Dir = cwd
 	}
 
 	handshakeConfig, pluginSetMap := p.getPluginInterface()
@@ -564,7 +569,7 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 		}
 	case DispatcherV3:
 		logger.Debug("negotiated gRPC with plugin process (v3)")
-		if err = d.RunCommand(buildAdditionalInfo(logger), args, NewCoreCLIHelper(ctx)); err != nil {
+		if err = d.RunCommand(buildAdditionalInfo(logger), args, NewCoreCLIHelper(ctx, config, fs)); err != nil {
 			return err
 		}
 	default:

--- a/pkg/plugins/proto/main.pb.go
+++ b/pkg/plugins/proto/main.pb.go
@@ -809,6 +809,102 @@ func (x *KeychainFindCredentialsResponse) GetKeys() []string {
 	return nil
 }
 
+type RunPeerPluginRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PluginName    string                 `protobuf:"bytes,1,opt,name=plugin_name,json=pluginName,proto3" json:"plugin_name,omitempty"`
+	Args          []string               `protobuf:"bytes,2,rep,name=args,proto3" json:"args,omitempty"`
+	Cwd           string                 `protobuf:"bytes,3,opt,name=cwd,proto3" json:"cwd,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunPeerPluginRequest) Reset() {
+	*x = RunPeerPluginRequest{}
+	mi := &file_pkg_plugins_proto_main_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunPeerPluginRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunPeerPluginRequest) ProtoMessage() {}
+
+func (x *RunPeerPluginRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_plugins_proto_main_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunPeerPluginRequest.ProtoReflect.Descriptor instead.
+func (*RunPeerPluginRequest) Descriptor() ([]byte, []int) {
+	return file_pkg_plugins_proto_main_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *RunPeerPluginRequest) GetPluginName() string {
+	if x != nil {
+		return x.PluginName
+	}
+	return ""
+}
+
+func (x *RunPeerPluginRequest) GetArgs() []string {
+	if x != nil {
+		return x.Args
+	}
+	return nil
+}
+
+func (x *RunPeerPluginRequest) GetCwd() string {
+	if x != nil {
+		return x.Cwd
+	}
+	return ""
+}
+
+type RunPeerPluginResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunPeerPluginResponse) Reset() {
+	*x = RunPeerPluginResponse{}
+	mi := &file_pkg_plugins_proto_main_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunPeerPluginResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunPeerPluginResponse) ProtoMessage() {}
+
+func (x *RunPeerPluginResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_plugins_proto_main_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunPeerPluginResponse.ProtoReflect.Descriptor instead.
+func (*RunPeerPluginResponse) Descriptor() ([]byte, []int) {
+	return file_pkg_plugins_proto_main_proto_rawDescGZIP(), []int{18}
+}
+
 var File_pkg_plugins_proto_main_proto protoreflect.FileDescriptor
 
 const file_pkg_plugins_proto_main_proto_rawDesc = "" +
@@ -856,17 +952,24 @@ const file_pkg_plugins_proto_main_proto_rawDesc = "" +
 	"\adeleted\x18\x01 \x01(\bR\adeleted\" \n" +
 	"\x1eKeychainFindCredentialsRequest\"5\n" +
 	"\x1fKeychainFindCredentialsResponse\x12\x12\n" +
-	"\x04keys\x18\x01 \x03(\tR\x04keys2I\n" +
+	"\x04keys\x18\x01 \x03(\tR\x04keys\"]\n" +
+	"\x14RunPeerPluginRequest\x12\x1f\n" +
+	"\vplugin_name\x18\x01 \x01(\tR\n" +
+	"pluginName\x12\x12\n" +
+	"\x04args\x18\x02 \x03(\tR\x04args\x12\x10\n" +
+	"\x03cwd\x18\x03 \x01(\tR\x03cwd\"\x17\n" +
+	"\x15RunPeerPluginResponse2I\n" +
 	"\x04Main\x12A\n" +
 	"\n" +
-	"RunCommand\x12\x18.proto.RunCommandRequest\x1a\x19.proto.RunCommandResponse2\x99\x04\n" +
+	"RunCommand\x12\x18.proto.RunCommandRequest\x1a\x19.proto.RunCommandResponse2\xe5\x04\n" +
 	"\rCoreCLIHelper\x12/\n" +
 	"\x04Echo\x12\x12.proto.EchoRequest\x1a\x13.proto.EchoResponse\x12J\n" +
 	"\rSendAnalytics\x12\x1b.proto.SendAnalyticsRequest\x1a\x1c.proto.SendAnalyticsResponse\x12\\\n" +
 	"\x13KeychainGetPassword\x12!.proto.KeychainGetPasswordRequest\x1a\".proto.KeychainGetPasswordResponse\x12\\\n" +
 	"\x13KeychainSetPassword\x12!.proto.KeychainSetPasswordRequest\x1a\".proto.KeychainSetPasswordResponse\x12e\n" +
 	"\x16KeychainDeletePassword\x12$.proto.KeychainDeletePasswordRequest\x1a%.proto.KeychainDeletePasswordResponse\x12h\n" +
-	"\x17KeychainFindCredentials\x12%.proto.KeychainFindCredentialsRequest\x1a&.proto.KeychainFindCredentialsResponseB,Z*github.com/stripe/stripe-cli/plugins/protob\x06proto3"
+	"\x17KeychainFindCredentials\x12%.proto.KeychainFindCredentialsRequest\x1a&.proto.KeychainFindCredentialsResponse\x12J\n" +
+	"\rRunPeerPlugin\x12\x1b.proto.RunPeerPluginRequest\x1a\x1c.proto.RunPeerPluginResponseB,Z*github.com/stripe/stripe-cli/plugins/protob\x06proto3"
 
 var (
 	file_pkg_plugins_proto_main_proto_rawDescOnce sync.Once
@@ -880,7 +983,7 @@ func file_pkg_plugins_proto_main_proto_rawDescGZIP() []byte {
 	return file_pkg_plugins_proto_main_proto_rawDescData
 }
 
-var file_pkg_plugins_proto_main_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_pkg_plugins_proto_main_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_pkg_plugins_proto_main_proto_goTypes = []any{
 	(*RunCommandRequest)(nil),               // 0: proto.RunCommandRequest
 	(*RunCommandResponse)(nil),              // 1: proto.RunCommandResponse
@@ -899,6 +1002,8 @@ var file_pkg_plugins_proto_main_proto_goTypes = []any{
 	(*KeychainDeletePasswordResponse)(nil),  // 14: proto.KeychainDeletePasswordResponse
 	(*KeychainFindCredentialsRequest)(nil),  // 15: proto.KeychainFindCredentialsRequest
 	(*KeychainFindCredentialsResponse)(nil), // 16: proto.KeychainFindCredentialsResponse
+	(*RunPeerPluginRequest)(nil),            // 17: proto.RunPeerPluginRequest
+	(*RunPeerPluginResponse)(nil),           // 18: proto.RunPeerPluginResponse
 }
 var file_pkg_plugins_proto_main_proto_depIdxs = []int32{
 	2,  // 0: proto.RunCommandRequest.additional_info:type_name -> proto.AdditionalInfo
@@ -911,15 +1016,17 @@ var file_pkg_plugins_proto_main_proto_depIdxs = []int32{
 	11, // 7: proto.CoreCLIHelper.KeychainSetPassword:input_type -> proto.KeychainSetPasswordRequest
 	13, // 8: proto.CoreCLIHelper.KeychainDeletePassword:input_type -> proto.KeychainDeletePasswordRequest
 	15, // 9: proto.CoreCLIHelper.KeychainFindCredentials:input_type -> proto.KeychainFindCredentialsRequest
-	1,  // 10: proto.Main.RunCommand:output_type -> proto.RunCommandResponse
-	6,  // 11: proto.CoreCLIHelper.Echo:output_type -> proto.EchoResponse
-	8,  // 12: proto.CoreCLIHelper.SendAnalytics:output_type -> proto.SendAnalyticsResponse
-	10, // 13: proto.CoreCLIHelper.KeychainGetPassword:output_type -> proto.KeychainGetPasswordResponse
-	12, // 14: proto.CoreCLIHelper.KeychainSetPassword:output_type -> proto.KeychainSetPasswordResponse
-	14, // 15: proto.CoreCLIHelper.KeychainDeletePassword:output_type -> proto.KeychainDeletePasswordResponse
-	16, // 16: proto.CoreCLIHelper.KeychainFindCredentials:output_type -> proto.KeychainFindCredentialsResponse
-	10, // [10:17] is the sub-list for method output_type
-	3,  // [3:10] is the sub-list for method input_type
+	17, // 10: proto.CoreCLIHelper.RunPeerPlugin:input_type -> proto.RunPeerPluginRequest
+	1,  // 11: proto.Main.RunCommand:output_type -> proto.RunCommandResponse
+	6,  // 12: proto.CoreCLIHelper.Echo:output_type -> proto.EchoResponse
+	8,  // 13: proto.CoreCLIHelper.SendAnalytics:output_type -> proto.SendAnalyticsResponse
+	10, // 14: proto.CoreCLIHelper.KeychainGetPassword:output_type -> proto.KeychainGetPasswordResponse
+	12, // 15: proto.CoreCLIHelper.KeychainSetPassword:output_type -> proto.KeychainSetPasswordResponse
+	14, // 16: proto.CoreCLIHelper.KeychainDeletePassword:output_type -> proto.KeychainDeletePasswordResponse
+	16, // 17: proto.CoreCLIHelper.KeychainFindCredentials:output_type -> proto.KeychainFindCredentialsResponse
+	18, // 18: proto.CoreCLIHelper.RunPeerPlugin:output_type -> proto.RunPeerPluginResponse
+	11, // [11:19] is the sub-list for method output_type
+	3,  // [3:11] is the sub-list for method input_type
 	3,  // [3:3] is the sub-list for extension type_name
 	3,  // [3:3] is the sub-list for extension extendee
 	0,  // [0:3] is the sub-list for field type_name
@@ -936,7 +1043,7 @@ func file_pkg_plugins_proto_main_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_plugins_proto_main_proto_rawDesc), len(file_pkg_plugins_proto_main_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   17,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/plugins/proto/main.proto
+++ b/pkg/plugins/proto/main.proto
@@ -39,6 +39,7 @@ service CoreCLIHelper {
   rpc KeychainSetPassword(KeychainSetPasswordRequest) returns (KeychainSetPasswordResponse);
   rpc KeychainDeletePassword(KeychainDeletePasswordRequest) returns (KeychainDeletePasswordResponse);
   rpc KeychainFindCredentials(KeychainFindCredentialsRequest) returns (KeychainFindCredentialsResponse);
+  rpc RunPeerPlugin(RunPeerPluginRequest) returns (RunPeerPluginResponse);
 }
 
 message EchoRequest {
@@ -87,4 +88,13 @@ message KeychainFindCredentialsRequest {
 
 message KeychainFindCredentialsResponse {
   repeated string keys = 1;
+}
+
+message RunPeerPluginRequest {
+  string plugin_name = 1;
+  repeated string args = 2;
+  string cwd = 3;
+}
+
+message RunPeerPluginResponse {
 }

--- a/pkg/plugins/proto/main_grpc.pb.go
+++ b/pkg/plugins/proto/main_grpc.pb.go
@@ -127,6 +127,7 @@ const (
 	CoreCLIHelper_KeychainSetPassword_FullMethodName     = "/proto.CoreCLIHelper/KeychainSetPassword"
 	CoreCLIHelper_KeychainDeletePassword_FullMethodName  = "/proto.CoreCLIHelper/KeychainDeletePassword"
 	CoreCLIHelper_KeychainFindCredentials_FullMethodName = "/proto.CoreCLIHelper/KeychainFindCredentials"
+	CoreCLIHelper_RunPeerPlugin_FullMethodName           = "/proto.CoreCLIHelper/RunPeerPlugin"
 )
 
 // CoreCLIHelperClient is the client API for CoreCLIHelper service.
@@ -139,6 +140,7 @@ type CoreCLIHelperClient interface {
 	KeychainSetPassword(ctx context.Context, in *KeychainSetPasswordRequest, opts ...grpc.CallOption) (*KeychainSetPasswordResponse, error)
 	KeychainDeletePassword(ctx context.Context, in *KeychainDeletePasswordRequest, opts ...grpc.CallOption) (*KeychainDeletePasswordResponse, error)
 	KeychainFindCredentials(ctx context.Context, in *KeychainFindCredentialsRequest, opts ...grpc.CallOption) (*KeychainFindCredentialsResponse, error)
+	RunPeerPlugin(ctx context.Context, in *RunPeerPluginRequest, opts ...grpc.CallOption) (*RunPeerPluginResponse, error)
 }
 
 type coreCLIHelperClient struct {
@@ -209,6 +211,16 @@ func (c *coreCLIHelperClient) KeychainFindCredentials(ctx context.Context, in *K
 	return out, nil
 }
 
+func (c *coreCLIHelperClient) RunPeerPlugin(ctx context.Context, in *RunPeerPluginRequest, opts ...grpc.CallOption) (*RunPeerPluginResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RunPeerPluginResponse)
+	err := c.cc.Invoke(ctx, CoreCLIHelper_RunPeerPlugin_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // CoreCLIHelperServer is the server API for CoreCLIHelper service.
 // All implementations must embed UnimplementedCoreCLIHelperServer
 // for forward compatibility.
@@ -219,6 +231,7 @@ type CoreCLIHelperServer interface {
 	KeychainSetPassword(context.Context, *KeychainSetPasswordRequest) (*KeychainSetPasswordResponse, error)
 	KeychainDeletePassword(context.Context, *KeychainDeletePasswordRequest) (*KeychainDeletePasswordResponse, error)
 	KeychainFindCredentials(context.Context, *KeychainFindCredentialsRequest) (*KeychainFindCredentialsResponse, error)
+	RunPeerPlugin(context.Context, *RunPeerPluginRequest) (*RunPeerPluginResponse, error)
 	mustEmbedUnimplementedCoreCLIHelperServer()
 }
 
@@ -246,6 +259,9 @@ func (UnimplementedCoreCLIHelperServer) KeychainDeletePassword(context.Context, 
 }
 func (UnimplementedCoreCLIHelperServer) KeychainFindCredentials(context.Context, *KeychainFindCredentialsRequest) (*KeychainFindCredentialsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method KeychainFindCredentials not implemented")
+}
+func (UnimplementedCoreCLIHelperServer) RunPeerPlugin(context.Context, *RunPeerPluginRequest) (*RunPeerPluginResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RunPeerPlugin not implemented")
 }
 func (UnimplementedCoreCLIHelperServer) mustEmbedUnimplementedCoreCLIHelperServer() {}
 func (UnimplementedCoreCLIHelperServer) testEmbeddedByValue()                       {}
@@ -376,6 +392,24 @@ func _CoreCLIHelper_KeychainFindCredentials_Handler(srv interface{}, ctx context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _CoreCLIHelper_RunPeerPlugin_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RunPeerPluginRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CoreCLIHelperServer).RunPeerPlugin(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CoreCLIHelper_RunPeerPlugin_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CoreCLIHelperServer).RunPeerPlugin(ctx, req.(*RunPeerPluginRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // CoreCLIHelper_ServiceDesc is the grpc.ServiceDesc for CoreCLIHelper service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -406,6 +440,10 @@ var CoreCLIHelper_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "KeychainFindCredentials",
 			Handler:    _CoreCLIHelper_KeychainFindCredentials_Handler,
+		},
+		{
+			MethodName: "RunPeerPlugin",
+			Handler:    _CoreCLIHelper_RunPeerPlugin_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
Allows a V3 plugin to invoke another installed plugin by name with a list of arguments and an optional working directory (cwd), routed through the host CLI via the existing gRPC broker.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
