### PR TITLE
Resolve plugin subcommand paths for telemetry analytics

### DIFF
--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -14,6 +15,16 @@ import (
 	"github.com/stripe/stripe-cli/pkg/plugins"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
+
+var pluginTelemetryFlagsWithValues = map[string]struct{}{
+	"--api-key":      {},
+	"--color":        {},
+	"--config":       {},
+	"--device-name":  {},
+	"--log-level":    {},
+	"--project-name": {},
+	"-p":             {},
+}
 
 type pluginTemplateCmd struct {
 	cfg        *config.Config
@@ -141,4 +152,81 @@ func subsliceAfter(sl []string, str string) []string {
 		}
 	}
 	return make([]string, 0)
+}
+
+func resolvePluginTelemetryCommandPath(cmd *cobra.Command, argv []string) string {
+	if cmd == nil {
+		return ""
+	}
+
+	basePath := cmd.CommandPath()
+	pluginRoot := pluginRootCommand(cmd)
+	if pluginRoot == nil {
+		return basePath
+	}
+
+	// If Cobra already resolved plugin subcommand stubs from the manifest,
+	// trust that path instead of trying to infer it from argv.
+	if len(strings.Fields(basePath)) > len(strings.Fields(pluginRoot.CommandPath())) {
+		return basePath
+	}
+
+	pluginArgs := subsliceAfter(argv, pluginRoot.Name())
+	subcommand := firstPluginTelemetrySubcommand(pluginArgs)
+	if subcommand == "" {
+		return basePath
+	}
+
+	return basePath + " " + subcommand
+}
+
+func pluginRootCommand(cmd *cobra.Command) *cobra.Command {
+	if cmd == nil || !plugins.IsPluginCommand(cmd) {
+		return nil
+	}
+
+	pluginRoot := cmd
+	for pluginRoot.Parent() != nil && plugins.IsPluginCommand(pluginRoot.Parent()) {
+		pluginRoot = pluginRoot.Parent()
+	}
+
+	return pluginRoot
+}
+
+func firstPluginTelemetrySubcommand(args []string) string {
+	skipNext := false
+
+	for _, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+
+		if arg == "--" {
+			break
+		}
+
+		if arg == "--help" || arg == "-h" || arg == "--version" || arg == "-v" {
+			continue
+		}
+
+		if strings.HasPrefix(arg, "--") {
+			flagName, _, hasValue := strings.Cut(arg, "=")
+			if _, ok := pluginTelemetryFlagsWithValues[flagName]; ok && !hasValue {
+				skipNext = true
+			}
+			continue
+		}
+
+		if strings.HasPrefix(arg, "-") && arg != "-" {
+			if _, ok := pluginTelemetryFlagsWithValues[arg]; ok {
+				skipNext = true
+			}
+			continue
+		}
+
+		return arg
+	}
+
+	return ""
 }

--- a/pkg/cmd/plugin_cmds_test.go
+++ b/pkg/cmd/plugin_cmds_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -153,4 +154,75 @@ func TestSubsliceAfter(t *testing.T) {
 			assert.Equal(t, tt.expected, subsliceAfter(tt.sl, tt.str))
 		})
 	}
+}
+
+func TestResolvePluginTelemetryCommandPathAddsFirstPluginSubcommand(t *testing.T) {
+	root := &cobra.Command{Use: "stripe"}
+	pluginCmd := &cobra.Command{
+		Use:         "projects",
+		Annotations: map[string]string{"scope": "plugin"},
+	}
+	root.AddCommand(pluginCmd)
+
+	assert.Equal(
+		t,
+		"stripe projects catalog",
+		resolvePluginTelemetryCommandPath(pluginCmd, []string{"stripe", "projects", "catalog"}),
+	)
+}
+
+func TestResolvePluginTelemetryCommandPathSkipsPluginGlobalFlags(t *testing.T) {
+	root := &cobra.Command{Use: "stripe"}
+	pluginCmd := &cobra.Command{
+		Use:         "projects",
+		Annotations: map[string]string{"scope": "plugin"},
+	}
+	root.AddCommand(pluginCmd)
+
+	assert.Equal(
+		t,
+		"stripe projects catalog",
+		resolvePluginTelemetryCommandPath(pluginCmd, []string{"stripe", "projects", "--color", "off", "--project-name", "demo", "catalog"}),
+	)
+}
+
+func TestResolvePluginTelemetryCommandPathLeavesTopLevelWhenNoSubcommand(t *testing.T) {
+	root := &cobra.Command{Use: "stripe"}
+	pluginCmd := &cobra.Command{
+		Use:         "projects",
+		Annotations: map[string]string{"scope": "plugin"},
+	}
+	root.AddCommand(pluginCmd)
+
+	assert.Equal(
+		t,
+		"stripe projects",
+		resolvePluginTelemetryCommandPath(pluginCmd, []string{"stripe", "projects", "--help"}),
+	)
+}
+
+func TestResolvePluginTelemetryCommandPathUsesResolvedPluginStubPath(t *testing.T) {
+	root := &cobra.Command{Use: "stripe"}
+	pluginCmd := &cobra.Command{
+		Use:         "projects",
+		Annotations: map[string]string{"scope": "plugin"},
+	}
+	billingCmd := &cobra.Command{
+		Use:         "billing",
+		Annotations: map[string]string{"scope": "plugin"},
+	}
+	listCmd := &cobra.Command{
+		Use:         "list",
+		Annotations: map[string]string{"scope": "plugin"},
+	}
+
+	root.AddCommand(pluginCmd)
+	pluginCmd.AddCommand(billingCmd)
+	billingCmd.AddCommand(listCmd)
+
+	assert.Equal(
+		t,
+		"stripe projects billing list",
+		resolvePluginTelemetryCommandPath(listCmd, []string{"stripe", "projects", "billing", "list", "--json"}),
+	)
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -71,6 +71,9 @@ var rootCmd = &cobra.Command{
 		telemetryMetadata := stripe.GetEventMetadata(cmd.Context())
 		if telemetryMetadata != nil {
 			telemetryMetadata.SetCobraCommandContext(cmd)
+			if plugins.IsPluginCommand(cmd) {
+				telemetryMetadata.SetCommandPath(resolvePluginTelemetryCommandPath(cmd, os.Args))
+			}
 			telemetryMetadata.SetMerchant(merchant)
 			telemetryMetadata.SetUserAgent(useragent.GetEncodedUserAgent())
 


### PR DESCRIPTION
Infer the first plugin subcommand from argv so telemetry events report the full command path (e.g. "stripe projects catalog") instead of just the plugin root. When Cobra has already resolved subcommand stubs from the plugin manifest, trust that path directly.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
