### PR TITLE
Route unauthenticated plugin metadata requests to dashboard API

### DIFF
--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -28,7 +28,8 @@ type InstallCmd struct {
 	Cmd *cobra.Command
 	fs  afero.Fs
 
-	apiBaseURL string
+	apiBaseURL       string
+	dashboardBaseURL string
 }
 
 // NewInstallCmd creates a command for installing plugins
@@ -49,6 +50,8 @@ func NewInstallCmd(config *config.Config) *InstallCmd {
 	// Hidden configuration flags, useful for dev/debugging
 	ic.Cmd.Flags().StringVar(&ic.apiBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
 	ic.Cmd.Flags().MarkHidden("api-base") // #nosec G104
+	ic.Cmd.Flags().StringVar(&ic.dashboardBaseURL, "dashboard-base", "", "Sets the dashboard base URL")
+	ic.Cmd.Flags().MarkHidden("dashboard-base") // #nosec G104
 
 	return ic
 }
@@ -67,8 +70,20 @@ func parseInstallArg(arg string) (string, string) {
 	return plugin, version
 }
 
+func resolveDashboardBaseURL(apiBaseURL, dashboardBaseURL string) string {
+	if dashboardBaseURL != "" {
+		return dashboardBaseURL
+	}
+
+	return stripe.DashboardBaseURLForAPIBaseURL(apiBaseURL)
+}
+
 func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	if err := stripe.ValidateAPIBaseURL(ic.apiBaseURL); err != nil {
+		return err
+	}
+	dashboardBaseURL := resolveDashboardBaseURL(ic.apiBaseURL, ic.dashboardBaseURL)
+	if err := stripe.ValidateDashboardBaseURL(dashboardBaseURL); err != nil {
 		return err
 	}
 
@@ -76,7 +91,7 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	pluginName, version := parseInstallArg(args[0])
 	ic.setInstallTelemetryMetadata(cmd.Context(), pluginName)
 	isLatest := len(version) == 0
-	resolvedPlugin, err := plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL)
+	resolvedPlugin, err := plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL, dashboardBaseURL)
 	if err != nil {
 		accountID, aErr := ic.cfg.GetProfile().GetAccountID()
 		if aErr != nil || accountID == "" {
@@ -87,10 +102,10 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 			if input != "" {
 				return fmt.Errorf("login canceled")
 			}
-			if lErr := login.Login(cmd.Context(), stripe.DefaultDashboardBaseURL, ic.cfg); lErr != nil {
+			if lErr := login.Login(cmd.Context(), dashboardBaseURL, ic.cfg); lErr != nil {
 				return lErr
 			}
-			resolvedPlugin, err = plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL)
+			resolvedPlugin, err = plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL, dashboardBaseURL)
 		}
 		if err != nil {
 			return err
@@ -119,7 +134,7 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
-	if err := resolvedPlugin.Install(ctx, ic.cfg, ic.fs, ic.apiBaseURL); err != nil {
+	if err := resolvedPlugin.Install(ctx, ic.cfg, ic.fs, ic.apiBaseURL, dashboardBaseURL); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/plugin/upgrade.go
+++ b/pkg/cmd/plugin/upgrade.go
@@ -21,7 +21,8 @@ type UpgradeCmd struct {
 	Cmd *cobra.Command
 	fs  afero.Fs
 
-	apiBaseURL string
+	apiBaseURL       string
+	dashboardBaseURL string
 }
 
 // NewUpgradeCmd creates a new command for upgrading plugins
@@ -41,12 +42,18 @@ func NewUpgradeCmd(config *config.Config) *UpgradeCmd {
 	// Hidden configuration flags, useful for dev/debugging
 	uc.Cmd.Flags().StringVar(&uc.apiBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
 	uc.Cmd.Flags().MarkHidden("api-base") // #nosec G104
+	uc.Cmd.Flags().StringVar(&uc.dashboardBaseURL, "dashboard-base", "", "Sets the dashboard base URL")
+	uc.Cmd.Flags().MarkHidden("dashboard-base") // #nosec G104
 
 	return uc
 }
 
 func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	if err := stripe.ValidateAPIBaseURL(uc.apiBaseURL); err != nil {
+		return err
+	}
+	dashboardBaseURL := resolveDashboardBaseURL(uc.apiBaseURL, uc.dashboardBaseURL)
+	if err := stripe.ValidateDashboardBaseURL(dashboardBaseURL); err != nil {
 		return err
 	}
 
@@ -56,7 +63,7 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
-	resolvedPlugin, err := plugins.ResolvePluginForUpgrade(ctx, uc.cfg, uc.fs, args[0], uc.apiBaseURL)
+	resolvedPlugin, err := plugins.ResolvePluginForUpgrade(ctx, uc.cfg, uc.fs, args[0], uc.apiBaseURL, dashboardBaseURL)
 	if err != nil {
 		return err
 	}
@@ -75,7 +82,7 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 
 	prevVersion := plugin.InstalledVersion(uc.cfg, uc.fs)
 
-	if err := resolvedPlugin.Install(ctx, uc.cfg, uc.fs, uc.apiBaseURL); err != nil {
+	if err := resolvedPlugin.Install(ctx, uc.cfg, uc.fs, uc.apiBaseURL, dashboardBaseURL); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -77,6 +77,7 @@ func withPrivatePreview() option {
 
 func newPluginHintCmd(cfg *config.Config, name, description string, opts ...option) *pluginHintCmd {
 	fs := afero.NewOsFs()
+	dashboardBaseURL := stripe.DashboardBaseURLForAPIBaseURL(stripe.DefaultAPIBaseURL)
 
 	p := &pluginHintCmd{
 		name:        name,
@@ -94,10 +95,10 @@ func newPluginHintCmd(cfg *config.Config, name, description string, opts ...opti
 				return err
 			}
 			version := plugin.LookUpLatestVersion()
-			return plugin.Install(ctx, cfg, fs, version, stripe.DefaultAPIBaseURL)
+			return plugin.Install(ctx, cfg, fs, version, stripe.DefaultAPIBaseURL, dashboardBaseURL)
 		},
 		loginFn: func(ctx context.Context) error {
-			return login.Login(ctx, stripe.DefaultDashboardBaseURL, cfg)
+			return login.Login(ctx, dashboardBaseURL, cfg)
 		},
 		accountIDFn:   cfg.GetProfile().GetAccountID,
 		openBrowserFn: open.Browser,

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -293,26 +293,31 @@ func (p *Plugin) InstalledVersion(config config.IConfig, fs afero.Fs) string {
 }
 
 // Install installs the plugin of the given version.
-func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, baseURL string) error {
-	return p.install(ctx, cfg, fs, version, baseURL, "", false)
+func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, apiBaseURL, dashboardBaseURL string) error {
+	return p.install(ctx, cfg, fs, version, apiBaseURL, dashboardBaseURL, "", false)
 }
 
-func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, baseURL, resolvedBinaryURL string, skipMetadataLookup bool) error {
+func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, apiBaseURL, dashboardBaseURL, resolvedBinaryURL string, skipMetadataLookup bool) error {
 	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)
 
 	apiKey, _ := cfg.GetProfile().GetAPIKey(false)
 	pluginToInstall := p
 	pluginDownloadURL := resolvedBinaryURL
 	downloadURLFromMetadata := resolvedBinaryURL != ""
+	metadataBaseURL := apiBaseURL
+	if apiKey == "" && dashboardBaseURL != "" {
+		metadataBaseURL = dashboardBaseURL
+	}
 
 	if !skipMetadataLookup {
 		metadataEndpoint := "/v1/stripecli/get-plugin-metadata"
 		if apiKey == "" {
-			metadataEndpoint = "/v1/stripecli/plugins_metadata"
+			metadataEndpoint = "/ajax/stripecli/plugins_metadata"
 		}
 
 		log.WithFields(log.Fields{
 			"prefix":   "plugins.plugin.Install",
+			"base_url": metadataBaseURL,
 			"endpoint": metadataEndpoint,
 			"plugin":   p.Shortname,
 			"version":  version,
@@ -320,7 +325,7 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 			"arch":     runtime.GOARCH,
 		}).Debug("Fetching plugin metadata for install")
 
-		pluginMetadata, err := requests.GetPluginMetadata(ctx, baseURL, stripe.APIVersion, apiKey, cfg.GetProfile(), p.Shortname, version, runtime.GOOS, runtime.GOARCH)
+		pluginMetadata, err := requests.GetPluginMetadata(ctx, apiBaseURL, dashboardBaseURL, stripe.APIVersion, apiKey, cfg.GetProfile(), p.Shortname, version, runtime.GOOS, runtime.GOARCH)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"prefix": "plugins.plugin.Install",
@@ -340,7 +345,7 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 
 	if pluginDownloadURL == "" {
 		var err error
-		pluginDownloadURL, err = getLegacyPluginDownloadURL(ctx, cfg, apiKey, baseURL, version, pluginToInstall)
+		pluginDownloadURL, err = getLegacyPluginDownloadURL(ctx, cfg, apiKey, apiBaseURL, version, pluginToInstall)
 		if err != nil {
 			ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
 
@@ -372,7 +377,7 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 			"prefix": "plugins.plugin.Install",
 		}).Debugf("could not download plugin from metadata URL, falling back to plugin URL lookup: %s", err)
 
-		fallbackURL, fallbackErr := getLegacyPluginDownloadURL(ctx, cfg, apiKey, baseURL, version, pluginToInstall)
+		fallbackURL, fallbackErr := getLegacyPluginDownloadURL(ctx, cfg, apiKey, apiBaseURL, version, pluginToInstall)
 		if fallbackErr != nil {
 			log.WithFields(log.Fields{
 				"prefix": "plugins.plugin.Install",
@@ -597,14 +602,15 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 		// before reinstalling so stale cached local metadata does not pin us to an
 		// older release.
 		if version == "" {
-			resolvedPlugin, err := resolvePluginForAutoInstall(ctx, config, fs, p.Shortname, stripe.DefaultAPIBaseURL)
+			dashboardBaseURL := stripe.DashboardBaseURLForAPIBaseURL(stripe.DefaultAPIBaseURL)
+			resolvedPlugin, err := resolvePluginForAutoInstall(ctx, config, fs, p.Shortname, stripe.DefaultAPIBaseURL, dashboardBaseURL)
 			if err != nil {
 				return err
 			}
 
 			p = resolvedPlugin.Plugin
 			version = resolvedPlugin.Version
-			if err := resolvedPlugin.Install(ctx, config, fs, stripe.DefaultAPIBaseURL); err != nil {
+			if err := resolvedPlugin.Install(ctx, config, fs, stripe.DefaultAPIBaseURL, dashboardBaseURL); err != nil {
 				return err
 			}
 		}

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -52,7 +52,7 @@ func TestInstall(t *testing.T) {
 	testServers := setUpServers(t, manifestContent, nil)
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.Nil(t, err)
 	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, err := afero.Exists(fs, file)
@@ -74,7 +74,7 @@ func TestInstallRollsBackPersistedStateWhenConfigWriteFails(t *testing.T) {
 	defer testServers.CloseAll()
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.ErrorIs(t, err, config.WriteErr)
 
 	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
@@ -122,7 +122,7 @@ func TestInstallUsesPluginMetadataEndpointWhenAPIKeyAvailable(t *testing.T) {
 	defer stripeServer.Close()
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 }
 
@@ -143,9 +143,14 @@ func TestInstallUsesAnonymousPluginMetadataEndpointWhenAPIKeyUnavailable(t *test
 	}))
 	defer artifactoryServer.Close()
 
-	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		t.Fatalf("anonymous plugin metadata install should not hit the API host: %s", req.URL.String())
+	}))
+	defer apiServer.Close()
+
+	dashboardServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/v1/stripecli/plugins_metadata":
+		case "/ajax/stripecli/plugins_metadata":
 			body, err := json.Marshal(requests.PluginMetadata{
 				BinaryURL:      fmt.Sprintf("%s/appA/2.0.1/%s/%s/stripe-cli-app-a", artifactoryServer.URL, runtime.GOOS, runtime.GOARCH),
 				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
@@ -158,10 +163,10 @@ func TestInstallUsesAnonymousPluginMetadataEndpointWhenAPIKeyUnavailable(t *test
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
 	}))
-	defer stripeServer.Close()
+	defer dashboardServer.Close()
 
 	plugin := &Plugin{Shortname: "appA"}
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", apiServer.URL, dashboardServer.URL)
 	require.NoError(t, err)
 
 	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
@@ -202,7 +207,7 @@ func TestInstallFallsBackIfPluginMetadataEndpointFails(t *testing.T) {
 	defer fallbackServer.Close()
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", fallbackServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", fallbackServer.URL, fallbackServer.URL)
 	require.NoError(t, err)
 }
 
@@ -250,7 +255,7 @@ func TestInstallFallsBackIfMetadataBinaryURLReturnsNotFound(t *testing.T) {
 	defer stripeServer.Close()
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	require.Equal(t, 1, pluginURLLookups)
 
@@ -305,7 +310,7 @@ func TestInstallFallsBackIfMetadataBinaryURLVerificationFails(t *testing.T) {
 	defer stripeServer.Close()
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	require.Equal(t, 1, pluginURLLookups)
 
@@ -349,7 +354,7 @@ func TestInstallPersistsLocalMetadataWithoutManifest(t *testing.T) {
 	defer stripeServer.Close()
 
 	plugin := &Plugin{Shortname: "appA"}
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 
 	cachedPlugin, err := readLocalPluginMetadata(config, fs, "appA")
@@ -391,7 +396,7 @@ func TestResolvePluginForInstallUsesMetadataWithoutCachedManifest(t *testing.T) 
 	}))
 	defer stripeServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	plugin := resolvedPlugin.Plugin
 	version := resolvedPlugin.Version
@@ -431,7 +436,7 @@ func TestResolvePluginForInstallResolvesLatestVersionFromMetadata(t *testing.T) 
 	}))
 	defer stripeServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	plugin := resolvedPlugin.Plugin
 	version := resolvedPlugin.Version
@@ -469,7 +474,7 @@ func TestResolvePluginForInstallFallsBackToManifestLookupWhenMetadataFails(t *te
 	}))
 	defer fallbackServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", fallbackServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", fallbackServer.URL, fallbackServer.URL)
 	require.NoError(t, err)
 	plugin := resolvedPlugin.Plugin
 	version := resolvedPlugin.Version
