### PR TITLE
Use plugin metadata endpoint for plugin installs when API key is available

### DIFF
--- a/pkg/cmd/plugin/backfill_test.go
+++ b/pkg/cmd/plugin/backfill_test.go
@@ -1,0 +1,178 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/99designs/keyring"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/plugins"
+	"github.com/stripe/stripe-cli/pkg/requests"
+)
+
+type pluginRegistryServers struct {
+	artifactory *httptest.Server
+	stripe      *httptest.Server
+}
+
+func (s *pluginRegistryServers) Close() {
+	s.artifactory.Close()
+	s.stripe.Close()
+}
+
+func TestRunInstallCmdBackfillsLocalMetadataWhenVersionAlreadyInstalled(t *testing.T) {
+	cfg, fs, cleanup := setupPluginCommandTest(t)
+	defer cleanup()
+
+	servers := newPluginRegistryServers(t, testPluginManifest())
+	defer servers.Close()
+
+	configPath := cfg.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	pluginBinaryPath := filepath.Join(configPath, "plugins", "appA", "2.0.1", "stripe-cli-app-a"+plugins.GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("already installed"), 0755))
+
+	ic := NewInstallCmd(cfg)
+	ic.fs = fs
+	ic.apiBaseURL = servers.stripe.URL
+	ic.Cmd.SetContext(context.Background())
+
+	require.NoError(t, ic.runInstallCmd(ic.Cmd, []string{"appA@2.0.1"}))
+	assertLocalMetadataBackfilled(t, cfg, fs, configPath)
+}
+
+func TestRunUpgradeCmdBackfillsLocalMetadataWhenAlreadyInstalled(t *testing.T) {
+	cfg, fs, cleanup := setupPluginCommandTest(t)
+	defer cleanup()
+
+	servers := newPluginRegistryServers(t, testPluginManifest())
+	defer servers.Close()
+
+	configPath := cfg.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	pluginBinaryPath := filepath.Join(configPath, "plugins", "appA", "2.0.1", "stripe-cli-app-a"+plugins.GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("already installed"), 0755))
+
+	uc := NewUpgradeCmd(cfg)
+	uc.fs = fs
+	uc.apiBaseURL = servers.stripe.URL
+	uc.Cmd.SetContext(context.Background())
+
+	require.NoError(t, uc.runUpgradeCmd(uc.Cmd, []string{"appA"}))
+	assertLocalMetadataBackfilled(t, cfg, fs, configPath)
+}
+
+func setupPluginCommandTest(t *testing.T) (*config.Config, afero.Fs, func()) {
+	t.Helper()
+
+	xdgConfigHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	cfg := &config.Config{
+		Color:        "auto",
+		LogLevel:     "info",
+		ProfilesFile: profilesFile,
+		Profile:      config.Profile{ProfileName: "default"},
+	}
+	cfg.InitConfig()
+	cfg.Profile.APIKey = "rk_test_11111111111111111111111111"
+	config.KeyRing = keyring.NewArrayKeyring(nil)
+
+	return cfg, afero.NewMemMapFs(), func() {
+		viper.Reset()
+	}
+}
+
+func newPluginRegistryServers(t *testing.T, manifest []byte) *pluginRegistryServers {
+	t.Helper()
+
+	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/plugins.toml":
+			_, _ = res.Write(manifest)
+		default:
+			t.Fatalf("unexpected artifactory request: %s", req.URL.String())
+		}
+	}))
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-url":
+			body, err := json.Marshal(requests.PluginData{
+				PluginBaseURL:       artifactoryServer.URL,
+				AdditionalManifests: nil,
+			})
+			require.NoError(t, err)
+			_, _ = res.Write(body)
+		case "/v1/stripecli/get-plugin-metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      artifactoryServer.URL + "/appA/2.0.1/" + runtime.GOOS + "/" + runtime.GOARCH + "/stripe-cli-app-a",
+				PluginManifest: string(manifest),
+			})
+			require.NoError(t, err)
+			_, _ = res.Write(body)
+		default:
+			t.Fatalf("unexpected stripe request: %s", req.URL.String())
+		}
+	}))
+
+	return &pluginRegistryServers{
+		artifactory: artifactoryServer,
+		stripe:      stripeServer,
+	}
+}
+
+func testPluginManifest() []byte {
+	return []byte(fmt.Sprintf(`[[Plugin]]
+  Shortname = "appA"
+  Shortdesc = "App A"
+  Binary = "stripe-cli-app-a"
+  MagicCookieValue = "APP-A-COOKIE"
+
+  [[Plugin.Command]]
+    Name = "serve"
+    Desc = "Serve app A"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "2.0.1"
+    Sum = "abc123"
+`, runtime.GOARCH, runtime.GOOS))
+}
+
+func assertLocalMetadataBackfilled(t *testing.T, cfg *config.Config, fs afero.Fs, configPath string) {
+	t.Helper()
+
+	metadataPath := filepath.Join(configPath, "plugin-metadata", "appA.toml")
+	metadataExists, err := afero.Exists(fs, metadataPath)
+	require.NoError(t, err)
+	require.True(t, metadataExists)
+
+	require.Equal(t, []string{"appA"}, cfg.GetInstalledPlugins())
+
+	manifestPath := filepath.Join(configPath, "plugins.toml")
+	manifestExists, err := afero.Exists(fs, manifestPath)
+	require.NoError(t, err)
+	if manifestExists {
+		require.NoError(t, fs.Remove(manifestPath))
+	}
+
+	plugin, err := plugins.LookUpPlugin(context.Background(), cfg, fs, "appA")
+	require.NoError(t, err)
+	require.Equal(t, "stripe-cli-app-a", plugin.Binary)
+	require.Len(t, plugin.Commands, 1)
+	require.Equal(t, "serve", plugin.Commands[0].Name)
+}

--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -74,20 +74,10 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	color := ansi.Color(os.Stdout)
 	pluginName, version := parseInstallArg(args[0])
 	ic.setInstallTelemetryMetadata(cmd.Context(), pluginName)
