### PR TITLE
Embed commit SHA in dev builds and skip update check for non-release …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ TEST_PATTERN?=.
 TEST_OPTIONS?=
 PROTOC_FAILURE_MESSAGE="\nFailed to compile protobuf files: protoc exited with code $$?. Ensure you have the latest version of protoc: https://grpc.io/docs/protoc-installation/\n"
 
+GIT_SHA := $(shell git rev-parse HEAD 2>/dev/null)
+GIT_DIRTY := $(shell git diff-index --quiet HEAD 2>/dev/null || echo "dirty")
+BUILD_VERSION := $(if $(GIT_DIRTY),master,$(or $(GIT_SHA),master))
+
 export GO111MODULE := on
 export GOBIN := $(shell pwd)/bin
 export PATH := $(GOBIN):$(PATH)
@@ -74,7 +78,7 @@ ci: build-all-platforms test go-mod-tidy protoc-ci
 # Build a beta version of stripe
 build:
 	go generate ./...
-	go build -o stripe cmd/stripe/main.go
+	go build -ldflags="-X github.com/stripe/stripe-cli/pkg/version.Version=$(BUILD_VERSION)" -o stripe cmd/stripe/main.go
 .PHONY: build
 
 # Build a beta version of stripe with the `dev` tag

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ TEST_PATTERN?=.
 TEST_OPTIONS?=
 PROTOC_FAILURE_MESSAGE="\nFailed to compile protobuf files: protoc exited with code $$?. Ensure you have the latest version of protoc: https://grpc.io/docs/protoc-installation/\n"
 
+GIT_SHA := $(shell git rev-parse HEAD 2>/dev/null)
+GIT_DIRTY := $(shell git diff-index --quiet HEAD 2>/dev/null || echo "dirty")
+BUILD_VERSION := $(if $(GIT_DIRTY),master,$(or $(GIT_SHA),master))
+
 export GO111MODULE := on
 export GOBIN := $(shell pwd)/bin
 export PATH := $(GOBIN):$(PATH)
@@ -75,7 +79,7 @@ ci: build-all-platforms test go-mod-tidy protoc-ci
 # Build a beta version of stripe
 build:
 	go generate ./...
-	go build -trimpath -o stripe cmd/stripe/main.go
+	go build -trimpath -ldflags="-X github.com/stripe/stripe-cli/pkg/version.Version=$(BUILD_VERSION)" -o stripe cmd/stripe/main.go
 .PHONY: build
 
 # Build a beta version of stripe with the `dev` tag

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v72/github"
+	goversion "github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
@@ -16,7 +17,7 @@ import (
 // Version of the CLI.
 // This is set to the actual version by GoReleaser, identify by the
 // git tag assigned to the release. Versions built from source will
-// always show master.
+// show master or the commit SHA.
 var Version = "master"
 
 // Template for the version string.
@@ -25,8 +26,7 @@ var Template = fmt.Sprintf("stripe version %s\n", Version)
 // CheckLatestVersion makes a request to the GitHub API to pull the latest
 // release of the CLI
 func CheckLatestVersion() {
-	// master is the dev version, we don't want to check against that every time
-	if Version != "master" {
+	if _, err := goversion.NewSemver(Version); err == nil {
 		s := ansi.StartNewSpinner("Checking for new versions...", os.Stdout)
 		latest := getLatestVersion()
 


### PR DESCRIPTION
…versions

`make build` now injects the git SHA via ldflags when the working tree is clean, matching how GoReleaser sets the version for releases. CheckLatestVersion skips the GitHub API check unless the version parses as a valid semver (i.e. a real release), so SHA and "master" builds are unaffected.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
