### PR TITLE
Distribute Stripe CLI via npm (`npx @stripe/cli`)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export GH_HOST=github.com

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -102,3 +102,51 @@ jobs:
       - run: sh scripts/install-test.sh docker
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+
+  npm:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/install-test.sh
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: bash scripts/install-test.sh npm
+        env:
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+
+  npm-no-optional:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/install-test.sh
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: bash scripts/install-test.sh npm-no-optional
+        env:
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+
+  npx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/install-test.sh
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: bash scripts/install-test.sh npx
+        env:
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -114,7 +114,7 @@ jobs:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - run: bash scripts/install-test.sh npm
@@ -129,7 +129,7 @@ jobs:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - run: bash scripts/install-test.sh npm-no-optional
@@ -144,7 +144,7 @@ jobs:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - run: bash scripts/install-test.sh npx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write # Required for OIDC to npm
 
 jobs:
   canary-tests:
@@ -117,10 +118,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Derive version from tag
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
@@ -143,12 +145,12 @@ jobs:
       - name: Publish platform packages
         run: |
           for dir in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
-            npm publish npm/$dir --access public
+            npm publish ./npm/$dir --access public
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish wrapper package
-        run: npm publish npm/wrapper --access public
+        run: npm publish ./npm/wrapper --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,10 +147,6 @@ jobs:
           for dir in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
             npm publish ./npm/$dir --access public
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish wrapper package
         run: npm publish ./npm/wrapper --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,3 +108,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VIRUSTOTAL_API_KEY: ${{ secrets.VIRUSTOTAL_API_KEY }}
+
+  publish-npm:
+    needs: [build-mac, build-linux, build-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Derive version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+
+      - name: Download and extract platform binaries from GitHub Release
+        run: node npm/scripts/fetch-binaries.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ env.VERSION }}
+
+      - name: Stamp version into all package.json files
+        run: node npm/scripts/stamp-version.js ${{ env.VERSION }}
+
+      - name: Copy README into each package
+        run: |
+          for dir in wrapper darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
+            cp README.md npm/$dir/README.md
+          done
+
+      - name: Publish platform packages
+        run: |
+          for dir in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
+            npm publish npm/$dir --access public
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish wrapper package
+        run: npm publish npm/wrapper --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,11 @@ stripe-completion.bash
 stripe-completion.zsh
 stripe.fish
 
+# npm distribution (binaries placed by CI, vendor/ by postinstall fallback)
+npm/*/bin/stripe
+npm/*/bin/stripe.exe
+npm/wrapper/vendor/
+npm/_tmp/
+
 # Claude Code local configuration (auto-added)
 .claude/*.local.*

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ npm/*/bin/stripe.exe
 npm/*/README.md
 npm/wrapper/vendor/
 npm/_tmp/
+!npm/wrapper/bin
 
 # Claude Code local configuration (auto-added)
 .claude/*.local.*

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ stripe.fish
 # npm distribution (binaries placed by CI, vendor/ by postinstall fallback)
 npm/*/bin/stripe
 npm/*/bin/stripe.exe
+npm/*/README.md
 npm/wrapper/vendor/
 npm/_tmp/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,9 @@ Templates live in `pkg/gen/*.go.tpl`. Build tags `gen_resources` and `events_lis
 
 ## GitHub CLI
 
-Always set `GH_HOST=github.com` when running `gh` commands to ensure they target public GitHub, not GitHub Enterprise:
+`GH_HOST` should be `github.com` to ensure `gh` commands target public GitHub, not GitHub Enterprise. This should already be configured through `.envrc`.  If `GH_HOST` isn't yet showing `github.com`, then run `direnv allow`.
+
+If `direnv` isn't installed, you can fallback by setting `GH_HOST` on all `gh` commands:
 
 ```bash
 GH_HOST=github.com gh pr create ...

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ Stripe CLI is available for macOS, Windows, and Linux for distros like Ubuntu, D
 
 ### npm (macOS, Linux, Windows)
 
-If you have Node.js >= 18 installed, you can install via npm or run directly with npx:
+If you have Node.js >= 18 installed, you can install via npm:
 
 ```sh
 npm install -g @stripe/cli
 ```
+
+You can also directly execute commands via `npx`, although this won't add `stripe` to your `PATH`:
 
 ```sh
 npx @stripe/cli login

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Stripe CLI is available for macOS, Windows, and Linux for distros like Ubuntu, D
 
 ### npm (macOS, Linux, Windows)
 
-If you have Node.js >= 18 installed, you can install via npm:
+If you have Node.js >= 18 installed, you can install via `npm`:
 
 ```sh
 npm install -g @stripe/cli

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ The Stripe CLI helps you build, test, and manage your Stripe integration right f
 
 Stripe CLI is available for macOS, Windows, and Linux for distros like Ubuntu, Debian, RedHat and CentOS.
 
