### PR TITLE
Fix --api-key flag silently ignored when STRIPE_API_KEY env var is set

### DIFF
--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -219,6 +219,15 @@ func (p *Profile) GetAccountID() (string, error) {
 
 // GetAPIKey will return the existing key for the given profile
 func (p *Profile) GetAPIKey(livemode bool) (string, error) {
+	if p.APIKey != "" {
+		err := validators.APIKey(p.APIKey)
+		if err != nil {
+			return "", err
+		}
+
+		return p.APIKey, nil
+	}
+
 	envKey := os.Getenv("STRIPE_API_KEY")
 	if envKey != "" {
 		err := validators.APIKey(envKey)
@@ -227,15 +236,6 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 		}
 
 		return envKey, nil
-	}
-
-	if p.APIKey != "" {
-		err := validators.APIKey(p.APIKey)
-		if err != nil {
-			return "", err
-		}
-
-		return p.APIKey, nil
 	}
 
 	var key string


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
When `STRIPE_API_KEY` was set in the environment, the `--api-key` CLI flag was silently ignored. As per CLI precedence (flags should  beat env vars) and could cause commands to operate on the wrong account with no warning.

Fixes #1581 

I just changed the order in the code,no code added 😅