### PR TITLE
Support unauthenticated plugin lookup for install and upgrade

### DIFF
--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -75,10 +75,12 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	pluginName, version := parseInstallArg(args[0])
 	ic.setInstallTelemetryMetadata(cmd.Context(), pluginName)
 	isLatest := len(version) == 0
-	plugin, version, err := plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL)
+	resolvedPlugin, err := plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL)
 	if err != nil {
 		return err
 	}
+	plugin := resolvedPlugin.Plugin
+	version = resolvedPlugin.Version
 
 	if plugin.IsVersionInstalled(ic.cfg, ic.fs, version) {
 		if err := plugins.PersistInstalledPluginState(ic.cfg, ic.fs, *plugin); err != nil {
@@ -100,7 +102,7 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
-	if err := plugin.Install(ctx, ic.cfg, ic.fs, version, ic.apiBaseURL); err != nil {
+	if err := resolvedPlugin.Install(ctx, ic.cfg, ic.fs, ic.apiBaseURL); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/plugin/upgrade.go
+++ b/pkg/cmd/plugin/upgrade.go
@@ -56,19 +56,12 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
-	// Refresh the plugin info before proceeding
-	refreshErr := plugins.RefreshPluginManifest(cmd.Context(), uc.cfg, uc.fs, uc.apiBaseURL)
-	if refreshErr != nil {
-		log.Debug(refreshErr)
-		fmt.Println("Unable to refresh plugin manifest, continuing with cached plugin metadata or manifest...")
-	}
-
-	plugin, err := plugins.ResolvePluginForUpgrade(uc.cfg, uc.fs, args[0])
+	resolvedPlugin, err := plugins.ResolvePluginForUpgrade(ctx, uc.cfg, uc.fs, args[0], uc.apiBaseURL)
 	if err != nil {
 		return err
 	}
-
-	version := plugin.LookUpLatestVersion()
+	plugin := resolvedPlugin.Plugin
+	version := resolvedPlugin.Version
 
 	color := ansi.Color(os.Stdout)
 
@@ -82,7 +75,7 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 
 	prevVersion := plugin.InstalledVersion(uc.cfg, uc.fs)
 
-	if err := plugin.Install(ctx, uc.cfg, uc.fs, version, uc.apiBaseURL); err != nil {
+	if err := resolvedPlugin.Install(ctx, uc.cfg, uc.fs, uc.apiBaseURL); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -292,19 +292,28 @@ func (p *Plugin) InstalledVersion(config config.IConfig, fs afero.Fs) string {
 	return ""
 }
 
-// Install installs the plugin of the given version
+// Install installs the plugin of the given version.
 func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, baseURL string) error {
+	return p.install(ctx, cfg, fs, version, baseURL, "", false)
+}
+
+func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, baseURL, resolvedBinaryURL string, skipMetadataLookup bool) error {
 	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)
 
 	apiKey, _ := cfg.GetProfile().GetAPIKey(false)
 	pluginToInstall := p
-	var pluginDownloadURL string
-	downloadURLFromMetadata := false
+	pluginDownloadURL := resolvedBinaryURL
+	downloadURLFromMetadata := resolvedBinaryURL != ""
 
-	if apiKey != "" {
+	if !skipMetadataLookup {
+		metadataEndpoint := "/v1/stripecli/get-plugin-metadata"
+		if apiKey == "" {
+			metadataEndpoint = "/v1/stripecli/plugins_metadata"
+		}
+
 		log.WithFields(log.Fields{
 			"prefix":   "plugins.plugin.Install",
-			"endpoint": "/v1/stripecli/get-plugin-metadata",
+			"endpoint": metadataEndpoint,
 			"plugin":   p.Shortname,
 			"version":  version,
 			"os":       runtime.GOOS,
@@ -356,7 +365,8 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	}
 
 	// Pull down bin, verify, and save to disk
-	err := pluginToInstall.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version)
+	var err error
+	err = pluginToInstall.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version)
 	if err != nil && downloadURLFromMetadata {
 		log.WithFields(log.Fields{
 			"prefix": "plugins.plugin.Install",
@@ -587,15 +597,14 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 		// before reinstalling so stale cached local metadata does not pin us to an
 		// older release.
 		if version == "" {
-			pluginToInstall, resolvedVersion, err := resolvePluginForAutoInstall(ctx, config, fs, p.Shortname, stripe.DefaultAPIBaseURL)
+			resolvedPlugin, err := resolvePluginForAutoInstall(ctx, config, fs, p.Shortname, stripe.DefaultAPIBaseURL)
 			if err != nil {
 				return err
 			}
 
-			p = pluginToInstall
-			version = resolvedVersion
-			err = p.Install(ctx, config, fs, version, stripe.DefaultAPIBaseURL)
-			if err != nil {
+			p = resolvedPlugin.Plugin
+			version = resolvedPlugin.Version
+			if err := resolvedPlugin.Install(ctx, config, fs, stripe.DefaultAPIBaseURL); err != nil {
 				return err
 			}
 		}

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -526,21 +527,53 @@ func TestResolvedPluginInstallUsesResolvedMetadataWithoutSecondLookup(t *testing
 	require.Equal(t, 1, metadataLookups)
 }
 
-func TestResolvedPluginInstallDoesNotRetryMetadataAfterManifestFallback(t *testing.T) {
+func TestResolvedPluginInstallRetriesMetadataAfterManifestFallback(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
 	config.InitConfig()
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	binaryBody := []byte("hello, I am generate_1.0.0")
+	binarySum := fmt.Sprintf("%x", sha256.Sum256(binaryBody))
+	manifestContent := []byte(fmt.Sprintf(`[[Plugin]]
+  Shortname = "generate"
+  Shortdesc = "Generate things"
+  Binary = "stripe-cli-generate"
+  MagicCookieValue = "GENERATE-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "1.0.0"
+    Sum = "%s"
+`, runtime.GOARCH, runtime.GOOS, binarySum))
+
+	metadataManifest := fmt.Sprintf(`[[Plugin]]
+  Shortname = "generate"
+  Shortdesc = "Generate things"
+  Binary = "stripe-cli-generate"
+  MagicCookieValue = "GENERATE-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "1.0.0"
+    Sum = "%s"
+    Runtime = {node = "20"}
+`, runtime.GOARCH, runtime.GOOS, binarySum)
 
 	var metadataLookups int
 	var pluginURLLookups int
+
+	nodeBinaryPath := GetNodeBinaryPath(config, "20")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(nodeBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, nodeBinaryPath, []byte("node"), 0755))
 
 	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
 		case "/plugins.toml":
 			res.Write(manifestContent)
-		case fmt.Sprintf("/appA/2.0.1/%s/%s/stripe-cli-app-a", runtime.GOOS, runtime.GOARCH):
-			res.Write([]byte("hello, I am appA_2.0.1"))
+		case fmt.Sprintf("/generate/1.0.0/%s/%s/stripe-cli-generate", runtime.GOOS, runtime.GOARCH):
+			res.Write(binaryBody)
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -551,8 +584,18 @@ func TestResolvedPluginInstallDoesNotRetryMetadataAfterManifestFallback(t *testi
 		switch req.URL.Path {
 		case "/v1/stripecli/get-plugin-metadata":
 			metadataLookups++
-			res.WriteHeader(http.StatusInternalServerError)
-			_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
+			if metadataLookups == 1 {
+				res.WriteHeader(http.StatusInternalServerError)
+				_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
+				return
+			}
+
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      fmt.Sprintf("%s/generate/1.0.0/%s/%s/stripe-cli-generate", artifactoryServer.URL, runtime.GOOS, runtime.GOARCH),
+				PluginManifest: metadataManifest,
+			})
+			require.NoError(t, err)
+			res.Write(body)
 		case "/v1/stripecli/get-plugin-url":
 			pluginURLLookups++
 			body, err := json.Marshal(requests.PluginData{
@@ -567,15 +610,21 @@ func TestResolvedPluginInstallDoesNotRetryMetadataAfterManifestFallback(t *testi
 	}))
 	defer stripeServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", stripeServer.URL)
 	require.NoError(t, err)
 	require.Equal(t, 1, metadataLookups)
 	require.Equal(t, 1, pluginURLLookups)
 
 	err = resolvedPlugin.Install(context.Background(), config, fs, stripeServer.URL)
 	require.NoError(t, err)
-	require.Equal(t, 1, metadataLookups)
-	require.Equal(t, 2, pluginURLLookups)
+	require.Equal(t, 2, metadataLookups)
+	require.Equal(t, 1, pluginURLLookups)
+
+	cachedPlugin, err := readLocalPluginMetadata(config, fs, "generate")
+	require.NoError(t, err)
+	release := cachedPlugin.getReleaseForVersion("1.0.0")
+	require.NotNil(t, release)
+	require.Equal(t, "20", release.Runtime["node"])
 }
 
 func TestResolvePluginForAutoInstallPrefersFreshMetadataWhenLocalMetadataIsStale(t *testing.T) {

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -125,6 +125,55 @@ func TestInstallUsesPluginMetadataEndpointWhenAPIKeyAvailable(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestInstallUsesAnonymousPluginMetadataEndpointWhenAPIKeyUnavailable(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.Profile.APIKey = ""
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch {
+		case strings.Contains(req.URL.String(), "/appA/2.0.1"):
+			res.Write([]byte("hello, I am appA_2.0.1"))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer artifactoryServer.Close()
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/plugins_metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      fmt.Sprintf("%s/appA/2.0.1/%s/%s/stripe-cli-app-a", artifactoryServer.URL, runtime.GOOS, runtime.GOARCH),
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-url":
+			t.Fatalf("install should not fall back to /v1/stripecli/get-plugin-url when anonymous plugin metadata is available")
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	plugin := &Plugin{Shortname: "appA"}
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL)
+	require.NoError(t, err)
+
+	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
+	fileExists, err := afero.Exists(fs, file)
+	require.NoError(t, err)
+	require.True(t, fileExists)
+
+	cachedPlugin, err := readLocalPluginMetadata(config, fs, "appA")
+	require.NoError(t, err)
+	require.Equal(t, "stripe-cli-app-a", cachedPlugin.Binary)
+	require.Equal(t, []string{"appA"}, config.GetInstalledPlugins())
+}
+
 func TestInstallFallsBackIfPluginMetadataEndpointFails(t *testing.T) {
 	fs := setUpFS()
 	config := &TestConfig{}
@@ -341,11 +390,14 @@ func TestResolvePluginForInstallUsesMetadataWithoutCachedManifest(t *testing.T) 
 	}))
 	defer stripeServer.Close()
 
-	plugin, version, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL)
 	require.NoError(t, err)
+	plugin := resolvedPlugin.Plugin
+	version := resolvedPlugin.Version
 	require.NotNil(t, plugin)
 	require.Equal(t, "appA", plugin.Shortname)
 	require.Equal(t, "2.0.1", version)
+	require.Equal(t, "https://example.test/appA/2.0.1", resolvedPlugin.BinaryURL)
 	require.Equal(t, 1, metadataLookups)
 
 	_, err = fs.Stat("/plugins.toml")
@@ -378,10 +430,13 @@ func TestResolvePluginForInstallResolvesLatestVersionFromMetadata(t *testing.T) 
 	}))
 	defer stripeServer.Close()
 
-	plugin, version, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "", stripeServer.URL)
 	require.NoError(t, err)
+	plugin := resolvedPlugin.Plugin
+	version := resolvedPlugin.Version
 	require.NotNil(t, plugin)
 	require.Equal(t, "2.0.1", version)
+	require.Equal(t, "https://example.test/appA/latest", resolvedPlugin.BinaryURL)
 	require.Equal(t, 1, metadataLookups)
 }
 
@@ -413,15 +468,114 @@ func TestResolvePluginForInstallFallsBackToManifestLookupWhenMetadataFails(t *te
 	}))
 	defer fallbackServer.Close()
 
