### PR TITLE
Improve expired API key error message

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -148,7 +148,7 @@ func Execute(ctx context.Context) {
 		case errors.Is(err, errNotAuthenticated):
 			// whoami already printed output; just exit non-zero
 		case requests.IsAPIKeyExpiredError(err):
-			fmt.Fprintln(os.Stderr, "The API key provided has expired. Obtain a new key from the Dashboard or run `stripe login` and try again.")
+			fmt.Fprintln(os.Stderr, apiKeyExpiredMessage(projectNameFlag))
 		case isLoginRequiredError && projectNameFlag != "default":
 			fmt.Fprintf(os.Stderr, "You provided the project name \"%[1]s\" (either via the \"--project-name\" flag or the \"STRIPE_PROJECT_NAME\" environment variable), but no config for that project was found.\nPlease run `stripe login --project-name=%[1]s` to enable commands for this project.\n", projectNameFlag)
 		case isLoginRequiredError:
@@ -185,6 +185,13 @@ func Execute(ctx context.Context) {
 			fmt.Println("You provided the \"--color\" flag but did not specify any command. The \"--color\" flag configures the color output of a specified command.")
 		}
 	}
+}
+
+func apiKeyExpiredMessage(profileName string) string {
+	if profileName == "default" {
+		return "The API key for the default profile has expired. Run `stripe login` to re-authenticate."
+	}
+	return fmt.Sprintf("The API key for profile %q has expired. Run `stripe login --project-name=%s` to re-authenticate.", profileName, profileName)
 }
 
 var keysToReBind []string

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -189,7 +189,8 @@ func Execute(ctx context.Context) {
 
 func apiKeyExpiredMessage(profileName string) string {
 	if profileName == "default" {
-		return "The API key for the default profile has expired. Run `stripe login` to re-authenticate."
+		return "The API key for the default profile has expired. Run `stripe login` to re-authenticate.\n" +
+			"If you recently ran `stripe login` and still see this error, it may have authenticated a different profile — run `stripe whoami` to confirm."
 	}
 	return fmt.Sprintf("The API key for profile %q has expired. Run `stripe login --project-name=%s` to re-authenticate.", profileName, profileName)
 }

--- a/pkg/cmd/root_expired_key_test.go
+++ b/pkg/cmd/root_expired_key_test.go
@@ -10,6 +10,7 @@ func TestAPIKeyExpiredMessage_DefaultProfile(t *testing.T) {
 	msg := apiKeyExpiredMessage("default")
 	require.Contains(t, msg, "default profile")
 	require.Contains(t, msg, "`stripe login`")
+	require.Contains(t, msg, "`stripe whoami`")
 	require.NotContains(t, msg, "--project-name")
 }
 

--- a/pkg/cmd/root_expired_key_test.go
+++ b/pkg/cmd/root_expired_key_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIKeyExpiredMessage_DefaultProfile(t *testing.T) {
+	msg := apiKeyExpiredMessage("default")
+	require.Contains(t, msg, "default profile")
+	require.Contains(t, msg, "`stripe login`")
+	require.NotContains(t, msg, "--project-name")
+}
+
+func TestAPIKeyExpiredMessage_NamedProfile(t *testing.T) {
+	msg := apiKeyExpiredMessage("work")
+	require.Contains(t, msg, `"work"`)
+	require.Contains(t, msg, "--project-name=work")
+}


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
When a command fails due to an expired API key, the previous error message was generic and unhelpful:

>  "The API key provided has expired. Obtain a new key from the Dashboard or run stripe login and try again."      

This gave no indication of which profile's key had expired or how to fix it for that specific profile, which was especially confusing in multi-profile setups where a user might run stripe login (updating a different profile) and still see the same error.                                                                                     
                                                            
The new messages are:                                                                                             
- Default profile: `The API key for the default profile has expired. Run stripe login to re-authenticate. If you  
  recently ran stripe login and still see this error, it may have authenticated a different profile — run stripe 
  whoami to confirm.`                                                                                              
- Named profile: `The API key for profile "work" has expired. Run stripe login --project-name=work to
  re-authenticate.`