### PR TITLE
[stripe-samples] added .env overrides to allow samples to better cust…

### DIFF
--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -68,6 +68,8 @@ type SampleConfigIntegration struct {
 	Clients []string `json:"clients"`
 	// Servers are the backend server implementations available for a sample
 	Servers []string `json:"servers"`
+	// ClientEnvOverrides maps client name to env var overrides applied during .env generation
+	ClientEnvOverrides map[string]map[string]string `json:"clientEnvOverrides,omitempty"`
 }
 
 func (i *SampleConfigIntegration) hasClients() bool {
@@ -382,6 +384,12 @@ func (s *SampleManager) WriteDotEnv(ctx context.Context, sampleLocation string) 
 		}
 		for k, v := range envVars {
 			dotenv[k] = v
+		}
+
+		if overrides, ok := s.SelectedConfig.Integration.ClientEnvOverrides[s.SelectedConfig.Client]; ok {
+			for k, v := range overrides {
+				dotenv[k] = v
+			}
 		}
 
 		envFile := filepath.Join(sampleLocation, "server", ".env")

--- a/pkg/samples/samples_test.go
+++ b/pkg/samples/samples_test.go
@@ -270,3 +270,162 @@ func TestWriteDotEnvWorksForRegularFile(t *testing.T) {
 	assert.Contains(t, envContent, "STRIPE_PUBLISHABLE_KEY")
 	assert.Contains(t, envContent, "STRIPE_WEBHOOK_SECRET")
 }