-
-	// Refresh the plugin before proceeding
-	if err := plugins.RefreshPluginManifest(cmd.Context(), ic.cfg, ic.fs, ic.apiBaseURL); err != nil {
-		return err
-	}
-
-	plugin, err := plugins.LookUpPlugin(cmd.Context(), ic.cfg, ic.fs, pluginName)
+	isLatest := len(version) == 0
+	plugin, version, err := plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL)
 	if err != nil {
 		return err
-	}
-
-	isLatest := len(version) == 0
-	if isLatest {
-		version = plugin.LookUpLatestVersion()
 	}
 
 	if plugin.IsVersionInstalled(ic.cfg, ic.fs, version) {

--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -81,6 +81,9 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if plugin.IsVersionInstalled(ic.cfg, ic.fs, version) {
+		if err := plugins.PersistInstalledPluginState(ic.cfg, ic.fs, *plugin); err != nil {
+			return err
+		}
 		if isLatest {
 			fmt.Println(color.Green(fmt.Sprintf("✔ v%s is already installed (latest).", version)))
 		} else {

--- a/pkg/cmd/plugin/upgrade.go
+++ b/pkg/cmd/plugin/upgrade.go
@@ -57,13 +57,13 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	})
 
 	// Refresh the plugin info before proceeding
-	if err := plugins.RefreshPluginManifest(cmd.Context(), uc.cfg, uc.fs, uc.apiBaseURL); err != nil {
-		log.Debug(err)
-		fmt.Println("Unable to refresh plugin manifest, continuing with cached manifest...")
+	refreshErr := plugins.RefreshPluginManifest(cmd.Context(), uc.cfg, uc.fs, uc.apiBaseURL)
+	if refreshErr != nil {
+		log.Debug(refreshErr)
+		fmt.Println("Unable to refresh plugin manifest, continuing with cached plugin metadata or manifest...")
 	}
 
-	plugin, err := plugins.LookUpPlugin(cmd.Context(), uc.cfg, uc.fs, args[0])
-
+	plugin, err := plugins.ResolvePluginForUpgrade(uc.cfg, uc.fs, args[0])
 	if err != nil {
 		return err
 	}
@@ -73,6 +73,9 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	color := ansi.Color(os.Stdout)
 
 	if plugin.IsVersionInstalled(uc.cfg, uc.fs, version) {
+		if err := plugins.PersistInstalledPluginState(uc.cfg, uc.fs, *plugin); err != nil {
+			return err
+		}
 		fmt.Println(color.Green(fmt.Sprintf("✔ v%s is already installed (latest).", version)))
 		return nil
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -266,23 +266,33 @@ func init() {
 	// config is not initialized by cobra at this point, so we need to temporarily initialize it
 	Config.InitConfig()
 
-	// get a list of installed plugins, validate against the manifest
-	// and finally add each validated plugin as a command
-	nfs := afero.NewOsFs()
-	pluginList := Config.GetInstalledPlugins()
-
-	installedPluginSet := make(map[string]bool)
-	for _, p := range pluginList {
-		plugin, err := plugins.LookUpPlugin(context.Background(), &Config, nfs, p)
-		if err == nil {
-			installedPluginSet[p] = true
-			rootCmd.AddCommand(newPluginTemplateCmd(&Config, &plugin).cmd)
-		}
-	}
+	installedPluginSet := registerInstalledPlugins(rootCmd, &Config, afero.NewOsFs())
 
 	// For known plugins not yet installed, add a hint command so users get
 	// a helpful message instead of "unknown command".
 	pluginhints.AddHintCommands(rootCmd, &Config, installedPluginSet)
+}
+
+func registerInstalledPlugins(root *cobra.Command, cfg *config.Config, fs afero.Fs) map[string]bool {
+	pluginNames, err := plugins.GetInstalledPluginNames(cfg, fs)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"prefix": "cmd.registerInstalledPlugins",
+		}).Debugf("could not list installed plugins: %s", err)
+		pluginNames = cfg.GetInstalledPlugins()
+	}
+
+	installedPluginSet := make(map[string]bool)
+	for _, pluginName := range pluginNames {
+		plugin, err := plugins.LookUpPlugin(context.Background(), cfg, fs, pluginName)
+		if err != nil {
+			continue
+		}
+		installedPluginSet[pluginName] = true
+		root.AddCommand(newPluginTemplateCmd(cfg, &plugin).cmd)
+	}
+
+	return installedPluginSet
 }
 
 func addV2BillingStubs(rootCmd *cobra.Command) {

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -449,6 +449,9 @@ func (p *Plugin) Uninstall(ctx context.Context, config config.IConfig, fs afero.
 
 	err = fs.RemoveAll(pluginDir)
 	if err != nil {
+		if rollbackErr := rollbackInstalledPluginState(config, fs, p.Shortname, previousState); rollbackErr != nil {
+			return fmt.Errorf("failed to remove plugin files for %s: %w; rollback failed: %v", p.Shortname, err, rollbackErr)
+		}
 		return err
 	}
 

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -298,6 +298,7 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	apiKey, _ := cfg.GetProfile().GetAPIKey(false)
 	pluginToInstall := p
 	var pluginDownloadURL string
+	downloadURLFromMetadata := false
 
 	if apiKey != "" {
 		log.WithFields(log.Fields{
@@ -323,12 +324,13 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 
 			pluginToInstall = pluginFromMetadata
 			pluginDownloadURL = pluginMetadata.BinaryURL
+			downloadURLFromMetadata = true
 		}
 	}
 
 	if pluginDownloadURL == "" {
-		pluginData, err := requests.GetPluginData(ctx, baseURL, stripe.APIVersion, apiKey, cfg.GetProfile())
-
+		var err error
+		pluginDownloadURL, err = getLegacyPluginDownloadURL(ctx, cfg, apiKey, baseURL, version, pluginToInstall)
 		if err != nil {
 			ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
 
@@ -338,8 +340,6 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 
 			return errors.New("you don't seem to have access to this plugin")
 		}
-
-		pluginDownloadURL = fmt.Sprintf("%s/%s/%s/%s/%s/%s", pluginData.PluginBaseURL, pluginToInstall.Shortname, version, runtime.GOOS, runtime.GOARCH, pluginToInstall.Binary)
 	}
 
 	// Check if this plugin requires a runtime and install it if needed
@@ -356,6 +356,23 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 
 	// Pull down bin, verify, and save to disk
 	err := pluginToInstall.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version)
+	if err != nil && downloadURLFromMetadata {
+		var notFoundErr *remoteResourceNotFoundError
+		if errors.As(err, &notFoundErr) {
+			log.WithFields(log.Fields{
+				"prefix": "plugins.plugin.Install",
+			}).Debugf("could not download plugin from metadata URL, falling back to plugin URL lookup: %s", err)
+
+			fallbackURL, fallbackErr := getLegacyPluginDownloadURL(ctx, cfg, apiKey, baseURL, version, pluginToInstall)
+			if fallbackErr != nil {
+				log.WithFields(log.Fields{
+					"prefix": "plugins.plugin.Install",
+				}).Debugf("could not look up fallback plugin URL after metadata download failed: %s", fallbackErr)
+			} else {
+				err = pluginToInstall.downloadAndSavePlugin(cfg, fallbackURL, fs, version)
+			}
+		}
+	}
 
 	if err != nil {
 		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), os.Stdout)
@@ -385,6 +402,15 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	ansi.StopSpinner(spinner, "", os.Stdout)
 
 	return nil
+}
+
+func getLegacyPluginDownloadURL(ctx context.Context, cfg config.IConfig, apiKey, baseURL, version string, plugin *Plugin) (string, error) {
+	pluginData, err := requests.GetPluginData(ctx, baseURL, stripe.APIVersion, apiKey, cfg.GetProfile())
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s/%s/%s/%s/%s/%s", pluginData.PluginBaseURL, plugin.Shortname, version, runtime.GOOS, runtime.GOARCH, plugin.Binary), nil
 }
 
 // Uninstall removes a plugin from the disk and from the config's installed plugins list

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -203,16 +203,65 @@ func (p *Plugin) LookUpLatestVersion() string {
 
 // getReleaseForVersion finds the release object for a specific version on the current platform
 func (p *Plugin) getReleaseForVersion(version string) *Release {
-	opsystem := runtime.GOOS
-	arch := runtime.GOARCH
+	return p.getRelease(version, runtime.GOOS, runtime.GOARCH)
+}
 
+func (p *Plugin) getRelease(version, opsystem, arch string) *Release {
 	for _, release := range p.Releases {
 		if release.Version == version && release.OS == opsystem && release.Arch == arch {
-			return &release
+			releaseCopy := release
+			return &releaseCopy
 		}
 	}
 
 	return nil
+}
+
+func copyRuntime(runtimeRequirements map[string]string) map[string]string {
+	if len(runtimeRequirements) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(runtimeRequirements))
+	for name, version := range runtimeRequirements {
+		cloned[name] = version
+	}
+
+	return cloned
+}
+
+func (p *Plugin) pluginFromMetadata(pluginManifest string) (*Plugin, error) {
+	pluginList, err := validatePluginManifest([]byte(pluginManifest))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, candidate := range pluginList.Plugins {
+		if candidate.Shortname != p.Shortname {
+			continue
+		}
+
+		if len(candidate.Commands) == 0 && len(p.Commands) > 0 {
+			candidate.Commands = p.Commands
+		}
+
+		for i := range candidate.Releases {
+			if len(candidate.Releases[i].Runtime) != 0 {
+				continue
+			}
+
+			existingRelease := p.getRelease(candidate.Releases[i].Version, candidate.Releases[i].OS, candidate.Releases[i].Arch)
+			if existingRelease == nil || len(existingRelease.Runtime) == 0 {
+				continue
+			}
+
+			candidate.Releases[i].Runtime = copyRuntime(existingRelease.Runtime)
+		}
+
+		return &candidate, nil
+	}
+
+	return nil, fmt.Errorf("plugin metadata response did not include plugin %s", p.Shortname)
 }
 
 // IsVersionInstalled returns true if the given version of the plugin is already installed on disk.
@@ -247,21 +296,54 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)
 
 	apiKey, _ := cfg.GetProfile().GetAPIKey(false)
+	pluginToInstall := p
+	var pluginDownloadURL string
 
-	pluginData, err := requests.GetPluginData(ctx, baseURL, stripe.APIVersion, apiKey, cfg.GetProfile())
-
-	if err != nil {
-		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
-
+	if apiKey != "" {
 		log.WithFields(log.Fields{
-			"prefix": "plugins.plugin.Install",
-		}).Debugf("install error: %s", err)
+			"prefix":   "plugins.plugin.Install",
+			"endpoint": "/v1/stripecli/get-plugin-metadata",
+			"plugin":   p.Shortname,
+			"version":  version,
+			"os":       runtime.GOOS,
+			"arch":     runtime.GOARCH,
+		}).Debug("Fetching plugin metadata for install")
 
-		return errors.New("you don't seem to have access to this plugin")
+		pluginMetadata, err := requests.GetPluginMetadata(ctx, baseURL, stripe.APIVersion, apiKey, cfg.GetProfile(), p.Shortname, version, runtime.GOOS, runtime.GOARCH)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"prefix": "plugins.plugin.Install",
+			}).Debugf("could not fetch plugin metadata, falling back to plugin URL lookup: %s", err)
+		} else {
+			pluginFromMetadata, err := p.pluginFromMetadata(pluginMetadata.PluginManifest)
+			if err != nil {
+				ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
+				return err
+			}
+
+			pluginToInstall = pluginFromMetadata
+			pluginDownloadURL = pluginMetadata.BinaryURL
+		}
+	}
+
+	if pluginDownloadURL == "" {
+		pluginData, err := requests.GetPluginData(ctx, baseURL, stripe.APIVersion, apiKey, cfg.GetProfile())
+
+		if err != nil {
+			ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
+
+			log.WithFields(log.Fields{
+				"prefix": "plugins.plugin.Install",
+			}).Debugf("install error: %s", err)
+
+			return errors.New("you don't seem to have access to this plugin")
+		}
+
+		pluginDownloadURL = fmt.Sprintf("%s/%s/%s/%s/%s/%s", pluginData.PluginBaseURL, pluginToInstall.Shortname, version, runtime.GOOS, runtime.GOARCH, pluginToInstall.Binary)
 	}
 
 	// Check if this plugin requires a runtime and install it if needed
-	release := p.getReleaseForVersion(version)
+	release := pluginToInstall.getReleaseForVersion(version)
 	if release != nil {
 		if nodeVersion, requiresNode := GetRuntimeRequirement(*release); requiresNode {
 			ansi.StopSpinner(spinner, "", os.Stdout)
@@ -272,10 +354,8 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 		}
 	}
 
-	pluginDownloadURL := fmt.Sprintf("%s/%s/%s/%s/%s/%s", pluginData.PluginBaseURL, p.Shortname, version, runtime.GOOS, runtime.GOARCH, p.Binary)
-
 	// Pull down bin, verify, and save to disk
-	err = p.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version)
+	err := pluginToInstall.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version)
 
 	if err != nil {
 		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), os.Stdout)

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -379,22 +379,18 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 		return err
 	}
 
-	installedList := cfg.GetInstalledPlugins()
-
-	// check for plugin already in list (ie. in the case of an upgrade)
-	isInstalled := false
-	for _, name := range installedList {
-		if name == p.Shortname {
-			isInstalled = true
+	if err := PersistInstalledPluginState(cfg, fs, *pluginToInstall); err != nil {
+		pluginPath := pluginToInstall.getPluginInstallPath(cfg, version)
+		if cleanupErr := fs.RemoveAll(pluginPath); cleanupErr != nil {
+			log.WithFields(log.Fields{
+				"prefix": "plugins.plugin.Install",
+				"path":   pluginPath,
+			}).Debugf("could not clean up plugin after local metadata write failure: %s", cleanupErr)
 		}
-	}
 
-	if !isInstalled {
-		installedList = append(installedList, p.Shortname)
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), os.Stdout)
+		return err
 	}
-
-	// sync list of installed plugins to file
-	cfg.WriteConfigField("installed_plugins", installedList)
 
 	// Once the plugin is successfully downloaded, clean up other versions
 	p.cleanUpPluginPath(cfg, fs, version)
@@ -424,23 +420,35 @@ func (p *Plugin) Uninstall(ctx context.Context, config config.IConfig, fs afero.
 		}
 	}
 
