### PR TITLE
Show cursor during spinner

### DIFF
--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -141,7 +141,7 @@ func StartNewSpinner(msg string, w io.Writer) *spinner.Spinner {
 		return nil
 	}
 
-	s := spinner.New(getCharset(), duration)
+	s := spinner.New(getCharset(), duration, spinner.WithHiddenCursor(false))
 	s.Writer = w
 
 	if msg != "" {


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

There's an issue where the cursor disappears when we render the spinner and doesn't come back, which is really annoying. This fixes the issue by never hiding it.

Although hiding the cursor may be "cleaner," I don't think it's worth the effort to manage its visibility.

Before: I hit ^c during login and the cursor disappears.

https://github.com/user-attachments/assets/76337d43-bb8f-451e-8edd-ab391b62a71f

After: The cursor stays visible.

https://github.com/user-attachments/assets/26d9e4a2-643e-4648-982d-e333a86060e4