### PR TITLE
Fix misleading error when installing non-existent plugin

### DIFF
--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -98,26 +98,41 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 		if errors.As(err, &pluginNotFound) {
 			accountID, aErr := ic.cfg.GetProfile().GetAccountID()
 			if aErr != nil || accountID == "" {
-				return fmt.Errorf("no plugin named %q found. If this is a private plugin, run 'stripe login' and try again", pluginName)
+				fmt.Printf("No plugin named %q found. If this is a private plugin, you must be logged in to install it.\n\n", pluginName)
+				fmt.Print("Press Enter to run 'stripe login', or type anything to cancel")
+				var input string
+				fmt.Fscanln(os.Stdin, &input)
+				if input != "" {
+					return fmt.Errorf("login canceled")
+				}
+				if lErr := login.Login(cmd.Context(), dashboardBaseURL, ic.cfg); lErr != nil {
+					return lErr
+				}
+				resolvedPlugin, err = plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL, dashboardBaseURL)
+				if err != nil {
+					return fmt.Errorf("no plugin named %q exists", pluginName)
+				}
+			} else {
+				return fmt.Errorf("no plugin named %q exists", pluginName)
 			}
-			return fmt.Errorf("no plugin named %q exists", pluginName)
-		}
-		accountID, aErr := ic.cfg.GetProfile().GetAccountID()
-		if aErr != nil || accountID == "" {
-			fmt.Printf("You must be logged in to install the \"%s\" plugin.\n\n", pluginName)
-			fmt.Print("Press Enter to run 'stripe login', or type anything to cancel")
-			var input string
-			fmt.Fscanln(os.Stdin, &input)
-			if input != "" {
-				return fmt.Errorf("login canceled")
+		} else {
+			accountID, aErr := ic.cfg.GetProfile().GetAccountID()
+			if aErr != nil || accountID == "" {
+				fmt.Printf("You must be logged in to install the \"%s\" plugin.\n\n", pluginName)
+				fmt.Print("Press Enter to run 'stripe login', or type anything to cancel")
+				var input string
+				fmt.Fscanln(os.Stdin, &input)
+				if input != "" {
+					return fmt.Errorf("login canceled")
+				}
+				if lErr := login.Login(cmd.Context(), dashboardBaseURL, ic.cfg); lErr != nil {
+					return lErr
+				}
+				resolvedPlugin, err = plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL, dashboardBaseURL)
 			}
-			if lErr := login.Login(cmd.Context(), dashboardBaseURL, ic.cfg); lErr != nil {
-				return lErr
+			if err != nil {
+				return err
 			}
-			resolvedPlugin, err = plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL, dashboardBaseURL)
-		}
-		if err != nil {
-			return err
 		}
 	}
 	plugin := resolvedPlugin.Plugin