-	if pluginIdx == -1 {
-		return errors.New("this plugin doesn't seem to be installed, canceling")
+	pluginDir := p.getPluginInstallPath(config, "")
+	dirExists, err := afero.DirExists(fs, pluginDir)
+	if err != nil {
+		return err
+	}
+	metadataPath := getLocalPluginMetadataPath(config, p.Shortname)
+	metadataExists, err := afero.Exists(fs, metadataPath)
+	if err != nil {
+		return err
 	}
 
-	pluginDir := p.getPluginInstallPath(config, "")
-
-	err := fs.RemoveAll(pluginDir)
+	if pluginIdx == -1 && !dirExists && !metadataExists {
+		return errors.New("this plugin doesn't seem to be installed, canceling")
+	}
+	err = fs.RemoveAll(pluginDir)
 
 	if err != nil {
 		return err
 	}
 
-	// remove plugin from installed plugins list in profile
-	installedList := make([]string, 0)
-	installedList = append(installedList, pluginList[:pluginIdx]...)
-	installedList = append(installedList, pluginList[pluginIdx+1:]...)
-	config.WriteConfigField("installed_plugins", installedList)
+	if err := removeLocalPluginMetadata(config, fs, p.Shortname); err != nil {
+		log.WithFields(log.Fields{
+			"prefix": "plugins.plugin.Uninstall",
+			"plugin": p.Shortname,
+		}).Debugf("could not remove local plugin metadata: %s", err)
+	}
+	if err := RemoveInstalledPlugin(config, p.Shortname); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -578,10 +578,18 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 			return err
 		}
 
-		// if plugin is not installed locally, then we should install it first
+		// If the plugin binary is missing locally, resolve the freshest metadata
+		// before reinstalling so stale cached local metadata does not pin us to an
+		// older release.
 		if version == "" {
-			version = p.LookUpLatestVersion()
-			err := p.Install(ctx, config, fs, version, stripe.DefaultAPIBaseURL)
+			pluginToInstall, resolvedVersion, err := resolvePluginForAutoInstall(ctx, config, fs, p.Shortname, stripe.DefaultAPIBaseURL)
+			if err != nil {
+				return err
+			}
+
+			p = pluginToInstall
+			version = resolvedVersion
+			err = p.Install(ctx, config, fs, version, stripe.DefaultAPIBaseURL)
 			if err != nil {
 				return err
 			}

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -357,20 +357,17 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	// Pull down bin, verify, and save to disk
 	err := pluginToInstall.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version)
 	if err != nil && downloadURLFromMetadata {
-		var notFoundErr *remoteResourceNotFoundError
-		if errors.As(err, &notFoundErr) {
+		log.WithFields(log.Fields{
+			"prefix": "plugins.plugin.Install",
+		}).Debugf("could not download plugin from metadata URL, falling back to plugin URL lookup: %s", err)
+
+		fallbackURL, fallbackErr := getLegacyPluginDownloadURL(ctx, cfg, apiKey, baseURL, version, pluginToInstall)
+		if fallbackErr != nil {
 			log.WithFields(log.Fields{
 				"prefix": "plugins.plugin.Install",
-			}).Debugf("could not download plugin from metadata URL, falling back to plugin URL lookup: %s", err)
-
-			fallbackURL, fallbackErr := getLegacyPluginDownloadURL(ctx, cfg, apiKey, baseURL, version, pluginToInstall)
-			if fallbackErr != nil {
-				log.WithFields(log.Fields{
-					"prefix": "plugins.plugin.Install",
-				}).Debugf("could not look up fallback plugin URL after metadata download failed: %s", fallbackErr)
-			} else {
-				err = pluginToInstall.downloadAndSavePlugin(cfg, fallbackURL, fs, version)
-			}
+			}).Debugf("could not look up fallback plugin URL after metadata download failed: %s", fallbackErr)
+		} else {
+			err = pluginToInstall.downloadAndSavePlugin(cfg, fallbackURL, fs, version)
 		}
 	}
 
