### PR TITLE
Capture plugin name in install telemetry

### DIFF
--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -72,13 +72,13 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	color := ansi.Color(os.Stdout)
+	pluginName, version := parseInstallArg(args[0])
+	ic.setInstallTelemetryMetadata(cmd.Context(), pluginName)
 
 	// Refresh the plugin before proceeding
 	if err := plugins.RefreshPluginManifest(cmd.Context(), ic.cfg, ic.fs, ic.apiBaseURL); err != nil {
 		return err
 	}
-
-	pluginName, version := parseInstallArg(args[0])
 
 	plugin, err := plugins.LookUpPlugin(cmd.Context(), ic.cfg, ic.fs, pluginName)
 	if err != nil {
@@ -127,6 +127,13 @@ func versionChangeVerb(from, to string) string {
 		return "downgraded"
 	}
 	return "upgraded"
+}
+
+func (ic *InstallCmd) setInstallTelemetryMetadata(ctx context.Context, pluginName string) {
+	telemetryMetadata := stripe.GetEventMetadata(ctx)
+	if telemetryMetadata != nil {
+		telemetryMetadata.SetPluginName(pluginName)
+	}
 }
 
 func withSIGTERMCancel(ctx context.Context, onCancel func()) context.Context {

--- a/pkg/cmd/plugin/install_test.go
+++ b/pkg/cmd/plugin/install_test.go
@@ -1,9 +1,12 @@
 package plugin
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 func TestParseArg(t *testing.T) {
@@ -16,4 +19,14 @@ func TestParseArg(t *testing.T) {
 	plugin, version = parseInstallArg("apps@2.0.1")
 	require.Equal(t, "apps", plugin)
 	require.Equal(t, "2.0.1", version)
+}
+
+func TestSetInstallTelemetryMetadata(t *testing.T) {
+	installCmd := &InstallCmd{}
+	metadata := stripe.NewEventMetadata()
+	ctx := stripe.WithEventMetadata(context.Background(), metadata)
+
+	installCmd.setInstallTelemetryMetadata(ctx, "apps")
+
+	require.Equal(t, "apps", metadata.PluginName)
 }

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -37,15 +37,16 @@ const DefaultTelemetryEndpoint = "https://r.stripe.com/0"
 
 // CLIAnalyticsEventMetadata is the structure that holds telemetry data context that is ultimately sent to the Stripe Analytics Service.
 type CLIAnalyticsEventMetadata struct {
-	InvocationID      string `url:"invocation_id"`      // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
-	UserAgent         string `url:"user_agent"`         // the application that is used to create this request
-	CommandPath       string `url:"command_path"`       // the command or gRPC method that initiated this request
-	CommandFlags      string `url:"command_flags"`      // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
-	Merchant          string `url:"merchant"`           // the merchant ID: ex. acct_xxxx
-	CLIVersion        string `url:"cli_version"`        // the version of the CLI
-	OS                string `url:"os"`                 // the OS of the system
-	GeneratedResource bool   `url:"generated_resource"` // whether or not this was a generated resource
-	AIAgent           string `url:"ai_agent,omitempty"` // the AI coding agent that invoked the CLI, if any
+	InvocationID      string `url:"invocation_id"`         // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
+	UserAgent         string `url:"user_agent"`            // the application that is used to create this request
+	CommandPath       string `url:"command_path"`          // the command or gRPC method that initiated this request
+	CommandFlags      string `url:"command_flags"`         // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
+	PluginName        string `url:"plugin_name,omitempty"` // the plugin being installed, when relevant
+	Merchant          string `url:"merchant"`              // the merchant ID: ex. acct_xxxx
+	CLIVersion        string `url:"cli_version"`           // the version of the CLI
+	OS                string `url:"os"`                    // the OS of the system
+	GeneratedResource bool   `url:"generated_resource"`    // whether or not this was a generated resource
+	AIAgent           string `url:"ai_agent,omitempty"`    // the AI coding agent that invoked the CLI, if any
 }
 
 // TelemetryClient is an interface that can send two types of events: an API request, and just general events.
@@ -141,6 +142,11 @@ func (e *CLIAnalyticsEventMetadata) SetCommandPath(commandPath string) {
 // SetCommandFlags sets the flags on the CLIAnalyticsEventContext object
 func (e *CLIAnalyticsEventMetadata) SetCommandFlags(commandFlags string) {
 	e.CommandFlags = commandFlags
+}
+
+// SetPluginName sets the plugin name on the CLIAnalyticsEventContext object
+func (e *CLIAnalyticsEventMetadata) SetPluginName(pluginName string) {
+	e.PluginName = pluginName
 }
 
 // SendAPIRequestEvent is a special function for API requests

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -83,6 +83,12 @@ func TestSetMerchant(t *testing.T) {
 	require.Equal(t, merchant, tel.Merchant)
 }
 
+func TestSetPluginName(t *testing.T) {
+	tel := stripe.NewEventMetadata()
+	tel.SetPluginName("apps")
+	require.Equal(t, "apps", tel.PluginName)
+}
+
 // AnalyticsClient Tests
 func TestSendAPIRequestEvent(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -98,6 +104,7 @@ func TestSendAPIRequestEvent(t *testing.T) {
 		require.Contains(t, bodyString, "livemode=false")
 		require.Contains(t, bodyString, "merchant=acct_1234")
 		require.Contains(t, bodyString, "os=darwin")
+		require.Contains(t, bodyString, "plugin_name=apps")
 		require.Contains(t, bodyString, "request_id=req_zzz")
 		require.Contains(t, bodyString, "user_agent=Unit+Test")
 		// ai_agent should not be present when empty (omitempty)
@@ -112,6 +119,7 @@ func TestSendAPIRequestEvent(t *testing.T) {
 		CLIVersion:        "master",
 		OS:                "darwin",
 		CommandPath:       "stripe test",
+		PluginName:        "apps",
 		Merchant:          "acct_1234",
 		GeneratedResource: false,
 	}
@@ -154,6 +162,7 @@ func TestSendEvent(t *testing.T) {
 		require.Contains(t, bodyString, "invocation_id=123456")
 		require.Contains(t, bodyString, "merchant=acct_1234")
 		require.Contains(t, bodyString, "os=darwin")
+		require.Contains(t, bodyString, "plugin_name=apps")
 		require.Contains(t, bodyString, "user_agent=Unit+Test")
 		// ai_agent should not be present when empty (omitempty)
 		require.NotContains(t, bodyString, "ai_agent")
@@ -167,6 +176,7 @@ func TestSendEvent(t *testing.T) {
 		CLIVersion:        "master",
 		OS:                "darwin",
 		CommandPath:       "stripe test",
+		PluginName:        "apps",
 		Merchant:          "acct_1234",
 		GeneratedResource: false,
 	}


### PR DESCRIPTION
## Summary
- add an optional `plugin_name` field to CLI telemetry metadata
- set `plugin_name` during `stripe plugin install <plugin>` before manifest refresh or install requests run
- cover the new field in telemetry and install command tests

## Testing
- go test ./pkg/stripe ./pkg/cmd/plugin