@@ -518,11 +523,11 @@ func TestResolvedPluginInstallUsesResolvedMetadataWithoutSecondLookup(t *testing
 	}))
 	defer stripeServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	require.Equal(t, 1, metadataLookups)
 
-	err = resolvedPlugin.Install(context.Background(), config, fs, stripeServer.URL)
+	err = resolvedPlugin.Install(context.Background(), config, fs, stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	require.Equal(t, 1, metadataLookups)
 }
@@ -610,12 +615,12 @@ func TestResolvedPluginInstallRetriesMetadataAfterManifestFallback(t *testing.T)
 	}))
 	defer stripeServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	require.Equal(t, 1, metadataLookups)
 	require.Equal(t, 1, pluginURLLookups)
 
-	err = resolvedPlugin.Install(context.Background(), config, fs, stripeServer.URL)
+	err = resolvedPlugin.Install(context.Background(), config, fs, stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	require.Equal(t, 2, metadataLookups)
 	require.Equal(t, 1, pluginURLLookups)
@@ -651,7 +656,7 @@ func TestResolvePluginForAutoInstallPrefersFreshMetadataWhenLocalMetadataIsStale
 	testServers := setUpServers(t, manifestContent, nil)
 	defer testServers.CloseAll()
 
-	resolvedPlugin, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", testServers.StripeServer.URL)
+	resolvedPlugin, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.NoError(t, err)
 	plugin := resolvedPlugin.Plugin
 	version := resolvedPlugin.Version
@@ -689,7 +694,7 @@ func TestResolvePluginForAutoInstallFallsBackToCachedManifestWhenFreshLookupFail
 	}))
 	defer failingServer.Close()
 