+
+func TestWriteDotEnvAppliesClientOverride(t *testing.T) {
+	sampleDir := t.TempDir()
+	serverDir := filepath.Join(sampleDir, "server")
+	require.NoError(t, os.MkdirAll(serverDir, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(sampleDir, ".env.example"), []byte("DOMAIN=http://localhost:4242\n"), 0o644))
+
+	sm := &SampleManager{
+		Fs: afero.NewOsFs(),
+		SampleConfig: SampleConfig{
+			ConfigureDotEnv: true,
+		},
+		SelectedConfig: SelectedConfig{
+			Integration: &SampleConfigIntegration{
+				Name:    "main",
+				Servers: []string{"node"},
+				ClientEnvOverrides: map[string]map[string]string{
+					"react-cra": {"DOMAIN": "http://localhost:3000"},
+				},
+			},
+			Client: "react-cra",
+			Server: "node",
+		},
+		ConfigureDotEnv: func(ctx context.Context, cfg *config.Config) (map[string]string, error) {
+			return map[string]string{
+				"STRIPE_SECRET_KEY":      "sk_test_123",
+				"STRIPE_PUBLISHABLE_KEY": "pk_test_123",
+			}, nil
+		},
+	}
+
+	err := sm.WriteDotEnv(context.Background(), sampleDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(serverDir, ".env"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `DOMAIN="http://localhost:3000"`)
+}
+
+func TestWriteDotEnvNoOverrideForDifferentClient(t *testing.T) {
+	sampleDir := t.TempDir()
+	serverDir := filepath.Join(sampleDir, "server")
+	require.NoError(t, os.MkdirAll(serverDir, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(sampleDir, ".env.example"), []byte("DOMAIN=http://localhost:4242\n"), 0o644))
+
+	sm := &SampleManager{
+		Fs: afero.NewOsFs(),
+		SampleConfig: SampleConfig{
+			ConfigureDotEnv: true,
+		},
+		SelectedConfig: SelectedConfig{
+			Integration: &SampleConfigIntegration{
+				Name:    "main",
+				Servers: []string{"node"},
+				ClientEnvOverrides: map[string]map[string]string{
+					"react-cra": {"DOMAIN": "http://localhost:3000"},
+				},
+			},
+			Client: "html",
+			Server: "node",
+		},
+		ConfigureDotEnv: func(ctx context.Context, cfg *config.Config) (map[string]string, error) {
+			return map[string]string{
+				"STRIPE_SECRET_KEY":      "sk_test_123",
+				"STRIPE_PUBLISHABLE_KEY": "pk_test_123",
+			}, nil
+		},
+	}
+
+	err := sm.WriteDotEnv(context.Background(), sampleDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(serverDir, ".env"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `DOMAIN="http://localhost:4242"`)
+}
+
+func TestWriteDotEnvNilOverridesMap(t *testing.T) {
+	sampleDir := t.TempDir()
+	serverDir := filepath.Join(sampleDir, "server")
+	require.NoError(t, os.MkdirAll(serverDir, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(sampleDir, ".env.example"), []byte("DOMAIN=http://localhost:4242\n"), 0o644))
+
+	sm := &SampleManager{
+		Fs: afero.NewOsFs(),
+		SampleConfig: SampleConfig{
+			ConfigureDotEnv: true,
+		},
+		SelectedConfig: SelectedConfig{
+			Integration: &SampleConfigIntegration{
+				Name:    "main",
+				Servers: []string{"node"},
+				// ClientEnvOverrides intentionally nil
+			},
+			Client: "react-cra",
+			Server: "node",
+		},
+		ConfigureDotEnv: func(ctx context.Context, cfg *config.Config) (map[string]string, error) {
+			return map[string]string{
+				"STRIPE_SECRET_KEY":      "sk_test_123",
+				"STRIPE_PUBLISHABLE_KEY": "pk_test_123",
+			}, nil
+		},
+	}
+
+	err := sm.WriteDotEnv(context.Background(), sampleDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(serverDir, ".env"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `DOMAIN="http://localhost:4242"`)
+}
+
+func TestWriteDotEnvOverrideWinsOverExample(t *testing.T) {
+	sampleDir := t.TempDir()
+	serverDir := filepath.Join(sampleDir, "server")
+	require.NoError(t, os.MkdirAll(serverDir, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(sampleDir, ".env.example"), []byte("DOMAIN=http://localhost:4242\nPORT=4242\n"), 0o644))
+
+	sm := &SampleManager{
+		Fs: afero.NewOsFs(),
+		SampleConfig: SampleConfig{
+			ConfigureDotEnv: true,
+		},
+		SelectedConfig: SelectedConfig{
+			Integration: &SampleConfigIntegration{
+				Name:    "main",
+				Servers: []string{"node"},
+				ClientEnvOverrides: map[string]map[string]string{
+					"react-cra": {"DOMAIN": "http://localhost:3000"},
+				},
+			},
+			Client: "react-cra",
+			Server: "node",
+		},
+		ConfigureDotEnv: func(ctx context.Context, cfg *config.Config) (map[string]string, error) {
+			return map[string]string{
+				"STRIPE_SECRET_KEY":      "sk_test_123",
+				"STRIPE_PUBLISHABLE_KEY": "pk_test_123",
+			}, nil
+		},
+	}
+
+	err := sm.WriteDotEnv(context.Background(), sampleDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(serverDir, ".env"))
+	require.NoError(t, err)
+	envContent := string(content)
+	// Override wins over .env.example default
+	assert.Contains(t, envContent, `DOMAIN="http://localhost:3000"`)
+	assert.NotContains(t, envContent, `DOMAIN="http://localhost:4242"`)
+	// Non-overridden vars preserved
+	assert.Contains(t, envContent, "PORT=4242")
+}


### PR DESCRIPTION
…omize env variables

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

## Summary

Add `clientEnvOverrides` field to the `.cli.json` schema so samples can declare per-client env var overrides, applied during `.env` generation in `stripe samples create`.

## Motivation

When a user selects a React or Vue client (e.g. `react-cra`), the generated `server/.env` gets `DOMAIN=http://localhost:4242` (the server port). But React/Vue dev servers run on port 3000, so Stripe redirect URLs (`return_url`, `success_url`) point to the wrong port and break the flow. This change lets sample authors declare overrides like `{"react-cra": {"DOMAIN": "http://localhost:3000"}}` in `.cli.json`, which the CLI applies at `.env` write time.

## Test matrix

| Scenario | Client | `clientEnvOverrides` | Expected `DOMAIN` in `.env` |
|---|---|---|---|
| Override applied | `react-cra` | `{"react-cra": {"DOMAIN": "http://localhost:3000"}}` | `http://localhost:3000` |
| Non-matching client | `html` | `{"react-cra": {"DOMAIN": "http://localhost:3000"}}` | `http://localhost:4242` (from `.env.example`) |
| Nil overrides map | `react-cra` | `nil` | `http://localhost:4242` (no panic) |
| Override wins over `.env.example` | `react-cra` | `{"react-cra": {"DOMAIN": "http://localhost:3000"}}` | `http://localhost:3000`, not `4242`; other vars like `PORT` preserved |
| Symlink `.env` (existing test) | any | any | Error: refuses to write through symlink |
| Regular file (existing test) | any | none | `.env` written with Stripe keys |

## Follow-up PRs (JSON-only, separate repos)

- `stripe-samples/accept-a-payment`: Add `clientEnvOverrides` to `prebuilt-checkout-page` and `elements-with-checkout-sessions` integrations
- `stripe-samples/checkout-one-time-payments`: Add `clientEnvOverrides` to `main` integration, remove comment workaround from `.env.example`