### PR TITLE
Re-enable test workflow on pull_request events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
-on: push
+on:
+  push:
+  pull_request:
 name: Test
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Re-adds `pull_request` trigger to the test workflow
- Fixes fork PRs being unable to satisfy required `test (1.26.0, ...)` branch protection checks

The test workflow was changed to push-only in #1560, which inadvertently broke CI for all fork/external PRs. Fork pushes only fire workflows on the fork repo, so the required checks never appear on community PRs.

This workflow doesn't use secrets, so it's safe to run on fork PRs.

## Test plan
- [x] Verify this PR itself triggers the `test (1.26.0, ...)` checks
- [ ] Verify existing fork PRs (e.g. #1549) get CI runs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)