### PR TITLE
Improve output formatting for databases commands

### DIFF
--- a/pkg/cmd/resource/databases.go
+++ b/pkg/cmd/resource/databases.go
@@ -7,9 +7,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"runtime"
 	"strings"
 	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
@@ -21,7 +24,7 @@ import (
 const (
 	databaseJSONFlagName               = "json"
 	databaseRequestVersion             = "unsafe-development"
-	databaseDeleteConfirmationPhrase   = "remove StripeDB"
+	databaseDeleteConfirmationPhrase   = "delete database"
 	databaseUserDeleteConfirmationText = "remove user"
 )
 
@@ -53,6 +56,7 @@ type databaseObject struct {
 	Created    string             `json:"created"`
 	Status     string             `json:"status"`
 	APIVersion string             `json:"api_version"`
+	Name       string             `json:"name"` // TODO: remove placeholder once API ships display_name
 	Connection databaseConnection `json:"connection"`
 	User       *databaseUser      `json:"user"`
 }
@@ -267,7 +271,15 @@ func newDatabaseUsersDeleteCmd(parentCmd *cobra.Command, cfg *config.Config) *co
 }
 
 func runDatabaseCreate(cmd *cobra.Command, opCmd *OperationCmd, args []string) error {
+	var sp *spinner.Spinner
+	if !jsonOutputEnabled(cmd) {
+		sp = ansi.StartNewSpinner("Creating StripeDB instance...", cmd.ErrOrStderr())
+	}
 	body, err := executeDatabaseOperation(cmd, opCmd, args)
+	if sp != nil {
+		ansi.StopSpinner(sp, "", cmd.ErrOrStderr())
+	}
+
 	if err != nil || body == nil {
 		return err
 	}
@@ -287,7 +299,38 @@ func runDatabaseCreate(cmd *cobra.Command, opCmd *OperationCmd, args []string) e
 	}
 
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "Created StripeDB instance %s\n", database.ID)
+
+	// Leading blank line to match design spec
+	fmt.Fprintln(out)
+
+	// Progress steps (static, shown after API responds)
+	checkMark := "✓"
+	circle := "○"
+	if !databaseUnicodeSupported() {
+		checkMark = "[done]"
+		circle = "o"
+	}
+	steps := []struct {
+		glyph string
+		label string
+		color func(io.Writer, string) string
+	}{
+		{checkMark, "Provisioned database", textGreen},
+		{checkMark, "Generated credentials", textGreen},
+		{circle, "Syncing data...", textYellow},
+	}
+	for _, s := range steps {
+		fmt.Fprintf(out, "  %s %s\n", s.color(out, s.glyph), s.label)
+		if sp != nil {
+			time.Sleep(30 * time.Millisecond)
+		}
+	}
+	fmt.Fprintln(out)
+
+	fmt.Fprintf(out, "Created StripeDB instance %s (%s)\n",
+		textCyan(out, databaseTruncateID(database.ID)),
+		databaseDisplayName(database),
+	)
 	printDatabaseIndentedMetadataLine(out, "API Version", database.APIVersion)
 	printDatabaseIndentedMetadataLine(out, "Mode", databaseModeLabel(database.Livemode))
 
@@ -299,16 +342,38 @@ func runDatabaseCreate(cmd *cobra.Command, opCmd *OperationCmd, args []string) e
 		{Label: "URL", Value: user.URL},
 	})
 
