### PR TITLE
Prefer --api-key over STRIPE_API_KEY

### DIFF
--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -184,10 +184,13 @@ func resolveKeyInfo(profile *config.Profile, livemode bool) whoamiKeyInfo {
 // command, if any. These are the sources that GetAPIKey checks before the
 // persisted config/keyring, and which are mode-agnostic in that function.
 func overrideAPIKey(profile *config.Profile) string {
+	if profile.APIKey != "" {
+		return profile.APIKey
+	}
 	if key := os.Getenv("STRIPE_API_KEY"); key != "" {
 		return key
 	}
-	return profile.APIKey
+	return ""
 }
 
 // apiKeyIsLivemode reports whether a key's prefix indicates live mode.

--- a/pkg/cmd/whoami_test.go
+++ b/pkg/cmd/whoami_test.go
@@ -130,6 +130,29 @@ func TestWhoamiWithEnvVarKey(t *testing.T) {
 	assert.False(t, result.LiveModeKey.Available)
 }
 
+func TestWhoamiFlagKeyTakesPrecedenceOverEnvVar(t *testing.T) {
+	config.KeyRing = keyring.NewArrayKeyring([]keyring.Item{})
+	t.Setenv("STRIPE_API_KEY", "sk_test_envvar1234567890")
+
+	wc := newWhoamiCmd()
+	wc.profile = &config.Profile{
+		ProfileName: "default",
+		DeviceName:  "test-device",
+		APIKey:      "rk_live_flag1234567890",
+	}
+	wc.format = "json"
+
+	out, err := runWhoami(t, wc)
+	require.NoError(t, err)
+
+	var result whoamiOutput
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+
+	assert.True(t, result.Authenticated)
+	assert.False(t, result.TestModeKey.Available)
+	assert.True(t, result.LiveModeKey.Available)
+}
+
 func TestAPIKeyIsLivemode(t *testing.T) {
 	assert.False(t, apiKeyIsLivemode("sk_test_abc123"))
 	assert.True(t, apiKeyIsLivemode("sk_live_abc123"))

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -219,6 +219,15 @@ func (p *Profile) GetAccountID() (string, error) {
 
 // GetAPIKey will return the existing key for the given profile
 func (p *Profile) GetAPIKey(livemode bool) (string, error) {
+	if p.APIKey != "" {
+		err := validators.APIKey(p.APIKey)
+		if err != nil {
+			return "", err
+		}
+
+		return p.APIKey, nil
+	}
+
 	envKey := os.Getenv("STRIPE_API_KEY")
 	if envKey != "" {
 		err := validators.APIKey(envKey)
@@ -227,15 +236,6 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 		}
 
 		return envKey, nil
-	}
-
-	if p.APIKey != "" {
-		err := validators.APIKey(p.APIKey)
-		if err != nil {
-			return "", err
-		}
-
-		return p.APIKey, nil
 	}
 
 	var key string

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -283,6 +283,28 @@ func TestLiveModeAPIKeyKeychainItemReplaced(t *testing.T) {
 	cleanUp(c.ProfilesFile)
 }
 
+func TestGetAPIKeyFlagTakesPrecedenceOverEnvVar(t *testing.T) {
+	t.Setenv("STRIPE_API_KEY", "sk_test_envvar1234567890")
+
+	p := Profile{
+		APIKey: "rk_live_flag1234567890",
+	}
+
+	key, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "rk_live_flag1234567890", key)
+}
+
+func TestGetAPIKeyFallsBackToEnvVar(t *testing.T) {
+	t.Setenv("STRIPE_API_KEY", "sk_test_envvar1234567890")
+
+	p := Profile{}
+
+	key, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_envvar1234567890", key)
+}
+
 func helperLoadBytes(t *testing.T, name string) []byte {
 	bytes, err := os.ReadFile(name)
 	if err != nil {


### PR DESCRIPTION
## Summary
- make the explicit `--api-key` override take precedence over `STRIPE_API_KEY`
- keep `STRIPE_API_KEY` as the fallback before persisted config/keychain credentials
- update `whoami` key classification and regression tests for flag/env precedence

Closes #1581.

## Testing
- `go test ./pkg/config -run TestGetAPIKey`
- `env HOME=$(mktemp -d) go test ./pkg/cmd -run TestWhoami`
- `env HOME=$(mktemp -d) go test ./pkg/config ./pkg/cmd -run 'TestGetAPIKey|TestWhoami'`

Note: a non-isolated local `go test ./pkg/config ./pkg/cmd` reads my machine's existing Stripe config and also hits an existing `TestGetLoginEmpty` template-state failure. The focused regression tests above pass with an isolated `HOME`.