### PR TITLE
Fix sandbox tests opening real browser tabs

### DIFF
--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/login"
 	"github.com/stripe/stripe-cli/pkg/sandbox"
 )
 
@@ -42,6 +43,9 @@ func setupSandboxTestConfig(t *testing.T) func() {
 	openBrowserFunc = func(url string) error { return nil }
 	canOpenBrowserFunc = func() bool { return true }
 
+	// Also mock the login package's browser opener (used by fallback flow)
+	restoreLoginBrowser := login.SetOpenBrowserForTesting(func(string) error { return nil })
+
 	// Mock git config
 	origGit := sandbox.GitConfigFunc
 	sandbox.GitConfigFunc = func(key string) string { return "" }
@@ -51,6 +55,7 @@ func setupSandboxTestConfig(t *testing.T) func() {
 		Config.Profile.ProfileName = origProfileName
 		openBrowserFunc = origOpen
 		canOpenBrowserFunc = origCanOpen
+		restoreLoginBrowser()
 		sandbox.GitConfigFunc = origGit
 		viper.Reset()
 	}

--- a/pkg/login/client_login.go
+++ b/pkg/login/client_login.go
@@ -17,6 +17,14 @@ import (
 var openBrowser = open.Browser
 var canOpenBrowser = open.CanOpenBrowser
 
+// SetOpenBrowserForTesting overrides the browser-opening function used by
+// the login flow. It returns a restore function that resets to the default.
+func SetOpenBrowserForTesting(fn func(string) error) (restore func()) {
+	orig := openBrowser
+	openBrowser = fn
+	return func() { openBrowser = orig }
+}
+
 const stripeCLIAuthPath = "/stripecli/auth"
 
 // TODO


### PR DESCRIPTION
## Summary
- Sandbox fallback tests (`FallsBackOnServerError`, `FallsBackOn429`, `FromGitResolves`, etc.) call `login.Login()` which uses its own `openBrowser` variable in `pkg/login` — separate from `openBrowserFunc` mocked in `pkg/cmd`
- This caused ~4 real browser tabs to open to `dashboard.stripe.com` when running `go test ./pkg/cmd/` locally
- Added `login.SetOpenBrowserForTesting()` and wired it into `setupSandboxTestConfig` so both browser openers are mocked

## Test plan
- [x] `go test -v -run "TestSandbox" ./pkg/cmd/` passes without opening browser tabs
- [x] `go build ./...` compiles cleanly
- [x] Full `make test` still passes (only pre-existing `pkg/git` failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)