+### npm (macOS, Linux, Windows)
+
+If you have Node.js >= 18 installed, you can install via npm or run directly with npx:
+
+```sh
+npm install -g @stripe/cli
+```
+
+```sh
+npx @stripe/cli login
+```
+
 ### macOS
 
 Stripe CLI is available on macOS via [Homebrew](https://brew.sh/):
@@ -97,7 +109,7 @@ docker build -t stripe-cli -f Dockerfile-cli .
 
 ```sh
 docker run --rm -it -v stripe-config://root/.config/stripe/ -v stripe-gpg://root/.gnupg/ -v stripe-pass://root/.password-store/ stripe-cli $command
-``` 
+```
 
 > For live mode requests append `--live` after `$command`.
 

--- a/cmd/stripe/main.go
+++ b/cmd/stripe/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -22,6 +23,11 @@ func main() {
 			Timeout: time.Second * 3,
 		}
 		telemetryClient := &stripe.AnalyticsTelemetryClient{HTTPClient: httpClient}
+		if raw := os.Getenv("STRIPE_TELEMETRY_URL"); raw != "" {
+			if parsed, err := url.Parse(raw); err == nil {
+				telemetryClient.BaseURL = parsed
+			}
+		}
 		contextWithTelemetry := stripe.WithTelemetryClient(ctx, telemetryClient)
 
 		cmd.Execute(contextWithTelemetry)

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli-darwin-arm64",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "The Stripe CLI macOS arm64 binary",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",
@@ -8,10 +8,16 @@
     "type": "git",
     "url": "https://github.com/stripe/stripe-cli.git"
   },
-  "os": ["darwin"],
-  "cpu": ["arm64"],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
   "bin": {
     "stripe": "bin/stripe"
   },
-  "files": ["bin/stripe"]
+  "files": [
+    "bin/stripe"
+  ]
 }

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli-darwin-arm64",
-  "version": "0.0.1",
+  "version": "1.42.1",
   "description": "The Stripe CLI macOS arm64 binary",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@stripe/cli-darwin-arm64",
+  "version": "0.0.0",
+  "description": "The Stripe CLI macOS arm64 binary",
+  "homepage": "https://stripe.com/docs/stripe-cli",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stripe/stripe-cli.git"
+  },
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "bin": {
+    "stripe": "bin/stripe"
+  },
+  "files": ["bin/stripe"]
+}

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli-darwin-x64",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "The Stripe CLI macOS x64 binary",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",
@@ -8,10 +8,16 @@
     "type": "git",
     "url": "https://github.com/stripe/stripe-cli.git"
   },
-  "os": ["darwin"],
-  "cpu": ["x64"],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
   "bin": {
     "stripe": "bin/stripe"
   },
-  "files": ["bin/stripe"]
+  "files": [
+    "bin/stripe"
+  ]
 }

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli-darwin-x64",
-  "version": "0.0.1",
+  "version": "1.42.1",
   "description": "The Stripe CLI macOS x64 binary",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@stripe/cli-darwin-x64",
+  "version": "0.0.0",
+  "description": "The Stripe CLI macOS x64 binary",
+  "homepage": "https://stripe.com/docs/stripe-cli",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stripe/stripe-cli.git"
+  },
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "bin": {
+    "stripe": "bin/stripe"
+  },
+  "files": ["bin/stripe"]
+}

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@stripe/cli-linux-arm64",
+  "version": "0.0.0",
+  "description": "The Stripe CLI Linux arm64 binary",
+  "homepage": "https://stripe.com/docs/stripe-cli",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stripe/stripe-cli.git"
+  },
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "bin": {
+    "stripe": "bin/stripe"
+  },
+  "files": ["bin/stripe"]
+}

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli-linux-arm64",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "The Stripe CLI Linux arm64 binary",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",
@@ -8,10 +8,16 @@
     "type": "git",
     "url": "https://github.com/stripe/stripe-cli.git"
   },
-  "os": ["linux"],
-  "cpu": ["arm64"],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
   "bin": {
     "stripe": "bin/stripe"
   },
-  "files": ["bin/stripe"]
+  "files": [
+    "bin/stripe"
+  ]
 }

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli-linux-arm64",
-  "version": "0.0.1",
+  "version": "1.42.1",
   "description": "The Stripe CLI Linux arm64 binary",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli-linux-x64",
-  "version": "0.0.1",
+  "version": "1.42.1",
   "description": "The Stripe CLI Linux x64 binary",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli-linux-x64",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "The Stripe CLI Linux x64 binary",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",
@@ -8,10 +8,16 @@
     "type": "git",
     "url": "https://github.com/stripe/stripe-cli.git"
   },
-  "os": ["linux"],
-  "cpu": ["x64"],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
   "bin": {
     "stripe": "bin/stripe"
   },
-  "files": ["bin/stripe"]
+  "files": [
+    "bin/stripe"
+  ]
 }

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@stripe/cli-linux-x64",
+  "version": "0.0.0",
+  "description": "The Stripe CLI Linux x64 binary",
+  "homepage": "https://stripe.com/docs/stripe-cli",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stripe/stripe-cli.git"
+  },
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "bin": {
+    "stripe": "bin/stripe"
+  },
+  "files": ["bin/stripe"]
+}

--- a/npm/scripts/fetch-binaries.js
+++ b/npm/scripts/fetch-binaries.js
@@ -69,6 +69,7 @@ async function main() {
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
   console.log('\nDone.');
+  process.exit(0);
 }
 
 function download(url, dest) {

--- a/npm/scripts/fetch-binaries.js
+++ b/npm/scripts/fetch-binaries.js
@@ -1,0 +1,118 @@
+/**
+ * CI helper: download platform binaries from the GitHub Release and place
+ * each one in the correct npm/<platform>/bin/ directory.
+ *
+ * Requires env:
+ *   VERSION       - release version without leading "v" (e.g. "1.40.9")
+ *   GITHUB_TOKEN  - optional, for authenticated GitHub API requests
+ *
+ * Usage: node npm/scripts/fetch-binaries.js
+ */
+'use strict';
+const https  = require('https');
+const fs     = require('fs');
+const path   = require('path');
+const crypto = require('crypto');
+const { execFileSync } = require('child_process');
+
+const PLATFORMS = require('../wrapper/platforms.json');
+const VERSION      = process.env.VERSION;
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+if (!VERSION) {
+  console.error('fetch-binaries: VERSION environment variable is required');
+  process.exit(1);
+}
+
+const BASE    = `https://github.com/stripe/stripe-cli/releases/download/v${VERSION}`;
+const repoRoot = path.resolve(__dirname, '..', '..');
+const tmpDir   = path.join(repoRoot, 'npm', '_tmp');
+fs.mkdirSync(tmpDir, { recursive: true });
+
+const downloadedChecksums = new Set();
+
+async function main() {
+  for (const [platformKey, config] of Object.entries(PLATFORMS)) {
+    const archive      = config.archiveTemplate.replace('${VERSION}', VERSION);
+    const checksumFile = config.checksums;
+    const binaryName   = config.bin;
+
+    console.log(`\n[${platformKey}] ${archive}`);
+
+    const archivePath  = path.join(tmpDir, archive);
+    const checksumPath = path.join(tmpDir, checksumFile);
+    const outDir       = path.join(repoRoot, 'npm', platformKey, 'bin');
+    fs.mkdirSync(outDir, { recursive: true });
+
+    if (!downloadedChecksums.has(checksumFile)) {
+      console.log(`  downloading ${checksumFile}...`);
+      await download(`${BASE}/${checksumFile}`, checksumPath);
+      downloadedChecksums.add(checksumFile);
+    }
+
+    console.log(`  downloading ${archive}...`);
+    await download(`${BASE}/${archive}`, archivePath);
+
+    console.log(`  verifying SHA256...`);
+    verifySha256(archivePath, checksumPath, archive);
+
+    console.log(`  extracting ${binaryName}...`);
+    if (archive.endsWith('.zip')) {
+      execFileSync('unzip', ['-q', '-o', archivePath, binaryName, '-d', outDir]);
+    } else {
+      execFileSync('tar', ['xzf', archivePath, '-C', outDir, binaryName]);
+      fs.chmodSync(path.join(outDir, binaryName), 0o755);
+    }
+
+    console.log(`  -> npm/${platformKey}/bin/${binaryName}`);
+  }
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  console.log('\nDone.');
+}
+
+function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    const headers = { 'User-Agent': 'stripe-cli-npm-publish' };
+    if (GITHUB_TOKEN) headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
+
+    function get(u, withAuth) {
+      const opts = withAuth ? { headers } : { headers: { 'User-Agent': headers['User-Agent'] } };
+      https.get(u, opts, res => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          get(res.headers.location, false);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode} for ${u}`));
+          return;
+        }
+        res.pipe(file);
+        file.on('finish', () => file.close(resolve));
+      }).on('error', reject);
+    }
+
+    get(url, true);
+  });
+}
+
+function verifySha256(filePath, checksumPath, archiveName) {
+  const content  = fs.readFileSync(checksumPath, 'utf8');
+  const line     = content.split('\n').find(l => l.includes(archiveName));
+  if (!line) {
+    console.error(`  checksum entry not found for ${archiveName}`);
+    process.exit(1);
+  }
+  const expected = line.trim().split(/\s+/)[0];
+  const actual   = crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+  if (actual !== expected) {
+    console.error(`  checksum mismatch: expected ${expected}, got ${actual}`);
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('fetch-binaries failed:', err.message);
+  process.exit(1);
+});

--- a/npm/scripts/stamp-version.js
+++ b/npm/scripts/stamp-version.js
@@ -1,0 +1,48 @@
+/**
+ * CI helper: stamp the release version into all npm package.json files.
+ * Replaces the placeholder "0.0.0" with the actual release version.
+ *
+ * Usage: node npm/scripts/stamp-version.js <version>
+ *   e.g. node npm/scripts/stamp-version.js 1.40.9
+ */
+'use strict';
+const fs   = require('fs');
+const path = require('path');
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+/.test(version)) {
+  console.error('stamp-version: usage: node stamp-version.js <version>  (e.g. 1.40.9)');
+  process.exit(1);
+}
+
+const PACKAGE_DIRS = [
+  'wrapper',
+  'darwin-arm64',
+  'darwin-x64',
+  'linux-x64',
+  'linux-arm64',
+  'win32-x64',
+];
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+for (const dir of PACKAGE_DIRS) {
+  const pkgPath = path.join(repoRoot, 'npm', dir, 'package.json');
+  const raw     = fs.readFileSync(pkgPath, 'utf8');
+  const pkg     = JSON.parse(raw);
+
+  pkg.version = version;
+
+  // Also update the version pins in optionalDependencies (wrapper only).
+  if (pkg.optionalDependencies) {
+    for (const dep of Object.keys(pkg.optionalDependencies)) {
+      pkg.optionalDependencies[dep] = version;
+    }
+  }
+
+  // Preserve trailing newline and 2-space indent to match the existing style.
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  console.log(`  stamped ${dir}/package.json → ${version}`);
+}
+
+console.log(`\nAll package.json files stamped with version ${version}.`);

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli-win32-x64",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "The Stripe CLI Windows x64 binary",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",
@@ -8,10 +8,16 @@
     "type": "git",
     "url": "https://github.com/stripe/stripe-cli.git"
   },
-  "os": ["win32"],
-  "cpu": ["x64"],
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
   "bin": {
     "stripe": "bin/stripe.exe"
   },
-  "files": ["bin/stripe.exe"]
+  "files": [
+    "bin/stripe.exe"
+  ]
 }

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli-win32-x64",
-  "version": "0.0.1",
+  "version": "1.42.1",
   "description": "The Stripe CLI Windows x64 binary",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@stripe/cli-win32-x64",
+  "version": "0.0.0",
+  "description": "The Stripe CLI Windows x64 binary",
+  "homepage": "https://stripe.com/docs/stripe-cli",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stripe/stripe-cli.git"
+  },
+  "os": ["win32"],
+  "cpu": ["x64"],
+  "bin": {
+    "stripe": "bin/stripe.exe"
+  },
+  "files": ["bin/stripe.exe"]
+}

--- a/npm/wrapper/bin/shim.js
+++ b/npm/wrapper/bin/shim.js
@@ -20,5 +20,9 @@ try {
   binPath = path.join(__dirname, '..', 'vendor', 'bin', platform.bin);
 }
 
-const result = spawnSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
+const isNpx = __dirname.includes('_npx');
+const result = spawnSync(binPath, process.argv.slice(2), {
+  stdio: 'inherit',
+  env: { ...process.env, STRIPE_INSTALL_METHOD: isNpx ? 'npx' : 'npm' },
+});
 process.exit(result.status ?? 1);

--- a/npm/wrapper/bin/shim.js
+++ b/npm/wrapper/bin/shim.js
@@ -20,7 +20,7 @@ try {
   binPath = path.join(__dirname, '..', 'vendor', 'bin', platform.bin);
 }
 
-const isNpx = __dirname.includes('_npx');
+const isNpx = !!process.env.npm_config_user_agent;
 const result = spawnSync(binPath, process.argv.slice(2), {
   stdio: 'inherit',
   env: { ...process.env, STRIPE_INSTALL_METHOD: isNpx ? 'npx' : 'npm' },

--- a/npm/wrapper/bin/shim.js
+++ b/npm/wrapper/bin/shim.js
@@ -20,9 +20,21 @@ try {
   binPath = path.join(__dirname, '..', 'vendor', 'bin', platform.bin);
 }
 
-const isNpx = !!process.env.npm_config_user_agent;
+// Detect invocation method using npm-injected env vars:
+// - npm_config_user_agent is set by npm/npx at invocation time but never by a direct shell exec,
+//   so its absence means the user ran `stripe` directly (global install, PATH symlink).
+// - npm_lifecycle_event is set to the script name during `npm run` but not by npx,
+//   so its presence distinguishes `npm run` scripts from a bare `npx @stripe/cli` call.
+let installMethod;
+if (!process.env.npm_config_user_agent) {
+  installMethod = 'npm_global';
+} else if (process.env.npm_lifecycle_event) {
+  installMethod = 'npm_run';
+} else {
+  installMethod = 'npx';
+}
 const result = spawnSync(binPath, process.argv.slice(2), {
   stdio: 'inherit',
-  env: { ...process.env, STRIPE_INSTALL_METHOD: isNpx ? 'npx' : 'npm' },
+  env: { ...process.env, STRIPE_INSTALL_METHOD: installMethod },
 });
 process.exit(result.status ?? 1);

--- a/npm/wrapper/bin/shim.js
+++ b/npm/wrapper/bin/shim.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+'use strict';
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const PLATFORMS = require('../platforms.json');
+
+const key = `${process.platform}-${process.arch}`;
+const platform = PLATFORMS[key];
+if (!platform) {
+  console.error(`@stripe/cli: unsupported platform "${key}". See https://docs.stripe.com/stripe-cli`);
+  process.exit(1);
+}
+
+let binPath;
+try {
+  const pkgDir = path.dirname(require.resolve(`${platform.pkg}/package.json`));
+  binPath = path.join(pkgDir, 'bin', platform.bin);
+} catch {
+  binPath = path.join(__dirname, '..', 'vendor', 'bin', platform.bin);
+}
+
+const result = spawnSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/npm/wrapper/package.json
+++ b/npm/wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli",
-  "version": "0.0.1",
+  "version": "1.42.1",
   "description": "The Stripe CLI",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",
@@ -15,11 +15,11 @@
     "postinstall": "node scripts/postinstall.js"
   },
   "optionalDependencies": {
-    "@stripe/cli-darwin-arm64": "0.0.1",
-    "@stripe/cli-darwin-x64": "0.0.1",
-    "@stripe/cli-linux-x64": "0.0.1",
-    "@stripe/cli-linux-arm64": "0.0.1",
-    "@stripe/cli-win32-x64": "0.0.1"
+    "@stripe/cli-darwin-arm64": "1.42.1",
+    "@stripe/cli-darwin-x64": "1.42.1",
+    "@stripe/cli-linux-x64": "1.42.1",
+    "@stripe/cli-linux-arm64": "1.42.1",
+    "@stripe/cli-win32-x64": "1.42.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/npm/wrapper/package.json
+++ b/npm/wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/cli",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "The Stripe CLI",
   "homepage": "https://stripe.com/docs/stripe-cli",
   "license": "MIT",
@@ -15,14 +15,18 @@
     "postinstall": "node scripts/postinstall.js"
   },
   "optionalDependencies": {
-    "@stripe/cli-darwin-arm64": "0.0.0",
-    "@stripe/cli-darwin-x64":   "0.0.0",
-    "@stripe/cli-linux-x64":    "0.0.0",
-    "@stripe/cli-linux-arm64":  "0.0.0",
-    "@stripe/cli-win32-x64":    "0.0.0"
+    "@stripe/cli-darwin-arm64": "0.0.1",
+    "@stripe/cli-darwin-x64": "0.0.1",
+    "@stripe/cli-linux-x64": "0.0.1",
+    "@stripe/cli-linux-arm64": "0.0.1",
+    "@stripe/cli-win32-x64": "0.0.1"
   },
   "engines": {
     "node": ">=18.0.0"
   },