-	plugin, version, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", fallbackServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", fallbackServer.URL)
 	require.NoError(t, err)
+	plugin := resolvedPlugin.Plugin
+	version := resolvedPlugin.Version
 	require.NotNil(t, plugin)
 	require.Equal(t, "appA", plugin.Shortname)
 	require.Equal(t, "2.0.1", version)
+	require.Empty(t, resolvedPlugin.BinaryURL)
 	require.Equal(t, 1, pluginURLLookups)
 
 	_, err = fs.Stat("/plugins.toml")
 	require.NoError(t, err)
+}
+
+func TestResolvedPluginInstallUsesResolvedMetadataWithoutSecondLookup(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	var metadataLookups int
+	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch {
+		case strings.Contains(req.URL.String(), "/appA/2.0.1"):
+			res.Write([]byte("hello, I am appA_2.0.1"))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer artifactoryServer.Close()
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			metadataLookups++
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      fmt.Sprintf("%s/appA/2.0.1/%s/%s/stripe-cli-app-a", artifactoryServer.URL, runtime.GOOS, runtime.GOARCH),
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-url":
+			t.Fatalf("resolved install should not fall back to /v1/stripecli/get-plugin-url when metadata is available")
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, 1, metadataLookups)
+
+	err = resolvedPlugin.Install(context.Background(), config, fs, stripeServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, 1, metadataLookups)
+}
+
+func TestResolvedPluginInstallDoesNotRetryMetadataAfterManifestFallback(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	var metadataLookups int
+	var pluginURLLookups int
+
+	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/plugins.toml":
+			res.Write(manifestContent)
+		case fmt.Sprintf("/appA/2.0.1/%s/%s/stripe-cli-app-a", runtime.GOOS, runtime.GOARCH):
+			res.Write([]byte("hello, I am appA_2.0.1"))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer artifactoryServer.Close()
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			metadataLookups++
+			res.WriteHeader(http.StatusInternalServerError)
+			_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
+		case "/v1/stripecli/get-plugin-url":
+			pluginURLLookups++
+			body, err := json.Marshal(requests.PluginData{
+				PluginBaseURL:       artifactoryServer.URL,
+				AdditionalManifests: nil,
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, 1, metadataLookups)
+	require.Equal(t, 1, pluginURLLookups)
+
+	err = resolvedPlugin.Install(context.Background(), config, fs, stripeServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, 1, metadataLookups)
+	require.Equal(t, 2, pluginURLLookups)
 }
 
 func TestResolvePluginForAutoInstallPrefersFreshMetadataWhenLocalMetadataIsStale(t *testing.T) {
@@ -448,8 +602,10 @@ func TestResolvePluginForAutoInstallPrefersFreshMetadataWhenLocalMetadataIsStale
 	testServers := setUpServers(t, manifestContent, nil)
 	defer testServers.CloseAll()
 
-	plugin, version, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", testServers.StripeServer.URL)
+	resolvedPlugin, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", testServers.StripeServer.URL)
 	require.NoError(t, err)
+	plugin := resolvedPlugin.Plugin
+	version := resolvedPlugin.Version
 	require.NotNil(t, plugin)
 	require.Equal(t, "2.0.1", version)
 	require.Equal(t, "2.0.1", plugin.LookUpLatestVersion())
@@ -484,8 +640,10 @@ func TestResolvePluginForAutoInstallFallsBackToCachedManifestWhenFreshLookupFail
 	}))
 	defer failingServer.Close()
 
