### PR TITLE
Add canary tests for v2 API endpoints and triggers

### DIFF
--- a/canary/README.md
+++ b/canary/README.md
@@ -94,6 +94,12 @@ Tests that require a valid Stripe test API key:
 | `TestAPILogsTailCapture` | `stripe logs tail --format JSON` + API call | Logs tail captures requests |
 | `TestAPIConfigSetAndUseAPIKey` | `stripe config --set` + API call | Config-based auth |
 | `TestAPIConfigMultipleProfiles` | `--project-name` flag | Multi-profile support |
+| `TestAPIV2CoreEventsList` | `stripe v2 core events list` | V2 resource commands work |
+| `TestAPIV2CoreEventDestinationsList` | `stripe v2 core event_destinations list` | V2 namespace routing |
+| `TestAPIV2BillingMeterEventSessionCreate` | `stripe v2 billing meter_event_sessions create` | V2 POST with JSON body |
+| `TestAPIV2RawGet` | `stripe get /v2/core/events` | Raw GET to v2 path |
+| `TestAPIV2RawPost` | `stripe post /v2/billing/meter_event_session` | Raw POST to v2 path (JSON content-type) |
+| `TestAPIV2TriggerMeterNoMeterFound` | `stripe trigger v1.billing.meter.no_meter_found` | V2 trigger fixtures execute |
 
 ## Environment Variables
 

--- a/canary/v2_api_test.go
+++ b/canary/v2_api_test.go
@@ -1,0 +1,162 @@
+package canary
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stripe/stripe-cli/canary/testutil"
+)
+
+// =============================================================================
+// V2 API Resource Tests - Require STRIPE_API_KEY
+// =============================================================================
+
+func TestAPIV2CoreEventsList(t *testing.T) {
+	requireAPIKey(t)
+	runner := getRunner(t, testutil.WithEnv(map[string]string{
+		"STRIPE_API_KEY": testutil.GetAPIKey(),
+	}))
+
+	result, err := runner.Run("v2", "core", "events", "list", "--limit", "2")
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe v2 core events list': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(result.Stdout), &data); err != nil {
+		errorf(t, "Output is not valid JSON: %v. Output: %s", err, result.Stdout)
+	}
+
+	if _, ok := data["data"]; !ok {
+		errorf(t, "Expected response to contain 'data' field, got: %s", result.Stdout)
+	}
+}
+
+func TestAPIV2CoreEventDestinationsList(t *testing.T) {
+	requireAPIKey(t)
+	runner := getRunner(t, testutil.WithEnv(map[string]string{
+		"STRIPE_API_KEY": testutil.GetAPIKey(),
+	}))
+
+	result, err := runner.Run("v2", "core", "event_destinations", "list")
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe v2 core event_destinations list': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(result.Stdout), &data); err != nil {
+		errorf(t, "Output is not valid JSON: %v. Output: %s", err, result.Stdout)
+	}
+
+	if _, ok := data["data"]; !ok {
+		errorf(t, "Expected response to contain 'data' field, got: %s", result.Stdout)
+	}
+}
+
+func TestAPIV2BillingMeterEventSessionCreate(t *testing.T) {
+	requireAPIKey(t)
+	runner := getRunner(t, testutil.WithEnv(map[string]string{
+		"STRIPE_API_KEY": testutil.GetAPIKey(),
+	}))
+
+	result, err := runner.Run("v2", "billing", "meter_event_sessions", "create")
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe v2 billing meter_event_sessions create': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(result.Stdout), &data); err != nil {
+		errorf(t, "Output is not valid JSON: %v. Output: %s", err, result.Stdout)
+	}
+
+	if _, ok := data["authentication_token"]; !ok {
+		errorf(t, "Expected response to contain 'authentication_token' field, got: %s", result.Stdout)
+	}
+}
+
+func TestAPIV2RawGet(t *testing.T) {
+	requireAPIKey(t)
+	runner := getRunner(t, testutil.WithEnv(map[string]string{
+		"STRIPE_API_KEY": testutil.GetAPIKey(),
+	}))
+
+	result, err := runner.Run("get", "/v2/core/events", "-d", `{"limit": 1}`)
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe get /v2/core/events': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(result.Stdout), &data); err != nil {
+		errorf(t, "Output is not valid JSON: %v. Output: %s", err, result.Stdout)
+	}
+
+	if _, ok := data["data"]; !ok {
+		errorf(t, "Expected response to contain 'data' field, got: %s", result.Stdout)
+	}
+}
+
+func TestAPIV2RawPost(t *testing.T) {
+	requireAPIKey(t)
+	runner := getRunner(t, testutil.WithEnv(map[string]string{
+		"STRIPE_API_KEY": testutil.GetAPIKey(),
+	}))
+
+	result, err := runner.Run("post", "/v2/billing/meter_event_session")
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe post /v2/billing/meter_event_session': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(result.Stdout), &data); err != nil {
+		errorf(t, "Output is not valid JSON: %v. Output: %s", err, result.Stdout)
+	}
+
+	if _, ok := data["authentication_token"]; !ok {
+		errorf(t, "Expected response to contain 'authentication_token' field, got: %s", result.Stdout)
+	}
+}
+
+func TestAPIV2TriggerMeterNoMeterFound(t *testing.T) {
+	requireAPIKey(t)
+	runner := getRunner(t, testutil.WithEnv(map[string]string{
+		"STRIPE_API_KEY": testutil.GetAPIKey(),
+	}))
+
+	runner = runner.WithTimeout(60 * time.Second)
+
+	result, err := runner.Run("trigger", "v1.billing.meter.no_meter_found")
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe trigger v1.billing.meter.no_meter_found': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	combinedOutput := result.Stdout + result.Stderr
+	if !strings.Contains(strings.ToLower(combinedOutput), "meter") {
+		errorf(t, "Expected output to mention 'meter', got: %s", combinedOutput)
+	}
+}


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

v2 APIs have their own request shape, so we should cover them in the canary. This will ensure changes to auth don't break these flows unexpectedly.

Tested by triggering the workflow manually and seeing the requests succeed: https://github.com/stripe/stripe-cli/actions/runs/26467782853