-  "files": ["bin/shim.js", "scripts/postinstall.js", "platforms.json"]
+  "files": [
+    "bin/shim.js",
+    "scripts/postinstall.js",
+    "platforms.json"
+  ]
 }

--- a/npm/wrapper/package.json
+++ b/npm/wrapper/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@stripe/cli",
+  "version": "0.0.0",
+  "description": "The Stripe CLI",
+  "homepage": "https://stripe.com/docs/stripe-cli",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stripe/stripe-cli.git"
+  },
+  "bin": {
+    "stripe": "bin/shim.js"
+  },
+  "scripts": {
+    "postinstall": "node scripts/postinstall.js"
+  },
+  "optionalDependencies": {
+    "@stripe/cli-darwin-arm64": "0.0.0",
+    "@stripe/cli-darwin-x64":   "0.0.0",
+    "@stripe/cli-linux-x64":    "0.0.0",
+    "@stripe/cli-linux-arm64":  "0.0.0",
+    "@stripe/cli-win32-x64":    "0.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": ["bin/shim.js", "scripts/postinstall.js", "platforms.json"]
+}

--- a/npm/wrapper/platforms.json
+++ b/npm/wrapper/platforms.json
@@ -1,0 +1,32 @@
+{
+  "darwin-arm64": {
+    "pkg": "@stripe/cli-darwin-arm64",
+    "archiveTemplate": "stripe_${VERSION}_mac-os_arm64.tar.gz",
+    "checksums": "stripe-mac-checksums.txt",
+    "bin": "stripe"
+  },
+  "darwin-x64": {
+    "pkg": "@stripe/cli-darwin-x64",
+    "archiveTemplate": "stripe_${VERSION}_mac-os_x86_64.tar.gz",
+    "checksums": "stripe-mac-checksums.txt",
+    "bin": "stripe"
+  },
+  "linux-x64": {
+    "pkg": "@stripe/cli-linux-x64",
+    "archiveTemplate": "stripe_${VERSION}_linux_x86_64.tar.gz",
+    "checksums": "stripe-linux-checksums.txt",
+    "bin": "stripe"
+  },
+  "linux-arm64": {
+    "pkg": "@stripe/cli-linux-arm64",
+    "archiveTemplate": "stripe_${VERSION}_linux_arm64.tar.gz",
+    "checksums": "stripe-linux-checksums.txt",
+    "bin": "stripe"
+  },
+  "win32-x64": {
+    "pkg": "@stripe/cli-win32-x64",
+    "archiveTemplate": "stripe_${VERSION}_windows_x86_64.zip",
+    "checksums": "stripe-windows-checksums.txt",
+    "bin": "stripe.exe"
+  }
+}

