### PR TITLE
Publish stripe climate commitment subcommands

### DIFF
--- a/pkg/cmd/resource/climate.go
+++ b/pkg/cmd/resource/climate.go
@@ -41,7 +41,6 @@ func AddClimateCommitmentsSubCmds(rootCmd *cobra.Command, cfg *config.Config) {
 	}
 
 	rCommitmentCmd := NewResourceCmd(climateCmd, "commitment")
-	rCommitmentCmd.Cmd.Hidden = true
 
 	newClimateEnableCmd(rCommitmentCmd.Cmd, cfg)
 	newClimateShowCmd(rCommitmentCmd.Cmd, cfg)

--- a/pkg/cmd/resource/climate_test.go
+++ b/pkg/cmd/resource/climate_test.go
@@ -33,10 +33,6 @@ func setupCommitmentsCmd(t *testing.T) *cobra.Command {
 	return nil
 }
 
-func TestAddClimateCommitmentSubCmds_IsHidden(t *testing.T) {
-	assert.True(t, setupCommitmentsCmd(t).Hidden)
-}
-
 func TestAddClimateCommitmentSubCmds_HasExpectedOperations(t *testing.T) {
 	ops := make(map[string]bool)
 	for _, c := range setupCommitmentsCmd(t).Commands() {


### PR DESCRIPTION
### Reviewers
r? @vicky-stripe @mfix-stripe 
cc @stripe/developer-products

### Summary
This marks the `stripe climate commitment` subcommands introduced in https://github.com/stripe/stripe-cli/pull/1599 as public.