### PR TITLE
fix: direct unauthenticated users to login when docs plugin is unavailable

### DIFF
--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/login"
 	"github.com/stripe/stripe-cli/pkg/plugins"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -77,7 +78,23 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	isLatest := len(version) == 0
 	resolvedPlugin, err := plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL)
 	if err != nil {
-		return err
+		accountID, aErr := ic.cfg.GetProfile().GetAccountID()
+		if aErr != nil || accountID == "" {
+			fmt.Printf("You must be logged in to install the \"%s\" plugin.\n\n", pluginName)
+			fmt.Print("Press Enter to run 'stripe login', or type anything to cancel")
+			var input string
+			fmt.Fscanln(os.Stdin, &input)
+			if input != "" {
+				return fmt.Errorf("login canceled")
+			}
+			if lErr := login.Login(cmd.Context(), stripe.DefaultDashboardBaseURL, ic.cfg); lErr != nil {
+				return lErr
+			}
+			resolvedPlugin, err = plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	plugin := resolvedPlugin.Plugin
 	version = resolvedPlugin.Version

--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/login"
 	"github.com/stripe/stripe-cli/pkg/open"
 	"github.com/stripe/stripe-cli/pkg/plugins"
 	"github.com/stripe/stripe-cli/pkg/stripe"
@@ -54,6 +55,7 @@ type pluginHintCmd struct {
 
 	lookupFn      func(ctx context.Context) error
 	installFn     func(ctx context.Context) error
+	loginFn       func(ctx context.Context) error
 	accountIDFn   func() (string, error)
 	openBrowserFn func(url string) error
 	stdin         io.Reader
@@ -88,6 +90,9 @@ func newPluginHintCmd(cfg *config.Config, name, description string, opts ...opti
 			}
 			version := plugin.LookUpLatestVersion()
 			return plugin.Install(ctx, cfg, fs, version, stripe.DefaultAPIBaseURL)
+		},
+		loginFn: func(ctx context.Context) error {
+			return login.Login(ctx, stripe.DefaultDashboardBaseURL, cfg)
 		},
 		accountIDFn:   cfg.GetProfile().GetAccountID,
 		openBrowserFn: open.Browser,
@@ -124,12 +129,11 @@ func (p *pluginHintCmd) run(cmd *cobra.Command, args []string) error {
 		return p.suggestNotAvailable()
 	}
 
-	// If the user is not logged in, direct them to login rather than a manual
-	// install that will also fail unauthenticated.
+	// If the user is not logged in, offer to kick off the login flow rather than
+	// a manual install that will also fail unauthenticated.
 	accountID, err := p.accountIDFn()
 	if err != nil || accountID == "" {
-		fmt.Fprintf(p.stdout, "Run 'stripe login' to access the \"%s\" plugin.\n", p.name)
-		return nil
+		return p.promptLogin(ctx)
 	}
 
 	fmt.Fprintf(p.stdout, "The \"%s\" plugin is not currently available. Run 'stripe plugin install %s' to try installing it manually.\n", p.name, p.name)
@@ -157,6 +161,21 @@ func (p *pluginHintCmd) promptInstall(ctx context.Context) error {
 	fmt.Fprintln(p.stdout, color.Green("✔ installation complete."))
 
 	return nil
+}
+
+func (p *pluginHintCmd) promptLogin(ctx context.Context) error {
+	fmt.Fprintf(p.stdout, "You must be logged in to access the \"%s\" plugin.\n", p.name)
+	fmt.Fprintf(p.stdout, "\n")
+	fmt.Fprintf(p.stdout, "Press Enter to run 'stripe login', or type anything to cancel")
+
+	var input string
+	fmt.Fscanln(p.stdin, &input)
+
+	if input != "" {
+		return fmt.Errorf("login canceled")
+	}
+
+	return p.loginFn(ctx)
 }
 
 func (p *pluginHintCmd) suggestNotAvailable() error {

--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -124,6 +124,14 @@ func (p *pluginHintCmd) run(cmd *cobra.Command, args []string) error {
 		return p.suggestNotAvailable()
 	}
 
+	// If the user is not logged in, direct them to login rather than a manual
+	// install that will also fail unauthenticated.
+	accountID, err := p.accountIDFn()
+	if err != nil || accountID == "" {
+		fmt.Fprintf(p.stdout, "Run 'stripe login' to access the \"%s\" plugin.\n", p.name)
+		return nil
+	}
+
 	fmt.Fprintf(p.stdout, "The \"%s\" plugin is not currently available. Run 'stripe plugin install %s' to try installing it manually.\n", p.name, p.name)
 	return nil
 }

--- a/pkg/cmd/pluginhints/pluginhints_test.go
+++ b/pkg/cmd/pluginhints/pluginhints_test.go
@@ -15,12 +15,15 @@ import (
 )
 
 // newTestCmd builds a pluginHintCmd with all side effects mocked out.
+// By default accountIDFn reports a logged-in account; override in tests that
+// need to simulate an unauthenticated user.
 func newTestCmd(name string, opts ...option) *pluginHintCmd {
 	p := &pluginHintCmd{
 		name:        name,
 		description: "Test description.",
 		stdout:      &bytes.Buffer{},
 		stdin:       strings.NewReader(""),
+		accountIDFn: func() (string, error) { return "acct_test", nil },
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -48,14 +51,38 @@ func TestRun_PluginFound_CallsPromptInstall(t *testing.T) {
 	assert.Contains(t, p.output(), "The \"generate\" plugin is required")
 }
 
-func TestRun_PluginNotFound_PrivatePreviewFalse_PrintsInstallHint(t *testing.T) {
-	p := newTestCmd("apps")
+func TestRun_PluginNotFound_PrivatePreviewFalse_LoggedIn_PrintsInstallHint(t *testing.T) {
+	p := newTestCmd("apps") // accountIDFn returns "acct_test" by default
 	p.lookupFn = func(ctx context.Context) error { return errors.New("not found") }
 
 	err := p.run(p.Command, nil)
 
 	require.NoError(t, err)
 	assert.Contains(t, p.output(), "stripe plugin install apps")
+}
+
+func TestRun_PluginNotFound_PrivatePreviewFalse_NotLoggedIn_PrintsLoginHint(t *testing.T) {
+	p := newTestCmd("docs")
+	p.lookupFn = func(ctx context.Context) error { return errors.New("not found") }
+	p.accountIDFn = func() (string, error) { return "", nil }
+
+	err := p.run(p.Command, nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, p.output(), "stripe login")
+	assert.NotContains(t, p.output(), "stripe plugin install")
+}
+
+func TestRun_PluginNotFound_PrivatePreviewFalse_AccountIDError_PrintsLoginHint(t *testing.T) {
+	p := newTestCmd("docs")
+	p.lookupFn = func(ctx context.Context) error { return errors.New("not found") }
+	p.accountIDFn = func() (string, error) { return "", errors.New("not configured") }
+
+	err := p.run(p.Command, nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, p.output(), "stripe login")
+	assert.NotContains(t, p.output(), "stripe plugin install")
 }
 
 func TestRun_PluginNotFound_PrivatePreviewTrue_ExitsWithOne(t *testing.T) {

--- a/pkg/cmd/pluginhints/pluginhints_test.go
+++ b/pkg/cmd/pluginhints/pluginhints_test.go
@@ -24,6 +24,7 @@ func newTestCmd(name string, opts ...option) *pluginHintCmd {
 		stdout:      &bytes.Buffer{},
 		stdin:       strings.NewReader(""),
 		accountIDFn: func() (string, error) { return "acct_test", nil },
+		loginFn:     func(ctx context.Context) error { return nil },
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -61,26 +62,32 @@ func TestRun_PluginNotFound_PrivatePreviewFalse_LoggedIn_PrintsInstallHint(t *te
 	assert.Contains(t, p.output(), "stripe plugin install apps")
 }
 
-func TestRun_PluginNotFound_PrivatePreviewFalse_NotLoggedIn_PrintsLoginHint(t *testing.T) {
+func TestRun_PluginNotFound_PrivatePreviewFalse_NotLoggedIn_PromptsLogin(t *testing.T) {
 	p := newTestCmd("docs")
 	p.lookupFn = func(ctx context.Context) error { return errors.New("not found") }
 	p.accountIDFn = func() (string, error) { return "", nil }
+	loginCalled := false
+	p.loginFn = func(ctx context.Context) error { loginCalled = true; return nil }
 
 	err := p.run(p.Command, nil)
 
 	require.NoError(t, err)
+	assert.True(t, loginCalled)
 	assert.Contains(t, p.output(), "stripe login")
 	assert.NotContains(t, p.output(), "stripe plugin install")
 }
 
-func TestRun_PluginNotFound_PrivatePreviewFalse_AccountIDError_PrintsLoginHint(t *testing.T) {
+func TestRun_PluginNotFound_PrivatePreviewFalse_AccountIDError_PromptsLogin(t *testing.T) {
 	p := newTestCmd("docs")
 	p.lookupFn = func(ctx context.Context) error { return errors.New("not found") }
 	p.accountIDFn = func() (string, error) { return "", errors.New("not configured") }
+	loginCalled := false
+	p.loginFn = func(ctx context.Context) error { loginCalled = true; return nil }
 
 	err := p.run(p.Command, nil)
 
 	require.NoError(t, err)
+	assert.True(t, loginCalled)
 	assert.Contains(t, p.output(), "stripe login")
 	assert.NotContains(t, p.output(), "stripe plugin install")
 }
@@ -151,6 +158,43 @@ func TestPromptInstall_InstallError_ReturnsError(t *testing.T) {
 	err := p.promptInstall(context.Background())
 
 	assert.EqualError(t, err, "install failed")
+}
+
+// --- promptLogin ---
+
+func TestPromptLogin_EnterKey_LogsIn(t *testing.T) {
+	p := newTestCmd("docs")
+	p.stdin = strings.NewReader("\n")
+	loginCalled := false
+	p.loginFn = func(ctx context.Context) error { loginCalled = true; return nil }
+
+	err := p.promptLogin(context.Background())
+
+	require.NoError(t, err)
+	assert.True(t, loginCalled)
+	assert.Contains(t, p.output(), "stripe login")
+}
+
+func TestPromptLogin_OtherInput_CancelsLogin(t *testing.T) {
+	p := newTestCmd("docs")
+	p.stdin = strings.NewReader("n\n")
+	loginCalled := false
+	p.loginFn = func(ctx context.Context) error { loginCalled = true; return nil }
+
+	err := p.promptLogin(context.Background())
+
+	assert.EqualError(t, err, "login canceled")
+	assert.False(t, loginCalled)
+}
+
+func TestPromptLogin_LoginError_ReturnsError(t *testing.T) {
+	p := newTestCmd("docs")
+	p.stdin = strings.NewReader("\n")
+	p.loginFn = func(ctx context.Context) error { return errors.New("login failed") }
+
+	err := p.promptLogin(context.Background())
+
+	assert.EqualError(t, err, "login failed")
 }
 
 // --- suggestNotAvailable ---

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -344,6 +344,9 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 
 	manifestPlugin, err := LookUpPluginInManifest(ctx, config, fs, pluginName)
 	if err != nil {
+		if apiKey == "" {
+			return nil, fmt.Errorf("could not find a plugin named %s. Run 'stripe login' and try again", pluginName)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

This PR redirects unauthenticated users to stripe login when they try to access the docs plugin

- **`stripe docs`**

Before: 
<img width="794" height="36" alt="Screenshot 2026-05-21 at 3 49 00 PM" src="https://github.com/user-attachments/assets/90e31431-ea84-4328-b8cf-2e2350ce68fd" />

After
<img width="528" height="73" alt="Screenshot 2026-05-21 at 3 50 26 PM" src="https://github.com/user-attachments/assets/030679af-af65-43ea-8140-d483cd184803" />






- **`stripe plugin install docs`**

Before: 
<img width="589" height="42" alt="Screenshot 2026-05-21 at 3 50 52 PM" src="https://github.com/user-attachments/assets/e2d8099a-c7a9-4ddd-9d8b-b7113844b2e9" />

After

<img width="593" height="32" alt="Screenshot 2026-05-21 at 3 51 56 PM" src="https://github.com/user-attachments/assets/206d5e11-2cc6-4dd0-ab6c-90472a542d4d" />
