### PR TITLE
Improve plugin list to fetch from live API endpoint

### DIFF
--- a/pkg/cmd/plugin/list.go
+++ b/pkg/cmd/plugin/list.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/config"
@@ -17,20 +15,18 @@ import (
 
 // ListCmd is the struct used for configuring the plugin list command.
 type ListCmd struct {
-	cfg             *config.Config
-	Cmd             *cobra.Command
-	fs              afero.Fs
-	refreshManifest func(context.Context, afero.Fs) error
+	cfg              *config.Config
+	Cmd              *cobra.Command
+	listPlugins      func(context.Context, config.IConfig, string, string) (plugins.PluginList, error)
+	apiBaseURL       string
+	dashboardBaseURL string
 }
 
 // NewListCmd creates a command for listing available plugins.
 func NewListCmd(config *config.Config) *ListCmd {
 	lc := &ListCmd{}
-	lc.fs = afero.NewOsFs()
 	lc.cfg = config
-	lc.refreshManifest = func(ctx context.Context, fs afero.Fs) error {
-		return plugins.RefreshPluginManifest(ctx, lc.cfg, fs, stripe.DefaultAPIBaseURL)
-	}
+	lc.listPlugins = plugins.ListPlugins
 
 	lc.Cmd = &cobra.Command{
 		Use:   "list",
@@ -40,24 +36,30 @@ func NewListCmd(config *config.Config) *ListCmd {
 		RunE:  lc.runListCmd,
 	}
 
+	// Hidden configuration flags, useful for dev/debugging
+	lc.Cmd.Flags().StringVar(&lc.apiBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
+	lc.Cmd.Flags().MarkHidden("api-base") // #nosec G104
+	lc.Cmd.Flags().StringVar(&lc.dashboardBaseURL, "dashboard-base", "", "Sets the dashboard base URL")
+	lc.Cmd.Flags().MarkHidden("dashboard-base") // #nosec G104
+
 	return lc
 }
 
 func (lc *ListCmd) runListCmd(cmd *cobra.Command, args []string) error {
+	if err := stripe.ValidateAPIBaseURL(lc.apiBaseURL); err != nil {
+		return err
+	}
+	dashboardBaseURL := resolveDashboardBaseURL(lc.apiBaseURL, lc.dashboardBaseURL)
+	if err := stripe.ValidateDashboardBaseURL(dashboardBaseURL); err != nil {
+		return err
+	}
+
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	if lc.refreshManifest != nil {
-		if err := lc.refreshManifest(ctx, lc.fs); err != nil {
-			log.WithFields(log.Fields{
-				"prefix": "cmd.plugin.ListCmd",
-			}).Debugf("could not refresh plugin manifest, falling back to cached plugin list: %s", err)
-		}
-	}
-
-	pluginList, err := plugins.GetPluginList(ctx, lc.cfg, lc.fs)
+	pluginList, err := lc.listPlugins(ctx, lc.cfg, lc.apiBaseURL, dashboardBaseURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/plugin/list_test.go
+++ b/pkg/cmd/plugin/list_test.go
@@ -5,75 +5,41 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/plugins"
 )
 
-func TestListCmdPrintsAvailablePluginsAfterRefresh(t *testing.T) {
-	cfg, fs, cleanup := setupPluginCommandTest(t)
+func TestListCmdPrintsAvailablePlugins(t *testing.T) {
+	cfg, _, cleanup := setupPluginCommandTest(t)
 	defer cleanup()
 
 	lc := NewListCmd(cfg)
-	lc.fs = fs
-	lc.refreshManifest = func(ctx context.Context, fs afero.Fs) error {
-		return writeListManifest(cfg, fs, testListManifest())
+	lc.listPlugins = func(ctx context.Context, cfg config.IConfig, apiBaseURL, dashboardBaseURL string) (plugins.PluginList, error) {
+		return testListPluginList(), nil
 	}
 
 	assertListOutput(t, executeListCmd(t, lc))
 }
 
-func TestListCmdFallsBackToCachedPluginsWhenRefreshFails(t *testing.T) {
-	cfg, fs, cleanup := setupPluginCommandTest(t)
+func TestListCmdReturnsEndpointErrorWithoutFallback(t *testing.T) {
+	cfg, _, cleanup := setupPluginCommandTest(t)
 	defer cleanup()
 
-	require.NoError(t, writeListManifest(cfg, fs, testListManifest()))
-
 	lc := NewListCmd(cfg)
-	lc.fs = fs
-	lc.refreshManifest = func(ctx context.Context, fs afero.Fs) error {
-		return errors.New("refresh failed")
+	lc.listPlugins = func(ctx context.Context, cfg config.IConfig, apiBaseURL, dashboardBaseURL string) (plugins.PluginList, error) {
+		return plugins.PluginList{}, errors.New("list failed")
 	}
 
-	assertListOutput(t, executeListCmd(t, lc))
-}
-
-func TestListCmdIgnoresLocalPluginMetadata(t *testing.T) {
-	cfg, fs, cleanup := setupPluginCommandTest(t)
-	defer cleanup()
-
-	require.NoError(t, writeListManifest(cfg, fs, testListManifest()))
-	require.NoError(t, writeListPluginMetadata(cfg, fs, `[[Plugin]]
-  Shortname = "docs"
-  Shortdesc = "Local docs plugin"
-  Binary = "stripe-cli-docs"
-  MagicCookieValue = "DOCS-COOKIE"
-
-  [[Plugin.Release]]
-    Arch = "arm64"
-    OS = "darwin"
-    Version = "1.0.0"
-    Sum = "docs"
-`))
-
-	lc := NewListCmd(cfg)
-	lc.fs = fs
-	lc.refreshManifest = func(ctx context.Context, fs afero.Fs) error {
-		return errors.New("refresh failed")
-	}
-
-	rendered := executeListCmd(t, lc)
-	assertListOutput(t, rendered)
-	require.NotContains(t, rendered, "docs")
+	err := executeListCmdErr(t, lc)
+	require.EqualError(t, err, "list failed")
 }
 
 func executeListCmd(t *testing.T, lc *ListCmd) string {
@@ -89,26 +55,15 @@ func executeListCmd(t *testing.T, lc *ListCmd) string {
 	return output.String()
 }
 
-func writeListManifest(cfg *config.Config, fs afero.Fs, manifest string) error {
-	configPath := cfg.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
-	manifestPath := filepath.Join(configPath, "plugins.toml")
+func executeListCmdErr(t *testing.T, lc *ListCmd) error {
+	t.Helper()
 
-	if err := fs.MkdirAll(configPath, 0755); err != nil {
-		return err
-	}
+	var output bytes.Buffer
+	lc.Cmd.SetOut(&output)
+	lc.Cmd.SetErr(&output)
+	lc.Cmd.SetContext(context.Background())
 
-	return afero.WriteFile(fs, manifestPath, []byte(manifest), 0644)
-}
-
-func writeListPluginMetadata(cfg *config.Config, fs afero.Fs, manifest string) error {
-	configPath := cfg.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
-	metadataPath := filepath.Join(configPath, "plugin-metadata", "docs.toml")
-
-	if err := fs.MkdirAll(filepath.Dir(metadataPath), 0755); err != nil {
-		return err
-	}
-
-	return afero.WriteFile(fs, metadataPath, []byte(manifest), 0644)
+	return lc.Cmd.Execute()
 }
 
 func assertListOutput(t *testing.T, rendered string) {
@@ -142,53 +97,57 @@ func requirePluginRow(t *testing.T, rendered, shortname, shortdesc string) {
 	)
 }
 
-func testListManifest() string {
-	return fmt.Sprintf(`[[Plugin]]
-  Shortname = "tools"
-  Shortdesc = "Search internal Stripe operations"
-  Binary = "stripe-cli-tools"
-  MagicCookieValue = "TOOLS-COOKIE"
-
-  [[Plugin.Release]]
-    Arch = "%s"
-    OS = "%s"
-    Version = "1.0.0"
-    Sum = "tools"
-
-[[Plugin]]
-  Shortname = "apps"
-  Shortdesc = "Build and manage Stripe Apps"
-  Binary = "stripe-cli-apps"
-  MagicCookieValue = "APPS-COOKIE"
-
-  [[Plugin.Release]]
-    Arch = "%s"
-    OS = "%s"
-    Version = "2.0.0"
-    Sum = "apps"
-
-[[Plugin]]
-  Shortname = "projects"
-  Shortdesc = "Scaffold Stripe integration projects"
-  Binary = "stripe-cli-projects"
-  MagicCookieValue = "PROJECTS-COOKIE"
-
-  [[Plugin.Release]]
-    Arch = "%s"
-    OS = "%s"
-    Version = "3.0.0"
-    Sum = "projects"
-
-[[Plugin]]
-  Shortname = "windows-only"
-  Shortdesc = "Should be filtered on non-Windows platforms"
-  Binary = "stripe-cli-windows-only"
-  MagicCookieValue = "WINDOWS-COOKIE"
-
-  [[Plugin.Release]]
-    Arch = "amd64"
-    OS = "windows"
-    Version = "1.0.0"
-    Sum = "windows-only"
-`, runtime.GOARCH, runtime.GOOS, runtime.GOARCH, runtime.GOOS, runtime.GOARCH, runtime.GOOS)
+func testListPluginList() plugins.PluginList {
+	return plugins.PluginList{
+		Plugins: []plugins.Plugin{
+			{
+				Shortname: "tools",
+				Shortdesc: "Search internal Stripe operations",
+				Binary:    "stripe-cli-tools",
+				Releases: []plugins.Release{
+					{
+						Arch:    runtime.GOARCH,
+						OS:      runtime.GOOS,
+						Version: "1.0.0",
+					},
+				},
+			},
+			{
+				Shortname: "apps",
+				Shortdesc: "Build and manage Stripe Apps",
+				Binary:    "stripe-cli-apps",
+				Releases: []plugins.Release{
+					{
+						Arch:    runtime.GOARCH,
+						OS:      runtime.GOOS,
+						Version: "2.0.0",
+					},
+				},
+			},
+			{
+				Shortname: "projects",
+				Shortdesc: "Scaffold Stripe integration projects",
+				Binary:    "stripe-cli-projects",
+				Releases: []plugins.Release{
+					{
+						Arch:    runtime.GOARCH,
+						OS:      runtime.GOOS,
+						Version: "3.0.0",
+					},
+				},
+			},
+			{
+				Shortname: "windows-only",
+				Shortdesc: "Should be filtered on non-Windows platforms",
+				Binary:    "stripe-cli-windows-only",
+				Releases: []plugins.Release{
+					{
+						Arch:    "amd64",
+						OS:      "windows",
+						Version: "1.0.0",
+					},
+				},
+			},
+		},
+	}
 }

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -47,26 +47,26 @@ type CommandInfo struct {
 
 // Plugin contains the plugin properties
 type Plugin struct {
-	Shortname        string        `toml:"Shortname"`
-	Shortdesc        string        `toml:"Shortdesc"`
-	Binary           string        `toml:"Binary"`
-	Releases         []Release     `toml:"Release"`
-	MagicCookieValue string        `toml:"MagicCookieValue"`
-	Commands         []CommandInfo `toml:"Command,omitempty"`
+	Shortname        string        `toml:"Shortname" json:"shortname"`
+	Shortdesc        string        `toml:"Shortdesc" json:"shortdesc"`
+	Binary           string        `toml:"Binary" json:"binary"`
+	Releases         []Release     `toml:"Release" json:"releases"`
+	MagicCookieValue string        `toml:"MagicCookieValue" json:"magic_cookie_value,omitempty"`
+	Commands         []CommandInfo `toml:"Command,omitempty" json:"commands,omitempty"`
 }
 
 // PluginList contains a list of plugins
 type PluginList struct {
-	Plugins []Plugin `toml:"Plugin"`
+	Plugins []Plugin `toml:"Plugin" json:"plugins"`
 }
 
 // Release is the type that holds release data for a specific build of a plugin
 type Release struct {
-	Arch    string            `toml:"Arch"`
-	OS      string            `toml:"OS"`
-	Version string            `toml:"Version"`
-	Sum     string            `toml:"Sum"`
-	Runtime map[string]string `toml:"Runtime,omitempty"`
+	Arch    string            `toml:"Arch" json:"arch"`
+	OS      string            `toml:"OS" json:"os"`
+	Version string            `toml:"Version" json:"version"`
+	Sum     string            `toml:"Sum" json:"sum,omitempty"`
+	Runtime map[string]string `toml:"Runtime,omitempty" json:"runtime,omitempty"`
 }
 
 // getPluginInterface computes the correct metadata needed for starting the hcplugin client

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -272,7 +273,45 @@ func PersistInstalledPluginState(config config.IConfig, fs afero.Fs, plugin Plug
 	return nil
 }
 
-// GetPluginList builds a list of allowed plugins to be installed and run by the CLI.
+// ListPlugins fetches the live plugin list visible to the current caller for
+// the current platform using the list-plugins API endpoints.
+func ListPlugins(ctx context.Context, config config.IConfig, apiBaseURL, dashboardBaseURL string) (PluginList, error) {
+	apiKey, err := config.GetProfile().GetAPIKey(false)
+	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
+		return PluginList{}, err
+	}
+
+	if dashboardBaseURL == "" {
+		dashboardBaseURL = stripe.DashboardBaseURLForAPIBaseURL(apiBaseURL)
+	}
+
+	body, err := requests.GetPluginList(
+		ctx,
+		apiBaseURL,
+		dashboardBaseURL,
+		stripe.APIVersion,
+		apiKey,
+		config.GetProfile(),
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+	if err != nil {
+		return PluginList{}, err
+	}
+
+	var pluginList PluginList
+	if err := json.Unmarshal(body, &pluginList); err != nil {
+		return PluginList{}, fmt.Errorf("failed to decode plugin list response: %w", err)
+	}
+
+	if err := validatePluginListResponse(&pluginList); err != nil {
+		return PluginList{}, err
+	}
+
+	return pluginList, nil
+}
+
+// GetPluginList reads the cached global plugin manifest from disk.
 func GetPluginList(ctx context.Context, config config.IConfig, fs afero.Fs) (PluginList, error) {
 	pluginList, err := getCachedPluginList(config, fs)
 	if os.IsNotExist(err) {
@@ -784,6 +823,22 @@ func fetchPluginList(baseURL, manifestFilename string) (*PluginList, error) {
 		return nil, err
 	}
 	return validatePluginManifest(body)
+}
+
+func validatePluginListResponse(pluginList *PluginList) error {
+	if pluginList == nil {
+		return errors.New("received an empty plugin list response")
+	}
+	if pluginList.Plugins == nil {
+		pluginList.Plugins = []Plugin{}
+	}
+	if err := validateRuntimeVersions(pluginList); err != nil {
+		return err
+	}
+	for i := range pluginList.Plugins {
+		sortPluginReleases(pluginList.Plugins[i].Releases)
+	}
+	return nil
 }
 
 // validateRuntimeVersions validates that Runtime specifications only contain valid LTS Node.js versions

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 // CustomTestConfig is a test config that allows overriding the config folder path
@@ -121,6 +122,76 @@ func TestGetPluginListUsesManifestMetadataForOverlappingPlugin(t *testing.T) {
 	release := plugin.getReleaseForVersion("2.0.1")
 	require.NotNil(t, release)
 	require.Empty(t, release.Runtime)
+}
+
+func TestListPluginsUsesAuthenticatedEndpoint(t *testing.T) {
+	config := &TestConfig{}
+	config.InitConfig()
+
+	var authenticatedLookups int
+	apiServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/list-plugins":
+			authenticatedLookups++
+			require.Equal(t, runtime.GOOS, req.URL.Query().Get("os"))
+			require.Equal(t, runtime.GOARCH, req.URL.Query().Get("arch"))
+			require.Equal(t, "Bearer "+config.Profile.APIKey, req.Header.Get("Authorization"))
+			require.Equal(t, stripe.APIVersion, req.Header.Get("Stripe-Version"))
+			_, _ = res.Write(testListEndpointResponseJSON())
+		case "/ajax/stripecli/list-plugins":
+			t.Fatalf("authenticated list should not hit the anonymous endpoint: %s", req.URL.String())
+		default:
+			t.Fatalf("unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer apiServer.Close()
+
+	pluginList, err := ListPlugins(context.Background(), config, apiServer.URL, "")
+	require.NoError(t, err)
+	require.Equal(t, 1, authenticatedLookups)
+	require.Len(t, pluginList.Plugins, 1)
+	require.Equal(t, "apps", pluginList.Plugins[0].Shortname)
+	require.Equal(t, "Build and manage Stripe Apps", pluginList.Plugins[0].Shortdesc)
+	require.Len(t, pluginList.Plugins[0].Commands, 1)
+	require.Equal(t, "create", pluginList.Plugins[0].Commands[0].Name)
+	require.Len(t, pluginList.Plugins[0].Releases, 1)
+	require.Equal(t, "1.12.0", pluginList.Plugins[0].Releases[0].Version)
+	require.Equal(t, "20", pluginList.Plugins[0].Releases[0].Runtime["node"])
+}
+
+func TestListPluginsUsesAnonymousEndpointWhenAPIKeyNotConfigured(t *testing.T) {
+	config := &TestConfig{}
+	config.InitConfig()
+	config.Profile.APIKey = ""
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		t.Fatalf("anonymous list should not hit the API host: %s", req.URL.String())
+	}))
+	defer apiServer.Close()
+
+	var anonymousLookups int
+	dashboardServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/ajax/stripecli/list-plugins":
+			anonymousLookups++
+			require.Equal(t, runtime.GOOS, req.URL.Query().Get("os"))
+			require.Equal(t, runtime.GOARCH, req.URL.Query().Get("arch"))
+			require.Empty(t, req.Header.Get("Authorization"))
+			require.Equal(t, stripe.APIVersion, req.Header.Get("Stripe-Version"))
+			_, _ = res.Write(testListEndpointResponseJSON())
+		case "/v1/stripecli/list-plugins":
+			t.Fatalf("anonymous list should not hit the authenticated endpoint: %s", req.URL.String())
+		default:
+			t.Fatalf("unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer dashboardServer.Close()
+
+	pluginList, err := ListPlugins(context.Background(), config, apiServer.URL, dashboardServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, 1, anonymousLookups)
+	require.Len(t, pluginList.Plugins, 1)
+	require.Equal(t, "apps", pluginList.Plugins[0].Shortname)
 }
 
 func TestLookUpPlugin(t *testing.T) {
@@ -1348,4 +1419,33 @@ func TestResolvePluginForInstallSucceedsForGAPluginWhenNotLoggedIn(t *testing.T)
 	require.NotNil(t, resolvedPlugin.Plugin)
 	require.Equal(t, "appA", resolvedPlugin.Plugin.Shortname)
 	require.Equal(t, "2.0.1", resolvedPlugin.Version)
+}
+
+func testListEndpointResponseJSON() []byte {
+	return []byte(fmt.Sprintf(`{
+  "plugins": [
+    {
+      "shortname": "apps",
+      "shortdesc": "Build and manage Stripe Apps",
+      "binary": "stripe-cli-apps",
+      "commands": [
+        {
+          "name": "create",
+          "desc": "Create an app"
+        }
+      ],
+      "releases": [
+        {
+          "os": "%s",
+          "arch": "%s",
+          "version": "1.12.0",
+          "runtime": {
+            "node": "20"
+          }
+        }
+      ],
+      "binary_url": null
+    }
+  ]
+}`, runtime.GOOS, runtime.GOARCH))
 }

--- a/pkg/requests/plugin.go
+++ b/pkg/requests/plugin.go
@@ -40,7 +40,15 @@ func getPluginMetadataPath(apiKey string) string {
 	return "/v1/stripecli/get-plugin-metadata"
 }
 
-func getPluginMetadataBaseURL(apiKey, apiBaseURL, dashboardBaseURL string) string {
+func getPluginListPath(apiKey string) string {
+	if apiKey == "" {
+		return "/ajax/stripecli/list-plugins"
+	}
+
+	return "/v1/stripecli/list-plugins"
+}
+
+func getPluginEndpointBaseURL(apiKey, apiBaseURL, dashboardBaseURL string) string {
 	if apiKey == "" && dashboardBaseURL != "" {
 		return dashboardBaseURL
 	}
@@ -92,7 +100,7 @@ func GetPluginMetadata(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVer
 		version: apiVersion,
 	}
 
-	metadataBaseURL := getPluginMetadataBaseURL(apiKey, apiBaseURL, dashboardBaseURL)
+	metadataBaseURL := getPluginEndpointBaseURL(apiKey, apiBaseURL, dashboardBaseURL)
 	metadataPath := getPluginMetadataPath(apiKey)
 
 	log.WithFields(log.Fields{
@@ -128,4 +136,42 @@ func GetPluginMetadata(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVer
 	}
 
 	return metadata, nil
+}
+
+// GetPluginList returns the list of plugins visible to the current caller for
+// the requested platform. It uses the authenticated endpoint when an API key is
+// available and the anonymous endpoint otherwise.
+func GetPluginList(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVersion, apiKey string, profile *config.Profile, os, arch string) ([]byte, error) {
+	params := &RequestParameters{
+		data:    []string{},
+		version: apiVersion,
+	}
+
+	listBaseURL := getPluginEndpointBaseURL(apiKey, apiBaseURL, dashboardBaseURL)
+	listPath := getPluginListPath(apiKey)
+
+	log.WithFields(log.Fields{
+		"prefix":   "requests.GetPluginList",
+		"base_url": listBaseURL,
+		"endpoint": listPath,
+		"os":       os,
+		"arch":     arch,
+	}).Debug("Fetching plugin list")
+
+	base := &Base{
+		Profile:        profile,
+		Method:         http.MethodGet,
+		SuppressOutput: true,
+		APIBaseURL:     listBaseURL,
+	}
+
+	resp, err := base.MakeRequest(ctx, apiKey, listPath, params, map[string]interface{}{
+		"os":   os,
+		"arch": arch,
+	}, true, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }


### PR DESCRIPTION
Replace the manifest-refresh-then-read-from-disk approach with a direct API call to list-plugins endpoints (authenticated v1 or anonymous ajax), returning a JSON response that is decoded directly into the PluginList struct. This eliminates the local manifest dependency for listing and adds json struct tags to Plugin/Release types.



<img width="793" height="318" alt="Screenshot 2026-06-05 at 12 42 10 PM" src="https://github.com/user-attachments/assets/72fa6143-d52f-4e85-94fb-4712e3a1078d" />

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