-	status := strings.ToLower(database.Status)
-	if status != "" {
+	if user.Password != "" {
 		fmt.Fprintln(out)
-		fmt.Fprintf(out, "  %s %s. %s stripe databases retrieve %s\n",
+		fmt.Fprintln(out, textYellow(out, databaseWarningGlyph()+" Save this password now — it will not be shown again."))
+	}
+
+	fmt.Fprintln(out)
+	dashURL := databaseDashboardURL(database.ID, database.Livemode)
+	fmt.Fprintf(out, "  %s %s\n", textBoldCyan(out, "Dashboard:"), ansi.Linkify(dashURL, dashURL, out))
+
+	if database.Status != "" {
+		fmt.Fprintln(out)
+		statusVal := databaseStatusColored(out, database.Status, databaseStatusLabel(database.Status))
+		fmt.Fprintf(out, "  %s %s. %s\n  %s\n",
 			textMuted(out, "Current status:"),
-			status,
+			statusVal,
 			textFaint(out, "Check progress with:"),
-			database.ID,
+			textCyan(out, "stripe databases retrieve "+database.ID),
 		)
 	}
+
+	fmt.Fprintln(out)
+	// "Privacy Policy" and "Preview Terms" highlighted white; surrounding text faint
+	fmt.Fprintf(out, "%s %s %s %s\n",
+		textFaint(out, "By creating a database, you agree to the"),
+		textBold(out, "Privacy Policy"),
+		textFaint(out, "and"),
+		textBold(out, "Preview Terms."),
+	)
+	privacyURL := "https://stripe.com/privacy"
+	termsURL := "https://stripe.com/stripe-database-preview-terms"
+	fmt.Fprintf(out, "  %s\n", ansi.Linkify(privacyURL, privacyURL, out))
+	fmt.Fprintf(out, "  %s\n", ansi.Linkify(termsURL, termsURL, out))
 
 	return nil
 }
@@ -329,8 +394,50 @@ func runDatabaseRetrieve(cmd *cobra.Command, opCmd *OperationCmd, args []string)
 	}
 
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "StripeDB instance %s\n\n", database.ID)
-	printDatabaseTable(out, []databaseObject{database})
+	fmt.Fprintln(out)
+	// Show name + full dimmed ID once API ships display_name; fall back to full ID until then.
+	if database.Name != "" {
+		fmt.Fprintf(out, "%s %s\n  %s\n\n",
+			textBold(out, "StripeDB instance"),
+			database.Name,
+			textMuted(out, database.ID),
+		)
+	} else {
+		fmt.Fprintf(out, "%s %s\n\n",
+			textBold(out, "StripeDB instance"),
+			database.ID,
+		)
+	}
+
+	// Block 1: instance metadata (no section header)
+	printDatabaseDetailBlock(out, "", []databaseDetailField{
+		{Label: "Status", Value: databaseStatusColored(out, database.Status, databaseStatusCell(database.Status))},
+		{Label: "API Version", Value: database.APIVersion},
+		{Label: "Mode", Value: databaseModeLabel(database.Livemode)},
+		{Label: "Created", Value: databaseRelativeTimeAgo(database.Created)},
+	})
+
+	fmt.Fprintln(out)
+
+	// Block 2: connection details
+	printDatabaseDetailBlock(out, "Connection details:", []databaseDetailField{
+		{Label: "Host", Value: database.Connection.Host},
+		{Label: "Port", Value: func() string {
+			if database.Connection.Port == 0 {
+				return ""
+			}
+			return fmt.Sprintf("%d", database.Connection.Port)
+		}()},
+		{Label: "Database", Value: database.Connection.DatabaseName},
+	})
+
+	fmt.Fprintln(out)
+	dashURL := databaseDashboardURL(database.ID, database.Livemode)
+	fmt.Fprintf(out, "%s\n  %s\n",
+		textMuted(out, "View in Dashboard:"),
+		ansi.Linkify(dashURL, dashURL, out),
+	)
+	fmt.Fprintln(out)
 	return nil
 }
 
@@ -350,8 +457,10 @@ func runDatabaseList(cmd *cobra.Command, opCmd *OperationCmd, args []string) err
 	}
 
 	out := cmd.OutOrStdout()
+	fmt.Fprintln(out)
 	printDatabaseListHeading(out, opCmd.Profile)
 	printDatabaseTable(out, databases)
+	fmt.Fprintln(out)
 	return nil
 }
 
@@ -365,7 +474,10 @@ func runDatabaseDelete(cmd *cobra.Command, opCmd *OperationCmd, yes bool, args [
 		return fmt.Errorf("--yes is required with --json")
 	}
 
-	confirmed, err := confirmDatabaseAction(cmd, yes, "Warning: this will permanently delete your StripeDB instance.", databaseDeleteConfirmationPhrase)
+	dbName := databaseDisplayName(databaseObject{ID: args[0]})
+	warning := fmt.Sprintf("%s Warning: this will permanently delete %s (%s).",
+		databaseWarningGlyph(), dbName, databaseTruncateID(args[0]))
+	confirmed, err := confirmDatabaseAction(cmd, yes, warning, databaseDeleteConfirmationPhrase)
 	if err != nil || !confirmed {
 		return err
 	}
@@ -379,7 +491,13 @@ func runDatabaseDelete(cmd *cobra.Command, opCmd *OperationCmd, yes bool, args [
 		return writePrettyJSON(cmd, body)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Deleted StripeDB instance %s\n", args[0])
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "%s %s\n",
+		textGreen(out, "Deleted "+dbName),
+		textMuted(out, "("+databaseTruncateID(args[0])+")"),
+	)
+	fmt.Fprintln(out)
 	return nil
 }
 
@@ -399,7 +517,8 @@ func runDatabaseUsersCreate(cmd *cobra.Command, opCmd *OperationCmd, args []stri
 	}
 
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "Created StripeDB user %s\n", user.ID)
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "%s\n", textGreen(out, "Created StripeDB user "+user.ID))
 	printDatabaseIndentedMetadataLine(out, "Username", user.Username)
 	printDatabaseIndentedMetadataLine(out, "Mode", databaseModeLabel(user.Livemode))
 	fmt.Fprintln(out)
@@ -407,6 +526,13 @@ func runDatabaseUsersCreate(cmd *cobra.Command, opCmd *OperationCmd, args []stri
 		{Label: "Password", Value: user.Password},
 		{Label: "URL", Value: user.URL},
 	})
+
+	if user.Password != "" {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, textYellow(out, databaseWarningGlyph()+" Save this password now — it will not be shown again."))
+	}
+
+	fmt.Fprintln(out)
 	return nil
 }
 
@@ -425,7 +551,20 @@ func runDatabaseUsersRetrieve(cmd *cobra.Command, opCmd *OperationCmd, args []st
 		return err
 	}
 
-	printDatabaseUserSection(cmd.OutOrStdout(), args[0], []databaseUser{user})
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out)
+	dbName := databaseDisplayName(databaseObject{ID: args[0]})
+	fmt.Fprintf(out, "StripeDB user %s\n  %s\n\n",
+		user.ID,
+		textMuted(out, dbName+" ("+args[0]+")"),
+	)
+	printDatabaseDetailBlock(out, "Details:", []databaseDetailField{
+		{Label: "Username", Value: user.Username},
+		{Label: "Mode", Value: databaseModeLabel(user.Livemode)},
+		{Label: "Created", Value: databaseRelativeTimeAgo(user.Created)},
+		{Label: "Database", Value: args[0]},
+	})
+	fmt.Fprintln(out)
 	return nil
 }
 