-	resolvedPlugin, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", failingServer.URL)
+	resolvedPlugin, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", failingServer.URL, failingServer.URL)
 	require.NoError(t, err)
 	plugin := resolvedPlugin.Plugin
 	version := resolvedPlugin.Version
@@ -756,7 +761,7 @@ func TestInstallSucceedsIfNoAPIKey(t *testing.T) {
 	}()
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.Nil(t, err)
 	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, err := afero.Exists(fs, file)
@@ -774,7 +779,7 @@ func TestInstallFailsIfChecksumCouldNotBeFound(t *testing.T) {
 	testServers := setUpServers(t, manifestContent, nil)
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "0.0.0", testServers.StripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "0.0.0", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.EqualError(t, err, "could not locate a valid checksum for appA version 0.0.0")
 
 	// Require that we don't save the binary if checkum does not match
@@ -794,7 +799,7 @@ func TestInstallationFailsIfChecksumDoesNotMatch(t *testing.T) {
 	testServers := setUpServers(t, manifestContent, nil)
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appB")
-	err := plugin.Install(context.Background(), config, fs, "1.2.1", testServers.StripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "1.2.1", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.EqualError(t, err, "installed plugin 'appB' could not be verified, aborting installation")
 
 	// Require that we don't save the binary if checkum does not match
@@ -815,14 +820,14 @@ func TestInstallCleansOtherVersionsOfPlugin(t *testing.T) {
 
 	// Download plugin version 0.0.1
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "0.0.1", testServers.StripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "0.0.1", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.Nil(t, err)
 	file := fmt.Sprintf("/plugins/appA/0.0.1/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, _ := afero.Exists(fs, file)
 	require.True(t, fileExists, "Test setup failed -- did not download plugin version 0.0.1")
 
 	// Download valid plugin
-	err = plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
+	err = plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.Nil(t, err)
 	newFile := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, _ = afero.Exists(fs, newFile)
@@ -844,14 +849,14 @@ func TestInstallDoesNotCleanIfInstallFails(t *testing.T) {
 
 	// Download valid plugin
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.Nil(t, err)
 	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, _ := afero.Exists(fs, file)
 	require.True(t, fileExists, "Test setup failed -- did not download valid plugin")
 
 	// Install fails for the same plugin because the checksum could not be found in manifest
-	err = plugin.Install(context.Background(), config, fs, "0.0.0", testServers.StripeServer.URL)
+	err = plugin.Install(context.Background(), config, fs, "0.0.0", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.EqualError(t, err, "could not locate a valid checksum for appA version 0.0.0")
 	failedFile := fmt.Sprintf("/plugins/appA/0.0.0/stripe-cli-app-a%s", GetBinaryExtension())
 	fileExists, _ = afero.Exists(fs, failedFile)
@@ -945,7 +950,7 @@ func TestUninstall(t *testing.T) {
 
 	// install a plugin to be uninstalled
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL)
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.Nil(t, err)
 	metadataPath := getLocalPluginMetadataPath(config, "appA")
 	cacheExists, err := afero.Exists(fs, metadataPath)

--- a/pkg/plugins/test_utils.go
+++ b/pkg/plugins/test_utils.go
@@ -127,7 +127,7 @@ func setUpServers(t *testing.T, manifestContent []byte, additionalManifests map[
 				t.Error(err)
 			}
 			res.Write(body)
-		case "/v1/stripecli/get-plugin-metadata", "/v1/stripecli/plugins_metadata":
+		case "/v1/stripecli/get-plugin-metadata", "/ajax/stripecli/plugins_metadata":
 			pluginName := req.URL.Query().Get("plugin")
 			version := req.URL.Query().Get("version")
 			opsystem := req.URL.Query().Get("os")

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -49,7 +49,7 @@ type ResolvedPluginVersion struct {
 // resolved a concrete binary URL, it reuses that result and skips a second
 // metadata request. Otherwise it retries metadata during install so manifest or
 // cached fallbacks can still recover fresh release details.
-func (r *ResolvedPluginVersion) Install(ctx context.Context, config config.IConfig, fs afero.Fs, baseURL string) error {
+func (r *ResolvedPluginVersion) Install(ctx context.Context, config config.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string) error {
 	switch {
 	case r == nil:
 		return errors.New("missing resolved plugin version")
@@ -58,7 +58,7 @@ func (r *ResolvedPluginVersion) Install(ctx context.Context, config config.IConf
 	case r.Version == "":
 		return errors.New("missing plugin version")
 	default:
-		return r.Plugin.install(ctx, config, fs, r.Version, baseURL, r.BinaryURL, r.BinaryURL != "")
+		return r.Plugin.install(ctx, config, fs, r.Version, apiBaseURL, dashboardBaseURL, r.BinaryURL, r.BinaryURL != "")
 	}
 }
 
@@ -321,13 +321,13 @@ func LookUpPluginInManifest(ctx context.Context, config config.IConfig, fs afero
 
 // ResolvePluginForInstall resolves the plugin metadata needed by `stripe plugin install`
 // without requiring a manifest refresh on the metadata-backed path.
-func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, baseURL string) (*ResolvedPluginVersion, error) {
+func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
 	apiKey, err := config.GetProfile().GetAPIKey(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return nil, err
 	}
 
-	resolvedPlugin, err := resolvePluginFromMetadata(ctx, config, fs, pluginName, version, baseURL, apiKey)
+	resolvedPlugin, err := resolvePluginFromMetadata(ctx, config, fs, pluginName, version, apiBaseURL, dashboardBaseURL, apiKey)
 	if err == nil {
 		return resolvedPlugin, nil
 	}
@@ -338,7 +338,7 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 		"version": version,
 	}).Debugf("could not resolve plugin via plugin metadata endpoint, falling back to manifest lookup: %s", err)
 
-	if err := RefreshPluginManifest(ctx, config, fs, baseURL); err != nil {
+	if err := RefreshPluginManifest(ctx, config, fs, apiBaseURL); err != nil {
 		return nil, err
 	}
 
@@ -367,13 +367,13 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 // ResolvePluginForUpgrade resolves the latest plugin metadata for
 // `stripe plugin upgrade` using the plugin metadata endpoint first and cached
 // local metadata or the global manifest as fallback.
-func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, baseURL string) (*ResolvedPluginVersion, error) {
+func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
 	apiKey, err := config.GetProfile().GetAPIKey(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return nil, err
 	}
 
-	resolvedPlugin, endpointErr := resolvePluginFromMetadata(ctx, config, fs, pluginName, "", baseURL, apiKey)
+	resolvedPlugin, endpointErr := resolvePluginFromMetadata(ctx, config, fs, pluginName, "", apiBaseURL, dashboardBaseURL, apiKey)
 	if endpointErr == nil {
 		return resolvedPlugin, nil
 	}
@@ -383,7 +383,7 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 		"plugin": pluginName,
 	}).Debugf("could not resolve latest plugin via plugin metadata endpoint, falling back to cached plugin metadata or manifest: %s", endpointErr)
 
-	refreshErr := RefreshPluginManifest(ctx, config, fs, baseURL)
+	refreshErr := RefreshPluginManifest(ctx, config, fs, apiBaseURL)
 	if refreshErr != nil {
 		log.WithFields(log.Fields{
 			"prefix": "plugins.ResolvePluginForUpgrade",
@@ -445,8 +445,8 @@ func resolveCachedPluginForUpgrade(config config.IConfig, fs afero.Fs, pluginNam
 
 // resolvePluginForAutoInstall resolves the freshest plugin metadata to use when
 // a command is invoked but the local plugin binary is missing.
-func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, baseURL string) (*ResolvedPluginVersion, error) {
-	resolvedPlugin, err := ResolvePluginForInstall(ctx, config, fs, pluginName, "", baseURL)
+func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
+	resolvedPlugin, err := ResolvePluginForInstall(ctx, config, fs, pluginName, "", apiBaseURL, dashboardBaseURL)
 	if err == nil {
 		return resolvedPlugin, nil
 	}
@@ -589,7 +589,7 @@ func mergePluginMetadata(primary, fallback *Plugin) *Plugin {
 	return &pluginCopy
 }
 
-func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, baseURL, apiKey string) (*ResolvedPluginVersion, error) {
+func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, apiBaseURL, dashboardBaseURL, apiKey string) (*ResolvedPluginVersion, error) {
 	basePlugin := &Plugin{Shortname: pluginName}
 	if cachedPlugin, err := readLocalPluginMetadata(config, fs, pluginName); err == nil {
 		basePlugin = &cachedPlugin
@@ -597,7 +597,7 @@ func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs af
 		basePlugin = &cachedPlugin
 	}
 
-	pluginMetadata, err := requests.GetPluginMetadata(ctx, baseURL, stripe.APIVersion, apiKey, config.GetProfile(), pluginName, version, runtime.GOOS, runtime.GOARCH)
+	pluginMetadata, err := requests.GetPluginMetadata(ctx, apiBaseURL, dashboardBaseURL, stripe.APIVersion, apiKey, config.GetProfile(), pluginName, version, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -325,7 +325,7 @@ func TestResolvePluginForInstallUsesLocalMetadataAsMetadataBase(t *testing.T) {
 	}))
 	defer stripeServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	plugin := resolvedPlugin.Plugin
 	version := resolvedPlugin.Version
@@ -345,9 +345,14 @@ func TestResolvePluginForInstallUsesAnonymousMetadataWithoutCachedManifest(t *te
 	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
 
 	var metadataLookups int
-	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		t.Fatalf("anonymous install resolution should not hit the API host: %s", req.URL.String())
+	}))
+	defer apiServer.Close()
+
+	dashboardServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/v1/stripecli/plugins_metadata":
+		case "/ajax/stripecli/plugins_metadata":
 			metadataLookups++
 			body, err := json.Marshal(requests.PluginMetadata{
 				BinaryURL:      "https://example.test/appA/2.0.1",
@@ -361,9 +366,9 @@ func TestResolvePluginForInstallUsesAnonymousMetadataWithoutCachedManifest(t *te
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
 	}))
-	defer stripeServer.Close()
+	defer dashboardServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", apiServer.URL, dashboardServer.URL)
 	require.NoError(t, err)
 	plugin := resolvedPlugin.Plugin
 	version := resolvedPlugin.Version
@@ -397,7 +402,7 @@ func TestResolvePluginForInstallFallsBackToManifestLookupWhenAnonymousMetadataFa
 
 	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/v1/stripecli/plugins_metadata":
+		case "/ajax/stripecli/plugins_metadata":
 			res.WriteHeader(http.StatusInternalServerError)
 			res.Write([]byte(`{"error":{"message":"boom"}}`))
 		default:
@@ -406,7 +411,7 @@ func TestResolvePluginForInstallFallsBackToManifestLookupWhenAnonymousMetadataFa
 	}))
 	defer failingServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", failingServer.URL)
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", failingServer.URL, failingServer.URL)
 	require.NoError(t, err)
 	plugin := resolvedPlugin.Plugin
 	version := resolvedPlugin.Version
@@ -477,7 +482,7 @@ func TestResolvePluginForUpgradeUsesMetadataEndpointWhenAvailable(t *testing.T) 
 	}))
 	defer stripeServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	plugin := resolvedPlugin.Plugin
 	require.Equal(t, "0.1.26", plugin.LookUpLatestVersion())
@@ -520,9 +525,14 @@ func TestResolvePluginForUpgradeUsesAnonymousMetadataEndpointWhenAPIKeyUnavailab
 	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
 
 	var metadataLookups int
-	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		t.Fatalf("anonymous upgrade resolution should not hit the API host: %s", req.URL.String())
+	}))
+	defer apiServer.Close()
+
+	dashboardServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/v1/stripecli/plugins_metadata":
+		case "/ajax/stripecli/plugins_metadata":
 			metadataLookups++
 			require.Equal(t, "", req.URL.Query().Get("version"))
 			body, err := json.Marshal(requests.PluginMetadata{
@@ -548,9 +558,9 @@ func TestResolvePluginForUpgradeUsesAnonymousMetadataEndpointWhenAPIKeyUnavailab
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
 	}))
