### PR TITLE
Read consolidated Stripe-Notice header

### DIFF
--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -318,11 +318,16 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 
 	// Print upgrade notices to stderr so users never miss them, regardless of --show-headers.
 	if !rb.SuppressOutput {
-		if notice := resp.Header.Get("Stripe-Api-Version-Upgrade-Notice"); notice != "" {
-			fmt.Fprintln(os.Stderr, ansi.Color(os.Stderr).Yellow("API version upgrade notice: "+notice))
-		}
-		if notice := resp.Header.Get("Stripe-Api-Integration-Path-Upgrade-Notice"); notice != "" {
-			fmt.Fprintln(os.Stderr, ansi.Color(os.Stderr).Yellow("API integration path upgrade notice: "+notice))
+		if notice := resp.Header.Get("Stripe-Notice"); notice != "" {
+			fmt.Fprintln(os.Stderr, ansi.Color(os.Stderr).Yellow(notice))
+		} else {
+			// TODO: Remove this fallback once the gateway rollout of Stripe-Notice is complete.
+			if notice := resp.Header.Get("Stripe-Api-Version-Upgrade-Notice"); notice != "" {
+				fmt.Fprintln(os.Stderr, ansi.Color(os.Stderr).Yellow("API version upgrade notice: "+notice))
+			}
+			if notice := resp.Header.Get("Stripe-Api-Integration-Path-Upgrade-Notice"); notice != "" {
+				fmt.Fprintln(os.Stderr, ansi.Color(os.Stderr).Yellow("API integration path upgrade notice: "+notice))
+			}
 		}
 	}
 

--- a/pkg/requests/base_test.go
+++ b/pkg/requests/base_test.go
@@ -634,9 +634,9 @@ func captureStderr(t *testing.T, fn func()) string {
 	return string(out)
 }
 
-func TestMakeRequest_VersionUpgradeNotice(t *testing.T) {
+func TestMakeRequest_StripeNotice(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Stripe-Api-Version-Upgrade-Notice", "Please upgrade to the latest API version.")
+		w.Header().Set("Stripe-Notice", "Please upgrade to the latest API version.")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{}`))
 	}))
@@ -650,12 +650,13 @@ func TestMakeRequest_VersionUpgradeNotice(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	require.Contains(t, out, "API version upgrade notice: Please upgrade to the latest API version.")
+	require.Contains(t, out, "Please upgrade to the latest API version.")
 }
 
-func TestMakeRequest_IntegrationPathUpgradeNotice(t *testing.T) {
+func TestMakeRequest_StripeNoticeMultiNotice(t *testing.T) {
+	multiNotice := "2 notices for this request: (1) Please upgrade to the latest API version. (2) Please migrate to the new integration path."
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Stripe-Api-Integration-Path-Upgrade-Notice", "Please migrate to the new integration path.")
+		w.Header().Set("Stripe-Notice", multiNotice)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{}`))
 	}))
@@ -669,10 +670,10 @@ func TestMakeRequest_IntegrationPathUpgradeNotice(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	require.Contains(t, out, "API integration path upgrade notice: Please migrate to the new integration path.")
+	require.Contains(t, out, multiNotice)
 }
 
-func TestMakeRequest_BothUpgradeNotices(t *testing.T) {
+func TestMakeRequest_FallbackToOldHeaders(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Stripe-Api-Version-Upgrade-Notice", "Upgrade your API version.")
 		w.Header().Set("Stripe-Api-Integration-Path-Upgrade-Notice", "Migrate your integration path.")
@@ -708,13 +709,12 @@ func TestMakeRequest_NoUpgradeNotice(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	require.NotContains(t, out, "upgrade notice:")
+	require.Empty(t, out)
 }
 
 func TestMakeRequest_UpgradeNoticeSuppressed(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Stripe-Api-Version-Upgrade-Notice", "Please upgrade.")
-		w.Header().Set("Stripe-Api-Integration-Path-Upgrade-Notice", "Please migrate.")
+		w.Header().Set("Stripe-Notice", "Please upgrade.")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{}`))
 	}))
@@ -728,7 +728,7 @@ func TestMakeRequest_UpgradeNoticeSuppressed(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	require.NotContains(t, out, "upgrade notice:")
+	require.Empty(t, out)
 }
 
 func TestParseJSONDataFlag(t *testing.T) {


### PR DESCRIPTION
## Summary

- Read the new consolidated `Stripe-Notice` response header instead of the two separate `Stripe-Api-Version-Upgrade-Notice` and `Stripe-Api-Integration-Path-Upgrade-Notice` headers.
- Print the header value as-is (it's already human-readable, including multi-notice numbered format).
- Fall back to the old headers when `Stripe-Notice` is absent, for backward compatibility during the gateway rollout.

## Test plan

- [ ] `TestMakeRequest_StripeNotice` — single notice via new header
- [ ] `TestMakeRequest_StripeNoticeMultiNotice` — numbered multi-notice format printed as-is
- [ ] `TestMakeRequest_FallbackToOldHeaders` — old headers still work when new header is absent
- [ ] `TestMakeRequest_NoUpgradeNotice` — no output when no notice headers present
- [ ] `TestMakeRequest_UpgradeNoticeSuppressed` — `SuppressOutput` silences the new header