--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -3,6 +3,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -93,6 +94,14 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	isLatest := len(version) == 0
 	resolvedPlugin, err := plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL, dashboardBaseURL)
 	if err != nil {
+		var pluginNotFound *plugins.ErrPluginNotFound
+		if errors.As(err, &pluginNotFound) {
+			accountID, aErr := ic.cfg.GetProfile().GetAccountID()
+			if aErr != nil || accountID == "" {
+				return fmt.Errorf("no plugin named %q found. If this is a private plugin, run 'stripe login' and try again", pluginName)
+			}
+			return fmt.Errorf("no plugin named %q exists", pluginName)
+		}
 		accountID, aErr := ic.cfg.GetProfile().GetAccountID()
 		if aErr != nil || accountID == "" {
 			fmt.Printf("You must be logged in to install the \"%s\" plugin.\n\n", pluginName)

--- a/pkg/cmd/plugin/install_test.go
+++ b/pkg/cmd/plugin/install_test.go
@@ -2,10 +2,15 @@ package plugin
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
@@ -29,4 +34,90 @@ func TestSetInstallTelemetryMetadata(t *testing.T) {
 	installCmd.setInstallTelemetryMetadata(ctx, "apps")
 
 	require.Equal(t, "apps", metadata.PluginName)
+}
+
+func TestRunInstallCmdNonExistentPluginNotLoggedIn(t *testing.T) {
+	cfg, fs, cleanup := setupPluginCommandTest(t)
+	defer cleanup()
+	cfg.Profile.APIKey = ""
+	cfg.Profile.AccountID = ""
+
+	manifest := testPluginManifest()
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/ajax/stripecli/plugins_metadata":
+			res.WriteHeader(http.StatusNotFound)
+			res.Write([]byte(`{"error":{"message":"not found"}}`))
+		case "/plugins.toml":
+			res.Write(manifest)
+		default:
+			res.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	originalPluginData := requests.DefaultPluginData
+	requests.DefaultPluginData = requests.PluginData{
+		PluginBaseURL:       server.URL,
+		AdditionalManifests: nil,
+	}
+	defer func() { requests.DefaultPluginData = originalPluginData }()
+
+	// Redirect stdin to simulate user typing "cancel" to skip login prompt
+	origStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	w.WriteString("cancel\n")
+	w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	ic := NewInstallCmd(cfg)
+	ic.fs = fs
+	ic.apiBaseURL = server.URL
+	ic.Cmd.SetContext(context.Background())
+
+	err := ic.runInstallCmd(ic.Cmd, []string{"nonexistent-plugin"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "login canceled")
+}
+
+func TestRunInstallCmdNonExistentPluginLoggedIn(t *testing.T) {
+	cfg, fs, cleanup := setupPluginCommandTest(t)
+	defer cleanup()
+	cfg.Profile.AccountID = "acct_123"
+
+	manifest := testPluginManifest()
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			res.WriteHeader(http.StatusNotFound)
+			res.Write([]byte(`{"error":{"message":"not found"}}`))
+		case "/v1/stripecli/get-plugin-url":
+			body, _ := json.Marshal(requests.PluginData{
+				PluginBaseURL:       serverURL,
+				AdditionalManifests: nil,
+			})
+			res.Write(body)
+		case "/plugins.toml":
+			res.Write(manifest)
+		default:
+			res.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	ic := NewInstallCmd(cfg)
+	ic.fs = fs
+	ic.apiBaseURL = server.URL
+	ic.Cmd.SetContext(context.Background())
+
+	err := ic.runInstallCmd(ic.Cmd, []string{"nonexistent-plugin"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no plugin named")
+	require.Contains(t, err.Error(), "nonexistent-plugin")
+	require.Contains(t, err.Error(), "exists")
 }

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -344,10 +344,7 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 
 	manifestPlugin, err := LookUpPluginInManifest(ctx, config, fs, pluginName)
 	if err != nil {
-		if apiKey == "" {
-			return nil, fmt.Errorf("could not find a plugin named %s. Run 'stripe login' and try again", pluginName)
-		}
-		return nil, err
+		return nil, &ErrPluginNotFound{Name: pluginName}
 	}
 
 	manifestVersion := version
@@ -919,6 +916,16 @@ type remoteResourceNotFoundError struct {
 
 func (e *remoteResourceNotFoundError) Error() string {
 	return fmt.Sprintf("remote resource not found: url=%s", e.URL)
+}
+
+// ErrPluginNotFound is returned when a plugin cannot be found in either the
+// metadata endpoint or the global manifest.
+type ErrPluginNotFound struct {
+	Name string
+}
+
+func (e *ErrPluginNotFound) Error() string {
+	return fmt.Sprintf("no plugin named %q exists", e.Name)
 }
 
 // FetchRemoteResource returns the remote resource body

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -1175,3 +1175,107 @@ func TestRefreshPluginManifestRefusesSymlinkedParent(t *testing.T) {
 	_, err = os.Stat(filepath.Join(victimDir, "plugins.toml"))
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
+
+func TestResolvePluginForInstallReturnsErrPluginNotFoundWhenLoggedIn(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			res.WriteHeader(http.StatusNotFound)
+			res.Write([]byte(`{"error":{"message":"not found"}}`))
+		case "/v1/stripecli/get-plugin-url":
+			body, _ := json.Marshal(requests.PluginData{
+				PluginBaseURL:       testServers.ArtifactoryServer.URL,
+				AdditionalManifests: nil,
+			})
+			res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer failingServer.Close()
+
+	_, err := ResolvePluginForInstall(context.Background(), config, fs, "nonexistent", "1.0.0", failingServer.URL, failingServer.URL)
+	require.Error(t, err)
+
+	var pluginNotFound *ErrPluginNotFound
+	require.ErrorAs(t, err, &pluginNotFound)
+	require.Equal(t, "nonexistent", pluginNotFound.Name)
+}
+
+func TestResolvePluginForInstallReturnsErrPluginNotFoundWhenNotLoggedIn(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.Profile.APIKey = ""
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	originalPluginData := requests.DefaultPluginData
+	requests.DefaultPluginData = requests.PluginData{
+		PluginBaseURL:       testServers.ArtifactoryServer.URL,
+		AdditionalManifests: nil,
+	}
+	defer func() {
+		requests.DefaultPluginData = originalPluginData
+	}()
+
+	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/ajax/stripecli/plugins_metadata":
+			res.WriteHeader(http.StatusNotFound)
+			res.Write([]byte(`{"error":{"message":"not found"}}`))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer failingServer.Close()
+
+	_, err := ResolvePluginForInstall(context.Background(), config, fs, "nonexistent", "1.0.0", failingServer.URL, failingServer.URL)
+	require.Error(t, err)
+
+	var pluginNotFound *ErrPluginNotFound
+	require.ErrorAs(t, err, &pluginNotFound)
+	require.Equal(t, "nonexistent", pluginNotFound.Name)
+}
+
+func TestResolvePluginForInstallSucceedsForGAPluginWhenNotLoggedIn(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.Profile.APIKey = ""
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	dashboardServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/ajax/stripecli/plugins_metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "https://example.test/appA/2.0.1",
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer dashboardServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		t.Fatalf("anonymous resolution should not hit the API host: %s", req.URL.String())
+	}))
+	defer apiServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", apiServer.URL, dashboardServer.URL)
+	require.NoError(t, err)
+	require.NotNil(t, resolvedPlugin.Plugin)
+	require.Equal(t, "appA", resolvedPlugin.Plugin.Shortname)
+	require.Equal(t, "2.0.1", resolvedPlugin.Version)
+}


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

When `stripe plugin install xx` fails because the plugin doesn't exist, the CLI now returns a clear "no plugin named X exists/found" error instead of misleadingly saying "You must be logged in to install xx"


Before:
```
 % stripe plugin install abc    
You must be logged in to install the "abc" plugin.

Press Enter to run 'stripe login', or type anything to cancel
```

After:
```
% bin/stripe plugin install abc   
No plugin named "abc" found. If this is a private plugin, you must be logged in to install it.

Press Enter to run 'stripe login', or type anything to cancel

Your pairing code is: xxxxxxx
This pairing code verifies your authentication with Stripe.
Press Enter to open the browser or visit https://dashboard.stripe.com/stripecli/confirm_auth?t=asdfgggh (^C to quit)> Done! The Stripe CLI is configured for Sandbox2 with account id acct_123
Please note: this key will expire after 90 days, at which point you'll need to re-authenticate.

no plugin named "abc" exists
```


| # | Auth State | Plugin | Expected Outcome |
|---|---|---|---|
| 1 | Not logged in | Exists (GA) | Installs successfully |
| 2 | Not logged in | Exists (private preview) | `no plugin named "X" found. If this is a private plugin, run 'stripe login' and try again` |
| 3 | Not logged in | Does not exist | Same as 2 (indistinguishable without auth) |
| 4 | Logged in | Exists (GA) | Installs successfully |
| 5 | Logged in | Exists (private preview, user has access) | Installs successfully |
| 6 | Logged in | Exists (private preview, user lacks access) | `no plugin named "X" exists` |
| 7 | Logged in | Does not exist | `no plugin named "X" exists` |