-	defer stripeServer.Close()
+	defer dashboardServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", stripeServer.URL)
+	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", apiServer.URL, dashboardServer.URL)
 	require.NoError(t, err)
 	plugin := resolvedPlugin.Plugin
 	require.Equal(t, "0.1.26", plugin.LookUpLatestVersion())
@@ -597,7 +607,7 @@ func TestResolvePluginForUpgradeFallsBackToCachedMetadataWhenEndpointFails(t *te
 	}))
 	defer failingServer.Close()
 
-	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", failingServer.URL)
+	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", failingServer.URL, failingServer.URL)
 	require.NoError(t, err)
 	plugin := resolvedPlugin.Plugin
 	require.Equal(t, localPlugin, *plugin)

--- a/pkg/requests/plugin.go
+++ b/pkg/requests/plugin.go
@@ -34,10 +34,18 @@ var DefaultPluginData = PluginData{
 
 func getPluginMetadataPath(apiKey string) string {
 	if apiKey == "" {
-		return "/v1/stripecli/plugins_metadata"
+		return "/ajax/stripecli/plugins_metadata"
 	}
 
 	return "/v1/stripecli/get-plugin-metadata"
+}
+
+func getPluginMetadataBaseURL(apiKey, apiBaseURL, dashboardBaseURL string) string {
+	if apiKey == "" && dashboardBaseURL != "" {
+		return dashboardBaseURL
+	}
+
+	return apiBaseURL
 }
 
 // GetPluginData returns the plugin download information
@@ -78,20 +86,33 @@ func GetPluginData(ctx context.Context, baseURL, apiVersion, apiKey string, prof
 // GetPluginMetadata returns plugin-specific manifest and binary information.
 // It uses the authenticated endpoint when an API key is available and the
 // anonymous endpoint otherwise.
-func GetPluginMetadata(ctx context.Context, baseURL, apiVersion, apiKey string, profile *config.Profile, pluginName, version, os, arch string) (PluginMetadata, error) {
+func GetPluginMetadata(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVersion, apiKey string, profile *config.Profile, pluginName, version, os, arch string) (PluginMetadata, error) {
 	params := &RequestParameters{
 		data:    []string{},
 		version: apiVersion,
 	}
 
+	metadataBaseURL := getPluginMetadataBaseURL(apiKey, apiBaseURL, dashboardBaseURL)
+	metadataPath := getPluginMetadataPath(apiKey)
+
+	log.WithFields(log.Fields{
+		"prefix":   "requests.GetPluginMetadata",
+		"base_url": metadataBaseURL,
+		"endpoint": metadataPath,
+		"plugin":   pluginName,
+		"version":  version,
+		"os":       os,
+		"arch":     arch,
+	}).Debug("Fetching plugin metadata")
+
 	base := &Base{
 		Profile:        profile,
 		Method:         http.MethodGet,
 		SuppressOutput: true,
-		APIBaseURL:     baseURL,
+		APIBaseURL:     metadataBaseURL,
 	}
 
-	resp, err := base.MakeRequest(ctx, apiKey, getPluginMetadataPath(apiKey), params, map[string]interface{}{
+	resp, err := base.MakeRequest(ctx, apiKey, metadataPath, params, map[string]interface{}{
 		"plugin":  pluginName,
 		"version": version,
 		"os":      os,

--- a/pkg/stripe/url.go
+++ b/pkg/stripe/url.go
@@ -2,7 +2,9 @@ package stripe
 
 import (
 	"errors"
+	"net/url"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -62,4 +64,38 @@ func ValidateDashboardBaseURL(dashboardBaseURL string) error {
 		return nil
 	}
 	return errInvalidDashboardBaseURL
+}
+
+// DashboardBaseURLForAPIBaseURL derives the matching dashboard base URL for a
+// given API base URL. This keeps dev and QA hosts aligned without requiring a
+// separate dashboard override in the common case.
+func DashboardBaseURLForAPIBaseURL(apiBaseURL string) string {
+	if apiBaseURL == "" {
+		return DefaultDashboardBaseURL
+	}
+
+	parsedBaseURL, err := url.Parse(apiBaseURL)
+	if err != nil || parsedBaseURL.Host == "" {
+		return DefaultDashboardBaseURL
+	}
+
+	switch {
+	case parsedBaseURL.Host == "api.stripe.com":
+		parsedBaseURL.Host = "dashboard.stripe.com"
+	case parsedBaseURL.Host == "qa-api.stripe.com":
+		parsedBaseURL.Host = "qa-dashboard.stripe.com"
+	case strings.Contains(parsedBaseURL.Host, "--api-dev.dev.stripe.me"):
+		parsedBaseURL.Host = strings.Replace(parsedBaseURL.Host, "--api-dev.dev.stripe.me", "--dashboard-dev.dev.stripe.me", 1)
+	case strings.Contains(parsedBaseURL.Host, "--api-iso.dev.stripe.me"):
+		parsedBaseURL.Host = strings.Replace(parsedBaseURL.Host, "--api-iso.dev.stripe.me", "--dashboard-iso.dev.stripe.me", 1)
+	default:
+		parsedBaseURL.Host = strings.Replace(parsedBaseURL.Host, "api-", "manage-", 1)
+	}
+
+	parsedBaseURL.Path = ""
+	parsedBaseURL.RawPath = ""
+	parsedBaseURL.RawQuery = ""
+	parsedBaseURL.Fragment = ""
+
+	return parsedBaseURL.String()
 }

--- a/pkg/stripe/url_test.go
+++ b/pkg/stripe/url_test.go
@@ -32,6 +32,8 @@ func TestValidateDashboardBaseURLWorks(t *testing.T) {
 	assert.Nil(t, ValidateDashboardBaseURL("http://foo-manage-mydev.dev.stripe.me"))
 	assert.Nil(t, ValidateDashboardBaseURL("https://foo-lv5r9y--manage-mydev.dev.stripe.me/"))
 	assert.Nil(t, ValidateDashboardBaseURL("https://foo-0-lv5r9y--manage-dashboard-proxy-mydev.dev.stripe.me/"))
+	assert.Nil(t, ValidateDashboardBaseURL("https://foo-0-lv5r9y--dashboard-dev.dev.stripe.me/"))
+	assert.Nil(t, ValidateDashboardBaseURL("https://foo-0-lv5r9y--dashboard-iso.dev.stripe.me/"))
 	assert.Nil(t, ValidateDashboardBaseURL("http://127.0.0.1"))
 	assert.Nil(t, ValidateDashboardBaseURL("http://127.0.0.1:1337"))
 
@@ -39,4 +41,17 @@ func TestValidateDashboardBaseURLWorks(t *testing.T) {
 	assert.ErrorIs(t, ValidateDashboardBaseURL("https://unknowndomain"), errInvalidDashboardBaseURL)
 	assert.ErrorIs(t, ValidateDashboardBaseURL("localhost"), errInvalidDashboardBaseURL)
 	assert.ErrorIs(t, ValidateDashboardBaseURL("anything_else"), errInvalidDashboardBaseURL)
+}
+
+func TestDashboardBaseURLForAPIBaseURLWorks(t *testing.T) {
+	assert.Equal(t, "https://dashboard.stripe.com", DashboardBaseURLForAPIBaseURL(""))
+	assert.Equal(t, "https://dashboard.stripe.com", DashboardBaseURLForAPIBaseURL("https://api.stripe.com"))
+	assert.Equal(t, "https://dashboard.stripe.com", DashboardBaseURLForAPIBaseURL("https://api.stripe.com/v1"))
+	assert.Equal(t, "https://qa-dashboard.stripe.com", DashboardBaseURLForAPIBaseURL("https://qa-api.stripe.com"))
+	assert.Equal(t, "http://foo-manage-mydev.dev.stripe.me", DashboardBaseURLForAPIBaseURL("http://foo-api-mydev.dev.stripe.me"))
+	assert.Equal(t, "https://foo-lv5r9y--manage-mydev.dev.stripe.me", DashboardBaseURLForAPIBaseURL("https://foo-lv5r9y--api-mydev.dev.stripe.me/"))
+	assert.Equal(t, "https://foo-lv5r9y--dashboard-iso.dev.stripe.me", DashboardBaseURLForAPIBaseURL("https://foo-lv5r9y--api-iso.dev.stripe.me"))
+	assert.Equal(t, "https://foo-0-lv5r9y--dashboard-dev.dev.stripe.me", DashboardBaseURLForAPIBaseURL("https://foo-0-lv5r9y--api-dev.dev.stripe.me"))
+	assert.Equal(t, "https://foo-0-lv5r9y--dashboard-iso.dev.stripe.me", DashboardBaseURLForAPIBaseURL("https://foo-0-lv5r9y--api-iso.dev.stripe.me"))
+	assert.Equal(t, "http://127.0.0.1:1337", DashboardBaseURLForAPIBaseURL("http://127.0.0.1:1337"))
 }


### PR DESCRIPTION
Unauthenticated plugin lookups now hit the dashboard `/ajax/stripecli/plugins_metadata` endpoint instead of the API server. This adds a `--dashboard-base` flag to install/upgrade commands, derives the dashboard URL from the API base URL automatically, and threads the dashboard base URL through the plugin resolution and install paths.


Manually tested: 

Public release:
<img width="1239" height="268" alt="Screenshot 2026-05-27 at 9 51 53 PM" src="https://github.com/user-attachments/assets/500cc3c2-a59f-483a-81e3-138922edb7f9" />

Conditional release:
<img width="1240" height="213" alt="Screenshot 2026-05-27 at 9 54 14 PM" src="https://github.com/user-attachments/assets/48016947-aab6-4d1b-ae2a-139fa7bcf2fd" />

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