@@ -434,19 +431,24 @@ func (p *Plugin) Uninstall(ctx context.Context, config config.IConfig, fs afero.
 	if pluginIdx == -1 && !dirExists && !metadataExists {
 		return errors.New("this plugin doesn't seem to be installed, canceling")
 	}
-	err = fs.RemoveAll(pluginDir)
 
+	previousState, err := snapshotInstalledPluginState(config, fs, p.Shortname)
 	if err != nil {
 		return err
 	}
 
 	if err := removeLocalPluginMetadata(config, fs, p.Shortname); err != nil {
-		log.WithFields(log.Fields{
-			"prefix": "plugins.plugin.Uninstall",
-			"plugin": p.Shortname,
-		}).Debugf("could not remove local plugin metadata: %s", err)
+		return err
 	}
 	if err := RemoveInstalledPlugin(config, p.Shortname); err != nil {
+		if rollbackErr := rollbackInstalledPluginState(config, fs, p.Shortname, previousState); rollbackErr != nil {
+			return fmt.Errorf("failed to update uninstall state for plugin %s: %w; rollback failed: %v", p.Shortname, err, rollbackErr)
+		}
+		return err
+	}
+
+	err = fs.RemoveAll(pluginDir)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -424,6 +424,73 @@ func TestResolvePluginForInstallFallsBackToManifestLookupWhenMetadataFails(t *te
 	require.NoError(t, err)
 }
 
+func TestResolvePluginForAutoInstallPrefersFreshMetadataWhenLocalMetadataIsStale(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	stalePlugin := Plugin{
+		Shortname:        "appA",
+		Binary:           "stripe-cli-app-a",
+		MagicCookieValue: "0337A75A-C3C4-4DCF-A9EF-E7A144E5A291",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.1",
+				Sum:     "abc123",
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, stalePlugin))
+
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	plugin, version, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", testServers.StripeServer.URL)
+	require.NoError(t, err)
+	require.NotNil(t, plugin)
+	require.Equal(t, "2.0.1", version)
+	require.Equal(t, "2.0.1", plugin.LookUpLatestVersion())
+}
+
+func TestResolvePluginForAutoInstallFallsBackToCachedManifestWhenFreshLookupFails(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	stalePlugin := Plugin{
+		Shortname:        "appA",
+		Binary:           "stripe-cli-app-a",
+		MagicCookieValue: "0337A75A-C3C4-4DCF-A9EF-E7A144E5A291",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.1",
+				Sum:     "abc123",
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, stalePlugin))
+
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	require.NoError(t, afero.WriteFile(fs, "/plugins.toml", manifestContent, os.ModePerm))
+
+	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusInternalServerError)
+		_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
+	}))
+	defer failingServer.Close()
+
+	plugin, version, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", failingServer.URL)
+	require.NoError(t, err)
+	require.NotNil(t, plugin)
+	require.Equal(t, "2.0.1", version)
+	require.Equal(t, "2.0.1", plugin.LookUpLatestVersion())
+}
+
 func TestVerifyChecksumSkipsLocalDevelopmentVersion(t *testing.T) {
 	plugin := Plugin{Shortname: "appA"}
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -168,6 +168,114 @@ func TestInstallFallsBackIfMetadataBinaryURLReturnsNotFound(t *testing.T) {
 	require.True(t, fileExists)
 }
 
+func TestResolvePluginForInstallUsesMetadataWithoutCachedManifest(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	var metadataLookups int
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			metadataLookups++
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "https://example.test/appA/2.0.1",
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-url":
+			t.Fatalf("install resolution should not fall back to /v1/stripecli/get-plugin-url when metadata is available")
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	plugin, version, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL)
+	require.NoError(t, err)
+	require.NotNil(t, plugin)
+	require.Equal(t, "appA", plugin.Shortname)
+	require.Equal(t, "2.0.1", version)
+	require.Equal(t, 1, metadataLookups)
+
+	_, err = fs.Stat("/plugins.toml")
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestResolvePluginForInstallResolvesLatestVersionFromMetadata(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	var metadataLookups int
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			metadataLookups++
+			require.Equal(t, "", req.URL.Query().Get("version"))
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "https://example.test/appA/latest",
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-url":
+			t.Fatalf("install resolution should not fall back to /v1/stripecli/get-plugin-url when metadata can resolve latest")
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	plugin, version, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "", stripeServer.URL)
+	require.NoError(t, err)
+	require.NotNil(t, plugin)
+	require.Equal(t, "2.0.1", version)
+	require.Equal(t, 1, metadataLookups)
+}
+
+func TestResolvePluginForInstallFallsBackToManifestLookupWhenMetadataFails(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	var pluginURLLookups int
+	fallbackServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			res.WriteHeader(http.StatusInternalServerError)
+			res.Write([]byte(`{"error":{"message":"boom"}}`))
+		case "/v1/stripecli/get-plugin-url":
+			pluginURLLookups++
+			body, err := json.Marshal(requests.PluginData{
+				PluginBaseURL:       testServers.ArtifactoryServer.URL,
+				AdditionalManifests: nil,
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer fallbackServer.Close()
+
+	plugin, version, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", fallbackServer.URL)
+	require.NoError(t, err)
+	require.NotNil(t, plugin)
+	require.Equal(t, "appA", plugin.Shortname)
+	require.Equal(t, "2.0.1", version)
+	require.Equal(t, 1, pluginURLLookups)
+
+	_, err = fs.Stat("/plugins.toml")
+	require.NoError(t, err)
+}
+
 func TestVerifyChecksumSkipsLocalDevelopmentVersion(t *testing.T) {
 	plugin := Plugin{Shortname: "appA"}
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -43,6 +44,32 @@ func TestInstall(t *testing.T) {
 	require.True(t, fileExists)
 
 	require.Equal(t, []string{"appA"}, config.GetInstalledPlugins())
+}
+
+func TestInstallRollsBackPersistedStateWhenConfigWriteFails(t *testing.T) {
+	fs := setUpFS()
+	config := &FailingWriteConfig{
+		WriteErr:                 errors.New("boom"),
+		MutateInstalledPluginsOn: true,
+	}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
+	require.ErrorIs(t, err, config.WriteErr)
+
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
+	fileExists, err := afero.Exists(fs, file)
+	require.NoError(t, err)
+	require.False(t, fileExists)
+
+	metadataExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "appA"))
+	require.NoError(t, err)
+	require.False(t, metadataExists)
+	require.Empty(t, config.GetInstalledPlugins())
 }
 
 func TestInstallUsesPluginMetadataEndpointWhenAPIKeyAvailable(t *testing.T) {
@@ -126,6 +153,61 @@ func TestInstallFallsBackIfMetadataBinaryURLReturnsNotFound(t *testing.T) {
 		switch req.URL.Path {
 		case fmt.Sprintf("/appA/2.0.1/%s/%s/binary", runtime.GOOS, runtime.GOARCH):
 			res.WriteHeader(http.StatusNotFound)
+		case fmt.Sprintf("/appA/2.0.1/%s/%s/stripe-cli-app-a", runtime.GOOS, runtime.GOARCH):
+			res.Write([]byte("hello, I am appA_2.0.1"))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer artifactoryServer.Close()
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      fmt.Sprintf("%s/appA/2.0.1/%s/%s/binary", artifactoryServer.URL, runtime.GOOS, runtime.GOARCH),
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-url":
+			pluginURLLookups++
+			body, err := json.Marshal(requests.PluginData{
+				PluginBaseURL:       artifactoryServer.URL,
+				AdditionalManifests: nil,
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, 1, pluginURLLookups)
+
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
+	fileExists, err := afero.Exists(fs, file)
+	require.NoError(t, err)
+	require.True(t, fileExists)
+}
+
+func TestInstallFallsBackIfMetadataBinaryURLVerificationFails(t *testing.T) {
+	fs := setUpFS()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	var pluginURLLookups int
+
+	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case fmt.Sprintf("/appA/2.0.1/%s/%s/binary", runtime.GOOS, runtime.GOARCH):
+			res.WriteHeader(http.StatusInternalServerError)
+			res.Write([]byte("html error page"))
 		case fmt.Sprintf("/appA/2.0.1/%s/%s/stripe-cli-app-a", runtime.GOOS, runtime.GOARCH):
 			res.Write([]byte("hello, I am appA_2.0.1"))
 		default:
@@ -626,4 +708,81 @@ func TestUninstallSucceedsWithLocalMetadataOnly(t *testing.T) {
 	require.False(t, dirExists)
 
 	require.Equal(t, 0, len(config.GetInstalledPlugins()))
+}
+
+func TestUninstallReturnsErrorWithoutRemovingFilesWhenMetadataRemovalFails(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.InstalledPlugins = []string{"docs"}
+	plugin := Plugin{
+		Shortname:        "docs",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+			},
+		},
+	}
+
+	require.NoError(t, writeLocalPluginMetadata(config, fs, plugin))
+	pluginFile := fmt.Sprintf("/plugins/docs/1.0.0/stripe-cli-docs%s", GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll("/plugins/docs/1.0.0", 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginFile, []byte("installed"), 0755))
+
+	err := plugin.Uninstall(context.Background(), config, afero.NewReadOnlyFs(fs))
+	require.Error(t, err)
+
+	cacheExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "docs"))
+	require.NoError(t, err)
+	require.True(t, cacheExists)
+
+	fileExists, err := afero.Exists(fs, pluginFile)
+	require.NoError(t, err)
+	require.True(t, fileExists)
+	require.Equal(t, []string{"docs"}, config.GetInstalledPlugins())
+}
+
+func TestUninstallRollsBackStateWhenConfigWriteFails(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &FailingWriteConfig{
+		WriteErr:                 errors.New("boom"),
+		MutateInstalledPluginsOn: true,
+	}
+	config.InitConfig()
+	config.InstalledPlugins = []string{"docs"}
+	plugin := Plugin{
+		Shortname:        "docs",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+			},
+		},
+	}
+
+	require.NoError(t, writeLocalPluginMetadata(config, fs, plugin))
+	pluginFile := fmt.Sprintf("/plugins/docs/1.0.0/stripe-cli-docs%s", GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll("/plugins/docs/1.0.0", 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginFile, []byte("installed"), 0755))
+
+	err := plugin.Uninstall(context.Background(), config, fs)
+	require.ErrorIs(t, err, config.WriteErr)
+
+	cacheExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "docs"))
+	require.NoError(t, err)
+	require.True(t, cacheExists)
+
+	fileExists, err := afero.Exists(fs, pluginFile)
+	require.NoError(t, err)
+	require.True(t, fileExists)
+	require.Equal(t, []string{"docs"}, config.GetInstalledPlugins())
 }

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -114,6 +114,60 @@ func TestInstallFallsBackIfPluginMetadataEndpointFails(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestInstallFallsBackIfMetadataBinaryURLReturnsNotFound(t *testing.T) {
+	fs := setUpFS()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	var pluginURLLookups int
+
+	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case fmt.Sprintf("/appA/2.0.1/%s/%s/binary", runtime.GOOS, runtime.GOARCH):
+			res.WriteHeader(http.StatusNotFound)
+		case fmt.Sprintf("/appA/2.0.1/%s/%s/stripe-cli-app-a", runtime.GOOS, runtime.GOARCH):
+			res.Write([]byte("hello, I am appA_2.0.1"))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer artifactoryServer.Close()
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      fmt.Sprintf("%s/appA/2.0.1/%s/%s/binary", artifactoryServer.URL, runtime.GOOS, runtime.GOARCH),
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-url":
+			pluginURLLookups++
+			body, err := json.Marshal(requests.PluginData{
+				PluginBaseURL:       artifactoryServer.URL,
+				AdditionalManifests: nil,
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, 1, pluginURLLookups)
+
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
+	fileExists, err := afero.Exists(fs, file)
+	require.NoError(t, err)
+	require.True(t, fileExists)
+}
+
 func TestVerifyChecksumSkipsLocalDevelopmentVersion(t *testing.T) {
 	plugin := Plugin{Shortname: "appA"}
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -2,8 +2,12 @@ package plugins
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -41,11 +45,116 @@ func TestInstall(t *testing.T) {
 	require.Equal(t, []string{"appA"}, config.GetInstalledPlugins())
 }
 
+func TestInstallUsesPluginMetadataEndpointWhenAPIKeyAvailable(t *testing.T) {
+	fs := setUpFS()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch {
+		case strings.Contains(req.URL.String(), "/appA/2.0.1"):
+			res.Write([]byte("hello, I am appA_2.0.1"))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer artifactoryServer.Close()
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      fmt.Sprintf("%s/appA/2.0.1/%s/%s/stripe-cli-app-a", artifactoryServer.URL, runtime.GOOS, runtime.GOARCH),
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-url":
+			t.Fatalf("install should not fall back to /v1/stripecli/get-plugin-url when plugin metadata is available")
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL)
+	require.NoError(t, err)
+}
+
+func TestInstallFallsBackIfPluginMetadataEndpointFails(t *testing.T) {
+	fs := setUpFS()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	fallbackServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			res.WriteHeader(http.StatusInternalServerError)
+			res.Write([]byte(`{"error":{"message":"boom"}}`))
+		case "/v1/stripecli/get-plugin-url":
+			body, err := json.Marshal(requests.PluginData{
+				PluginBaseURL:       testServers.ArtifactoryServer.URL,
+				AdditionalManifests: nil,
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer fallbackServer.Close()
+
+	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", fallbackServer.URL)
+	require.NoError(t, err)
+}
+
 func TestVerifyChecksumSkipsLocalDevelopmentVersion(t *testing.T) {
 	plugin := Plugin{Shortname: "appA"}
 
 	err := plugin.verifyChecksum(strings.NewReader("locally built binary"), localDevelopmentVersion)
 	require.NoError(t, err)
+}
+
+func TestPluginFromMetadataPreservesRuntimeRequirements(t *testing.T) {
+	plugin := &Plugin{
+		Shortname:        "generate",
+		Binary:           "stripe-cli-generate",
+		MagicCookieValue: "GENERATE-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+				Runtime: map[string]string{"node": "20"},
+			},
+		},
+	}
+
+	metadataManifest := fmt.Sprintf(`[[Plugin]]
+  Shortname = "generate"
+  Shortdesc = "Generate things"
+  Binary = "stripe-cli-generate"
+  MagicCookieValue = "GENERATE-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "1.0.0"
+    Sum = "abc123"
+`, runtime.GOARCH, runtime.GOOS)
+
+	resolved, err := plugin.pluginFromMetadata(metadataManifest)
+	require.NoError(t, err)
+	release := resolved.getReleaseForVersion("1.0.0")
+	require.NotNil(t, release)
+	require.Equal(t, "20", release.Runtime["node"])
 }
 
 func TestInstallSucceedsIfNoAPIKey(t *testing.T) {

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -26,7 +27,7 @@ type failRemoveAllFs struct {
 }
 
 func (fs *failRemoveAllFs) RemoveAll(name string) error {
-	if name == fs.path {
+	if filepath.Clean(name) == filepath.Clean(fs.path) {
 		return fs.err
 	}
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -168,6 +168,57 @@ func TestInstallFallsBackIfMetadataBinaryURLReturnsNotFound(t *testing.T) {
 	require.True(t, fileExists)
 }
 
+func TestInstallPersistsLocalMetadataWithoutManifest(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch {
+		case strings.Contains(req.URL.String(), "/appA/2.0.1"):
+			res.Write([]byte("hello, I am appA_2.0.1"))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer artifactoryServer.Close()
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      fmt.Sprintf("%s/appA/2.0.1/%s/%s/stripe-cli-app-a", artifactoryServer.URL, runtime.GOOS, runtime.GOARCH),
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-url":
+			t.Fatalf("install should not fall back to /v1/stripecli/get-plugin-url when plugin metadata is available")
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	plugin := &Plugin{Shortname: "appA"}
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL)
+	require.NoError(t, err)
+
+	cachedPlugin, err := readLocalPluginMetadata(config, fs, "appA")
+	require.NoError(t, err)
+	require.Equal(t, "stripe-cli-app-a", cachedPlugin.Binary)
+	require.NotNil(t, cachedPlugin.getReleaseForVersion("2.0.1"))
+	require.Equal(t, []string{"appA"}, config.GetInstalledPlugins())
+
+	lookedUpPlugin, err := LookUpPlugin(context.Background(), config, fs, "appA")
+	require.NoError(t, err)
+	require.Equal(t, cachedPlugin, lookedUpPlugin)
+
+	_, err = fs.Stat("/plugins.toml")
+	require.True(t, os.IsNotExist(err))
+}
+
 func TestResolvePluginForInstallUsesMetadataWithoutCachedManifest(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
@@ -525,11 +576,53 @@ func TestUninstall(t *testing.T) {
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
 	require.Nil(t, err)
+	metadataPath := getLocalPluginMetadataPath(config, "appA")
+	cacheExists, err := afero.Exists(fs, metadataPath)
+	require.NoError(t, err)
+	require.True(t, cacheExists)
 
 	pluginDir := "/plugins/appA"
 	err = plugin.Uninstall(context.Background(), config, fs)
 	require.Nil(t, err)
 	dirExists, _ := afero.Exists(fs, pluginDir)
+	require.False(t, dirExists)
+	cacheExists, err = afero.Exists(fs, metadataPath)
+	require.NoError(t, err)
+	require.False(t, cacheExists)
+
+	require.Equal(t, 0, len(config.GetInstalledPlugins()))
+}
+
+func TestUninstallSucceedsWithLocalMetadataOnly(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	plugin := Plugin{
+		Shortname:        "docs",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+			},
+		},
+	}
+
+	require.NoError(t, writeLocalPluginMetadata(config, fs, plugin))
+	require.NoError(t, fs.MkdirAll("/plugins/docs/1.0.0", 0755))
+
+	err := plugin.Uninstall(context.Background(), config, fs)
+	require.NoError(t, err)
+
+	cacheExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "docs"))
+	require.NoError(t, err)
+	require.False(t, cacheExists)
+
+	dirExists, err := afero.Exists(fs, "/plugins/docs")
+	require.NoError(t, err)
 	require.False(t, dirExists)
 
 	require.Equal(t, 0, len(config.GetInstalledPlugins()))

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -19,6 +19,20 @@ import (
 	"github.com/stripe/stripe-cli/pkg/requests"
 )
 
+type failRemoveAllFs struct {
+	afero.Fs
+	path string
+	err  error
+}
+
+func (fs *failRemoveAllFs) RemoveAll(name string) error {
+	if name == fs.path {
+		return fs.err
+	}
+
+	return fs.Fs.RemoveAll(name)
+}
+
 func TestLookUpLatestVersion(t *testing.T) {
 	fs := setUpFS()
 	config := &TestConfig{}
@@ -776,6 +790,50 @@ func TestUninstallRollsBackStateWhenConfigWriteFails(t *testing.T) {
 
 	err := plugin.Uninstall(context.Background(), config, fs)
 	require.ErrorIs(t, err, config.WriteErr)
+
+	cacheExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "docs"))
+	require.NoError(t, err)
+	require.True(t, cacheExists)
+
+	fileExists, err := afero.Exists(fs, pluginFile)
+	require.NoError(t, err)
+	require.True(t, fileExists)
+	require.Equal(t, []string{"docs"}, config.GetInstalledPlugins())
+}
+
+func TestUninstallRollsBackStateWhenPluginRemovalFails(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.InstalledPlugins = []string{"docs"}
+	plugin := Plugin{
+		Shortname:        "docs",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+			},
+		},
+	}
+
+	require.NoError(t, writeLocalPluginMetadata(config, fs, plugin))
+	pluginFile := fmt.Sprintf("/plugins/docs/1.0.0/stripe-cli-docs%s", GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll("/plugins/docs/1.0.0", 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginFile, []byte("installed"), 0755))
+
+	removeErr := errors.New("remove all failed")
+	failingFS := &failRemoveAllFs{
+		Fs:   fs,
+		path: "/plugins/docs",
+		err:  removeErr,
+	}
+
+	err := plugin.Uninstall(context.Background(), config, failingFS)
+	require.ErrorIs(t, err, removeErr)
 
 	cacheExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "docs"))
 	require.NoError(t, err)

