### PR TITLE
feat: accept rkcs (claimable sandbox) restricted key prefix

### DIFF
--- a/pkg/validators/validate.go
+++ b/pkg/validators/validate.go
@@ -63,7 +63,7 @@ func APIKey(input string) error {
 		return errors.New("you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
 	}
 
-	if keyParts[0] != "sk" && keyParts[0] != "rk" {
+	if keyParts[0] != "sk" && keyParts[0] != "rk" && keyParts[0] != "rkcs" {
 		return errors.New("the CLI only supports using a secret or restricted key")
 	}
 

--- a/pkg/validators/validate_test.go
+++ b/pkg/validators/validate_test.go
@@ -42,6 +42,11 @@ func TestTestmodeRestrictedAPIKey(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestClaimableSandboxRestrictedAPIKey(t *testing.T) {
+	err := APIKey("rkcs_test_12345")
+	require.NoError(t, err)
+}
+
 func TestHTTPMethod(t *testing.T) {
 	err := HTTPMethod("GET")
 	require.NoError(t, err)


### PR DESCRIPTION
The CLI key validator only accepted `sk` and `rk` prefixes, rejecting `rkcs_test_` keys (Restricted Key, Claimable Sandbox) with "the CLI only supports using a secret or restricted key". These keys are functionally restricted keys used by the claimable sandboxes feature for agentic IDE onboarding and should be accepted.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
