### PR TITLE
Avoid keychain password prompt in stripe whoami

### DIFF
--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"text/tabwriter"
 
@@ -157,42 +156,19 @@ func keyAvailabilityText(k whoamiKeyInfo) string {
 }
 
 // resolveKeyInfo determines key availability and expiry for the given mode.
-// If an in-memory override key (--api-key / STRIPE_API_KEY) is active, it is
-// classified by prefix and returned without expiry (not persisted). Otherwise,
-// the persisted config file (test) or keychain (live) is checked.
+// HasAPIKey handles all sources (env var, --api-key flag, config file, keyring)
+// without reading the secret, avoiding OS auth prompts on macOS.
 func resolveKeyInfo(profile *config.Profile, livemode bool) whoamiKeyInfo {
-	if key := overrideAPIKey(profile); key != "" {
-		return whoamiKeyInfo{Available: apiKeyIsLivemode(key) == livemode}
-	}
-
-	if livemode && config.KeyRing == nil {
-		return whoamiKeyInfo{Available: false}
-	}
-	if _, err := profile.GetAPIKey(livemode); err != nil {
+	if !profile.HasAPIKey(livemode) {
 		return whoamiKeyInfo{Available: false}
 	}
 
 	info := whoamiKeyInfo{Available: true}
-	if t, err := profile.GetExpiresAt(livemode); err == nil {
-		s := t.Format(config.DateStringFormat)
-		info.ExpiresAt = &s
+	if !profile.HasOverrideAPIKey() {
+		if t, err := profile.GetExpiresAt(livemode); err == nil {
+			s := t.Format(config.DateStringFormat)
+			info.ExpiresAt = &s
+		}
 	}
 	return info
-}
-
-// overrideAPIKey returns the in-memory key override in effect for this
-// command, if any. These are the sources that GetAPIKey checks before the
-// persisted config/keyring, and which are mode-agnostic in that function.
-func overrideAPIKey(profile *config.Profile) string {
-	if key := os.Getenv("STRIPE_API_KEY"); key != "" {
-		return key
-	}
-	return profile.APIKey
-}
-
-// apiKeyIsLivemode reports whether a key's prefix indicates live mode.
-// Stripe API keys have the form sk_test_..., sk_live_..., rk_test_..., rk_live_...
-func apiKeyIsLivemode(key string) bool {
-	parts := strings.SplitN(key, "_", 3)
-	return len(parts) >= 2 && parts[1] == "live"
 }

--- a/pkg/cmd/whoami_test.go
+++ b/pkg/cmd/whoami_test.go
@@ -82,6 +82,7 @@ func TestWhoamiWithTestKey(t *testing.T) {
 
 	assert.True(t, result.Authenticated)
 	assert.True(t, result.TestModeKey.Available)
+	assert.Nil(t, result.TestModeKey.ExpiresAt, "override keys have no expiry")
 	assert.False(t, result.LiveModeKey.Available)
 	assert.Equal(t, "acct_123", result.AccountID)
 }
@@ -106,6 +107,7 @@ func TestWhoamiWithLiveModeAPIKey(t *testing.T) {
 	assert.True(t, result.Authenticated)
 	assert.False(t, result.TestModeKey.Available)
 	assert.True(t, result.LiveModeKey.Available)
+	assert.Nil(t, result.LiveModeKey.ExpiresAt, "override keys have no expiry")
 }
 
 func TestWhoamiWithEnvVarKey(t *testing.T) {
@@ -127,14 +129,74 @@ func TestWhoamiWithEnvVarKey(t *testing.T) {
 
 	assert.True(t, result.Authenticated)
 	assert.True(t, result.TestModeKey.Available)
+	assert.Nil(t, result.TestModeKey.ExpiresAt, "override keys have no expiry")
 	assert.False(t, result.LiveModeKey.Available)
 }
 
-func TestAPIKeyIsLivemode(t *testing.T) {
-	assert.False(t, apiKeyIsLivemode("sk_test_abc123"))
-	assert.True(t, apiKeyIsLivemode("sk_live_abc123"))
-	assert.False(t, apiKeyIsLivemode("rk_test_abc123"))
-	assert.True(t, apiKeyIsLivemode("rk_live_abc123"))
+func TestWhoamiWithLiveModeEnvVarKey(t *testing.T) {
+	config.KeyRing = keyring.NewArrayKeyring([]keyring.Item{})
+	t.Setenv("STRIPE_API_KEY", "rk_live_envvar1234567890")
+
+	wc := newWhoamiCmd()
+	wc.profile = &config.Profile{
+		ProfileName: "default",
+		DeviceName:  "test-device",
+	}
+	wc.format = "json"
+
+	out, err := runWhoami(t, wc)
+	require.NoError(t, err)
+
+	var result whoamiOutput
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+
+	assert.True(t, result.Authenticated)
+	assert.False(t, result.TestModeKey.Available)
+	assert.True(t, result.LiveModeKey.Available)
+	assert.Nil(t, result.LiveModeKey.ExpiresAt, "override keys have no expiry")
+}
+
+// noPromptKeyring embeds ArrayKeyring for key storage but fails the test if
+// Get or GetMetadata are called — those operations would trigger an OS-level
+// auth prompt (e.g. macOS Keychain password dialog) on some platforms.
+type noPromptKeyring struct {
+	*keyring.ArrayKeyring
+	t *testing.T
+}
+
+func (k *noPromptKeyring) Get(key string) (keyring.Item, error) {
+	k.t.Fatal("Get would prompt for keychain password on some platforms")
+	return keyring.Item{}, nil
+}
+
+func (k *noPromptKeyring) GetMetadata(key string) (keyring.Metadata, error) {
+	k.t.Fatal("GetMetadata would prompt for keychain password on some platforms")
+	return keyring.Metadata{}, nil
+}
+
+func TestWhoamiLiveModeKeyDoesNotReadSecret(t *testing.T) {
+	kr := &noPromptKeyring{
+		ArrayKeyring: keyring.NewArrayKeyring([]keyring.Item{
+			{Key: "default.live_mode_api_key", Data: []byte("sk_live_1234567890abcdef")},
+		}),
+		t: t,
+	}
+	config.KeyRing = kr
+
+	wc := newWhoamiCmd()
+	wc.profile = &config.Profile{
+		ProfileName: "default",
+	}
+	wc.format = "json"
+
+	out, err := runWhoami(t, wc)
+	require.NoError(t, err)
+
+	var result whoamiOutput
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+
+	assert.True(t, result.Authenticated)
+	assert.True(t, result.LiveModeKey.Available)
 }
 
 func TestKeyAvailabilityText(t *testing.T) {

--- a/pkg/cmd/whoami_test.go
+++ b/pkg/cmd/whoami_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/99designs/keyring"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -22,6 +23,7 @@ func runWhoami(t *testing.T, wc *whoamiCmd) (string, error) {
 }
 
 func TestWhoamiNotAuthenticated(t *testing.T) {
+	viper.Reset()
 	config.KeyRing = keyring.NewArrayKeyring([]keyring.Item{})
 
 	wc := newWhoamiCmd()
@@ -37,6 +39,7 @@ func TestWhoamiNotAuthenticated(t *testing.T) {
 }
 
 func TestWhoamiNotAuthenticatedJSON(t *testing.T) {
+	viper.Reset()
 	config.KeyRing = keyring.NewArrayKeyring([]keyring.Item{})
 
 	wc := newWhoamiCmd()

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -224,6 +224,58 @@ func (p *Profile) GetAccountID() (string, error) {
 	return "", validators.ErrAccountIDNotConfigured
 }
 
+// HasOverrideAPIKey reports whether an in-memory API key override is active
+// (via STRIPE_API_KEY env var or --api-key flag).
+func (p *Profile) HasOverrideAPIKey() bool {
+	return os.Getenv("STRIPE_API_KEY") != "" || p.APIKey != ""
+}
+
+// isLivemodeKey reports whether a key's prefix indicates live mode.
+func isLivemodeKey(key string) bool {
+	parts := strings.SplitN(key, "_", 3)
+	return len(parts) >= 2 && parts[1] == "live"
+}
+
+// HasAPIKey reports whether an API key is available for the given mode without
+// reading its value. For live mode this checks the keyring key list only,
+// avoiding OS-level auth prompts (e.g. macOS Keychain) that would be required
+// to access the secret data.
+func (p *Profile) HasAPIKey(livemode bool) bool {
+	if key := os.Getenv("STRIPE_API_KEY"); key != "" {
+		return isLivemodeKey(key) == livemode
+	}
+	if p.APIKey != "" {
+		return isLivemodeKey(p.APIKey) == livemode
+	}
+
+	if !livemode {
+		if err := viper.ReadInConfig(); err != nil {
+			return false
+		}
+		if viper.IsSet(p.GetConfigField("secret_key")) {
+			p.RegisterAlias(TestModeAPIKeyName, "secret_key")
+		} else if viper.IsSet(p.GetConfigField("api_key")) {
+			p.RegisterAlias(TestModeAPIKeyName, "api_key")
+		}
+		return viper.GetString(p.GetConfigField(TestModeAPIKeyName)) != ""
+	}
+
+	if KeyRing == nil {
+		return false
+	}
+	fieldID := p.GetConfigField(LiveModeAPIKeyName)
+	existingKeys, err := KeyRing.Keys()
+	if err != nil {
+		return false
+	}
+	for _, item := range existingKeys {
+		if item == fieldID {
+			return true
+		}
+	}
+	return false
+}
+
 // GetAPIKey will return the existing key for the given profile
 func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 	envKey := os.Getenv("STRIPE_API_KEY")


### PR DESCRIPTION
### Reviewers
r?
cc @stripe/developer-products

### Summary

`stripe whoami` triggers the macOS Keychain password dialog even though it never displays the API key value — it only reports whether a key is available and when it expires.

The fix adds `Profile.HasAPIKey(livemode bool)` which checks the keyring key list via `Keys()` (metadata-only, no OS auth prompt) instead of calling `GetAPIKey` which reads the secret via `Get()` (triggers the prompt on macOS).

Also fixes a pre-existing issue where the whoami tests would fail on any machine with a real `~/.config/stripe/config.toml` because viper leaked host config into the test.