--- a/pkg/plugins/test_utils.go
+++ b/pkg/plugins/test_utils.go
@@ -21,11 +21,29 @@ type TestConfig struct {
 	config.Config
 }
 
+type FailingWriteConfig struct {
+	TestConfig
+	WriteErr                 error
+	MutateInstalledPluginsOn bool
+}
+
 // WriteConfigField mocks out the method so that we can ensure installed plugins data is written
 func (c *TestConfig) WriteConfigField(field string, value interface{}) error {
 	c.InstalledPlugins = value.([]string)
 
 	return nil
+}
+
+func (c *FailingWriteConfig) WriteConfigField(field string, value interface{}) error {
+	if c.MutateInstalledPluginsOn {
+		c.InstalledPlugins = append([]string(nil), value.([]string)...)
+	}
+
+	if c.WriteErr == nil {
+		return c.TestConfig.WriteConfigField(field, value)
+	}
+
+	return c.WriteErr
 }
 
 // GetConfigFolder returns the absolute path for the TestConfig

--- a/pkg/plugins/test_utils.go
+++ b/pkg/plugins/test_utils.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/spf13/afero"
 
 	"github.com/stripe/stripe-cli/pkg/config"
@@ -96,11 +98,27 @@ func setUpServers(t *testing.T, manifestContent []byte, additionalManifests map[
 
 	// The checksums in the test toml files are the same for each OS variation of the release for unit testing purposes
 	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		switch url := req.URL.String(); url {
+		switch req.URL.Path {
 		case "/v1/stripecli/get-plugin-url":
 			pd := requests.PluginData{
 				PluginBaseURL:       artifactoryServer.URL,
 				AdditionalManifests: additionalManifestNames,
+			}
+			body, err := json.Marshal(pd)
+			if err != nil {
+				t.Error(err)
+			}
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-metadata":
+			pluginName := req.URL.Query().Get("plugin")
+			version := req.URL.Query().Get("version")
+			opsystem := req.URL.Query().Get("os")
+			arch := req.URL.Query().Get("arch")
+
+			pluginManifest := singlePluginManifest(t, pluginName, manifestContent, additionalManifests)
+			pd := requests.PluginMetadata{
+				BinaryURL:      artifactoryServer.URL + "/" + pluginName + "/" + version + "/" + opsystem + "/" + arch + "/stripe-cli-" + strings.ReplaceAll(pluginName, "_", "-"),
+				PluginManifest: string(pluginManifest),
 			}
 			body, err := json.Marshal(pd)
 			if err != nil {
@@ -115,6 +133,41 @@ func setUpServers(t *testing.T, manifestContent []byte, additionalManifests map[
 	return TestServers{
 		ArtifactoryServer: artifactoryServer,
 		StripeServer:      stripeServer,
+	}
+}
+
+func singlePluginManifest(t *testing.T, pluginName string, manifestContent []byte, additionalManifests map[string][]byte) []byte {
+	t.Helper()
+
+	merged := &PluginList{}
+	if len(manifestContent) > 0 {
+		requireNoError(t, toml.Unmarshal(manifestContent, merged))
+	}
+
+	for _, content := range additionalManifests {
+		additionalPluginList := &PluginList{}
+		requireNoError(t, toml.Unmarshal(content, additionalPluginList))
+		mergePluginLists(merged, []*PluginList{additionalPluginList})
+	}
+
+	for _, plugin := range merged.Plugins {
+		if plugin.Shortname != pluginName {
+			continue
+		}
+
+		buffer := &bytes.Buffer{}
+		requireNoError(t, toml.NewEncoder(buffer).Encode(PluginList{Plugins: []Plugin{plugin}}))
+		return buffer.Bytes()
+	}
+
+	t.Fatalf("plugin %s not found in test manifests", pluginName)
+	return nil
+}
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -180,7 +180,7 @@ func LookUpPlugin(ctx context.Context, config config.IConfig, fs afero.Fs, plugi
 		return plugin, nil
 	}
 
-	if err != nil && !os.IsNotExist(err) {
+	if !os.IsNotExist(err) {
 		log.WithFields(log.Fields{
 			"prefix": "plugins.LookUpPlugin",
 			"plugin": pluginName,

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -56,6 +56,103 @@ func getPluginsDir(config config.IConfig) string {
 	return pluginsDir
 }
 
+func getLocalPluginMetadataDir(config config.IConfig) string {
+	configPath := config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	return filepath.Join(configPath, "plugin-metadata")
+}
+
+func getLocalPluginMetadataPath(config config.IConfig, pluginName string) string {
+	return filepath.Join(getLocalPluginMetadataDir(config), pluginName+".toml")
+}
+
+// GetInstalledPluginNames returns the union of plugin names recorded in config
+// and plugin names with persisted local metadata.
+func GetInstalledPluginNames(config config.IConfig, fs afero.Fs) ([]string, error) {
+	names := make([]string, 0)
+	seen := make(map[string]struct{})
+
+	for _, pluginName := range config.GetInstalledPlugins() {
+		if pluginName == "" {
+			continue
+		}
+		if _, exists := seen[pluginName]; exists {
+			continue
+		}
+		seen[pluginName] = struct{}{}
+		names = append(names, pluginName)
+	}
+
+	localMetadataNames, err := getLocalPluginMetadataNames(config, fs)
+	if err != nil {
+		return names, err
+	}
+
+	for _, pluginName := range localMetadataNames {
+		if _, exists := seen[pluginName]; exists {
+			continue
+		}
+		seen[pluginName] = struct{}{}
+		names = append(names, pluginName)
+	}
+
+	return names, nil
+}
+
+// RecordInstalledPlugin ensures a plugin name is persisted in installed_plugins.
+func RecordInstalledPlugin(config config.IConfig, pluginName string) error {
+	if pluginName == "" {
+		return nil
+	}
+
+	installedPlugins := config.GetInstalledPlugins()
+	for _, installedPlugin := range installedPlugins {
+		if installedPlugin == pluginName {
+			return nil
+		}
+	}
+
+	installedPlugins = append(installedPlugins, pluginName)
+	return config.WriteConfigField("installed_plugins", installedPlugins)
+}
+
+// RemoveInstalledPlugin removes a plugin name from installed_plugins if present.
+func RemoveInstalledPlugin(config config.IConfig, pluginName string) error {
+	if pluginName == "" {
+		return nil
+	}
+
+	installedPlugins := config.GetInstalledPlugins()
+	updatedPlugins := make([]string, 0, len(installedPlugins))
+	removed := false
+	for _, installedPlugin := range installedPlugins {
+		if installedPlugin == pluginName {
+			removed = true
+			continue
+		}
+		updatedPlugins = append(updatedPlugins, installedPlugin)
+	}
+
+	if !removed {
+		return nil
+	}
+
+	return config.WriteConfigField("installed_plugins", updatedPlugins)
+}
+
+// PersistInstalledPluginState ensures local metadata and installed_plugins are
+// both updated for a locally installed plugin.
+func PersistInstalledPluginState(config config.IConfig, fs afero.Fs, plugin Plugin) error {
+	if plugin.Shortname == "" {
+		return nil
+	}
+
+	if err := writeLocalPluginMetadata(config, fs, plugin); err != nil {
+		return err
+	}
+
+	return RecordInstalledPlugin(config, plugin.Shortname)
+}
+
 // GetPluginList builds a list of allowed plugins to be installed and run by the CLI
 func GetPluginList(ctx context.Context, config config.IConfig, fs afero.Fs) (PluginList, error) {
 	pluginList, err := getCachedPluginList(config, fs)
@@ -78,6 +175,23 @@ func GetPluginList(ctx context.Context, config config.IConfig, fs afero.Fs) (Plu
 
 // LookUpPlugin returns the matching plugin object
 func LookUpPlugin(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
+	plugin, err := readLocalPluginMetadata(config, fs, pluginName)
+	if err == nil {
+		return plugin, nil
+	}
+
+	if err != nil && !os.IsNotExist(err) {
+		log.WithFields(log.Fields{
+			"prefix": "plugins.LookUpPlugin",
+			"plugin": pluginName,
+		}).Debugf("could not read local plugin metadata, falling back to manifest lookup: %s", err)
+	}
+
+	return LookUpPluginInManifest(ctx, config, fs, pluginName)
+}
+
+// LookUpPluginInManifest returns plugin metadata from the cached global manifest.
+func LookUpPluginInManifest(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
 	pluginList, err := GetPluginList(ctx, config, fs)
 	if err != nil {
 		return Plugin{}, err
@@ -111,7 +225,7 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 		return nil, "", err
 	}
 
-	plugin, err := LookUpPlugin(ctx, config, fs, pluginName)
+	plugin, err := LookUpPluginInManifest(ctx, config, fs, pluginName)
 	if err != nil {
 		return nil, "", err
 	}
@@ -125,6 +239,38 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 	}
 
 	return &plugin, resolvedVersion, nil
+}
+
+// ResolvePluginForUpgrade resolves plugin metadata for `stripe plugin upgrade`
+// using persisted local metadata and the cached global manifest.
+func ResolvePluginForUpgrade(config config.IConfig, fs afero.Fs, pluginName string) (*Plugin, error) {
+	var localPlugin *Plugin
+	localPluginValue, localErr := readLocalPluginMetadata(config, fs, pluginName)
+	if localErr == nil {
+		localPlugin = &localPluginValue
+	} else if !os.IsNotExist(localErr) {
+		log.WithFields(log.Fields{
+			"prefix": "plugins.ResolvePluginForUpgrade",
+			"plugin": pluginName,
+		}).Debugf("could not read local plugin metadata for upgrade: %s", localErr)
+	}
+
+	var manifestPlugin *Plugin
+	manifestPluginValue, manifestErr := lookUpPluginInCachedManifest(config, fs, pluginName)
+	if manifestErr == nil {
+		manifestPlugin = &manifestPluginValue
+	}
+
+	plugin := selectPluginForUpgrade(localPlugin, manifestPlugin)
+	if plugin != nil {
+		return plugin, nil
+	}
+
+	if localErr != nil && !os.IsNotExist(localErr) {
+		return nil, localErr
+	}
+
+	return nil, manifestErr
 }
 
 func getCachedPluginList(config config.IConfig, fs afero.Fs) (PluginList, error) {
@@ -155,9 +301,100 @@ func findPlugin(pluginList PluginList, pluginName string) (Plugin, error) {
 	return Plugin{}, fmt.Errorf("could not find a plugin named %s", pluginName)
 }
 
+func selectPluginForUpgrade(localPlugin, manifestPlugin *Plugin) *Plugin {
+	switch {
+	case localPlugin == nil:
+		return mergePluginMetadata(manifestPlugin, nil)
+	case manifestPlugin == nil:
+		return mergePluginMetadata(localPlugin, nil)
+	case comparePluginVersions(localPlugin.LookUpLatestVersion(), manifestPlugin.LookUpLatestVersion()) >= 0:
+		return mergePluginMetadata(localPlugin, manifestPlugin)
+	default:
+		return mergePluginMetadata(manifestPlugin, localPlugin)
+	}
+}
+
+func comparePluginVersions(left, right string) int {
+	switch {
+	case left == "" && right == "":
+		return 0
+	case left == "":
+		return -1
+	case right == "":
+		return 1
+	}
+
+	leftVersion, leftErr := version.NewVersion(left)
+	rightVersion, rightErr := version.NewVersion(right)
+	if leftErr == nil && rightErr == nil {
+		switch {
+		case leftVersion.GreaterThan(rightVersion):
+			return 1
+		case leftVersion.LessThan(rightVersion):
+			return -1
+		default:
+			return 0
+		}
+	}
+
+	switch {
+	case left > right:
+		return 1
+	case left < right:
+		return -1
+	default:
+		return 0
+	}
+}
+
+func mergePluginMetadata(primary, fallback *Plugin) *Plugin {
+	if primary == nil {
+		if fallback == nil {
+			return nil
+		}
+		pluginCopy := *fallback
+		return &pluginCopy
+	}
+
+	pluginCopy := *primary
+	if fallback == nil {
+		return &pluginCopy
+	}
+
+	if pluginCopy.Shortdesc == "" {
+		pluginCopy.Shortdesc = fallback.Shortdesc
+	}
+	if pluginCopy.Binary == "" {
+		pluginCopy.Binary = fallback.Binary
+	}
+	if pluginCopy.MagicCookieValue == "" {
+		pluginCopy.MagicCookieValue = fallback.MagicCookieValue
+	}
+	if len(pluginCopy.Commands) == 0 && len(fallback.Commands) > 0 {
+		pluginCopy.Commands = fallback.Commands
+	}
+
+	for i := range pluginCopy.Releases {
+		if len(pluginCopy.Releases[i].Runtime) != 0 {
+			continue
+		}
+
+		fallbackRelease := fallback.getRelease(pluginCopy.Releases[i].Version, pluginCopy.Releases[i].OS, pluginCopy.Releases[i].Arch)
+		if fallbackRelease == nil || len(fallbackRelease.Runtime) == 0 {
+			continue
+		}
+
+		pluginCopy.Releases[i].Runtime = copyRuntime(fallbackRelease.Runtime)
+	}
+
+	return &pluginCopy
+}
+
 func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, baseURL, apiKey string) (*Plugin, string, error) {
 	basePlugin := &Plugin{Shortname: pluginName}
-	if cachedPlugin, err := lookUpCachedPlugin(config, fs, pluginName); err == nil {
+	if cachedPlugin, err := readLocalPluginMetadata(config, fs, pluginName); err == nil {
+		basePlugin = &cachedPlugin
+	} else if cachedPlugin, err := lookUpPluginInCachedManifest(config, fs, pluginName); err == nil {
 		basePlugin = &cachedPlugin
 	}
 
@@ -185,13 +422,74 @@ func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs af
 	return plugin, resolvedVersion, nil
 }
 
-func lookUpCachedPlugin(config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
+func lookUpPluginInCachedManifest(config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
 	pluginList, err := getCachedPluginList(config, fs)
 	if err != nil {
 		return Plugin{}, err
 	}
 
 	return findPlugin(pluginList, pluginName)
+}
+
+func readLocalPluginMetadata(config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
+	body, err := afero.ReadFile(fs, getLocalPluginMetadataPath(config, pluginName))
+	if err != nil {
+		return Plugin{}, err
+	}
+
+	pluginList, err := validatePluginManifest(body)
+	if err != nil {
+		return Plugin{}, err
+	}
+
+	return findPlugin(*pluginList, pluginName)
+}
+
+func writeLocalPluginMetadata(config config.IConfig, fs afero.Fs, plugin Plugin) error {
+	pluginMetadataDir := getLocalPluginMetadataDir(config)
+	if err := fs.MkdirAll(pluginMetadataDir, 0755); err != nil {
+		return err
+	}
+
+	body := new(bytes.Buffer)
+	if err := toml.NewEncoder(body).Encode(PluginList{Plugins: []Plugin{plugin}}); err != nil {
+		return err
+	}
+
+	return afero.WriteFile(fs, getLocalPluginMetadataPath(config, plugin.Shortname), body.Bytes(), 0644)
+}
+
+func removeLocalPluginMetadata(config config.IConfig, fs afero.Fs, pluginName string) error {
+	err := fs.Remove(getLocalPluginMetadataPath(config, pluginName))
+	if os.IsNotExist(err) {
+		return nil
+	}
+
+	return err
+}
+
+func getLocalPluginMetadataNames(config config.IConfig, fs afero.Fs) ([]string, error) {
+	entries, err := afero.ReadDir(fs, getLocalPluginMetadataDir(config))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".toml" {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(entry.Name(), ".toml"))
+	}
+	sort.Strings(names)
+
+	return names, nil
 }
 
 // RefreshPluginManifest refreshes the plugin manifest

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -29,6 +29,12 @@ import (
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
+type installedPluginStateSnapshot struct {
+	installedPlugins []string
+	localMetadata    []byte
+	hasLocalMetadata bool
+}
+
 // GetBinaryExtension returns the appropriate file extension for plugin binary
 func GetBinaryExtension() string {
 	if runtime.GOOS == "windows" {
@@ -63,6 +69,77 @@ func getLocalPluginMetadataDir(config config.IConfig) string {
 
 func getLocalPluginMetadataPath(config config.IConfig, pluginName string) string {
 	return filepath.Join(getLocalPluginMetadataDir(config), pluginName+".toml")
+}
+
+func snapshotInstalledPluginState(config config.IConfig, fs afero.Fs, pluginName string) (installedPluginStateSnapshot, error) {
+	snapshot := installedPluginStateSnapshot{
+		installedPlugins: append([]string(nil), config.GetInstalledPlugins()...),
+	}
+
+	body, err := afero.ReadFile(fs, getLocalPluginMetadataPath(config, pluginName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return snapshot, nil
+		}
+		return installedPluginStateSnapshot{}, err
+	}
+
+	snapshot.hasLocalMetadata = true
+	snapshot.localMetadata = append([]byte(nil), body...)
+	return snapshot, nil
+}
+
+func rollbackInstalledPluginState(config config.IConfig, fs afero.Fs, pluginName string, snapshot installedPluginStateSnapshot) error {
+	rollbackErrors := make([]string, 0, 2)
+
+	if err := restoreLocalPluginMetadata(config, fs, pluginName, snapshot); err != nil {
+		rollbackErrors = append(rollbackErrors, fmt.Sprintf("restore local plugin metadata: %v", err))
+	}
+
+	if err := restoreInstalledPluginList(config, snapshot.installedPlugins); err != nil {
+		rollbackErrors = append(rollbackErrors, fmt.Sprintf("restore installed_plugins: %v", err))
+	}
+
+	if len(rollbackErrors) != 0 {
+		return errors.New(strings.Join(rollbackErrors, "; "))
+	}
+
+	return nil
+}
+
+func restoreLocalPluginMetadata(config config.IConfig, fs afero.Fs, pluginName string, snapshot installedPluginStateSnapshot) error {
+	if snapshot.hasLocalMetadata {
+		return afero.WriteFile(fs, getLocalPluginMetadataPath(config, pluginName), snapshot.localMetadata, 0644)
+	}
+
+	return removeLocalPluginMetadata(config, fs, pluginName)
+}
+
+func restoreInstalledPluginList(config config.IConfig, installedPlugins []string) error {
+	if stringSlicesEqual(config.GetInstalledPlugins(), installedPlugins) {
+		return nil
+	}
+
+	err := config.WriteConfigField("installed_plugins", installedPlugins)
+	if err != nil && !stringSlicesEqual(config.GetInstalledPlugins(), installedPlugins) {
+		return err
+	}
+
+	return nil
+}
+
+func stringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+
+	return true
 }
 
 // GetInstalledPluginNames returns the union of plugin names recorded in config
@@ -146,11 +223,26 @@ func PersistInstalledPluginState(config config.IConfig, fs afero.Fs, plugin Plug
 		return nil
 	}
 
-	if err := writeLocalPluginMetadata(config, fs, plugin); err != nil {
+	previousState, err := snapshotInstalledPluginState(config, fs, plugin.Shortname)
+	if err != nil {
 		return err
 	}
 
-	return RecordInstalledPlugin(config, plugin.Shortname)
+	if err := writeLocalPluginMetadata(config, fs, plugin); err != nil {
+		if rollbackErr := rollbackInstalledPluginState(config, fs, plugin.Shortname, previousState); rollbackErr != nil {
+			return fmt.Errorf("failed to write local plugin metadata: %w; rollback failed: %v", err, rollbackErr)
+		}
+		return err
+	}
+
+	if err := RecordInstalledPlugin(config, plugin.Shortname); err != nil {
+		if rollbackErr := rollbackInstalledPluginState(config, fs, plugin.Shortname, previousState); rollbackErr != nil {
+			return fmt.Errorf("failed to record installed plugin %s: %w; rollback failed: %v", plugin.Shortname, err, rollbackErr)
+		}
+		return err
+	}
+
+	return nil
 }
 
 // GetPluginList builds a list of allowed plugins to be installed and run by the CLI

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -58,11 +58,7 @@ func getPluginsDir(config config.IConfig) string {
 
 // GetPluginList builds a list of allowed plugins to be installed and run by the CLI
 func GetPluginList(ctx context.Context, config config.IConfig, fs afero.Fs) (PluginList, error) {
-	var pluginList PluginList
-	configPath := config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
-	pluginManifestPath := filepath.Join(configPath, "plugins.toml")
-
-	file, err := afero.ReadFile(fs, pluginManifestPath)
+	pluginList, err := getCachedPluginList(config, fs)
 	if os.IsNotExist(err) {
 		log.Debug("The plugin manifest file does not exist. Downloading...")
 		err = RefreshPluginManifest(ctx, config, fs, stripe.DefaultAPIBaseURL)
@@ -70,9 +66,73 @@ func GetPluginList(ctx context.Context, config config.IConfig, fs afero.Fs) (Plu
 			log.Debug("Could not download plugin manifest")
 			return pluginList, err
 		}
-		file, err = afero.ReadFile(fs, pluginManifestPath)
+		return getCachedPluginList(config, fs)
 	}
 
+	if err != nil {
+		return pluginList, err
+	}
+
+	return pluginList, nil
+}
+
+// LookUpPlugin returns the matching plugin object
+func LookUpPlugin(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
+	pluginList, err := GetPluginList(ctx, config, fs)
+	if err != nil {
+		return Plugin{}, err
+	}
+
+	return findPlugin(pluginList, pluginName)
+}
+
+// ResolvePluginForInstall resolves the plugin metadata needed by `stripe plugin install`
+// without requiring a manifest refresh on the metadata-backed path.
+func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, baseURL string) (*Plugin, string, error) {
+	apiKey, err := config.GetProfile().GetAPIKey(false)
+	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
+		return nil, "", err
+	}
+
+	if apiKey != "" {
+		plugin, resolvedVersion, err := resolvePluginFromMetadata(ctx, config, fs, pluginName, version, baseURL, apiKey)
+		if err == nil {
+			return plugin, resolvedVersion, nil
+		}
+
+		log.WithFields(log.Fields{
+			"prefix":  "plugins.ResolvePluginForInstall",
+			"plugin":  pluginName,
+			"version": version,
+		}).Debugf("could not resolve plugin via metadata, falling back to manifest lookup: %s", err)
+	}
+
+	if err := RefreshPluginManifest(ctx, config, fs, baseURL); err != nil {
+		return nil, "", err
+	}
+
+	plugin, err := LookUpPlugin(ctx, config, fs, pluginName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resolvedVersion := version
+	if resolvedVersion == "" {
+		resolvedVersion = plugin.LookUpLatestVersion()
+	}
+	if resolvedVersion == "" {
+		return nil, "", fmt.Errorf("could not determine latest version for plugin %s", pluginName)
+	}
+
+	return &plugin, resolvedVersion, nil
+}
+
+func getCachedPluginList(config config.IConfig, fs afero.Fs) (PluginList, error) {
+	var pluginList PluginList
+	configPath := config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	pluginManifestPath := filepath.Join(configPath, "plugins.toml")
+
+	file, err := afero.ReadFile(fs, pluginManifestPath)
 	if err != nil {
 		return pluginList, err
 	}
@@ -85,21 +145,53 @@ func GetPluginList(ctx context.Context, config config.IConfig, fs afero.Fs) (Plu
 	return pluginList, nil
 }
 
-// LookUpPlugin returns the matching plugin object
-func LookUpPlugin(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
-	var plugin Plugin
-	pluginList, err := GetPluginList(ctx, config, fs)
-	if err != nil {
-		return plugin, err
-	}
-
+func findPlugin(pluginList PluginList, pluginName string) (Plugin, error) {
 	for _, p := range pluginList.Plugins {
 		if pluginName == p.Shortname {
 			return p, nil
 		}
 	}
 
-	return plugin, fmt.Errorf("could not find a plugin named %s", pluginName)
+	return Plugin{}, fmt.Errorf("could not find a plugin named %s", pluginName)
+}
+
+func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, baseURL, apiKey string) (*Plugin, string, error) {
+	basePlugin := &Plugin{Shortname: pluginName}
+	if cachedPlugin, err := lookUpCachedPlugin(config, fs, pluginName); err == nil {
+		basePlugin = &cachedPlugin
+	}
+
+	pluginMetadata, err := requests.GetPluginMetadata(ctx, baseURL, stripe.APIVersion, apiKey, config.GetProfile(), pluginName, version, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return nil, "", err
+	}
+
+	plugin, err := basePlugin.pluginFromMetadata(pluginMetadata.PluginManifest)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resolvedVersion := version
+	if resolvedVersion == "" {
+		resolvedVersion = plugin.LookUpLatestVersion()
+	}
+	if resolvedVersion == "" {
+		return nil, "", fmt.Errorf("plugin metadata response did not include a release for %s on %s/%s", pluginName, runtime.GOOS, runtime.GOARCH)
+	}
+	if plugin.getReleaseForVersion(resolvedVersion) == nil {
+		return nil, "", fmt.Errorf("plugin metadata response did not include plugin %s version %s for %s/%s", pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
+	}
+
+	return plugin, resolvedVersion, nil
+}
+
+func lookUpCachedPlugin(config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
+	pluginList, err := getCachedPluginList(config, fs)
+	if err != nil {
+		return Plugin{}, err
+	}
+
+	return findPlugin(pluginList, pluginName)
 }
 
 // RefreshPluginManifest refreshes the plugin manifest

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -365,6 +365,32 @@ func ResolvePluginForUpgrade(config config.IConfig, fs afero.Fs, pluginName stri
 	return nil, manifestErr
 }
 
+// resolvePluginForAutoInstall resolves the freshest plugin metadata to use when
+// a command is invoked but the local plugin binary is missing.
+func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, baseURL string) (*Plugin, string, error) {
+	plugin, version, err := ResolvePluginForInstall(ctx, config, fs, pluginName, "", baseURL)
+	if err == nil {
+		return plugin, version, nil
+	}
+
+	log.WithFields(log.Fields{
+		"prefix": "plugins.resolvePluginForAutoInstall",
+		"plugin": pluginName,
+	}).Debugf("could not resolve latest plugin metadata for auto-install, falling back to cached metadata: %s", err)
+
+	plugin, cachedErr := ResolvePluginForUpgrade(config, fs, pluginName)
+	if cachedErr != nil {
+		return nil, "", fmt.Errorf("could not resolve plugin %s for auto-install: latest lookup failed: %v; cached lookup failed: %w", pluginName, err, cachedErr)
+	}
+
+	version = plugin.LookUpLatestVersion()
+	if version == "" {
+		return nil, "", fmt.Errorf("could not determine latest version for plugin %s", pluginName)
+	}
+
+	return plugin, version, nil
+}
+
 func getCachedPluginList(config config.IConfig, fs afero.Fs) (PluginList, error) {
 	var pluginList PluginList
 	configPath := config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -3,9 +3,11 @@ package plugins
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -59,6 +61,279 @@ func TestLookUpPlugin(t *testing.T) {
 	require.Equal(t, "stripe-cli-app-b", plugin.Binary)
 	require.Equal(t, "FDBE6FB9-A149-44BD-9639-4D33D8B594E8", plugin.MagicCookieValue)
 	require.Equal(t, 4, len(plugin.Releases))
+}
+
+func TestLookUpPluginUsesLocalMetadataWhenManifestMissing(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+
+	localPlugin := Plugin{
+		Shortname:        "local-plugin",
+		Binary:           "stripe-cli-local-plugin",
+		MagicCookieValue: "LOCAL-PLUGIN-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+			},
+		},
+	}
+
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	plugin, err := LookUpPlugin(context.Background(), config, fs, "local-plugin")
+	require.NoError(t, err)
+	require.Equal(t, localPlugin, plugin)
+}
+
+func TestGetInstalledPluginNamesIncludesLocalMetadata(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InstalledPlugins = []string{"projects"}
+
+	localPlugin := Plugin{
+		Shortname:        "docs",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+			},
+		},
+	}
+
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	pluginNames, err := GetInstalledPluginNames(config, fs)
+	require.NoError(t, err)
+	require.Equal(t, []string{"projects", "docs"}, pluginNames)
+}
+
+func TestRecordInstalledPlugin(t *testing.T) {
+	config := &TestConfig{}
+
+	require.NoError(t, RecordInstalledPlugin(config, "docs"))
+	require.Equal(t, []string{"docs"}, config.GetInstalledPlugins())
+
+	require.NoError(t, RecordInstalledPlugin(config, "docs"))
+	require.Equal(t, []string{"docs"}, config.GetInstalledPlugins())
+}
+
+func TestRemoveInstalledPlugin(t *testing.T) {
+	config := &TestConfig{}
+	config.InstalledPlugins = []string{"projects", "docs"}
+
+	require.NoError(t, RemoveInstalledPlugin(config, "docs"))
+	require.Equal(t, []string{"projects"}, config.GetInstalledPlugins())
+
+	require.NoError(t, RemoveInstalledPlugin(config, "docs"))
+	require.Equal(t, []string{"projects"}, config.GetInstalledPlugins())
+}
+
+func TestPersistInstalledPluginState(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	plugin := Plugin{
+		Shortname:        "docs",
+		Shortdesc:        "Docs plugin",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Commands: []CommandInfo{
+			{
+				Name: "search",
+				Desc: "Search docs",
+			},
+		},
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+			},
+		},
+	}
+
+	require.NoError(t, PersistInstalledPluginState(config, fs, plugin))
+	require.Equal(t, []string{"docs"}, config.GetInstalledPlugins())
+
+	cachedPlugin, err := readLocalPluginMetadata(config, fs, "docs")
+	require.NoError(t, err)
+	require.Equal(t, plugin, cachedPlugin)
+}
+
+func TestLookUpPluginInManifestIgnoresLocalMetadata(t *testing.T) {
+	fs := setUpFS()
+	config := &TestConfig{}
+
+	localPlugin := Plugin{
+		Shortname:        "appA",
+		Binary:           "stripe-cli-local-app-a",
+		MagicCookieValue: "LOCAL-APP-A-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "9.9.9",
+				Sum:     "abc123",
+			},
+		},
+	}
+
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	plugin, err := LookUpPluginInManifest(context.Background(), config, fs, "appA")
+	require.NoError(t, err)
+	require.Equal(t, "stripe-cli-app-a", plugin.Binary)
+	require.Equal(t, "0337A75A-C3C4-4DCF-A9EF-E7A144E5A291", plugin.MagicCookieValue)
+}
+
+func TestResolvePluginForInstallUsesLocalMetadataAsMetadataBase(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	localPlugin := Plugin{
+		Shortname:        "generate",
+		Binary:           "stripe-cli-generate",
+		MagicCookieValue: "GENERATE-COOKIE",
+		Commands: []CommandInfo{
+			{
+				Name: "create",
+				Desc: "Create generated artifacts",
+			},
+		},
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+				Runtime: map[string]string{"node": "20"},
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	metadataManifest := fmt.Sprintf(`[[Plugin]]
+  Shortname = "generate"
+  Shortdesc = "Generate things"
+  Binary = "stripe-cli-generate"
+  MagicCookieValue = "GENERATE-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "1.0.0"
+    Sum = "abc123"
+`, runtime.GOARCH, runtime.GOOS)
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "https://example.test/generate/1.0.0",
+				PluginManifest: metadataManifest,
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	plugin, version, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", stripeServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", version)
+	require.Len(t, plugin.Commands, 1)
+	require.Equal(t, "create", plugin.Commands[0].Name)
+	release := plugin.getReleaseForVersion("1.0.0")
+	require.NotNil(t, release)
+	require.Equal(t, "20", release.Runtime["node"])
+}
+
+func TestResolvePluginForUpgradeUsesLocalMetadataWhenManifestMissing(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+
+	localPlugin := Plugin{
+		Shortname:        "docs",
+		Shortdesc:        "Docs plugin",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Commands: []CommandInfo{
+			{
+				Name: "search",
+				Desc: "Search docs",
+			},
+		},
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "0.1.25",
+				Sum:     "abc123",
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	plugin, err := ResolvePluginForUpgrade(config, fs, "docs")
+	require.NoError(t, err)
+	require.Equal(t, localPlugin, *plugin)
+}
+
+func TestResolvePluginForUpgradePrefersNewerManifestVersion(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+
+	localPlugin := Plugin{
+		Shortname:        "docs",
+		Shortdesc:        "Docs plugin",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Commands: []CommandInfo{
+			{
+				Name: "search",
+				Desc: "Search docs",
+			},
+		},
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "0.1.25",
+				Sum:     "abc123",
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	manifestContent := fmt.Sprintf(`[[Plugin]]
+  Shortname = "docs"
+  Shortdesc = "Docs plugin"
+  Binary = "stripe-cli-docs"
+  MagicCookieValue = "DOCS-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "0.1.26"
+    Sum = "def456"
+`, runtime.GOARCH, runtime.GOOS)
+	require.NoError(t, afero.WriteFile(fs, "/plugins.toml", []byte(manifestContent), os.ModePerm))
+
+	plugin, err := ResolvePluginForUpgrade(config, fs, "docs")
+	require.NoError(t, err)
+	require.Equal(t, "0.1.26", plugin.LookUpLatestVersion())
+	require.Len(t, plugin.Commands, 1)
+	require.Equal(t, "search", plugin.Commands[0].Name)
 }
 
 func TestRefreshPluginManifest(t *testing.T) {

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -165,6 +166,81 @@ func TestPersistInstalledPluginState(t *testing.T) {
 	cachedPlugin, err := readLocalPluginMetadata(config, fs, "docs")
 	require.NoError(t, err)
 	require.Equal(t, plugin, cachedPlugin)
+}
+
+func TestPersistInstalledPluginStateRollsBackOnConfigWriteFailure(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &FailingWriteConfig{
+		WriteErr:                 errors.New("boom"),
+		MutateInstalledPluginsOn: true,
+	}
+	plugin := Plugin{
+		Shortname:        "docs",
+		Shortdesc:        "Docs plugin",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+			},
+		},
+	}
+
+	err := PersistInstalledPluginState(config, fs, plugin)
+	require.ErrorIs(t, err, config.WriteErr)
+
+	metadataExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "docs"))
+	require.NoError(t, err)
+	require.False(t, metadataExists)
+	require.Empty(t, config.GetInstalledPlugins())
+}
+
+func TestPersistInstalledPluginStateRestoresPreviousMetadataOnConfigWriteFailure(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &FailingWriteConfig{
+		WriteErr:                 errors.New("boom"),
+		MutateInstalledPluginsOn: true,
+	}
+	existingPlugin := Plugin{
+		Shortname:        "docs",
+		Shortdesc:        "Existing docs plugin",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+			},
+		},
+	}
+	updatedPlugin := Plugin{
+		Shortname:        "docs",
+		Shortdesc:        "Updated docs plugin",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.1.0",
+				Sum:     "def456",
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, existingPlugin))
+
+	err := PersistInstalledPluginState(config, fs, updatedPlugin)
+	require.ErrorIs(t, err, config.WriteErr)
+
+	cachedPlugin, err := readLocalPluginMetadata(config, fs, "docs")
+	require.NoError(t, err)
+	require.Equal(t, existingPlugin, cachedPlugin)
+	require.Empty(t, config.GetInstalledPlugins())
 }
 
 func TestLookUpPluginInManifestIgnoresLocalMetadata(t *testing.T) {

--- a/pkg/requests/plugin.go
+++ b/pkg/requests/plugin.go
@@ -3,6 +3,7 @@ package requests
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
@@ -14,6 +15,12 @@ import (
 type PluginData struct {
 	PluginBaseURL       string   `json:"base_url"`
 	AdditionalManifests []string `json:"additional_manifests,omitempty"`
+}
+
+// PluginMetadata contains plugin-specific manifest and binary information.
+type PluginMetadata struct {
+	BinaryURL      string `json:"binary_url"`
+	PluginManifest string `json:"plugin_manifest"`
 }
 
 // defaultPluginBaseURL is the repository where plugins are hosted.
@@ -53,7 +60,45 @@ func GetPluginData(ctx context.Context, baseURL, apiVersion, apiKey string, prof
 	}
 
 	data := PluginData{}
-	json.Unmarshal(resp, &data)
+	if err := json.Unmarshal(resp, &data); err != nil {
+		return PluginData{}, fmt.Errorf("failed to decode plugin data response: %w", err)
+	}
 
 	return data, nil
+}
+
+// GetPluginMetadata returns plugin-specific manifest and binary information.
+func GetPluginMetadata(ctx context.Context, baseURL, apiVersion, apiKey string, profile *config.Profile, pluginName, version, os, arch string) (PluginMetadata, error) {
+	if apiKey == "" {
+		return PluginMetadata{}, fmt.Errorf("plugin metadata endpoint requires an API key")
+	}
+
+	params := &RequestParameters{
+		data:    []string{},
+		version: apiVersion,
+	}
+
+	base := &Base{
+		Profile:        profile,
+		Method:         http.MethodGet,
+		SuppressOutput: true,
+		APIBaseURL:     baseURL,
+	}
+
+	resp, err := base.MakeRequest(ctx, apiKey, "/v1/stripecli/get-plugin-metadata", params, map[string]interface{}{
+		"plugin":  pluginName,
+		"version": version,
+		"os":      os,
+		"arch":    arch,
+	}, true, nil)
+	if err != nil {
+		return PluginMetadata{}, err
+	}
+
+	metadata := PluginMetadata{}
+	if err := json.Unmarshal(resp, &metadata); err != nil {
+		return PluginMetadata{}, fmt.Errorf("failed to decode plugin metadata response: %w", err)
+	}
+
+	return metadata, nil
 }


### PR DESCRIPTION
Adds a new GetPluginMetadata request that fetches plugin-specific manifest and binary URL directly, falling back to the existing GetPluginData flow when the metadata endpoint is unavailable or the user has no API key.


This is the first step to migrate to the new metadata endpoint from jfrog's plugins.toml.

We will test it out on the docs plugin, since the read plugin_metadata method is only giving access to users with the docs gate, pay-server PR here: https://git.corp.stripe.com/stripe-internal/mint/pull/2146204 


Manually tested:

<img width="1257" height="229" alt="image" src="https://github.com/user-attachments/assets/0846142a-c697-4c83-91ec-e428ad700f3b" />

if logged in to a non-gated account: 
<img width="1422" height="146" alt="Screenshot 2026-05-07 at 5 45 10 PM" src="https://github.com/user-attachments/assets/31ae45ad-fe07-4e30-85ba-7f4ca0c84dfb" />


not logged in: (the new path endpoint is not called at all)
<img width="952" height="94" alt="Screenshot 2026-05-07 at 5 47 44 PM" src="https://github.com/user-attachments/assets/8ffc3de6-e145-456c-b0fa-b85f994e62ec" />


 ### Reviewers
r? @tomer-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
