### PR TITLE
Example: add new plugin hint

### DIFF
--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -41,6 +41,11 @@ func AddHintCommands(rootCmd *cobra.Command, cfg *config.Config, installedPlugin
 			newPluginHintCmd(cfg, "docs", "Browse Stripe documentation and API reference.").Command,
 		)
 	}
+	if !installedPluginSet["myNewPlugin"] {
+		rootCmd.AddCommand(
+			newPluginHintCmd(cfg, "myNewPlugin", "This is my new CLI plugin.").Command,
+		)
+	}
 }
 
 // pluginHintCmd is a placeholder Cobra command registered when a known plugin


### PR DESCRIPTION
 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
This is an example of adding a plugin hint entry. 

### Testing
Run
```
go build -o bin/stripe cmd/stripe/main.go
./bin/stripe --help
```
the new plugin hint will appear under the `other commands` section.
<img width="895" height="762" alt="Screenshot 2026-05-21 at 12 01 24 PM" src="https://github.com/user-attachments/assets/750cbbb2-a8a0-4cac-9ed9-bf20223c52a8" />