@@ -458,7 +597,7 @@ func runDatabaseUsersDelete(cmd *cobra.Command, opCmd *OperationCmd, yes bool, a
 		return fmt.Errorf("--yes is required with --json")
 	}
 
-	prompt := fmt.Sprintf("Warning: this will permanently remove StripeDB access for user %s.", args[1])
+	prompt := fmt.Sprintf("%s Warning: this will permanently remove StripeDB access for user %s.", databaseWarningGlyph(), args[1])
 	confirmed, err := confirmDatabaseAction(cmd, yes, prompt, databaseUserDeleteConfirmationText)
 	if err != nil || !confirmed {
 		return err
@@ -474,8 +613,9 @@ func runDatabaseUsersDelete(cmd *cobra.Command, opCmd *OperationCmd, yes bool, a
 	}
 
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "Deleted StripeDB user %s\n", args[1])
-	printDatabaseIndentedMetadataLine(out, "StripeDB", args[0])
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "%s\n", textGreen(out, "Deleted "+args[1]))
+	fmt.Fprintln(out)
 	return nil
 }
 
@@ -603,52 +743,72 @@ func writePrettyJSON(cmd *cobra.Command, body []byte) error {
 }
 
 func printDatabaseTable(out io.Writer, databases []databaseObject) {
-	headers := []string{"ID", "Host", "Status", "Created", "Mode", "API Version"}
-	rows := make([][]string, 0, len(databases))
-
-	for _, database := range databases {
-		rows = append(rows, []string{
-			database.ID,
-			database.Connection.Host,
-			strings.ToLower(database.Status),
-			databaseRelativeTime(database.Created),
-			databaseModeLabel(database.Livemode),
-			database.APIVersion,
-		})
-	}
-
-	printAlignedTable(out, headers, rows, "No StripeDB instances found.", func(i int, value string) string {
-		if i%2 == 1 {
-			return textMuted(out, value)
-		}
-		return value
-	})
+	// TODO: uncomment Name column when API ships the display_name field
+	// {
+	// 	header: "Name",
+	// 	value:  func(i int) string { return databaseDisplayName(databases[i]) },
+	// 	style:  func(o io.Writer, _ int, v string) string { return textCyan(o, v) },
+	// },
+	printTable(out, []tableColumn{
+		{
+			header: "ID",
+			value:  func(i int) string { return databases[i].ID },
+			style:  func(o io.Writer, _ int, v string) string { return textMuted(o, v) },
+		},
+		{
+			header: "Status",
+			value:  func(i int) string { return databaseStatusCell(databases[i].Status) },
+			style: func(o io.Writer, i int, v string) string {
+				return databaseStatusColored(o, databases[i].Status, v)
+			},
+		},
+		{
+			header: "Created",
+			value:  func(i int) string { return databaseRelativeTime(databases[i].Created) },
+			style:  func(o io.Writer, _ int, v string) string { return textMuted(o, v) },
+		},
+		{
+			header: "Mode",
+			value:  func(i int) string { return databaseModeLabel(databases[i].Livemode) },
+		},
+		{
+			header: "API Version",
+			value:  func(i int) string { return databases[i].APIVersion },
+			style:  func(o io.Writer, _ int, v string) string { return textMuted(o, v) },
+		},
+	}, len(databases), "No StripeDB instances found.")
 }
 
 func printDatabaseUserSection(out io.Writer, databaseID string, users []databaseUser) {
+	fmt.Fprintln(out)
 	fmt.Fprintf(out, "StripeDB users for %s\n\n", databaseID)
 	printDatabaseUserTable(out, users)
+	fmt.Fprintln(out)
 }
 
 func printDatabaseUserTable(out io.Writer, users []databaseUser) {
-	headers := []string{"ID", "Username", "Created", "Mode"}
-	rows := make([][]string, 0, len(users))
-
-	for _, user := range users {
-		rows = append(rows, []string{
-			user.ID,
-			user.Username,
-			databaseRelativeTime(user.Created),
-			databaseModeLabel(user.Livemode),
-		})
-	}
-
-	printAlignedTable(out, headers, rows, "No StripeDB users found.", func(i int, value string) string {
-		if i >= 2 {
-			return textMuted(out, value)
-		}
-		return value
-	})
+	printTable(out, []tableColumn{
+		{
+			header: "Username",
+			value:  func(i int) string { return users[i].Username },
+			style:  func(o io.Writer, _ int, v string) string { return textCyan(o, v) },
+		},
+		{
+			header: "ID",
+			value:  func(i int) string { return users[i].ID },
+			style:  func(o io.Writer, _ int, v string) string { return textMuted(o, v) },
+		},
+		{
+			header: "Created",
+			value:  func(i int) string { return databaseRelativeTime(users[i].Created) },
+			style:  func(o io.Writer, _ int, v string) string { return textMuted(o, v) },
+		},
+		{
+			header: "Mode",
+			value:  func(i int) string { return databaseModeLabel(users[i].Livemode) },
+			style:  func(o io.Writer, _ int, v string) string { return textMuted(o, v) },
+		},
+	}, len(users), "No StripeDB users found.")
 }
 
 func textBold(out io.Writer, text string) string {
@@ -663,12 +823,183 @@ func textFaint(out io.Writer, text string) string {
 	return ansi.Color(out).Faint(text).String()
 }
 
+func textCyan(out io.Writer, text string) string {
+	return ansi.Color(out).Cyan(text).String()
+}
+
+func textGreen(out io.Writer, text string) string {
+	return ansi.Color(out).Green(text).String()
+}
+
+func textYellow(out io.Writer, text string) string {
+	return ansi.Color(out).Yellow(text).String()
+}
+
+func textBoldCyan(out io.Writer, text string) string {
+	c := ansi.Color(out)
+	return c.BrightCyan(c.Bold(text)).String()
+}
+
+func textRed(out io.Writer, text string) string {
+	return ansi.Color(out).Red(text).String()
+}
+
+// databaseWarningGlyph returns ⚠ on Unicode-capable terminals, ! otherwise.
+func databaseWarningGlyph() string {
+	if databaseUnicodeSupported() {
+		return "⚠"
+	}
+	return "!"
+}
+
+// databaseRelativeTimeAgo wraps databaseRelativeTime and appends " ago" for
+// non-empty, non-"now" values (e.g. "5d ago"). Returns "just now" for "now".
+func databaseRelativeTimeAgo(raw string) string {
+	rel := databaseRelativeTime(raw)
+	switch rel {
+	case "", "now":
+		return "just now"
+	default:
+		return rel + " ago"
+	}
+}
+
+// databaseUnicodeSupported reports whether the current terminal renders Unicode glyphs correctly.
+// On Windows, only Windows Terminal (WT_SESSION) and ConEmu (ConEmuPID) are known-safe.
+func databaseUnicodeSupported() bool {
+	if runtime.GOOS == "windows" {
+		_, wt := os.LookupEnv("WT_SESSION")
+		_, ce := os.LookupEnv("ConEmuPID")
+		return wt || ce
+	}
+	return true
+}
+
+// visualWidth returns the display width of s after stripping ANSI escape sequences.
+// Uses rune count rather than byte count so multibyte glyphs (●, ─, ✓) measure as 1.
+func visualWidth(s string) int {
+	runes := []rune(s)
+	out := make([]rune, 0, len(runes))
+	i := 0
+	for i < len(runes) {
+		if runes[i] == '\x1b' && i+1 < len(runes) {
+			switch runes[i+1] {
+			case '[': // CSI: ESC [ ... letter
+				i += 2
+				for i < len(runes) && (runes[i] < 'A' || runes[i] > 'Z') && (runes[i] < 'a' || runes[i] > 'z') {
+					i++
+				}
+				if i < len(runes) {
+					i++
+				}
+				continue
+			case ']': // OSC: ESC ] ... ESC backslash
+				i += 2
+				for i < len(runes) {
+					if runes[i] == '\x1b' && i+1 < len(runes) && runes[i+1] == '\\' {
+						i += 2
+						break
+					}
+					i++
+				}
+				continue
+			}
+		}
+		out = append(out, runes[i])
+		i++
+	}
+	return len(out)
+}
+
+// databaseStatusLabel remaps internal API status values to user-facing labels.
+// Unknown statuses are title-cased and passed through unchanged.
+func databaseStatusLabel(rawStatus string) string {
+	switch strings.ToLower(rawStatus) {
+	case "ready":
+		return "Active"
+	case "backfilling":
+		return "Backfilling"
+	default:
+		if rawStatus == "" {
+			return ""
+		}
+		lower := strings.ToLower(rawStatus)
+		return strings.ToUpper(lower[:1]) + lower[1:]
+	}
+}
+
+// databaseStatusCell returns the plain-text display string for a status cell (glyph + label).
+// This is used for column-width calculation; color is applied separately at render time.
+func databaseStatusCell(rawStatus string) string {
+	label := databaseStatusLabel(rawStatus)
+	if databaseUnicodeSupported() {
+		switch strings.ToLower(rawStatus) {
+		case "ready":
+			return "● " + label
+		case "error":
+			return "✗ " + label
+		default:
+			return "○ " + label
+		}
+	}
+	switch strings.ToLower(rawStatus) {
+	case "ready":
+		return "* " + label
+	case "error":
+		return "x " + label
+	default:
+		return "o " + label
+	}
+}
+
+// databaseStatusColored wraps a status cell value with the appropriate terminal color.
+func databaseStatusColored(out io.Writer, rawStatus, cellValue string) string {
+	switch strings.ToLower(rawStatus) {
+	case "ready":
+		return textGreen(out, cellValue)
+	case "backfilling":
+		return textYellow(out, cellValue)
+	case "error":
+		return textRed(out, cellValue)
+	default:
+		return cellValue
+	}
+}
+
+// databaseTruncateID shortens a database ID by truncating the middle portion.
+// "db_1XyZ2aBcDeFgHiJkLmN8pQr" → "db_1Xy...N8pQr"
+func databaseTruncateID(id string) string {
+	const keep = 6
+	if len(id) <= keep*2+3 {
+		return id
+	}
+	return id[:keep] + "..." + id[len(id)-keep:]
+}
+
+// databaseDisplayName returns the human-readable display name for a database.
+// TODO: use db.Name once the API ships the display_name field; remove placeholder.
+func databaseDisplayName(db databaseObject) string {
+	if db.Name != "" {
+		return db.Name
+	}
+	return "StripeDB Instance"
+}
+
+// databaseDashboardURL returns the Dashboard URL for a database.
+// Test-mode databases use the /test/ path prefix.
+func databaseDashboardURL(id string, livemode bool) string {
+	if livemode {
+		return fmt.Sprintf("https://dashboard.stripe.com/data-management/databases/%s", id)
+	}
+	return fmt.Sprintf("https://dashboard.stripe.com/test/data-management/databases/%s", id)
+}
+
 func printDatabaseIndentedMetadataLine(out io.Writer, label, value string) {
 	if value == "" {
 		return
 	}
 
-	fmt.Fprintf(out, "  %s %s\n", textMuted(out, label+":"), value)
+	fmt.Fprintf(out, "  %s %s\n", textBoldCyan(out, label+":"), value)
 }
 
 func printDatabaseListHeading(out io.Writer, profile *config.Profile) {
@@ -702,7 +1033,9 @@ func printDatabaseDetailBlock(out io.Writer, title string, fields []databaseDeta
 		return
 	}
 
-	fmt.Fprintln(out, textBold(out, title))
+	if title != "" {
+		fmt.Fprintln(out, textBold(out, title))
+	}
 	for _, field := range fields {
 		if field.Value == "" {
 			continue
@@ -711,67 +1044,88 @@ func printDatabaseDetailBlock(out io.Writer, title string, fields []databaseDeta
 		label := field.Label + ":"
 		padding := labelWidth - len(label) + 2
 		fmt.Fprint(out, "  ")
-		fmt.Fprint(out, textMuted(out, label))
+		fmt.Fprint(out, textBoldCyan(out, label))
 		fmt.Fprint(out, strings.Repeat(" ", padding))
 		fmt.Fprintln(out, field.Value)
 	}
 }
 
-func printAlignedTable(out io.Writer, headers []string, rows [][]string, emptyMessage string, render func(int, string) string) {
-	if len(rows) == 0 {
+// tableColumn defines a single column in a CLI table.
+// value extracts the plain display string (used for width calculation).
+// style optionally wraps the plain value with ANSI formatting.
+// If style is nil the plain value is printed as-is.
+type tableColumn struct {
+	header string
+	value  func(rowIdx int) string
+	style  func(out io.Writer, rowIdx int, value string) string
+}
+
+func printTable(out io.Writer, columns []tableColumn, rowCount int, emptyMessage string) {
+	if rowCount == 0 {
 		fmt.Fprintln(out, textMuted(out, emptyMessage))
 		return
 	}
 
-	widths := tableColumnWidths(headers, rows)
-	printDatabaseTableRow(out, headers, widths, func(_ int, value string) string {
-		return textBold(out, value)
-	})
-	printDatabaseTableRow(out, tableSeparators(widths), widths, func(_ int, value string) string {
-		return textFaint(out, value)
-	})
-	for _, row := range rows {
-		printDatabaseTableRow(out, row, widths, render)
+	headers := make([]string, len(columns))
+	for i, col := range columns {
+		headers[i] = col.header
 	}
-}
-
-func tableColumnWidths(headers []string, rows [][]string) []int {
-	widths := make([]int, len(headers))
-	for i, header := range headers {
-		widths[i] = len(header)
+	rows := make([][]string, rowCount)
+	for i := 0; i < rowCount; i++ {
+		row := make([]string, len(columns))
+		for j, col := range columns {
+			row[j] = col.value(i)
+		}
+		rows[i] = row
 	}
 
+	widths := make([]int, len(columns))
+	for i, h := range headers {
+		widths[i] = visualWidth(h)
+	}
 	for _, row := range rows {
-		for i, value := range row {
-			if len(value) > widths[i] {
-				widths[i] = len(value)
+		for i, v := range row {
+			if w := visualWidth(v); w > widths[i] {
+				widths[i] = w
 			}
 		}
 	}
 
-	return widths
-}
-
-func tableSeparators(widths []int) []string {
-	separators := make([]string, len(widths))
-	for i, width := range widths {
-		separators[i] = strings.Repeat("-", width)
+	sep := "-"
+	if databaseUnicodeSupported() {
+		sep = "─"
 	}
-	return separators
-}
 
-func printDatabaseTableRow(out io.Writer, values []string, widths []int, render func(int, string) string) {
-	for i, value := range values {
-		fmt.Fprint(out, render(i, value))
-		if i == len(values)-1 {
-			continue
+	for i, h := range headers {
+		fmt.Fprint(out, textBold(out, h))
+		if i < len(headers)-1 {
+			fmt.Fprint(out, strings.Repeat(" ", widths[i]-visualWidth(h)+2))
 		}
-
-		padding := widths[i] - len(value) + 2
-		fmt.Fprint(out, strings.Repeat(" ", padding))
 	}
-
 	fmt.Fprintln(out)
+
+	for i, w := range widths {
+		fmt.Fprint(out, textFaint(out, strings.Repeat(sep, w)))
+		if i < len(widths)-1 {
+			fmt.Fprint(out, strings.Repeat(" ", 2))
+		}
+	}
+	fmt.Fprintln(out)
+
+	for rowIdx, row := range rows {
+		ri := rowIdx
+		for i, v := range row {
+			rendered := v
+			if columns[i].style != nil {
+				rendered = columns[i].style(out, ri, v)
+			}
+			fmt.Fprint(out, rendered)
+			if i < len(row)-1 {
+				fmt.Fprint(out, strings.Repeat(" ", widths[i]-visualWidth(v)+2))
+			}
+		}
+		fmt.Fprintln(out)
+	}
 }
 
 func databaseModeLabel(livemode bool) string {
@@ -848,6 +1202,7 @@ func confirmDatabaseAction(cmd *cobra.Command, autoConfirm bool, warning, confir
 	}
 
 	out := cmd.OutOrStdout()
+	fmt.Fprintln(out)
 	color := ansi.Color(out)
 	fmt.Fprintln(out, color.Yellow(warning).String())
 	if confirmationPhrase != "" {
@@ -872,8 +1227,5 @@ func confirmDatabaseAction(cmd *cobra.Command, autoConfirm bool, warning, confir
 		confirmed = trimmed == "y" || trimmed == "yes"
 	}
 
-	if confirmed {
-		fmt.Fprintln(out)
-	}
 	return confirmed, nil
 }

--- a/pkg/cmd/resource/databases_test.go
+++ b/pkg/cmd/resource/databases_test.go
@@ -248,7 +248,19 @@ func TestDatabaseCommands(t *testing.T) {
 
 		output, err := executeDatabaseCommand(root, nil, "create", "--api-version", "2026-01-28.clover")
 		require.NoError(t, err)
-		require.Equal(t, "Created StripeDB instance db_1XyZ2aBcDeFgHiJkLmN8pQr\n  API Version: 2026-01-28.clover\n  Mode: test\n\nConnection details:\n  Host:      db_1XyZ2aBcDeFgHiJkLmN8pQr.db.stripe.com\n  Username:  llama_user\n  Password:  pass_123\n  URL:       postgresql://llama_user:pass_123@db_1XyZ2aBcDeFgHiJkLmN8pQr.db.stripe.com:5432/data\n\n  Current status: backfilling. Check progress with: stripe databases retrieve db_1XyZ2aBcDeFgHiJkLmN8pQr\n", output)
+		require.Contains(t, output, "Creating StripeDB instance...")
+		require.Contains(t, output, "Created StripeDB instance db_1Xy...mN8pQr (StripeDB Instance)")
+		require.Contains(t, output, "API Version: 2026-01-28.clover")
+		require.Contains(t, output, "Mode: test")
+		require.Contains(t, output, "Host:      db_1XyZ2aBcDeFgHiJkLmN8pQr.db.stripe.com")
+		require.Contains(t, output, "Username:  llama_user")
+		require.Contains(t, output, "Password:  pass_123")
+		require.Contains(t, output, "Save this password now — it will not be shown again.")
+		require.Contains(t, output, "Dashboard:")
+		require.Contains(t, output, "https://dashboard.stripe.com/test/data-management/databases/db_1XyZ2aBcDeFgHiJkLmN8pQr")
+		require.Contains(t, output, "Current status: Backfilling. Check progress with:")
+		require.Contains(t, output, "https://stripe.com/privacy")
+		require.Contains(t, output, "https://stripe.com/stripe-database-preview-terms")
 	})
 
 	t.Run("create pretty prints json output", func(t *testing.T) {
@@ -268,8 +280,14 @@ func TestDatabaseCommands(t *testing.T) {
 
 		output, err := executeDatabaseCommand(root, nil, "retrieve", "db_1XyZ2aBcDeFgHiJkLmN8pQr")
 		require.NoError(t, err)
-		require.Contains(t, output, "ID")
-		require.Regexp(t, `db_1XyZ2aBcDeFgHiJkLmN8pQr\s+db_1XyZ2aBcDeFgHiJkLmN8pQr\.db\.stripe\.com\s+backfilling\s+5d\s+test\s+2026-01-28\.clover`, output)
+		require.Contains(t, output, "StripeDB instance db_1XyZ2aBcDeFgHiJkLmN8pQr")
+		require.Contains(t, output, "View in Dashboard:")
+		require.Contains(t, output, "Backfilling")
+		require.Contains(t, output, "ago") // Created field uses databaseRelativeTimeAgo
+		require.Contains(t, output, "test")
+		require.Contains(t, output, "2026-01-28.clover")
+		require.Contains(t, output, "db_1XyZ2aBcDeFgHiJkLmN8pQr.db.stripe.com")
+		require.Contains(t, output, "https://dashboard.stripe.com/test/data-management/databases/db_1XyZ2aBcDeFgHiJkLmN8pQr")
 	})
 
 	t.Run("list prints account databases", func(t *testing.T) {
@@ -283,8 +301,9 @@ func TestDatabaseCommands(t *testing.T) {
 		output, err := executeDatabaseCommand(root, nil, "list")
 		require.NoError(t, err)
 		require.Contains(t, output, `StripeDB instances for account acct_123`)
-		require.Regexp(t, `db_1XyZ2aBcDeFgHiJkLmN8pQr\s+db_1XyZ2aBcDeFgHiJkLmN8pQr\.db\.stripe\.com\s+backfilling\s+5d\s+test\s+2026-01-28\.clover`, output)
-		require.Regexp(t, `db_jS7fnaBcDeFgHiJkLmN8pQr\s+db_jS7fnaBcDeFgHiJkLmN8pQr\.db\.stripe\.com\s+ready\s+1y\s+test\s+2026-02-15\.clover`, output)
+		require.Contains(t, output, "ID")
+		require.Regexp(t, `db_1XyZ2aBcDeFgHiJkLmN8pQr\s+○ Backfilling\s+5d\s+test\s+2026-01-28\.clover`, output)
+		require.Regexp(t, `db_jS7fnaBcDeFgHiJkLmN8pQr\s+● Active\s+1y\s+test\s+2026-02-15\.clover`, output)
 	})
 
 	t.Run("list omits fake account placeholder when account is unavailable", func(t *testing.T) {
@@ -318,8 +337,8 @@ func TestDatabaseCommands(t *testing.T) {
 		root := newDatabaseTestRoot(&config.Config{})
 		output, err := executeDatabaseCommand(root, bytes.NewBufferString("n\n"), "delete", "db_1XyZ2aBcDeFgHiJkLmN8pQr")
 		require.NoError(t, err)
-		require.Contains(t, output, "Warning: this will permanently delete your StripeDB instance.")
-		require.Contains(t, output, `Type remove StripeDB to continue.`)
+		require.Contains(t, output, "Warning: this will permanently delete StripeDB Instance (db_1Xy...mN8pQr).")
+		require.Contains(t, output, `Type delete database to continue.`)
 	})
 
 	t.Run("delete removes database after confirmation phrase", func(t *testing.T) {
@@ -327,8 +346,9 @@ func TestDatabaseCommands(t *testing.T) {
 
 		output, err := executeDatabaseCommand(root, bytes.NewBufferString(databaseDeleteConfirmationPhrase+"\n"), "delete", "db_1XyZ2aBcDeFgHiJkLmN8pQr")
 		require.NoError(t, err)
-		require.Contains(t, output, `Type remove StripeDB to continue.`)
-		require.Contains(t, output, "Deleted StripeDB instance db_1XyZ2aBcDeFgHiJkLmN8pQr")
+		require.Contains(t, output, `Type delete database to continue.`)
+		require.Contains(t, output, "Deleted StripeDB Instance")
+		require.Contains(t, output, "(db_1Xy...mN8pQr)")
 	})
 
 	t.Run("delete requires yes with json output", func(t *testing.T) {
@@ -354,7 +374,11 @@ func TestDatabaseUserCommands(t *testing.T) {
 
 		output, err := executeDatabaseCommand(root, nil, "users", "create", "db_1XyZ2aBcDeFgHiJkLmN8pQr", "--username", "llama_user")
 		require.NoError(t, err)
-		require.Equal(t, "Created StripeDB user dbuser_1JqM7xBcDeFgHiJkLmN8pQrS\n  Username: llama_user\n  Mode: test\n\nConnection details:\n  Password:  new_pass_123\n  URL:       postgresql://llama_user:new_pass_123@db_1XyZ2aBcDeFgHiJkLmN8pQr.db.stripe.com:5432/data\n", output)
+		require.Contains(t, output, "Created StripeDB user dbuser_1JqM7xBcDeFgHiJkLmN8pQrS")
+		require.Contains(t, output, "Username: llama_user")
+		require.Contains(t, output, "Mode: test")
+		require.Contains(t, output, "Password:  new_pass_123")
+		require.Contains(t, output, "Save this password now — it will not be shown again.")
 	})
 
 	t.Run("create returns json", func(t *testing.T) {
@@ -370,8 +394,9 @@ func TestDatabaseUserCommands(t *testing.T) {
 
 		output, err := executeDatabaseCommand(root, nil, "users", "retrieve", "db_1XyZ2aBcDeFgHiJkLmN8pQr", "dbuser_1JqM7xBcDeFgHiJkLmN8pQrS")
 		require.NoError(t, err)
-		require.Contains(t, output, "StripeDB users for db_1XyZ2aBcDeFgHiJkLmN8pQr")
-		require.Regexp(t, `dbuser_1JqM7xBcDeFgHiJkLmN8pQrS\s+llama_user\s+2h\s+test`, output)
+		require.Contains(t, output, "StripeDB user dbuser_1JqM7xBcDeFgHiJkLmN8pQrS")
+		require.Contains(t, output, "Username:")
+		require.Contains(t, output, "llama_user")
 	})
 
 	t.Run("list prints database users", func(t *testing.T) {
@@ -380,8 +405,8 @@ func TestDatabaseUserCommands(t *testing.T) {
 		output, err := executeDatabaseCommand(root, nil, "users", "list", "db_1XyZ2aBcDeFgHiJkLmN8pQr")
 		require.NoError(t, err)
 		require.Contains(t, output, "StripeDB users for db_1XyZ2aBcDeFgHiJkLmN8pQr")
-		require.Regexp(t, `dbuser_1JqM7xBcDeFgHiJkLmN8pQrS\s+llama_user\s+2h\s+test`, output)
-		require.Regexp(t, `dbuser_4NtP9yBcDeFgHiJkLmN8pQrV\s+rotated_user\s+2mo\s+test`, output)
+		require.Regexp(t, `llama_user\s+dbuser_1JqM7xBcDeFgHiJkLmN8pQrS\s+2h\s+test`, output)
+		require.Regexp(t, `rotated_user\s+dbuser_4NtP9yBcDeFgHiJkLmN8pQrV\s+2mo\s+test`, output)
 	})
 
 	t.Run("delete with yes prints success", func(t *testing.T) {
@@ -389,7 +414,7 @@ func TestDatabaseUserCommands(t *testing.T) {
 
 		output, err := executeDatabaseCommand(root, nil, "users", "delete", "db_1XyZ2aBcDeFgHiJkLmN8pQr", "dbuser_1JqM7xBcDeFgHiJkLmN8pQrS", "--yes")
 		require.NoError(t, err)
-		require.Equal(t, "Deleted StripeDB user dbuser_1JqM7xBcDeFgHiJkLmN8pQrS\n  StripeDB: db_1XyZ2aBcDeFgHiJkLmN8pQr\n", output)
+		require.Contains(t, output, "Deleted dbuser_1JqM7xBcDeFgHiJkLmN8pQrS")
 	})
 
 	t.Run("delete after confirmation phrase prints success", func(t *testing.T) {
@@ -398,7 +423,7 @@ func TestDatabaseUserCommands(t *testing.T) {
 		output, err := executeDatabaseCommand(root, bytes.NewBufferString(databaseUserDeleteConfirmationText+"\n"), "users", "delete", "db_1XyZ2aBcDeFgHiJkLmN8pQr", "dbuser_1JqM7xBcDeFgHiJkLmN8pQrS")
 		require.NoError(t, err)
 		require.Contains(t, output, `Type remove user to continue.`)
-		require.Contains(t, output, "> \nDeleted StripeDB user dbuser_1JqM7xBcDeFgHiJkLmN8pQrS\n")
+		require.Contains(t, output, "Deleted dbuser_1JqM7xBcDeFgHiJkLmN8pQrS")
 	})
 }
 
@@ -422,14 +447,11 @@ func TestDatabaseOutputHelpers(t *testing.T) {
 
 		lines := strings.Split(strings.TrimSpace(out.String()), "\n")
 		require.Len(t, lines, 3)
-		require.Equal(t, []string{
-			strings.Repeat("-", len("db_1XyZ2aBcDeFgHiJkLmN8pQr")),
-			strings.Repeat("-", len("db_1XyZ2aBcDeFgHiJkLmN8pQr.db.stripe.com")),
-			strings.Repeat("-", len("backfilling")),
-			strings.Repeat("-", len("Created")),
-			strings.Repeat("-", len("test")),
-			strings.Repeat("-", len("2026-01-28.clover")),
-		}, strings.Fields(lines[1]))
+		// Columns: ID, Status (with glyph), Created, Mode, API Version (Name column disabled until API ships display_name)
+		separatorFields := strings.Fields(lines[1])
+		require.Len(t, separatorFields, 5)
+		// Verify separators use Unicode box-drawing characters
+		require.Contains(t, separatorFields[0], "─")
 	})
 
 	t.Run("table shows empty state", func(t *testing.T) {
@@ -459,8 +481,10 @@ func TestDatabaseOutputHelpers(t *testing.T) {
 
 		lines := strings.Split(strings.TrimSpace(out.String()), "\n")
 		require.Len(t, lines, 3)
-		require.Regexp(t, `^db_1\s+\x1b\[[0-9;]*mdb_1\.db\.stripe\.com\x1b\[[0-9;]*m\s+ready\s+\x1b\[[0-9;]*m5d\x1b\[[0-9;]*m\s+test\s+\x1b\[[0-9;]*m2026-01-28\.clover\x1b\[[0-9;]*m$`, lines[2])
-		require.NotRegexp(t, `\x1b\[[0-9;]*mready\x1b\[[0-9;]*m`, lines[2])
+		// Status column should be green-colored (ready = Active)
+		require.Regexp(t, `\x1b\[[0-9;]*m● Active\x1b\[[0-9;]*m`, lines[2])
+		// ID column should be muted
+		require.Regexp(t, `\x1b\[[0-9;]*mdb_1\x1b\[[0-9;]*m`, lines[2])
 	})
 
 	t.Run("relative time formats months and minutes differently", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Updates the pretty-print output for all `stripe databases` commands to be more scannable and consistent.

- **List**: cleaner table with colored status indicators (`● Active`, `○ Backfilling`), Unicode separators, muted secondary columns
- **Create**: progress steps after provisioning, bold cyan connection detail labels, password warning, dashboard link, privacy/terms notice
- **Retrieve**: split into two sections (instance metadata + connection details), `View in Dashboard` with clickable URL on supporting terminals
- **Delete / Users commands**: consistent leading/trailing blank lines, green success messages, full IDs shown (no truncation)

## Changes

- New `tableColumn` + `printTable` abstraction replaces `printAlignedTable` — each column owns its data extraction and styling, no more parallel arrays
- `visualWidth()` strips ANSI sequences before measuring column padding so colored cells align correctly
- `databaseUnicodeSupported()` gates Unicode glyphs on Windows (falls back to ASCII on `cmd.exe`, passes through on Windows Terminal)
- `databaseWarningGlyph()` and `databaseRelativeTimeAgo()` helpers eliminate duplication
- OSC-8 hyperlinks on dashboard and privacy URLs (clickable in iTerm2, VS Code terminal, Windows Terminal; plain text fallback elsewhere)

## Test plan

- `go test ./pkg/cmd/resource/ -run TestDatabase` passes
- built the CLI and tested commands individually