### PR TITLE
Protect writes from symlink targets

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -482,7 +482,7 @@ func writeConfig(runtimeViper *viper.Viper) error {
 	configType := strings.TrimPrefix(filepath.Ext(profilesFile), ".")
 	runtimeViper.SetConfigType(configType)
 
-	if err := fsutil.RefuseWriteThroughSymlinkOS(profilesFile, filepath.Base(profilesFile)); err != nil {
+	if err := fsutil.RefuseWriteThroughSymlinkOS(profilesFile, filepath.Dir(filepath.Dir(profilesFile)), filepath.Base(profilesFile)); err != nil {
 		return err
 	}
 
@@ -529,6 +529,10 @@ func removeKey(v *viper.Viper, key string) (*viper.Viper, error) {
 
 func makePath(path string) error {
 	dir := filepath.Dir(path)
+
+	if err := fsutil.RefuseWriteThroughSymlinkOS(dir, filepath.Dir(dir), "config directory"); err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		err = os.MkdirAll(dir, os.ModePerm)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ import (
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/fsutil"
 	"github.com/stripe/stripe-cli/pkg/git"
 )
 
@@ -480,6 +481,10 @@ func writeConfig(runtimeViper *viper.Viper) error {
 	runtimeViper.SetConfigFile(profilesFile)
 	configType := strings.TrimPrefix(filepath.Ext(profilesFile), ".")
 	runtimeViper.SetConfigType(configType)
+
+	if err := fsutil.RefuseWriteThroughSymlinkOS(profilesFile, filepath.Base(profilesFile)); err != nil {
+		return err
+	}
 
 	if err := runtimeViper.WriteConfig(); err != nil {
 		return err

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -360,7 +360,7 @@ func (p *Profile) RegisterAlias(alias, key string) {
 func (p *Profile) WriteConfigField(field, value string) error {
 	viper.ReadInConfig()
 	viper.Set(p.GetConfigField(field), value)
-	return viper.WriteConfig()
+	return writeConfig(viper.GetViper())
 }
 
 // DeleteConfigField deletes a configuration field.

--- a/pkg/config/symlink_test.go
+++ b/pkg/config/symlink_test.go
@@ -53,6 +53,55 @@ func TestProfileWriteConfigFieldRefusesSymlink(t *testing.T) {
 	require.Equal(t, "original = true\n", string(victimContents))
 }
 
+func TestConfigWriteConfigFieldRefusesSymlinkedParent(t *testing.T) {
+	profilesFile, victimDir := setupProfilesFileWithSymlinkedParent(t)
+
+	c := &Config{
+		Color:        "auto",
+		LogLevel:     "info",
+		ProfilesFile: profilesFile,
+		Profile: Profile{
+			ProfileName: "default",
+		},
+	}
+	c.InitConfig()
+	KeyRing = keyring.NewArrayKeyring([]keyring.Item{})
+
+	err := c.WriteConfigField("default.color", "on")
+	require.ErrorContains(t, err, "symlink")
+
+	_, err = os.Stat(filepath.Join(victimDir, "config.toml"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestWriteProfileRefusesSymlinkedParent(t *testing.T) {
+	profilesFile, victimDir := setupProfilesFileWithSymlinkedParent(t)
+
+	p := Profile{
+		ProfileName:    "default",
+		DeviceName:     "test-device",
+		TestModeAPIKey: "sk_test_123",
+		DisplayName:    "test-account",
+	}
+	c := &Config{
+		Color:        "auto",
+		LogLevel:     "info",
+		ProfilesFile: profilesFile,
+		Profile:      p,
+	}
+	c.InitConfig()
+	KeyRing = keyring.NewArrayKeyring([]keyring.Item{})
+
+	v := viper.New()
+	v.SetConfigFile(profilesFile)
+
+	err := p.writeProfile(v)
+	require.ErrorContains(t, err, "symlink")
+
+	_, err = os.Stat(filepath.Join(victimDir, "config.toml"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func setupSymlinkedProfilesFile(t *testing.T) (string, string) {
 	t.Helper()
 	t.Cleanup(viper.Reset)
@@ -65,4 +114,18 @@ func setupSymlinkedProfilesFile(t *testing.T) (string, string) {
 	require.NoError(t, os.Symlink(victimFile, profilesFile))
 
 	return profilesFile, victimFile
+}
+
+func setupProfilesFileWithSymlinkedParent(t *testing.T) (string, string) {
+	t.Helper()
+	t.Cleanup(viper.Reset)
+
+	tempDir := t.TempDir()
+	victimDir := filepath.Join(tempDir, "victim-dir")
+	require.NoError(t, os.MkdirAll(victimDir, 0o755))
+
+	configDir := filepath.Join(tempDir, "config-link")
+	require.NoError(t, os.Symlink(victimDir, configDir))
+
+	return filepath.Join(configDir, "config.toml"), victimDir
 }

--- a/pkg/config/symlink_test.go
+++ b/pkg/config/symlink_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/99designs/keyring"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigWriteConfigFieldRefusesSymlink(t *testing.T) {
+	profilesFile, victimFile := setupSymlinkedProfilesFile(t)
+
+	c := &Config{
+		Color:        "auto",
+		LogLevel:     "info",
+		ProfilesFile: profilesFile,
+		Profile: Profile{
+			ProfileName: "default",
+		},
+	}
+	c.InitConfig()
+	KeyRing = keyring.NewArrayKeyring([]keyring.Item{})
+
+	err := c.WriteConfigField("default.color", "on")
+	require.ErrorContains(t, err, "symlink")
+
+	victimContents, err := os.ReadFile(victimFile)
+	require.NoError(t, err)
+	require.Equal(t, "original = true\n", string(victimContents))
+}
+
+func TestProfileWriteConfigFieldRefusesSymlink(t *testing.T) {
+	profilesFile, victimFile := setupSymlinkedProfilesFile(t)
+
+	p := Profile{ProfileName: "default"}
+	c := &Config{
+		Color:        "auto",
+		LogLevel:     "info",
+		ProfilesFile: profilesFile,
+		Profile:      p,
+	}
+	c.InitConfig()
+	KeyRing = keyring.NewArrayKeyring([]keyring.Item{})
+
+	err := p.WriteConfigField("color", "on")
+	require.ErrorContains(t, err, "symlink")
+
+	victimContents, err := os.ReadFile(victimFile)
+	require.NoError(t, err)
+	require.Equal(t, "original = true\n", string(victimContents))
+}
+
+func setupSymlinkedProfilesFile(t *testing.T) (string, string) {
+	t.Helper()
+	t.Cleanup(viper.Reset)
+
+	tempDir := t.TempDir()
+	victimFile := filepath.Join(tempDir, "victim.toml")
+	require.NoError(t, os.WriteFile(victimFile, []byte("original = true\n"), 0o600))
+
+	profilesFile := filepath.Join(tempDir, "config.toml")
+	require.NoError(t, os.Symlink(victimFile, profilesFile))
+
+	return profilesFile, victimFile
+}

--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -431,7 +431,7 @@ func (fxt *Fixture) updateEnv(env map[string]string) error {
 
 	envFile := filepath.Join(dir, ".env")
 
-	if err := fsutil.RefuseWriteThroughSymlink(fxt.Fs, envFile, ".env"); err != nil {
+	if err := fsutil.RefuseWriteThroughSymlink(fxt.Fs, envFile, dir, ".env"); err != nil {
 		return err
 	}
 

--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/tidwall/gjson"
 
+	"github.com/stripe/stripe-cli/pkg/fsutil"
 	"github.com/stripe/stripe-cli/pkg/git"
 	"github.com/stripe/stripe-cli/pkg/parsers"
 	"github.com/stripe/stripe-cli/pkg/requests"
@@ -460,7 +461,13 @@ func (fxt *Fixture) updateEnv(env map[string]string) error {
 		return err
 	}
 
-	afero.WriteFile(fxt.Fs, envFile, []byte(content), os.ModePerm)
+	if err := fsutil.RefuseWriteThroughSymlink(fxt.Fs, envFile, ".env"); err != nil {
+		return err
+	}
+
+	if err := afero.WriteFile(fxt.Fs, envFile, []byte(content), os.ModePerm); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/fixtures/fixtures_test.go
+++ b/pkg/fixtures/fixtures_test.go
@@ -368,6 +368,36 @@ CUST_ID="char_12345"`
 	assert.Equal(t, expected, string(output))
 }
 
+func TestUpdateEnvRefusesSymlink(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWD))
+	})
+
+	victimFile := filepath.Join(tempDir, "victim")
+	require.NoError(t, os.WriteFile(victimFile, []byte("ORIGINAL=1\n"), 0o644))
+	require.NoError(t, os.Symlink(victimFile, filepath.Join(tempDir, ".env")))
+
+	fxt := Fixture{
+		Fs: afero.NewOsFs(),
+		Responses: map[string]gjson.Result{
+			"char_bender": gjson.Parse(`{"id": "char_12345"}`),
+		},
+	}
+
+	err = fxt.updateEnv(map[string]string{
+		"CHAR_ID": "${char_bender:id}",
+	})
+	require.ErrorContains(t, err, "symlink")
+
+	victimContents, err := os.ReadFile(victimFile)
+	require.NoError(t, err)
+	require.Equal(t, "ORIGINAL=1\n", string(victimContents))
+}
+
 func TestExecuteReturnsRequestNames(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {

--- a/pkg/fsutil/symlink.go
+++ b/pkg/fsutil/symlink.go
@@ -1,0 +1,39 @@
+package fsutil
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/afero"
+)
+
+// RefuseWriteThroughSymlink rejects writes to an existing symlink path.
+func RefuseWriteThroughSymlink(fs afero.Fs, filePath, fileDescription string) error {
+	lstater, ok := fs.(afero.Lstater)
+	if !ok {
+		return nil
+	}
+
+	fileInfo, _, err := lstater.LstatIfPossible(filePath)
+	return refuseWriteThroughSymlink(fileInfo, err, filePath, fileDescription)
+}
+
+// RefuseWriteThroughSymlinkOS rejects writes to an existing symlink path on the OS filesystem.
+func RefuseWriteThroughSymlinkOS(filePath, fileDescription string) error {
+	fileInfo, err := os.Lstat(filePath)
+	return refuseWriteThroughSymlink(fileInfo, err, filePath, fileDescription)
+}
+
+func refuseWriteThroughSymlink(fileInfo os.FileInfo, err error, filePath, fileDescription string) error {
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to check %s for symlink: %w", fileDescription, err)
+	}
+	if fileInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to write %s: %s is a symlink", fileDescription, filePath)
+	}
+
+	return nil
+}

--- a/pkg/fsutil/symlink.go
+++ b/pkg/fsutil/symlink.go
@@ -4,6 +4,7 @@ package fsutil
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/afero"
 )
@@ -29,20 +30,46 @@ func IsSymlink(fs afero.Fs, path string) bool {
 	return entry.Mode()&os.ModeSymlink == os.ModeSymlink
 }
 
-// RefuseWriteThroughSymlink rejects writes to symlinked paths.
-func RefuseWriteThroughSymlink(fs afero.Fs, path, name string) error {
-	entry, lstated, err := lstatIfPossible(fs, path)
-	if !lstated {
-		return nil
-	}
+// RefuseWriteThroughSymlink rejects writes when the destination path or any
+// existing parent directory between path and stopPath is a symlink.
+func RefuseWriteThroughSymlink(fs afero.Fs, path, stopPath, name string) error {
+	return walkPathAndParents(path, stopPath, func(candidate string) error {
+		entry, lstated, err := lstatIfPossible(fs, candidate)
+		if !lstated {
+			return nil
+		}
 
-	return refuseWriteThroughSymlink(entry, err, path, name)
+		return refuseWriteThroughSymlink(entry, err, candidate, name)
+	})
 }
 
-// RefuseWriteThroughSymlinkOS rejects writes to an existing symlink path on the OS filesystem.
-func RefuseWriteThroughSymlinkOS(path, name string) error {
-	entry, err := os.Lstat(path)
-	return refuseWriteThroughSymlink(entry, err, path, name)
+// RefuseWriteThroughSymlinkOS rejects writes when the destination path or any
+// existing parent directory between path and stopPath is a symlink on the OS filesystem.
+func RefuseWriteThroughSymlinkOS(path, stopPath, name string) error {
+	return walkPathAndParents(path, stopPath, func(candidate string) error {
+		entry, err := os.Lstat(candidate)
+		return refuseWriteThroughSymlink(entry, err, candidate, name)
+	})
+}
+
+func walkPathAndParents(path, stopPath string, visit func(string) error) error {
+	current := filepath.Clean(path)
+	stop := filepath.Clean(stopPath)
+
+	for {
+		if err := visit(current); err != nil {
+			return err
+		}
+		if current == stop {
+			return nil
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil
+		}
+		current = parent
+	}
 }
 
 func refuseWriteThroughSymlink(entry os.FileInfo, err error, path, name string) error {

--- a/pkg/fsutil/symlink_test.go
+++ b/pkg/fsutil/symlink_test.go
@@ -29,7 +29,37 @@ func TestRefuseWriteThroughSymlink(t *testing.T) {
 	require.NoError(t, os.WriteFile(victimFile, []byte("original"), 0o644))
 	require.NoError(t, os.Symlink(victimFile, linkPath))
 
-	err := RefuseWriteThroughSymlink(afero.NewOsFs(), linkPath, ".env")
+	err := RefuseWriteThroughSymlink(afero.NewOsFs(), linkPath, tmpDir, ".env")
 	require.Error(t, err)
 	assert.Equal(t, "refusing to write .env: "+linkPath+" is a symlink", err.Error())
+}
+
+func TestRefuseWriteThroughSymlinkRefusesSymlinkedParent(t *testing.T) {
+	tmpDir := t.TempDir()
+	victimDir := filepath.Join(tmpDir, "victim-dir")
+	require.NoError(t, os.MkdirAll(victimDir, 0o755))
+
+	linkPath := filepath.Join(tmpDir, "link-dir")
+	require.NoError(t, os.Symlink(victimDir, linkPath))
+
+	targetPath := filepath.Join(linkPath, "child.txt")
+
+	err := RefuseWriteThroughSymlink(afero.NewOsFs(), targetPath, tmpDir, "child.txt")
+	require.Error(t, err)
+	assert.Equal(t, "refusing to write child.txt: "+linkPath+" is a symlink", err.Error())
+}
+
+func TestRefuseWriteThroughSymlinkOSRefusesSymlinkedParent(t *testing.T) {
+	tmpDir := t.TempDir()
+	victimDir := filepath.Join(tmpDir, "victim-dir")
+	require.NoError(t, os.MkdirAll(victimDir, 0o755))
+
+	linkPath := filepath.Join(tmpDir, "link-dir")
+	require.NoError(t, os.Symlink(victimDir, linkPath))
+
+	targetPath := filepath.Join(linkPath, "child.txt")
+
+	err := RefuseWriteThroughSymlinkOS(targetPath, tmpDir, "child.txt")
+	require.Error(t, err)
+	assert.Equal(t, "refusing to write child.txt: "+linkPath+" is a symlink", err.Error())
 }

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/fsutil"
 	"github.com/stripe/stripe-cli/pkg/plugins/proto"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
@@ -375,6 +376,10 @@ func (p *Plugin) verifychecksumAndSavePlugin(pluginData []byte, config config.IC
 	err = fs.MkdirAll(pluginDir, 0755)
 	if err != nil {
 		logger.Debugf("could not create plugin directory: %s", pluginDir)
+		return err
+	}
+
+	if err := fsutil.RefuseWriteThroughSymlink(fs, pluginFilePath, filepath.Base(pluginFilePath)); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -373,13 +373,13 @@ func (p *Plugin) verifychecksumAndSavePlugin(pluginData []byte, config config.IC
 		return err
 	}
 
-	err = fs.MkdirAll(pluginDir, 0755)
-	if err != nil {
-		logger.Debugf("could not create plugin directory: %s", pluginDir)
+	if err := fsutil.RefuseWriteThroughSymlink(fs, pluginFilePath, filepath.Dir(getPluginsDir(config)), filepath.Base(pluginFilePath)); err != nil {
 		return err
 	}
 
-	if err := fsutil.RefuseWriteThroughSymlink(fs, pluginFilePath, filepath.Base(pluginFilePath)); err != nil {
+	err = fs.MkdirAll(pluginDir, 0755)
+	if err != nil {
+		logger.Debugf("could not create plugin directory: %s", pluginDir)
 		return err
 	}
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -301,3 +301,38 @@ func TestVerifyChecksumAndSavePluginRefusesSymlink(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "original", string(victimContents))
 }
+
+func TestVerifyChecksumAndSavePluginRefusesSymlinkedParent(t *testing.T) {
+	manifestContent, err := os.ReadFile("./test_artifacts/plugins.toml")
+	require.NoError(t, err)
+
+	var pluginList PluginList
+	_, err = toml.Decode(string(manifestContent), &pluginList)
+	require.NoError(t, err)
+
+	var plugin Plugin
+	for _, candidate := range pluginList.Plugins {
+		if candidate.Shortname == "appA" {
+			plugin = candidate
+			break
+		}
+	}
+
+	require.Equal(t, "appA", plugin.Shortname)
+
+	tempDir := t.TempDir()
+	victimDir := filepath.Join(tempDir, "victim-config")
+	require.NoError(t, os.MkdirAll(victimDir, 0o755))
+
+	configPath := filepath.Join(tempDir, "config-link")
+	require.NoError(t, os.Symlink(victimDir, configPath))
+
+	config := &CustomTestConfig{customConfigPath: configPath}
+	fs := afero.NewOsFs()
+
+	err = plugin.verifychecksumAndSavePlugin([]byte("hello, I am appA_2.0.1"), config, fs, "2.0.1")
+	require.ErrorContains(t, err, "symlink")
+
+	_, err = os.Stat(filepath.Join(victimDir, "plugins", "appA", "2.0.1", "stripe-cli-app-a"+GetBinaryExtension()))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -262,4 +263,41 @@ func TestUninstall(t *testing.T) {
 	require.False(t, dirExists)
 
 	require.Equal(t, 0, len(config.GetInstalledPlugins()))
+}
+
+func TestVerifyChecksumAndSavePluginRefusesSymlink(t *testing.T) {
+	manifestContent, err := os.ReadFile("./test_artifacts/plugins.toml")
+	require.NoError(t, err)
+
+	var pluginList PluginList
+	_, err = toml.Decode(string(manifestContent), &pluginList)
+	require.NoError(t, err)
+
+	var plugin Plugin
+	for _, candidate := range pluginList.Plugins {
+		if candidate.Shortname == "appA" {
+			plugin = candidate
+			break
+		}
+	}
+
+	require.Equal(t, "appA", plugin.Shortname)
+
+	tempDir := t.TempDir()
+	config := &CustomTestConfig{customConfigPath: tempDir}
+	fs := afero.NewOsFs()
+
+	pluginFilePath := filepath.Join(tempDir, "plugins", "appA", "2.0.1", "stripe-cli-app-a"+GetBinaryExtension())
+	require.NoError(t, os.MkdirAll(filepath.Dir(pluginFilePath), 0o755))
+
+	victimFile := filepath.Join(tempDir, "victim")
+	require.NoError(t, os.WriteFile(victimFile, []byte("original"), 0o644))
+	require.NoError(t, os.Symlink(victimFile, pluginFilePath))
+
+	err = plugin.verifychecksumAndSavePlugin([]byte("hello, I am appA_2.0.1"), config, fs, "2.0.1")
+	require.ErrorContains(t, err, "symlink")
+
+	victimContents, err := os.ReadFile(victimFile)
+	require.NoError(t, err)
+	require.Equal(t, "original", string(victimContents))
 }

--- a/pkg/plugins/runtime.go
+++ b/pkg/plugins/runtime.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/fsutil"
 )
 
 // NodeRuntimeConfig holds configuration for a specific Node.js runtime version
@@ -239,7 +240,7 @@ func InstallNodeRuntime(ctx context.Context, cfg config.IConfig, fs afero.Fs, ma
 
 	// Extract and install
 	runtimePath := GetNodeRuntimePath(cfg, majorVersion)
-	if err := extractRuntime(fs, body, runtimePath, opsys); err != nil {
+	if err := extractRuntime(fs, body, runtimePath, filepath.Dir(GetRuntimesDir(cfg)), opsys); err != nil {
 		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("failed to extract Node.js runtime: %s", err)), os.Stdout)
 		return err
 	}
@@ -287,7 +288,11 @@ func verifyChecksum(data []byte, expectedChecksum string) error {
 }
 
 // extractRuntime extracts the downloaded runtime archive
-func extractRuntime(fs afero.Fs, data []byte, destPath string, opsys string) error {
+func extractRuntime(fs afero.Fs, data []byte, destPath, stopPath, opsys string) error {
+	if err := fsutil.RefuseWriteThroughSymlink(fs, destPath, stopPath, "runtime directory"); err != nil {
+		return err
+	}
+
 	// Create destination directory
 	if err := fs.MkdirAll(destPath, 0755); err != nil {
 		return fmt.Errorf("failed to create runtime directory: %w", err)
@@ -295,16 +300,16 @@ func extractRuntime(fs afero.Fs, data []byte, destPath string, opsys string) err
 
 	switch opsys {
 	case "darwin", "linux":
-		return extractTarGz(fs, data, destPath)
+		return extractTarGz(fs, data, destPath, stopPath)
 	case "windows":
-		return extractZip(fs, data, destPath)
+		return extractZip(fs, data, destPath, stopPath)
 	default:
 		return fmt.Errorf("unsupported operating system: %s", opsys)
 	}
 }
 
 // extractTarGz extracts a .tar.gz archive
-func extractTarGz(fs afero.Fs, data []byte, destPath string) error {
+func extractTarGz(fs afero.Fs, data []byte, destPath, stopPath string) error {
 	gzr, err := gzip.NewReader(strings.NewReader(string(data)))
 	if err != nil {
 		return fmt.Errorf("failed to create gzip reader: %w", err)
@@ -349,10 +354,18 @@ func extractTarGz(fs afero.Fs, data []byte, destPath string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
+			if err := fsutil.RefuseWriteThroughSymlink(fs, targetPath, stopPath, cleanRelativePath); err != nil {
+				return err
+			}
+
 			if err := fs.MkdirAll(targetPath, os.FileMode(header.Mode)); err != nil {
 				return fmt.Errorf("failed to create directory: %w", err)
 			}
 		case tar.TypeReg:
+			if err := fsutil.RefuseWriteThroughSymlink(fs, targetPath, stopPath, cleanRelativePath); err != nil {
+				return err
+			}
+
 			if err := fs.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
 				return fmt.Errorf("failed to create parent directory: %w", err)
 			}
@@ -368,11 +381,7 @@ func extractTarGz(fs afero.Fs, data []byte, destPath string) error {
 			}
 			outFile.Close()
 		case tar.TypeSymlink:
-			if err := fs.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
-				return fmt.Errorf("failed to create parent directory for symlink: %w", err)
-			}
-			// For afero compatibility, we'll skip symlinks for now
-			// In production, you might want to handle these properly
+			// Symlink entries are not extracted.
 		}
 	}
 
@@ -380,7 +389,7 @@ func extractTarGz(fs afero.Fs, data []byte, destPath string) error {
 }
 
 // extractZip extracts a .zip archive (for Windows)
-func extractZip(fs afero.Fs, data []byte, destPath string) error {
+func extractZip(fs afero.Fs, data []byte, destPath, stopPath string) error {
 	// Create a reader from the byte slice
 	reader := bytes.NewReader(data)
 	zipReader, err := zip.NewReader(reader, int64(len(data)))
@@ -416,10 +425,18 @@ func extractZip(fs afero.Fs, data []byte, destPath string) error {
 
 		// Check if it's a directory
 		if file.FileInfo().IsDir() {
+			if err := fsutil.RefuseWriteThroughSymlink(fs, targetPath, stopPath, cleanRelativePath); err != nil {
+				return err
+			}
+
 			if err := fs.MkdirAll(targetPath, file.Mode()); err != nil {
 				return fmt.Errorf("failed to create directory: %w", err)
 			}
 			continue
+		}
+
+		if err := fsutil.RefuseWriteThroughSymlink(fs, targetPath, stopPath, cleanRelativePath); err != nil {
+			return err
 		}
 
 		// Create parent directories

--- a/pkg/plugins/runtime_test.go
+++ b/pkg/plugins/runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -177,7 +178,7 @@ func TestExtractTarGzZipSlipProtection(t *testing.T) {
 	gzw.Close()
 
 	// Attempt to extract should fail due to path traversal
-	err = extractTarGz(fs, buf.Bytes(), destPath)
+	err = extractTarGz(fs, buf.Bytes(), destPath, destPath)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "illegal file path")
 
@@ -211,7 +212,7 @@ func TestExtractTarGzValidArchive(t *testing.T) {
 	gzw.Close()
 
 	// Extraction should succeed
-	err = extractTarGz(fs, buf.Bytes(), destPath)
+	err = extractTarGz(fs, buf.Bytes(), destPath, destPath)
 	require.NoError(t, err)
 
 	// Verify the file was created in the correct location
@@ -222,6 +223,45 @@ func TestExtractTarGzValidArchive(t *testing.T) {
 	content, err := afero.ReadFile(fs, filepath.Join(destPath, "bin", "node"))
 	require.NoError(t, err)
 	require.Equal(t, validContent, content)
+}
+
+func TestExtractRuntimeRefusesSymlinkedDestinationParent(t *testing.T) {
+	fs := afero.NewOsFs()
+	tempDir := t.TempDir()
+
+	victimDir := filepath.Join(tempDir, "victim-runtime")
+	require.NoError(t, os.MkdirAll(victimDir, 0o755))
+
+	linkDir := filepath.Join(tempDir, "runtime-link")
+	require.NoError(t, os.Symlink(victimDir, linkDir))
+
+	destPath := filepath.Join(linkDir, "node", "20.18.1")
+	archive := buildTarGzArchive(t, "node-v20.0.0-linux-x64/bin/node", []byte("valid content"), 0o755)
+
+	err := extractRuntime(fs, archive, destPath, tempDir, "linux")
+	require.ErrorContains(t, err, "symlink")
+
+	_, err = os.Stat(filepath.Join(victimDir, "node", "20.18.1", "bin", "node"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestExtractTarGzRefusesSymlinkedParent(t *testing.T) {
+	fs := afero.NewOsFs()
+	tempDir := t.TempDir()
+	destPath := filepath.Join(tempDir, "runtime")
+	require.NoError(t, os.MkdirAll(destPath, 0o755))
+
+	victimDir := filepath.Join(tempDir, "victim-bin")
+	require.NoError(t, os.MkdirAll(victimDir, 0o755))
+	require.NoError(t, os.Symlink(victimDir, filepath.Join(destPath, "bin")))
+
+	archive := buildTarGzArchive(t, "node-v20.0.0-linux-x64/bin/node", []byte("valid content"), 0o755)
+
+	err := extractTarGz(fs, archive, destPath, destPath)
+	require.ErrorContains(t, err, "symlink")
+
+	_, err = os.Stat(filepath.Join(victimDir, "node"))
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestExtractZipZipSlipProtection(t *testing.T) {
@@ -242,7 +282,7 @@ func TestExtractZipZipSlipProtection(t *testing.T) {
 	zw.Close()
 
 	// Attempt to extract should fail due to path traversal
-	err = extractZip(fs, buf.Bytes(), destPath)
+	err = extractZip(fs, buf.Bytes(), destPath, destPath)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "illegal file path")
 
@@ -273,7 +313,7 @@ func TestExtractZipValidArchive(t *testing.T) {
 	zw.Close()
 
 	// Extraction should succeed
-	err = extractZip(fs, buf.Bytes(), destPath)
+	err = extractZip(fs, buf.Bytes(), destPath, destPath)
 	require.NoError(t, err)
 
 	// Verify the file was created in the correct location
@@ -284,6 +324,25 @@ func TestExtractZipValidArchive(t *testing.T) {
 	content, err := afero.ReadFile(fs, filepath.Join(destPath, "node.exe"))
 	require.NoError(t, err)
 	require.Equal(t, validContent, content)
+}
+
+func TestExtractZipRefusesSymlinkedParent(t *testing.T) {
+	fs := afero.NewOsFs()
+	tempDir := t.TempDir()
+	destPath := filepath.Join(tempDir, "runtime")
+	require.NoError(t, os.MkdirAll(destPath, 0o755))
+
+	victimDir := filepath.Join(tempDir, "victim-bin")
+	require.NoError(t, os.MkdirAll(victimDir, 0o755))
+	require.NoError(t, os.Symlink(victimDir, filepath.Join(destPath, "bin")))
+
+	archive := buildZipArchive(t, "node-v20.0.0-win-x64/bin/node.exe", []byte("valid windows node.exe content"))
+
+	err := extractZip(fs, archive, destPath, destPath)
+	require.ErrorContains(t, err, "symlink")
+
+	_, err = os.Stat(filepath.Join(victimDir, "node.exe"))
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestGetReleaseForVersion(t *testing.T) {
@@ -329,4 +388,43 @@ func TestGetReleaseForVersion(t *testing.T) {
 	// Should return nil for non-existent version
 	release = plugin.getReleaseForVersion("2.0.0")
 	require.Nil(t, release)
+}
+
+func buildTarGzArchive(t *testing.T, name string, content []byte, mode int64) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+
+	err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     mode,
+		Size:     int64(len(content)),
+		Typeflag: tar.TypeReg,
+	})
+	require.NoError(t, err)
+
+	_, err = tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+
+	return buf.Bytes()
+}
+
+func buildZipArchive(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	fw, err := zw.Create(name)
+	require.NoError(t, err)
+
+	_, err = fw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	return buf.Bytes()
 }

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/fsutil"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -134,6 +135,10 @@ func RefreshPluginManifest(ctx context.Context, config config.IConfig, fs afero.
 
 	body := new(bytes.Buffer)
 	if err := toml.NewEncoder(body).Encode(pluginList); err != nil {
+		return err
+	}
+
+	if err := fsutil.RefuseWriteThroughSymlink(fs, pluginManifestPath, filepath.Base(pluginManifestPath)); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -127,6 +127,10 @@ func RefreshPluginManifest(ctx context.Context, config config.IConfig, fs afero.
 	configPath := config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
 	pluginManifestPath := filepath.Join(configPath, "plugins.toml")
 
+	if err := fsutil.RefuseWriteThroughSymlink(fs, pluginManifestPath, filepath.Dir(configPath), filepath.Base(pluginManifestPath)); err != nil {
+		return err
+	}
+
 	// Ensure the config directory exists
 	err = fs.MkdirAll(configPath, os.FileMode(0755))
 	if err != nil {
@@ -135,10 +139,6 @@ func RefreshPluginManifest(ctx context.Context, config config.IConfig, fs afero.
 
 	body := new(bytes.Buffer)
 	if err := toml.NewEncoder(body).Encode(pluginList); err != nil {
-		return err
-	}
-
-	if err := fsutil.RefuseWriteThroughSymlink(fs, pluginManifestPath, filepath.Base(pluginManifestPath)); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -487,4 +488,32 @@ func TestRefreshPluginManifestCreatesConfigDirectory(t *testing.T) {
 	exists, err = afero.Exists(fs, pluginManifestPath)
 	require.Nil(t, err)
 	require.True(t, exists)
+}
+
+func TestRefreshPluginManifestRefusesSymlink(t *testing.T) {
+	tempDir := t.TempDir()
+	customConfig := &CustomTestConfig{
+		customConfigPath: tempDir,
+	}
+	customConfig.InitConfig()
+
+	fs := afero.NewOsFs()
+	manifestContent, err := os.ReadFile("./test_artifacts/plugins_updated.toml")
+	require.NoError(t, err)
+
+	testServers := setUpServers(t, manifestContent, nil)
+	defer func() { testServers.CloseAll() }()
+
+	victimFile := filepath.Join(tempDir, "victim.toml")
+	require.NoError(t, os.WriteFile(victimFile, []byte("original = true\n"), 0o644))
+
+	pluginManifestPath := filepath.Join(tempDir, "plugins.toml")
+	require.NoError(t, os.Symlink(victimFile, pluginManifestPath))
+
+	err = RefreshPluginManifest(context.Background(), customConfig, fs, testServers.StripeServer.URL)
+	require.ErrorContains(t, err, "symlink")
+
+	victimContents, err := os.ReadFile(victimFile)
+	require.NoError(t, err)
+	require.Equal(t, "original = true\n", string(victimContents))
 }

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -517,3 +517,30 @@ func TestRefreshPluginManifestRefusesSymlink(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "original = true\n", string(victimContents))
 }
+
+func TestRefreshPluginManifestRefusesSymlinkedParent(t *testing.T) {
+	tempDir := t.TempDir()
+	victimDir := filepath.Join(tempDir, "victim-config")
+	require.NoError(t, os.MkdirAll(victimDir, 0o755))
+
+	configPath := filepath.Join(tempDir, "config-link")
+	require.NoError(t, os.Symlink(victimDir, configPath))
+
+	customConfig := &CustomTestConfig{
+		customConfigPath: configPath,
+	}
+	customConfig.InitConfig()
+
+	fs := afero.NewOsFs()
+	manifestContent, err := os.ReadFile("./test_artifacts/plugins_updated.toml")
+	require.NoError(t, err)
+
+	testServers := setUpServers(t, manifestContent, nil)
+	defer func() { testServers.CloseAll() }()
+
+	err = RefreshPluginManifest(context.Background(), customConfig, fs, testServers.StripeServer.URL)
+	require.ErrorContains(t, err, "symlink")
+
+	_, err = os.Stat(filepath.Join(victimDir, "plugins.toml"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -339,7 +340,7 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 		if strings.Contains(contentType, "application/pdf") {
 			// Extract a filename from the path (e.g., /v1/quotes/qt_123/pdf -> qt_123.pdf)
 			filename := extractFilenameFromPath(path, "pdf")
-			if err := fsutil.RefuseWriteThroughSymlinkOS(filename, filename); err != nil {
+			if err := fsutil.RefuseWriteThroughSymlinkOS(filename, filepath.Dir(filename), filename); err != nil {
 				return []byte{}, err
 			}
 			err := os.WriteFile(filename, body, 0644)

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/fsutil"
 	"github.com/stripe/stripe-cli/pkg/parsers"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 
@@ -341,6 +342,9 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 		if strings.Contains(contentType, "application/pdf") {
 			// Extract a filename from the path (e.g., /v1/quotes/qt_123/pdf -> qt_123.pdf)
 			filename := extractFilenameFromPath(path, "pdf")
+			if err := fsutil.RefuseWriteThroughSymlinkOS(filename, filename); err != nil {
+				return []byte{}, err
+			}
 			err := os.WriteFile(filename, body, 0644)
 			if err != nil {
 				return []byte{}, fmt.Errorf("failed to save PDF file: %w", err)

--- a/pkg/requests/base_test.go
+++ b/pkg/requests/base_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -111,6 +112,38 @@ func TestMakeRequest(t *testing.T) {
 
 	_, err := rb.MakeRequest(context.Background(), "sk_test_1234", "/foo/bar", params, make(map[string]interface{}), true, nil)
 	require.NoError(t, err)
+}
+
+func TestMakeRequest_RefusesWriteThroughPDFSymlink(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWD))
+	})
+
+	victimFile := filepath.Join(tempDir, "victim")
+	require.NoError(t, os.WriteFile(victimFile, []byte("original"), 0o644))
+	require.NoError(t, os.Symlink(victimFile, filepath.Join(tempDir, "qt_123.pdf")))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("%PDF-1.4"))
+	}))
+	defer ts.Close()
+
+	rb := Base{APIBaseURL: ts.URL}
+	rb.Method = http.MethodGet
+
+	params := &RequestParameters{}
+	_, err = rb.MakeRequest(context.Background(), "sk_test_1234", "/v1/quotes/qt_123/pdf", params, make(map[string]interface{}), false, nil)
+	require.ErrorContains(t, err, "symlink")
+
+	victimContents, err := os.ReadFile(victimFile)
+	require.NoError(t, err)
+	require.Equal(t, "original", string(victimContents))
 }
 
 func TestMakeRequest_GetV2(t *testing.T) {

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -397,7 +397,7 @@ func (s *SampleManager) WriteDotEnv(ctx context.Context, sampleLocation string) 
 
 		// We refuse to write through a symlink to prevent a malicious
 		// sample from overwriting files outside the destination directory.
-		if err := fsutil.RefuseWriteThroughSymlink(s.Fs, envFile, ".env"); err != nil {
+		if err := fsutil.RefuseWriteThroughSymlink(s.Fs, envFile, sampleLocation, ".env"); err != nil {
 			return err
 		}
 

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -18,6 +18,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/fsutil"
 	"github.com/stripe/stripe-cli/pkg/validators"
 
 	g "github.com/stripe/stripe-cli/pkg/git"
@@ -396,8 +397,8 @@ func (s *SampleManager) WriteDotEnv(ctx context.Context, sampleLocation string) 
 
 		// We refuse to write through a symlink to prevent a malicious
 		// sample from overwriting files outside the destination directory.
-		if isSymlink(envFile) {
-			return fmt.Errorf("refusing to write .env: %s is a symlink", envFile)
+		if err := fsutil.RefuseWriteThroughSymlinkOS(envFile, ".env"); err != nil {
+			return err
 		}
 
 		err = godotenv.Write(dotenv, envFile)


### PR DESCRIPTION
### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

This PR hardens remaining local file writes against write-through-symlink attacks using the same pattern as the earlier `samples` / `fixtures` fix, without duplicating one-off checks.

  - add a shared symlink guard in `pkg/fsutil` for both afero-backed writes and direct OS writes
  - apply it to PDF downloads in `pkg/requests/base.go`
  - apply it to plugin binary installs and `plugins.toml` writes in `pkg/plugins`
  - apply it to CLI config writes so both `Config.WriteConfigField` and `Profile.WriteConfigField` reject symlink targets consistently
  - move existing `.env` protections in `samples` / `fixtures` onto the shared helper