-	plugin, version, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", failingServer.URL)
+	resolvedPlugin, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", failingServer.URL)
 	require.NoError(t, err)
+	plugin := resolvedPlugin.Plugin
+	version := resolvedPlugin.Version
 	require.NotNil(t, plugin)
 	require.Equal(t, "2.0.1", version)
 	require.Equal(t, "2.0.1", plugin.LookUpLatestVersion())

--- a/pkg/plugins/test_utils.go
+++ b/pkg/plugins/test_utils.go
@@ -127,17 +127,13 @@ func setUpServers(t *testing.T, manifestContent []byte, additionalManifests map[
 				t.Error(err)
 			}
 			res.Write(body)
-		case "/v1/stripecli/get-plugin-metadata":
+		case "/v1/stripecli/get-plugin-metadata", "/v1/stripecli/plugins_metadata":
 			pluginName := req.URL.Query().Get("plugin")
 			version := req.URL.Query().Get("version")
 			opsystem := req.URL.Query().Get("os")
 			arch := req.URL.Query().Get("arch")
 
-			pluginManifest := singlePluginManifest(t, pluginName, manifestContent, additionalManifests)
-			pd := requests.PluginMetadata{
-				BinaryURL:      artifactoryServer.URL + "/" + pluginName + "/" + version + "/" + opsystem + "/" + arch + "/stripe-cli-" + strings.ReplaceAll(pluginName, "_", "-"),
-				PluginManifest: string(pluginManifest),
-			}
+			pd := buildPluginMetadataResponse(t, artifactoryServer.URL, pluginName, version, opsystem, arch, manifestContent, additionalManifests)
 			body, err := json.Marshal(pd)
 			if err != nil {
 				t.Error(err)
@@ -151,6 +147,34 @@ func setUpServers(t *testing.T, manifestContent []byte, additionalManifests map[
 	return TestServers{
 		ArtifactoryServer: artifactoryServer,
 		StripeServer:      stripeServer,
+	}
+}
+
+func buildPluginMetadataResponse(t *testing.T, artifactoryBaseURL, pluginName, version, opsystem, arch string, manifestContent []byte, additionalManifests map[string][]byte) requests.PluginMetadata {
+	t.Helper()
+
+	pluginManifest := singlePluginManifest(t, pluginName, manifestContent, additionalManifests)
+	resolvedVersion := version
+	if resolvedVersion == "" {
+		pluginList, err := validatePluginManifest(pluginManifest)
+		requireNoError(t, err)
+
+		plugin, err := findPlugin(*pluginList, pluginName)
+		requireNoError(t, err)
+
+		for _, release := range plugin.Releases {
+			if release.OS == opsystem && release.Arch == arch {
+				resolvedVersion = release.Version
+			}
+		}
+		if resolvedVersion == "" {
+			t.Fatalf("plugin %s did not contain a release for %s/%s", pluginName, opsystem, arch)
+		}
+	}
+
+	return requests.PluginMetadata{
+		BinaryURL:      artifactoryBaseURL + "/" + pluginName + "/" + resolvedVersion + "/" + opsystem + "/" + arch + "/stripe-cli-" + strings.ReplaceAll(pluginName, "_", "-"),
+		PluginManifest: string(pluginManifest),
 	}
 }
 

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -36,6 +36,29 @@ type installedPluginStateSnapshot struct {
 	hasLocalMetadata bool
 }
 
+// ResolvedPluginVersion contains the resolved plugin metadata needed to
+// install a specific plugin version without re-querying the metadata endpoint.
+type ResolvedPluginVersion struct {
+	Plugin    *Plugin
+	Version   string
+	BinaryURL string
+}
+
+// Install installs the resolved plugin version using the already-resolved
+// plugin metadata and binary URL when available.
+func (r *ResolvedPluginVersion) Install(ctx context.Context, config config.IConfig, fs afero.Fs, baseURL string) error {
+	switch {
+	case r == nil:
+		return errors.New("missing resolved plugin version")
+	case r.Plugin == nil:
+		return errors.New("missing plugin metadata")
+	case r.Version == "":
+		return errors.New("missing plugin version")
+	default:
+		return r.Plugin.install(ctx, config, fs, r.Version, baseURL, r.BinaryURL, true)
+	}
+}
+
 // GetBinaryExtension returns the appropriate file extension for plugin binary
 func GetBinaryExtension() string {
 	if runtime.GOOS == "windows" {
@@ -295,48 +318,96 @@ func LookUpPluginInManifest(ctx context.Context, config config.IConfig, fs afero
 
 // ResolvePluginForInstall resolves the plugin metadata needed by `stripe plugin install`
 // without requiring a manifest refresh on the metadata-backed path.
-func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, baseURL string) (*Plugin, string, error) {
+func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, baseURL string) (*ResolvedPluginVersion, error) {
 	apiKey, err := config.GetProfile().GetAPIKey(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
-		return nil, "", err
+		return nil, err
 	}
 
-	if apiKey != "" {
-		plugin, resolvedVersion, err := resolvePluginFromMetadata(ctx, config, fs, pluginName, version, baseURL, apiKey)
-		if err == nil {
-			return plugin, resolvedVersion, nil
-		}
-
-		log.WithFields(log.Fields{
-			"prefix":  "plugins.ResolvePluginForInstall",
-			"plugin":  pluginName,
-			"version": version,
-		}).Debugf("could not resolve plugin via metadata, falling back to manifest lookup: %s", err)
+	resolvedPlugin, err := resolvePluginFromMetadata(ctx, config, fs, pluginName, version, baseURL, apiKey)
+	if err == nil {
+		return resolvedPlugin, nil
 	}
+
+	log.WithFields(log.Fields{
+		"prefix":  "plugins.ResolvePluginForInstall",
+		"plugin":  pluginName,
+		"version": version,
+	}).Debugf("could not resolve plugin via plugin metadata endpoint, falling back to manifest lookup: %s", err)
 
 	if err := RefreshPluginManifest(ctx, config, fs, baseURL); err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	plugin, err := LookUpPluginInManifest(ctx, config, fs, pluginName)
+	manifestPlugin, err := LookUpPluginInManifest(ctx, config, fs, pluginName)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	resolvedVersion := version
-	if resolvedVersion == "" {
-		resolvedVersion = plugin.LookUpLatestVersion()
+	manifestVersion := version
+	if manifestVersion == "" {
+		manifestVersion = manifestPlugin.LookUpLatestVersion()
 	}
-	if resolvedVersion == "" {
-		return nil, "", fmt.Errorf("could not determine latest version for plugin %s", pluginName)
+	if manifestVersion == "" {
+		return nil, fmt.Errorf("could not determine latest version for plugin %s", pluginName)
 	}
 
-	return &plugin, resolvedVersion, nil
+	return &ResolvedPluginVersion{
+		Plugin:  &manifestPlugin,
+		Version: manifestVersion,
+	}, nil
 }
 
-// ResolvePluginForUpgrade resolves plugin metadata for `stripe plugin upgrade`
-// using persisted local metadata and the cached global manifest.
-func ResolvePluginForUpgrade(config config.IConfig, fs afero.Fs, pluginName string) (*Plugin, error) {
+// ResolvePluginForUpgrade resolves the latest plugin metadata for
+// `stripe plugin upgrade` using the plugin metadata endpoint first and cached
+// local metadata or the global manifest as fallback.
+func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, baseURL string) (*ResolvedPluginVersion, error) {
+	apiKey, err := config.GetProfile().GetAPIKey(false)
+	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
+		return nil, err
+	}
+
+	resolvedPlugin, endpointErr := resolvePluginFromMetadata(ctx, config, fs, pluginName, "", baseURL, apiKey)
+	if endpointErr == nil {
+		return resolvedPlugin, nil
+	}
+
+	log.WithFields(log.Fields{
+		"prefix": "plugins.ResolvePluginForUpgrade",
+		"plugin": pluginName,
+	}).Debugf("could not resolve latest plugin via plugin metadata endpoint, falling back to cached plugin metadata or manifest: %s", endpointErr)
+
+	refreshErr := RefreshPluginManifest(ctx, config, fs, baseURL)
+	if refreshErr != nil {
+		log.WithFields(log.Fields{
+			"prefix": "plugins.ResolvePluginForUpgrade",
+			"plugin": pluginName,
+		}).Debugf("could not refresh plugin manifest for upgrade fallback: %s", refreshErr)
+	}
+
+	cachedPlugin, cachedErr := resolveCachedPluginForUpgrade(config, fs, pluginName)
+	if cachedErr == nil {
+		version, versionErr := getLatestResolvedPluginVersion(pluginName, cachedPlugin)
+		if versionErr != nil {
+			return nil, versionErr
+		}
+
+		return &ResolvedPluginVersion{
+			Plugin:  cachedPlugin,
+			Version: version,
+		}, nil
+	}
+
+	if refreshErr != nil {
+		return nil, fmt.Errorf("could not resolve plugin %s via plugin metadata endpoint: %v; cached lookup failed: %w; manifest refresh failed: %v", pluginName, endpointErr, cachedErr, refreshErr)
+	}
+
+	return nil, fmt.Errorf("could not resolve plugin %s via plugin metadata endpoint: %v; cached lookup failed: %w", pluginName, endpointErr, cachedErr)
+}
+
+// resolveCachedPluginForUpgrade resolves plugin metadata for upgrade using
+// persisted local metadata and the cached global manifest.
+func resolveCachedPluginForUpgrade(config config.IConfig, fs afero.Fs, pluginName string) (*Plugin, error) {
 	var localPlugin *Plugin
 	localPluginValue, localErr := readLocalPluginMetadata(config, fs, pluginName)
 	if localErr == nil {
@@ -368,10 +439,10 @@ func ResolvePluginForUpgrade(config config.IConfig, fs afero.Fs, pluginName stri
 
 // resolvePluginForAutoInstall resolves the freshest plugin metadata to use when
 // a command is invoked but the local plugin binary is missing.
-func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, baseURL string) (*Plugin, string, error) {
-	plugin, version, err := ResolvePluginForInstall(ctx, config, fs, pluginName, "", baseURL)
+func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, baseURL string) (*ResolvedPluginVersion, error) {
+	resolvedPlugin, err := ResolvePluginForInstall(ctx, config, fs, pluginName, "", baseURL)
 	if err == nil {
-		return plugin, version, nil
+		return resolvedPlugin, nil
 	}
 
 	log.WithFields(log.Fields{
@@ -379,17 +450,20 @@ func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs 
 		"plugin": pluginName,
 	}).Debugf("could not resolve latest plugin metadata for auto-install, falling back to cached metadata: %s", err)
 
-	plugin, cachedErr := ResolvePluginForUpgrade(config, fs, pluginName)
+	cachedPlugin, cachedErr := resolveCachedPluginForUpgrade(config, fs, pluginName)
 	if cachedErr != nil {
-		return nil, "", fmt.Errorf("could not resolve plugin %s for auto-install: latest lookup failed: %v; cached lookup failed: %w", pluginName, err, cachedErr)
+		return nil, fmt.Errorf("could not resolve plugin %s for auto-install: latest lookup failed: %v; cached lookup failed: %w", pluginName, err, cachedErr)
 	}
 
-	version = plugin.LookUpLatestVersion()
-	if version == "" {
-		return nil, "", fmt.Errorf("could not determine latest version for plugin %s", pluginName)
+	version, versionErr := getLatestResolvedPluginVersion(pluginName, cachedPlugin)
+	if versionErr != nil {
+		return nil, versionErr
 	}
 
-	return plugin, version, nil
+	return &ResolvedPluginVersion{
+		Plugin:  cachedPlugin,
+		Version: version,
+	}, nil
 }
 
 func getCachedPluginList(config config.IConfig, fs afero.Fs) (PluginList, error) {
@@ -509,7 +583,7 @@ func mergePluginMetadata(primary, fallback *Plugin) *Plugin {
 	return &pluginCopy
 }
 
-func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, baseURL, apiKey string) (*Plugin, string, error) {
+func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, baseURL, apiKey string) (*ResolvedPluginVersion, error) {
 	basePlugin := &Plugin{Shortname: pluginName}
 	if cachedPlugin, err := readLocalPluginMetadata(config, fs, pluginName); err == nil {
 		basePlugin = &cachedPlugin
@@ -519,12 +593,12 @@ func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs af
 
 	pluginMetadata, err := requests.GetPluginMetadata(ctx, baseURL, stripe.APIVersion, apiKey, config.GetProfile(), pluginName, version, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	plugin, err := basePlugin.pluginFromMetadata(pluginMetadata.PluginManifest)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	resolvedVersion := version
@@ -532,13 +606,30 @@ func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs af
 		resolvedVersion = plugin.LookUpLatestVersion()
 	}
 	if resolvedVersion == "" {
-		return nil, "", fmt.Errorf("plugin metadata response did not include a release for %s on %s/%s", pluginName, runtime.GOOS, runtime.GOARCH)
+		return nil, fmt.Errorf("plugin metadata response did not include a release for %s on %s/%s", pluginName, runtime.GOOS, runtime.GOARCH)
 	}
 	if plugin.getReleaseForVersion(resolvedVersion) == nil {
-		return nil, "", fmt.Errorf("plugin metadata response did not include plugin %s version %s for %s/%s", pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
+		return nil, fmt.Errorf("plugin metadata response did not include plugin %s version %s for %s/%s", pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
 	}
 
-	return plugin, resolvedVersion, nil
+	return &ResolvedPluginVersion{
+		Plugin:    plugin,
+		Version:   resolvedVersion,
+		BinaryURL: pluginMetadata.BinaryURL,
+	}, nil
+}
+
+func getLatestResolvedPluginVersion(pluginName string, plugin *Plugin) (string, error) {
+	if plugin == nil {
+		return "", fmt.Errorf("could not determine latest version for plugin %s", pluginName)
+	}
+
+	version := plugin.LookUpLatestVersion()
+	if version == "" {
+		return "", fmt.Errorf("could not determine latest version for plugin %s", pluginName)
+	}
+
+	return version, nil
 }
 
 func lookUpPluginInCachedManifest(config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -37,15 +37,18 @@ type installedPluginStateSnapshot struct {
 }
 
 // ResolvedPluginVersion contains the resolved plugin metadata needed to
-// install a specific plugin version without re-querying the metadata endpoint.
+// install a specific plugin version, including a resolved download URL when
+// the metadata endpoint already returned one.
 type ResolvedPluginVersion struct {
 	Plugin    *Plugin
 	Version   string
 	BinaryURL string
 }
 
-// Install installs the resolved plugin version using the already-resolved
-// plugin metadata and binary URL when available.
+// Install installs the resolved plugin version. If the metadata lookup already
+// resolved a concrete binary URL, it reuses that result and skips a second
+// metadata request. Otherwise it retries metadata during install so manifest or
+// cached fallbacks can still recover fresh release details.
 func (r *ResolvedPluginVersion) Install(ctx context.Context, config config.IConfig, fs afero.Fs, baseURL string) error {
 	switch {
 	case r == nil:
@@ -55,7 +58,7 @@ func (r *ResolvedPluginVersion) Install(ctx context.Context, config config.IConf
 	case r.Version == "":
 		return errors.New("missing plugin version")
 	default:
-		return r.Plugin.install(ctx, config, fs, r.Version, baseURL, r.BinaryURL, true)
+		return r.Plugin.install(ctx, config, fs, r.Version, baseURL, r.BinaryURL, r.BinaryURL != "")
 	}
 }
 

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -325,8 +325,10 @@ func TestResolvePluginForInstallUsesLocalMetadataAsMetadataBase(t *testing.T) {
 	}))
 	defer stripeServer.Close()
 
-	plugin, version, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", stripeServer.URL)
 	require.NoError(t, err)
+	plugin := resolvedPlugin.Plugin
+	version := resolvedPlugin.Version
 	require.Equal(t, "1.0.0", version)
 	require.Len(t, plugin.Commands, 1)
 	require.Equal(t, "create", plugin.Commands[0].Name)
@@ -335,7 +337,275 @@ func TestResolvePluginForInstallUsesLocalMetadataAsMetadataBase(t *testing.T) {
 	require.Equal(t, "20", release.Runtime["node"])
 }
 
-func TestResolvePluginForUpgradeUsesLocalMetadataWhenManifestMissing(t *testing.T) {
+func TestResolvePluginForInstallUsesAnonymousMetadataWithoutCachedManifest(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.Profile.APIKey = ""
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	var metadataLookups int
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/plugins_metadata":
+			metadataLookups++
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "https://example.test/appA/2.0.1",
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-url":
+			t.Fatalf("install resolution should not fall back to /v1/stripecli/get-plugin-url when anonymous metadata is available")
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL)
+	require.NoError(t, err)
+	plugin := resolvedPlugin.Plugin
+	version := resolvedPlugin.Version
+	require.NotNil(t, plugin)
+	require.Equal(t, "appA", plugin.Shortname)
+	require.Equal(t, "2.0.1", version)
+	require.Equal(t, "https://example.test/appA/2.0.1", resolvedPlugin.BinaryURL)
+	require.Equal(t, 1, metadataLookups)
+
+	_, err = fs.Stat("/plugins.toml")
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestResolvePluginForInstallFallsBackToManifestLookupWhenAnonymousMetadataFails(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.Profile.APIKey = ""
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	originalPluginData := requests.DefaultPluginData
+	requests.DefaultPluginData = requests.PluginData{
+		PluginBaseURL:       testServers.ArtifactoryServer.URL,
+		AdditionalManifests: nil,
+	}
+	defer func() {
+		requests.DefaultPluginData = originalPluginData
+	}()
+
+	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/plugins_metadata":
+			res.WriteHeader(http.StatusInternalServerError)
+			res.Write([]byte(`{"error":{"message":"boom"}}`))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer failingServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", failingServer.URL)
+	require.NoError(t, err)
+	plugin := resolvedPlugin.Plugin
+	version := resolvedPlugin.Version
+	require.NotNil(t, plugin)
+	require.Equal(t, "appA", plugin.Shortname)
+	require.Equal(t, "2.0.1", version)
+	require.Empty(t, resolvedPlugin.BinaryURL)
+
+	_, err = fs.Stat("/plugins.toml")
+	require.NoError(t, err)
+}
+
+func TestResolvePluginForUpgradeUsesMetadataEndpointWhenAvailable(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	localPlugin := Plugin{
+		Shortname:        "docs",
+		Shortdesc:        "Docs plugin",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Commands: []CommandInfo{
+			{
+				Name: "search",
+				Desc: "Search docs",
+			},
+		},
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "0.1.25",
+				Sum:     "abc123",
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	var metadataLookups int
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			metadataLookups++
+			require.Equal(t, "", req.URL.Query().Get("version"))
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL: "https://example.test/docs/latest",
+				PluginManifest: fmt.Sprintf(`[[Plugin]]
+  Shortname = "docs"
+  Shortdesc = "Docs plugin"
+  Binary = "stripe-cli-docs"
+  MagicCookieValue = "DOCS-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "0.1.26"
+    Sum = "def456"
+`, runtime.GOARCH, runtime.GOOS),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-url":
+			t.Fatalf("upgrade resolution should not fall back to /v1/stripecli/get-plugin-url when plugin metadata is available")
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", stripeServer.URL)
+	require.NoError(t, err)
+	plugin := resolvedPlugin.Plugin
+	require.Equal(t, "0.1.26", plugin.LookUpLatestVersion())
+	require.Equal(t, "0.1.26", resolvedPlugin.Version)
+	require.Equal(t, "https://example.test/docs/latest", resolvedPlugin.BinaryURL)
+	require.Len(t, plugin.Commands, 1)
+	require.Equal(t, "search", plugin.Commands[0].Name)
+	require.Equal(t, 1, metadataLookups)
+
+	_, err = fs.Stat("/plugins.toml")
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestResolvePluginForUpgradeUsesAnonymousMetadataEndpointWhenAPIKeyUnavailable(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.Profile.APIKey = ""
+
+	localPlugin := Plugin{
+		Shortname:        "docs",
+		Shortdesc:        "Docs plugin",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Commands: []CommandInfo{
+			{
+				Name: "search",
+				Desc: "Search docs",
+			},
+		},
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "0.1.25",
+				Sum:     "abc123",
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	var metadataLookups int
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/plugins_metadata":
+			metadataLookups++
+			require.Equal(t, "", req.URL.Query().Get("version"))
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL: "https://example.test/docs/latest",
+				PluginManifest: fmt.Sprintf(`[[Plugin]]
+  Shortname = "docs"
+  Shortdesc = "Docs plugin"
+  Binary = "stripe-cli-docs"
+  MagicCookieValue = "DOCS-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "0.1.26"
+    Sum = "def456"
+`, runtime.GOARCH, runtime.GOOS),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		case "/v1/stripecli/get-plugin-url":
+			t.Fatalf("upgrade resolution should not fall back to /v1/stripecli/get-plugin-url when anonymous plugin metadata is available")
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", stripeServer.URL)
+	require.NoError(t, err)
+	plugin := resolvedPlugin.Plugin
+	require.Equal(t, "0.1.26", plugin.LookUpLatestVersion())
+	require.Equal(t, "0.1.26", resolvedPlugin.Version)
+	require.Equal(t, "https://example.test/docs/latest", resolvedPlugin.BinaryURL)
+	require.Len(t, plugin.Commands, 1)
+	require.Equal(t, "search", plugin.Commands[0].Name)
+	require.Equal(t, 1, metadataLookups)
+
+	_, err = fs.Stat("/plugins.toml")
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestResolvePluginForUpgradeFallsBackToCachedMetadataWhenEndpointFails(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	localPlugin := Plugin{
+		Shortname:        "docs",
+		Shortdesc:        "Docs plugin",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Commands: []CommandInfo{
+			{
+				Name: "search",
+				Desc: "Search docs",
+			},
+		},
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "0.1.25",
+				Sum:     "abc123",
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusInternalServerError)
+		_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
+	}))
+	defer failingServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", failingServer.URL)
+	require.NoError(t, err)
+	plugin := resolvedPlugin.Plugin
+	require.Equal(t, localPlugin, *plugin)
+	require.Equal(t, "0.1.25", resolvedPlugin.Version)
+	require.Empty(t, resolvedPlugin.BinaryURL)
+}
+
+func TestResolveCachedPluginForUpgradeUsesLocalMetadataWhenManifestMissing(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
 
@@ -361,12 +631,12 @@ func TestResolvePluginForUpgradeUsesLocalMetadataWhenManifestMissing(t *testing.
 	}
 	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
 
-	plugin, err := ResolvePluginForUpgrade(config, fs, "docs")
+	plugin, err := resolveCachedPluginForUpgrade(config, fs, "docs")
 	require.NoError(t, err)
 	require.Equal(t, localPlugin, *plugin)
 }
 
-func TestResolvePluginForUpgradePrefersNewerManifestVersion(t *testing.T) {
+func TestResolveCachedPluginForUpgradePrefersNewerManifestVersion(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
 
@@ -406,7 +676,7 @@ func TestResolvePluginForUpgradePrefersNewerManifestVersion(t *testing.T) {
 `, runtime.GOARCH, runtime.GOOS)
 	require.NoError(t, afero.WriteFile(fs, "/plugins.toml", []byte(manifestContent), os.ModePerm))
 
-	plugin, err := ResolvePluginForUpgrade(config, fs, "docs")
+	plugin, err := resolveCachedPluginForUpgrade(config, fs, "docs")
 	require.NoError(t, err)
 	require.Equal(t, "0.1.26", plugin.LookUpLatestVersion())
 	require.Len(t, plugin.Commands, 1)

--- a/pkg/requests/plugin.go
+++ b/pkg/requests/plugin.go
@@ -32,6 +32,14 @@ var DefaultPluginData = PluginData{
 	AdditionalManifests: []string{},
 }
 
+func getPluginMetadataPath(apiKey string) string {
+	if apiKey == "" {
+		return "/v1/stripecli/plugins_metadata"
+	}
+
+	return "/v1/stripecli/get-plugin-metadata"
+}
+
 // GetPluginData returns the plugin download information
 func GetPluginData(ctx context.Context, baseURL, apiVersion, apiKey string, profile *config.Profile) (PluginData, error) {
 	// If no API key is available, use hardcoded fallback values
@@ -68,11 +76,9 @@ func GetPluginData(ctx context.Context, baseURL, apiVersion, apiKey string, prof
 }
 
 // GetPluginMetadata returns plugin-specific manifest and binary information.
+// It uses the authenticated endpoint when an API key is available and the
+// anonymous endpoint otherwise.
 func GetPluginMetadata(ctx context.Context, baseURL, apiVersion, apiKey string, profile *config.Profile, pluginName, version, os, arch string) (PluginMetadata, error) {
-	if apiKey == "" {
-		return PluginMetadata{}, fmt.Errorf("plugin metadata endpoint requires an API key")
-	}
-
 	params := &RequestParameters{
 		data:    []string{},
 		version: apiVersion,
@@ -85,7 +91,7 @@ func GetPluginMetadata(ctx context.Context, baseURL, apiVersion, apiKey string, 
 		APIBaseURL:     baseURL,
 	}
 
-	resp, err := base.MakeRequest(ctx, apiKey, "/v1/stripecli/get-plugin-metadata", params, map[string]interface{}{
+	resp, err := base.MakeRequest(ctx, apiKey, getPluginMetadataPath(apiKey), params, map[string]interface{}{
 		"plugin":  pluginName,
 		"version": version,
 		"os":      os,


### PR DESCRIPTION
Use the public /v1/stripecli/plugins_metadata endpoint when no API key is available, enabling plugin installs without authentication. Refactors resolve/install flow to use a ResolvedPlugin struct that carries the resolved version and optional pre-resolved binary URL.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
