### PR TITLE
Add 'tools' plugin hint command

### DIFF
--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -42,6 +42,11 @@ func AddHintCommands(rootCmd *cobra.Command, cfg *config.Config, installedPlugin
 			newPluginHintCmd(cfg, "docs", "Browse Stripe documentation and API reference.").Command,
 		)
 	}
+	if !installedPluginSet["tools"] {
+		rootCmd.AddCommand(
+			newPluginHintCmd(cfg, "tools", "Search, inspect, and execute Stripe operations not available in the public API.").Command,
+		)
+	}
 }
 
 // pluginHintCmd is a placeholder Cobra command registered when a known plugin


### PR DESCRIPTION
## Summary
Adds a hint command for the new 'tools' plugin so it appears in `stripe --help` and prompts installation.

The 'tools' plugin (formerly 'spec') provides API operation search, inspection, and execution for AI agents and developers.

## Test plan
- `go build && ./bin/stripe --help` shows 'tools' in Other commands
- `./bin/stripe tools` prompts install or shows availability message
- `go test ./pkg/cmd/pluginhints/...` passes