### PR TITLE
Restrict install-test workflow to workflow_dispatch and schedule only

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -2,11 +2,6 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '0 * * * *' # Every hour
-  push:
-    tags:
-    - '*'
-  pull_request:
-    types: [opened, edited]
 name: Package manager test
 permissions:
   contents: read


### PR DESCRIPTION
Remove push (tags) and pull_request triggers so the workflow only runs on manual dispatch or the hourly schedule.

This workflow is a smoke test against real production releases, and not any particular branch in development.