### PR TITLE
Refactor symlink protection for .env writes

### DIFF
--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/tidwall/gjson"
 
+	"github.com/stripe/stripe-cli/pkg/fsutil"
 	"github.com/stripe/stripe-cli/pkg/git"
 	"github.com/stripe/stripe-cli/pkg/parsers"
 	"github.com/stripe/stripe-cli/pkg/requests"
@@ -430,6 +431,10 @@ func (fxt *Fixture) updateEnv(env map[string]string) error {
 
 	envFile := filepath.Join(dir, ".env")
 
+	if err := fsutil.RefuseWriteThroughSymlink(fxt.Fs, envFile, ".env"); err != nil {
+		return err
+	}
+
 	exists, _ := afero.Exists(fxt.Fs, envFile)
 	if !exists {
 		// If there is no .env in the current directory, return and do nothing
@@ -440,6 +445,7 @@ func (fxt *Fixture) updateEnv(env map[string]string) error {
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 
 	dotenv, err := godotenv.Parse(file)
 	if err != nil {
@@ -460,7 +466,9 @@ func (fxt *Fixture) updateEnv(env map[string]string) error {
 		return err
 	}
 
-	afero.WriteFile(fxt.Fs, envFile, []byte(content), os.ModePerm)
+	if err := afero.WriteFile(fxt.Fs, envFile, []byte(content), os.ModePerm); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/fixtures/fixtures_test.go
+++ b/pkg/fixtures/fixtures_test.go
@@ -368,6 +368,38 @@ CUST_ID="char_12345"`
 	assert.Equal(t, expected, string(output))
 }
 
+func TestUpdateEnvRefusesSymlink(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(wd))
+	})
+
+	victimFile := filepath.Join(t.TempDir(), "victim.txt")
+	require.NoError(t, os.WriteFile(victimFile, []byte("original"), 0o644))
+	require.NoError(t, os.Symlink(victimFile, filepath.Join(tmpDir, ".env")))
+
+	fxt := Fixture{
+		Fs: afero.NewOsFs(),
+		Responses: map[string]gjson.Result{
+			"char_bender": gjson.Parse(`{"id": "char_12345"}`),
+		},
+	}
+
+	err = fxt.updateEnv(map[string]string{
+		"CHAR_ID": "${char_bender:id}",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink")
+
+	content, err := os.ReadFile(victimFile)
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(content))
+}
+
 func TestExecuteReturnsRequestNames(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {

--- a/pkg/fsutil/symlink.go
+++ b/pkg/fsutil/symlink.go
@@ -1,3 +1,4 @@
+// Package fsutil provides shared filesystem safety helpers.
 package fsutil
 
 import (

--- a/pkg/fsutil/symlink.go
+++ b/pkg/fsutil/symlink.go
@@ -1,0 +1,34 @@
+package fsutil
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/afero"
+)
+
+// IsSymlink returns true if path is a symbolic link.
+// Returns false if the path does not exist, cannot be lstat'd, or the
+// filesystem does not support symlink-aware lstat operations.
+func IsSymlink(fs afero.Fs, path string) bool {
+	lstater, ok := fs.(afero.Lstater)
+	if !ok {
+		return false
+	}
+
+	entry, lstated, err := lstater.LstatIfPossible(path)
+	if err != nil || !lstated {
+		return false
+	}
+
+	return entry.Mode()&os.ModeSymlink == os.ModeSymlink
+}
+
+// RefuseWriteThroughSymlink rejects writes to symlinked paths.
+func RefuseWriteThroughSymlink(fs afero.Fs, path, name string) error {
+	if IsSymlink(fs, path) {
+		return fmt.Errorf("refusing to write %s: %s is a symlink", name, path)
+	}
+
+	return nil
+}

--- a/pkg/fsutil/symlink_test.go
+++ b/pkg/fsutil/symlink_test.go
@@ -1,0 +1,35 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	victimFile := filepath.Join(tmpDir, "victim.txt")
+	linkPath := filepath.Join(tmpDir, ".env")
+
+	require.NoError(t, os.WriteFile(victimFile, []byte("original"), 0o644))
+	require.NoError(t, os.Symlink(victimFile, linkPath))
+
+	assert.True(t, IsSymlink(afero.NewOsFs(), linkPath))
+}
+
+func TestRefuseWriteThroughSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	victimFile := filepath.Join(tmpDir, "victim.txt")
+	linkPath := filepath.Join(tmpDir, ".env")
+
+	require.NoError(t, os.WriteFile(victimFile, []byte("original"), 0o644))
+	require.NoError(t, os.Symlink(victimFile, linkPath))
+
+	err := RefuseWriteThroughSymlink(afero.NewOsFs(), linkPath, ".env")
+	require.Error(t, err)
+	assert.Equal(t, "refusing to write .env: "+linkPath+" is a symlink", err.Error())
+}

--- a/pkg/samples/os.go
+++ b/pkg/samples/os.go
@@ -7,18 +7,9 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
-)
 
-// isSymlink returns true if the file at path is a symbolic link.
-// Returns false if the path does not exist or cannot be stat'd.
-func isSymlink(path string) bool {
-	// os.Lstat inspects the link entry itself (rather than following it like os.Stat)
-	entry, err := os.Lstat(path)
-	if err != nil {
-		return false
-	}
-	return entry.Mode().Type() == os.ModeSymlink
-}
+	"github.com/stripe/stripe-cli/pkg/fsutil"
+)
 
 // cacheFolder is the local directory where we place local copies of samples
 func (s *SampleManager) cacheFolder() (string, error) {
@@ -97,7 +88,7 @@ func (s *SampleManager) GetFiles(path string) ([]string, error) {
 		// We only want regular files, not directories or symlinks.
 		// Filtering symlinks prevents malicious sample repositories from
 		// using symlinks to escape the destination directory.
-		if !f.IsDir() && !isSymlink(filepath.Join(path, f.Name())) {
+		if !f.IsDir() && !fsutil.IsSymlink(s.Fs, filepath.Join(path, f.Name())) {
 			file = append(file, f.Name())
 		}
 	}

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -18,6 +18,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/fsutil"
 	"github.com/stripe/stripe-cli/pkg/validators"
 
 	g "github.com/stripe/stripe-cli/pkg/git"
@@ -396,8 +397,8 @@ func (s *SampleManager) WriteDotEnv(ctx context.Context, sampleLocation string) 
 
 		// We refuse to write through a symlink to prevent a malicious
 		// sample from overwriting files outside the destination directory.
-		if isSymlink(envFile) {
-			return fmt.Errorf("refusing to write .env: %s is a symlink", envFile)
+		if err := fsutil.RefuseWriteThroughSymlink(s.Fs, envFile, ".env"); err != nil {
+			return err
 		}
 
 		err = godotenv.Write(dotenv, envFile)


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

- Prevent stripe fixtures from following a symlinked `.env` before reading or writing fixture-generated env values. This closes the arbitrary file overwrite path where attacker-controlled fixture env entries could be written into a symlink target.
- Extract symlink detection and write refusal into a shared `pkg/fsutil` helper so `fixtures` and `samples` use the same implementation instead of duplicating the check.
- Keep existing behavior otherwise unchanged: if `.env` is missing, `fixtures` still no-op.