--- a/npm/wrapper/scripts/postinstall.js
+++ b/npm/wrapper/scripts/postinstall.js
@@ -1,0 +1,103 @@
+'use strict';
+const https  = require('https');
+const fs     = require('fs');
+const path   = require('path');
+const crypto = require('crypto');
+const { execFileSync } = require('child_process');
+
+const PKG       = require('../package.json');
+const PLATFORMS = require('../platforms.json');
+const VERSION   = PKG.version;
+const BASE      = `https://github.com/stripe/stripe-cli/releases/download/v${VERSION}`;
+
+const key      = `${process.platform}-${process.arch}`;
+const platform = PLATFORMS[key];
+
+if (!platform) {
+  console.warn(`@stripe/cli: unsupported platform "${key}", skipping binary download.`);
+  process.exit(0);
+}
+
+// If a platform package was already installed, nothing to do.
+try {
+  require.resolve(`${platform.pkg}/package.json`);
+  process.exit(0);
+} catch {}
+
+const archive      = platform.archiveTemplate.replace('${VERSION}', VERSION);
+const checksumFile = platform.checksums;
+const vendorDir    = path.join(__dirname, '..', 'vendor', 'bin');
+
+fs.mkdirSync(vendorDir, { recursive: true });
+
+const archivePath  = path.join(vendorDir, '..', archive);
+const checksumPath = path.join(vendorDir, '..', checksumFile);
+
+console.log(`@stripe/cli: platform package not found, downloading from GitHub Releases...`);
+
+async function main() {
+  await download(`${BASE}/${checksumFile}`, checksumPath);
+  await download(`${BASE}/${archive}`, archivePath);
+  verifySha256(archivePath, checksumPath, archive);
+  extractBinary(archivePath, vendorDir, platform.bin);
+  // Clean up downloaded archives.
+  fs.unlinkSync(archivePath);
+  fs.unlinkSync(checksumPath);
+  console.log(`@stripe/cli: binary installed successfully.`);
+}
+
+main().catch(err => {
+  console.error(`@stripe/cli: failed to download binary: ${err.message}`);
+  process.exit(1);
+});
+
+// ---------------------------------------------------------------------------
+
+function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    function get(u) {
+      https.get(u, res => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          get(res.headers.location);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode} for ${u}`));
+          return;
+        }
+        res.pipe(file);
+        file.on('finish', () => file.close(resolve));
+      }).on('error', reject);
+    }
+    get(url);
+  });
+}
+
+function verifySha256(filePath, checksumPath, archiveName) {
+  const content  = fs.readFileSync(checksumPath, 'utf8');
+  const line     = content.split('\n').find(l => l.includes(archiveName));
+  if (!line) {
+    throw new Error(`checksum entry not found for ${archiveName}`);
+  }
+  const expected = line.trim().split(/\s+/)[0];
+  const actual   = crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+  if (actual !== expected) {
+    throw new Error(`SHA256 mismatch for ${archiveName}\n  expected: ${expected}\n  actual:   ${actual}`);
+  }
+}
+
+function extractBinary(archivePath, outDir, binaryName) {
+  if (archivePath.endsWith('.zip')) {
+    execFileSync('powershell', [
+      '-NoProfile', '-NonInteractive', '-Command',
+      `$tmp = '${path.join(outDir, '..', '_extract')}'; ` +
+      `Expand-Archive -Path '${archivePath}' -DestinationPath $tmp -Force; ` +
+      `Move-Item -Path (Join-Path $tmp '${binaryName}') -Destination '${path.join(outDir, binaryName)}' -Force; ` +
+      `Remove-Item -Recurse -Force $tmp`,
+    ]);
+  } else {
+    execFileSync('tar', ['xzf', archivePath, '-C', outDir, binaryName]);
+    fs.chmodSync(path.join(outDir, binaryName), 0o755);
+  }
+}

--- a/npm/wrapper/scripts/postinstall.js
+++ b/npm/wrapper/scripts/postinstall.js
@@ -33,7 +33,7 @@ fs.mkdirSync(vendorDir, { recursive: true });
 const archivePath  = path.join(vendorDir, '..', archive);
 const checksumPath = path.join(vendorDir, '..', checksumFile);
 
-console.log(`@stripe/cli: platform package not found, downloading from GitHub Releases...`);
+console.log(`@stripe/cli: platform package not found, installation must have used --no-optional. Downloading from GitHub Releases...`);
 
 async function main() {
   await download(`${BASE}/${checksumFile}`, checksumPath);

--- a/npm/wrapper/scripts/postinstall.js
+++ b/npm/wrapper/scripts/postinstall.js
@@ -44,6 +44,7 @@ async function main() {
   fs.unlinkSync(archivePath);
   fs.unlinkSync(checksumPath);
   console.log(`@stripe/cli: binary installed successfully.`);
+  process.exit(0);
 }
 
 main().catch(err => {

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -47,6 +47,7 @@ type CLIAnalyticsEventMetadata struct {
 	OS                string `url:"os"`                    // the OS of the system
 	GeneratedResource bool   `url:"generated_resource"`    // whether or not this was a generated resource
 	AIAgent           string `url:"ai_agent,omitempty"`    // the AI coding agent that invoked the CLI, if any
+	InstallMethod     string `url:"install_method,omitempty"` // how the CLI was installed
 }
 
 // TelemetryClient is an interface that can send two types of events: an API request, and just general events.
@@ -77,6 +78,11 @@ func NewEventMetadata() *CLIAnalyticsEventMetadata {
 		CLIVersion:   version.Version,
 		OS:           runtime.GOOS,
 		AIAgent:      useragent.DetectAIAgent(os.Getenv),
+		InstallMethod: useragent.DetectInstallMethod(
+			os.Getenv,
+			os.Executable,
+			func(p string) error { _, err := os.Stat(p); return err },
+		),
 	}
 }
 

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -37,16 +37,16 @@ const DefaultTelemetryEndpoint = "https://r.stripe.com/0"
 
 // CLIAnalyticsEventMetadata is the structure that holds telemetry data context that is ultimately sent to the Stripe Analytics Service.
 type CLIAnalyticsEventMetadata struct {
-	InvocationID      string `url:"invocation_id"`         // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
-	UserAgent         string `url:"user_agent"`            // the application that is used to create this request
-	CommandPath       string `url:"command_path"`          // the command or gRPC method that initiated this request
-	CommandFlags      string `url:"command_flags"`         // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
-	PluginName        string `url:"plugin_name,omitempty"` // the plugin being installed, when relevant
-	Merchant          string `url:"merchant"`              // the merchant ID: ex. acct_xxxx
-	CLIVersion        string `url:"cli_version"`           // the version of the CLI
-	OS                string `url:"os"`                    // the OS of the system
-	GeneratedResource bool   `url:"generated_resource"`    // whether or not this was a generated resource
-	AIAgent           string `url:"ai_agent,omitempty"`    // the AI coding agent that invoked the CLI, if any
+	InvocationID      string `url:"invocation_id"`            // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
+	UserAgent         string `url:"user_agent"`               // the application that is used to create this request
+	CommandPath       string `url:"command_path"`             // the command or gRPC method that initiated this request
+	CommandFlags      string `url:"command_flags"`            // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
+	PluginName        string `url:"plugin_name,omitempty"`    // the plugin being installed, when relevant
+	Merchant          string `url:"merchant"`                 // the merchant ID: ex. acct_xxxx
+	CLIVersion        string `url:"cli_version"`              // the version of the CLI
+	OS                string `url:"os"`                       // the OS of the system
+	GeneratedResource bool   `url:"generated_resource"`       // whether or not this was a generated resource
+	AIAgent           string `url:"ai_agent,omitempty"`       // the AI coding agent that invoked the CLI, if any
 	InstallMethod     string `url:"install_method,omitempty"` // how the CLI was installed
 }
 

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/stripe/stripe-cli/pkg/version"
 )
@@ -24,6 +26,34 @@ func GetEncodedStripeUserAgent() string {
 // the `User-Agent` HTTP header.
 func GetEncodedUserAgent() string {
 	return encodedUserAgent
+}
+
+// DetectInstallMethod detects how the CLI was installed.
+// Returns one of: "npm", "npx", "homebrew", "scoop", "apt", or "unknown".
+func DetectInstallMethod(
+	getEnv func(string) string,
+	getExecutable func() (string, error),
+	statFile func(string) error,
+) string {
+	if method := getEnv("STRIPE_INSTALL_METHOD"); method != "" {
+		return method
+	}
+
+	if exe, err := getExecutable(); err == nil {
+		exeLower := strings.ToLower(filepath.ToSlash(exe))
+		if strings.Contains(exeLower, "/cellar/") || strings.Contains(exeLower, "/homebrew/") {
+			return "homebrew"
+		}
+		if strings.Contains(exeLower, "/scoop/apps/") {
+			return "scoop"
+		}
+	}
+
+	if err := statFile("/var/lib/dpkg/info/stripe.list"); err == nil {
+		return "apt"
+	}
+
+	return "unknown"
 }
 
 // DetectAIAgent detects if the CLI was invoked by a coding agent, based on well-known env vars.

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -29,7 +29,7 @@ func GetEncodedUserAgent() string {
 }
 
 // DetectInstallMethod detects how the CLI was installed.
-// Returns one of: "npm", "npx", "homebrew", "scoop", "apt", or "unknown".
+// Returns one of: "npm_global", "npm_run", "npx", "homebrew", "scoop", "apt", or "unknown".
 func DetectInstallMethod(
 	getEnv func(string) string,
 	getExecutable func() (string, error),

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -1,0 +1,64 @@
+package useragent
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func noStat(string) error { return errors.New("not found") }
+func yesStat(string) error { return nil }
+func errExe() (string, error) { return "", errors.New("error") }
+
+func exe(path string) func() (string, error) {
+	return func() (string, error) { return path, nil }
+}
+
+func env(val string) func(string) string {
+	return func(string) string { return val }
+}
+
+func noEnv(string) string { return "" }
+
+func TestDetectInstallMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVal   string
+		exePath  string
+		exeErr   bool
+		hasStat  bool
+		expected string
+	}{
+		{"npm via env", "npm", "/any/path", false, false, "npm"},
+		{"npx via env", "npx", "/any/path", false, false, "npx"},
+		{"homebrew cellar", "", "/opt/homebrew/Cellar/stripe/1.0/bin/stripe", false, false, "homebrew"},
+		{"homebrew usr local cellar", "", "/usr/local/Cellar/stripe/1.0/bin/stripe", false, false, "homebrew"},
+		{"scoop", "", "C:/Users/foo/scoop/apps/stripe/current/stripe.exe", false, false, "scoop"},
+		{"apt with dpkg file", "", "/usr/bin/stripe", false, true, "apt"},
+		{"unknown no dpkg file", "", "/usr/bin/stripe", false, false, "unknown"},
+		{"unknown exe error", "", "", true, false, "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getEnv := noEnv
+			if tt.envVal != "" {
+				getEnv = env(tt.envVal)
+			}
+
+			getExe := exe(tt.exePath)
+			if tt.exeErr {
+				getExe = errExe
+			}
+
+			statFn := noStat
+			if tt.hasStat {
+				statFn = yesStat
+			}
+
+			result := DetectInstallMethod(getEnv, getExe, statFn)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func noStat(string) error { return errors.New("not found") }
-func yesStat(string) error { return nil }
+func noStat(string) error     { return errors.New("not found") }
+func yesStat(string) error    { return nil }
 func errExe() (string, error) { return "", errors.New("error") }
 
 func exe(path string) func() (string, error) {

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -30,7 +30,8 @@ func TestDetectInstallMethod(t *testing.T) {
 		hasStat  bool
 		expected string
 	}{
-		{"npm via env", "npm", "/any/path", false, false, "npm"},
+		{"npm_global via env", "npm_global", "/any/path", false, false, "npm_global"},
+		{"npm_run via env", "npm_run", "/any/path", false, false, "npm_run"},
 		{"npx via env", "npx", "/any/path", false, false, "npx"},
 		{"homebrew cellar", "", "/opt/homebrew/Cellar/stripe/1.0/bin/stripe", false, false, "homebrew"},
 		{"homebrew usr local cellar", "", "/usr/local/Cellar/stripe/1.0/bin/stripe", false, false, "homebrew"},

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -32,6 +32,19 @@ run_install() {
     docker)
     ;;
 
+    npm)
+        npm install -g @stripe/cli
+    ;;
+
+    npm-no-optional)
+        npm install -g @stripe/cli --no-optional
+    ;;
+
+    npx)
+        npx --yes @stripe/cli --version
+        exit $?
+    ;;
+
     *)
         echo "Error! Invalid package manager supplied"
         echo ""


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

### Summary

Adds npm as an install channel for the Stripe CLI. After this ships, developers with Node >= 18 can run:

```
npx @stripe/cli login
npm install -g @stripe/cli
```

This doesn't replace existing install paths (Homebrew, apt, Scoop, Docker) — it adds a fast path for the majority of the CLI's audience who already have Node installed.

### Motivation

The Stripe CLI's primary audience is web developers integrating a payments API. Most already have Node.js. Today, installing the CLI on Windows requires Scoop (a package manager most developers haven't heard of), and every platform requires a separate tool. `npx @stripe/cli` is a universal one-liner.

### What's included

- **6 npm packages** under the `@stripe` scope: a wrapper (`@stripe/cli`) and 5 platform-specific binary packages (darwin-arm64, darwin-x64, linux-x64, linux-arm64, win32-x64)
- **`publish-npm` job** in the release workflow, gated on all three platform builds completing
- **Install-test coverage**: 3 new jobs (npm, npm-no-optional, npx) across platforms with PagerDuty alerting
- **Fallback for `--no-optional`**: the wrapper's postinstall downloads directly from GitHub Releases and verifies SHA256 checksums
- **Installer telemetry**: expands existing telemetry to include a `install_method` key, shim checks whether it's running via `npx` and reports accordingly. Also tries to check for installs by `brew`, `apt-get`, or `scoop`.

No changes to Go code. No changes to goreleaser configs. The existing release artifacts are reused as-is.  No need for an `NPM_TOKEN` variable in the repo, as we're using the Trusted Publisher workflow.

### Test plan

- [x] `node --check` passes on all JS files
- [x] `node npm/scripts/stamp-version.js 1.41.1` stamps all package.json files correctly
- [x] `VERSION=1.41.1 GITHUB_TOKEN=... node npm/scripts/fetch-binaries.js` downloads, verifies, and extracts all 5 platform binaries
- [x] Shim resolves platform package and launches binary (`node npm/wrapper/bin/shim.js --version` via local symlink)
- [x] Postinstall fallback exercises download → checksum → extraction path
- [x] Post-publish: `npm install -g @stripe/cli && stripe --version` on all 3 platforms (covered by new install-test jobs)
- [x] Post-publish: `npx --yes @stripe/cli --version` exits successfully
- [x] Post-publish: `npm install -g @stripe/cli --no-optional && stripe --version` exercises fallback path

<details>

<summary>
### How it works
</summary>


For anyone unfamiliar with the npm mechanisms at play:

### Platform selection via `optionalDependencies` + `os`/`cpu`

npm's `package.json` supports two fields that declare platform requirements:

```json
{ "os": ["darwin"], "cpu": ["arm64"] }
```

When a package declares these, npm will **skip installing it** on non-matching hosts. The wrapper package (`@stripe/cli`) lists all 5 platform packages as `optionalDependencies`:

```json
"optionalDependencies": {
  "@stripe/cli-darwin-arm64": "1.41.1",
  "@stripe/cli-darwin-x64": "1.41.1",
  ...
}
```

`optionalDependencies` means "install these if you can, don't fail if you can't." Combined with the `os`/`cpu` guards, npm installs **only** the one matching the user's machine (typically 15-50 MB). The other 4 are silently skipped.

#### The `bin` field and the shim

The wrapper declares `"bin": { "stripe": "bin/shim.js" }`. When installed globally (`npm install -g`), npm symlinks `stripe` into the user's PATH pointing at `shim.js`. The shim is 23 lines: it detects the current platform, finds the installed binary package via `require.resolve()`, and spawns it with all arguments forwarded and `stdio: 'inherit'` (transparent passthrough).

#### The `postinstall` fallback

If npm was run with `--no-optional` (or a corporate policy strips optional deps), no platform package is installed. The wrapper's `"scripts": { "postinstall": "node scripts/postinstall.js" }` detects this, downloads the correct archive from GitHub Releases, verifies the SHA256 checksum against goreleaser's published checksum files, and extracts the binary to a `vendor/bin/` directory. The shim falls back to this path when `require.resolve()` fails.

#### Why platform packages have a `bin` field too

Each platform package (e.g. `@stripe/cli-darwin-arm64`) also declares `"bin": { "stripe": "bin/stripe" }`. This is a safety net: if someone installs a platform package directly, the binary still gets symlinked correctly. It also allows npm to set the executable bit during installation on systems that require it.
```

</details>
