### PR TITLE
Add Oh My Zsh guidance to zsh completion instructions

### DIFF
--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -54,6 +54,9 @@ Suggested next steps:
     fpath=(~/.stripe $fpath)
     autoload -Uz compinit && compinit -i
 
+   If you use Oh My Zsh, add only the ` + "`fpath`" + ` line before ` + "`source $ZSH/oh-my-zsh.sh`" + `;
+   Oh My Zsh runs ` + "`compinit`" + ` for you.
+
 3. Source your ` + "`.zshrc`" + ` or open a new terminal session:
     source ~/.zshrc`
 

--- a/pkg/cmd/completion_test.go
+++ b/pkg/cmd/completion_test.go
@@ -105,6 +105,12 @@ func TestSelectShellAutoDetectsFish(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestZshCompletionInstructionsIncludeOhMyZshGuidance(t *testing.T) {
+	assert.Contains(t, zshCompletionInstructions, "Oh My Zsh")
+	assert.Contains(t, zshCompletionInstructions, "source $ZSH/oh-my-zsh.sh")
+	assert.Contains(t, zshCompletionInstructions, "Oh My Zsh runs `compinit` for you")
+}
+
 // runInTempDir executes fn in a temporary directory, restoring the original
 // working directory on cleanup.
 func runInTempDir(t *testing.T, fn func()) {


### PR DESCRIPTION
## Summary

Adds a brief note for Oh My Zsh users in the zsh completion instructions.

Oh My Zsh already runs `compinit` through `oh-my-zsh.sh`, so users typically only need to add Stripe's completion directory to `fpath` before sourcing Oh My Zsh.

Closes #1126

## Testing

```bash
go test ./pkg/cmd
```