### PR TITLE
Make plugin hint commands visible in `--help` for discoverability

### DIFF
--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -36,6 +36,11 @@ func AddHintCommands(rootCmd *cobra.Command, cfg *config.Config, installedPlugin
 			newPluginHintCmd(cfg, "projects", "This plugin scaffolds and manages Stripe integration projects.").Command,
 		)
 	}
+	if !installedPluginSet["docs"] {
+		rootCmd.AddCommand(
+			newPluginHintCmd(cfg, "docs", "Browse Stripe documentation and API reference.").Command,
+		)
+	}
 }
 
 // pluginHintCmd is a placeholder Cobra command registered when a known plugin
@@ -95,8 +100,8 @@ func newPluginHintCmd(cfg *config.Config, name, description string, opts ...opti
 	}
 
 	p.Command = &cobra.Command{
-		Use:    name,
-		Hidden: true,
+		Use:   name,
+		Short: description,
 		// Accept unknown flags/args so they aren't rejected before we can show the hint
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		RunE:               p.run,
@@ -119,6 +124,7 @@ func (p *pluginHintCmd) run(cmd *cobra.Command, args []string) error {
 		return p.suggestNotAvailable()
 	}
 
+	fmt.Fprintf(p.stdout, "The \"%s\" plugin is not currently available. Run 'stripe plugin install %s' to try installing it manually.\n", p.name, p.name)
 	return nil
 }
 

--- a/pkg/cmd/pluginhints/pluginhints_test.go
+++ b/pkg/cmd/pluginhints/pluginhints_test.go
@@ -48,14 +48,14 @@ func TestRun_PluginFound_CallsPromptInstall(t *testing.T) {
 	assert.Contains(t, p.output(), "The \"generate\" plugin is required")
 }
 
-func TestRun_PluginNotFound_PrivatePreviewFalse_ReturnsNil(t *testing.T) {
+func TestRun_PluginNotFound_PrivatePreviewFalse_PrintsInstallHint(t *testing.T) {
 	p := newTestCmd("apps")
 	p.lookupFn = func(ctx context.Context) error { return errors.New("not found") }
 
 	err := p.run(p.Command, nil)
 
 	require.NoError(t, err)
-	assert.Empty(t, p.output())
+	assert.Contains(t, p.output(), "stripe plugin install apps")
 }
 
 func TestRun_PluginNotFound_PrivatePreviewTrue_ExitsWithOne(t *testing.T) {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -53,7 +53,8 @@ var rootCmd = &cobra.Command{
 		"status":    "stripe",
 		"resources": "resources",
 		AIAgentHelpAnnotationKey: "  Visit https://docs.stripe.com/llms.txt?utm_source=cli for latest guidance on how to integrate correctly.\n" +
-			"  Run `npx skills add --all stripe/ai` to add all Stripe AI skills to your agent.",
+			"  Run `npx skills add --all stripe/ai` to add all Stripe AI skills to your agent.\n" +
+			"  Additional commands (apps, docs, generate, projects) are available as installable plugins — run the command directly to be prompted, or use `stripe plugin install <name>`.",
 	},
 	Version: version.Version,
 	Short:   "A CLI to help you integrate Stripe with your application",


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Uninstalled plugins (apps, docs, generate, projects) now appear in `stripe --help` with descriptions, so users and agents can discover them without prior knowledge. 

### Changes
`pkg/cmd/pluginhints/pluginhints.go`                                                                                                                                                                                          
- Removed Hidden: true from hint commands so they appear in stripe --help
- Added `Short:` description to each hint command — this was missing entirely before, so unhiding without this fix would have shown commands with blank descriptions                                                           
- Added `docs` to the hardcoded plugin list (it was in the manifest but not registered as a hint)                                                                   
- Added a fallback message when the manifest lookup fails. Previously the command silently returned nil, leaving users with no output and no guidance. Now it prints "Run 'stripe plugin install <name>' to try installing it manually.

`pkg/cmd/pluginhints/pluginhints_test.go`                                                                                                                                                                         
- Updated `TestRun_PluginNotFound_PrivatePreviewFalse_ReturnsNil` to assert the new fallback message is printed instead of asserting empty output   

`pkg/cmd/root.go`                                                                                                                                                                                                           
  - Updated the AIAgentHelpAnnotationKey annotation to mention that apps, docs, generate, and projects are available as installable plugins, so agents reading the help text know how to act on it                             
 

### Testing
- Built a local binary (go build -o bin/stripe ./cmd/stripe/main.go) and ran ./bin/stripe --help — confirmed docs, generate, and projects appear under "Other commands" with descriptions
<img width="1008" height="941" alt="Screenshot 2026-05-20 at 1 01 22 PM" src="https://github.com/user-attachments/assets/96bbd963-f577-4237-b5c8-c54e2bb37817" />

- Ran `./bin/stripe docs` — confirmed it prompts to install rather than erroring or silently doing nothing        
<img width="540" height="108" alt="Screenshot 2026-05-20 at 1 03 06 PM" src="https://github.com/user-attachments/assets/c5d3b87f-e716-43da-82ab-220c9c868ea2" />
