### PR TITLE
Harden coop command handoffs

### DIFF
--- a/pkg/cmd/coop_env.go
+++ b/pkg/cmd/coop_env.go
@@ -87,7 +87,7 @@ func buildSummarizePrompt(session *coop.Session) string {
 - Stripe Dashboard: https://dashboard.stripe.com/test
 - API docs: https://docs.stripe.com/api
 
-After writing the file, run "stripe coop next-steps" again to offer more options.`, session.Blueprint)
+After writing the file, run "stripe coop next-steps --session=%s --completed=summarize" again to offer more options.`, session.Blueprint, session.ID)
 }
 
 // projectEnvironment captures deploy targets detected in the working directory.

--- a/pkg/cmd/coop_nextsteps.go
+++ b/pkg/cmd/coop_nextsteps.go
@@ -133,13 +133,14 @@ func (nc *coopNextStepsCmd) runNextStepsCmd(cmd *cobra.Command, args []string) e
 		if lang == "" {
 			lang = "node"
 		}
+		next := fmt.Sprintf("stripe coop run deploy-stripe-projects --language=%s --parent-session=%s --parent-step=%s", lang, session.ID, selected)
 		return outputJSON(nextStepsResponse{
 			OK:          true,
 			SessionID:   session.ID,
 			Completed:   session.Blueprint,
 			Suggestions: suggestions,
 			AgentPrompt: "The developer wants to deploy. Start a new co-op session with the deploy blueprint.",
-			Next:        "stripe coop run deploy-stripe-projects --language=" + lang,
+			Next:        next,
 		})
 	case "add-integration":
 		return outputJSON(nextStepsResponse{
@@ -147,7 +148,7 @@ func (nc *coopNextStepsCmd) runNextStepsCmd(cmd *cobra.Command, args []string) e
 			SessionID:   session.ID,
 			Completed:   session.Blueprint,
 			Suggestions: suggestions,
-			AgentPrompt: "The developer wants to add another Stripe feature. Run 'stripe coop recommend' and ask what they need, then start a new session.",
+			AgentPrompt: fmt.Sprintf("The developer wants to add another Stripe feature. Run 'stripe coop recommend' and ask what they need, then start a new session with --parent-session=%s --parent-step=add-integration.", session.ID),
 			Next:        "stripe coop recommend",
 		})
 	case "done":

--- a/pkg/cmd/coop_nextsteps.go
+++ b/pkg/cmd/coop_nextsteps.go
@@ -118,54 +118,58 @@ func (nc *coopNextStepsCmd) runNextStepsCmd(cmd *cobra.Command, args []string) e
 		return fmt.Errorf("clearing next-step selection: %w", err)
 	}
 
+	return outputJSON(buildNextStepsResponse(session, suggestions, selected))
+}
+
+func buildNextStepsResponse(session *coop.Session, suggestions []suggestion, selected string) nextStepsResponse {
 	switch selected {
 	case "summarize":
-		return outputJSON(nextStepsResponse{
+		return nextStepsResponse{
 			OK:          true,
 			SessionID:   session.ID,
 			Completed:   session.Blueprint,
 			Suggestions: suggestions,
 			AgentPrompt: buildSummarizePrompt(session),
 			Next:        fmt.Sprintf("Write STRIPE.md, then run: stripe coop next-steps --session=%s --completed=summarize", session.ID),
-		})
+		}
 	case "deploy", "deploy-update":
 		lang := session.Settings["language"]
 		if lang == "" {
 			lang = "node"
 		}
 		next := fmt.Sprintf("stripe coop run deploy-stripe-projects --language=%s --parent-session=%s --parent-step=%s", lang, session.ID, selected)
-		return outputJSON(nextStepsResponse{
+		return nextStepsResponse{
 			OK:          true,
 			SessionID:   session.ID,
 			Completed:   session.Blueprint,
 			Suggestions: suggestions,
 			AgentPrompt: "The developer wants to deploy. Start a new co-op session with the deploy blueprint.",
 			Next:        next,
-		})
+		}
 	case "add-integration":
-		return outputJSON(nextStepsResponse{
+		return nextStepsResponse{
 			OK:          true,
 			SessionID:   session.ID,
 			Completed:   session.Blueprint,
 			Suggestions: suggestions,
 			AgentPrompt: fmt.Sprintf("The developer wants to add another Stripe feature. Run 'stripe coop recommend' and ask what they need, then start a new session with --parent-session=%s --parent-step=add-integration.", session.ID),
 			Next:        "stripe coop recommend",
-		})
+		}
 	case "done":
-		return outputJSON(nextStepsResponse{
+		return nextStepsResponse{
 			OK:          true,
 			SessionID:   session.ID,
 			Completed:   session.Blueprint,
 			AgentPrompt: "The developer is done. End the session.",
 			Next:        fmt.Sprintf("stripe coop stop --session=%s", session.ID),
-		})
+		}
 	default:
-		return outputJSON(nextStepsResponse{
+		return nextStepsResponse{
 			OK:          true,
 			SessionID:   session.ID,
 			Completed:   session.Blueprint,
 			AgentPrompt: fmt.Sprintf("The developer selected: %s", selected),
 			Next:        "stripe coop stop",
-		})
+		}
 	}
 }

--- a/pkg/cmd/coop_recover.go
+++ b/pkg/cmd/coop_recover.go
@@ -82,14 +82,14 @@ func (rc *coopRecoverCmd) runRecoverCmd(cmd *cobra.Command, args []string) error
 				SessionID: session.ID,
 				Diagnosis: "All steps were done but session was still marked active.",
 				Action:    "Marked session as completed.",
-				Next:      "stripe coop next-steps",
+				Next:      fmt.Sprintf("stripe coop next-steps --session=%s", session.ID),
 			})
 		}
 		return outputJSON(recoverResponse{
 			OK:        true,
 			SessionID: session.ID,
 			Diagnosis: "All steps are done but session is still marked active.",
-			Next:      "stripe coop recover --fix",
+			Next:      fmt.Sprintf("stripe coop recover --session=%s --fix", session.ID),
 		})
 	}
 
@@ -136,7 +136,7 @@ func (rc *coopRecoverCmd) runRecoverCmd(cmd *cobra.Command, args []string) error
 			OK:        true,
 			SessionID: session.ID,
 			Diagnosis: fmt.Sprintf("No step is active. Next pending step is %d (%s). The agent needs to start it.", nextStep, node.Title),
-			Next:      fmt.Sprintf("stripe coop step %d start --note=\"Resuming\"", nextStep),
+			Next:      fmt.Sprintf("stripe coop step %d start --session=%s --note=%s", nextStep, session.ID, quoteArg("Resuming")),
 		})
 	}
 
@@ -144,6 +144,6 @@ func (rc *coopRecoverCmd) runRecoverCmd(cmd *cobra.Command, args []string) error
 		OK:        true,
 		SessionID: session.ID,
 		Diagnosis: "Session is in an unexpected state. Consider aborting and starting over.",
-		Next:      "stripe coop stop --abort",
+		Next:      fmt.Sprintf("stripe coop stop --session=%s --abort", session.ID),
 	})
 }

--- a/pkg/cmd/coop_run.go
+++ b/pkg/cmd/coop_run.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -14,9 +15,11 @@ import (
 )
 
 type coopStartCmd struct {
-	cmd      *cobra.Command
-	language string
-	settings []string
+	cmd           *cobra.Command
+	language      string
+	settings      []string
+	parentSession string
+	parentStep    string
 }
 
 func newCoopStartCmd() *coopStartCmd {
@@ -37,6 +40,8 @@ This is the agent-facing command. Developers should use "stripe coop start" inst
 
 	sc.cmd.Flags().StringVar(&sc.language, "language", "", "Programming language for the integration")
 	sc.cmd.Flags().StringArrayVar(&sc.settings, "setting", nil, "Blueprint settings as key=value pairs")
+	sc.cmd.Flags().StringVar(&sc.parentSession, "parent-session", "", "Parent co-op session ID for follow-up work")
+	sc.cmd.Flags().StringVar(&sc.parentStep, "parent-step", "", "Parent next-step ID this session fulfills")
 
 	return sc
 }
@@ -70,6 +75,8 @@ func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	session := coop.NewSessionFromBlueprint(bp, sessionID, settings)
+	session.ParentSessionID = sc.parentSession
+	session.ParentStepID = sc.parentStep
 	session.CreatedAt = time.Now().UTC()
 
 	// Populate claim URL from config if sandbox was provisioned
@@ -104,7 +111,7 @@ func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
 			Step:      1,
 			State:     "created",
 			Message:   fmt.Sprintf("Session started: %s (%d steps)", bp.Title, session.TotalSteps()),
-			Next:      fmt.Sprintf("stripe coop step 1 start --session=%s --note=\"Beginning: %s\"", sessionID, session.Chapters[0].Nodes[0].Title),
+			Next:      fmt.Sprintf("stripe coop step 1 start --session=%s --note=%s", sessionID, quoteArg("Beginning: "+session.Chapters[0].Nodes[0].Title)),
 		},
 		AgentInstructions: agentInstructions(bp, session),
 		Steps:             steps,
@@ -186,6 +193,10 @@ func outputJSON(v interface{}) error {
 	return nil
 }
 
+func quoteArg(value string) string {
+	return strconv.Quote(value)
+}
+
 func outputCoopError(msg, hint string) error {
 	resp := coop.CommandResponse{
 		OK:    false,
@@ -194,6 +205,11 @@ func outputCoopError(msg, hint string) error {
 	}
 	data, _ := json.MarshalIndent(resp, "", "  ")
 	fmt.Fprintln(os.Stderr, string(data))
-	os.Exit(1)
-	return nil // unreachable
+	return coopRenderedError{}
+}
+
+type coopRenderedError struct{}
+
+func (coopRenderedError) Error() string {
+	return "coop command failed"
 }

--- a/pkg/cmd/coop_run.go
+++ b/pkg/cmd/coop_run.go
@@ -61,22 +61,7 @@ func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
 
 	sessionID := "coop_" + uuid.New().String()[:8]
 
-	settings := make(map[string]string)
-	if sc.language != "" {
-		settings["language"] = sc.language
-	}
-	for _, s := range sc.settings {
-		for i := range s {
-			if s[i] == '=' {
-				settings[s[:i]] = s[i+1:]
-				break
-			}
-		}
-	}
-
-	session := coop.NewSessionFromBlueprint(bp, sessionID, settings)
-	session.ParentSessionID = sc.parentSession
-	session.ParentStepID = sc.parentStep
+	session := sc.newSession(bp, sessionID)
 	session.CreatedAt = time.Now().UTC()
 
 	// Populate claim URL from config if sandbox was provisioned
@@ -118,6 +103,26 @@ func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	return outputJSON(resp)
+}
+
+func (sc *coopStartCmd) newSession(bp *coop.Blueprint, sessionID string) *coop.Session {
+	settings := make(map[string]string)
+	if sc.language != "" {
+		settings["language"] = sc.language
+	}
+	for _, s := range sc.settings {
+		for i := range s {
+			if s[i] == '=' {
+				settings[s[:i]] = s[i+1:]
+				break
+			}
+		}
+	}
+
+	session := coop.NewSessionFromBlueprint(bp, sessionID, settings)
+	session.ParentSessionID = sc.parentSession
+	session.ParentStepID = sc.parentStep
+	return session
 }
 
 type coopStartResponse struct {

--- a/pkg/cmd/coop_step.go
+++ b/pkg/cmd/coop_step.go
@@ -171,7 +171,7 @@ func (sc *coopStepCmd) doDone(store *coop.Store, session *coop.Session, stepNum 
 		msg = fmt.Sprintf("Completed: %s", node.Title)
 		if nextStep := session.NextPendingStep(stepNum); nextStep > 0 {
 			nextNode, _ := session.NodeByNumber(nextStep)
-			next = fmt.Sprintf("stripe coop step %d start --session=%s --note=\"Beginning: %s\"", nextStep, session.ID, nextNode.Title)
+			next = fmt.Sprintf("stripe coop step %d start --session=%s --note=%s", nextStep, session.ID, quoteArg("Beginning: "+nextNode.Title))
 		} else if session.IsComplete() {
 			msg += " All steps complete! Run next-steps — developer picks from TUI."
 			next = fmt.Sprintf("stripe coop next-steps --session=%s", session.ID)
@@ -242,7 +242,7 @@ func (sc *coopStepCmd) doAwait(store *coop.Store, session *coop.Session, stepNum
 		msg := fmt.Sprintf("Step %d auto-confirmed. Proceed to next step.", stepNum)
 		if nextStep := session.NextPendingStep(stepNum); nextStep > 0 {
 			nextNode, _ := session.NodeByNumber(nextStep)
-			next = fmt.Sprintf("stripe coop step %d start --session=%s --note=\"Beginning: %s\"", nextStep, session.ID, nextNode.Title)
+			next = fmt.Sprintf("stripe coop step %d start --session=%s --note=%s", nextStep, session.ID, quoteArg("Beginning: "+nextNode.Title))
 		} else if session.IsComplete() {
 			msg = fmt.Sprintf("Step %d auto-confirmed. All steps complete!", stepNum)
 			next = fmt.Sprintf("stripe coop next-steps --session=%s", session.ID)
@@ -266,7 +266,7 @@ func (sc *coopStepCmd) doAwait(store *coop.Store, session *coop.Session, stepNum
 		} else if nextStep := session.NextPendingStep(stepNum); nextStep > 0 {
 			nextNode, _ := session.NodeByNumber(nextStep)
 			msg = fmt.Sprintf("Step %d is done. Proceed to next step.", stepNum)
-			next = fmt.Sprintf("stripe coop step %d start --session=%s --note=\"Beginning: %s\"", nextStep, session.ID, nextNode.Title)
+			next = fmt.Sprintf("stripe coop step %d start --session=%s --note=%s", nextStep, session.ID, quoteArg("Beginning: "+nextNode.Title))
 		}
 		return outputJSON(coop.CommandResponse{
 			OK:        true,
@@ -318,7 +318,7 @@ func (sc *coopStepCmd) doAwait(store *coop.Store, session *coop.Session, stepNum
 			msg := fmt.Sprintf("Step %d confirmed by developer. Proceed to next step.", stepNum)
 			if nextStep := session.NextPendingStep(stepNum); nextStep > 0 {
 				nextNode, _ := session.NodeByNumber(nextStep)
-				next = fmt.Sprintf("stripe coop step %d start --session=%s --note=\"Beginning: %s\"", nextStep, session.ID, nextNode.Title)
+				next = fmt.Sprintf("stripe coop step %d start --session=%s --note=%s", nextStep, session.ID, quoteArg("Beginning: "+nextNode.Title))
 			} else if session.IsComplete() {
 				msg = fmt.Sprintf("Step %d confirmed. All steps complete! You MUST run the next command immediately — it shows the developer their options and blocks until they choose.", stepNum)
 				next = fmt.Sprintf("stripe coop next-steps --session=%s", session.ID)
@@ -423,7 +423,7 @@ func (sc *coopStepCmd) doSkip(store *coop.Store, session *coop.Session, stepNum 
 	next := ""
 	if nextStep := session.NextPendingStep(stepNum); nextStep > 0 {
 		nextNode, _ := session.NodeByNumber(nextStep)
-		next = fmt.Sprintf("stripe coop step %d start --session=%s --note=\"Beginning: %s\"", nextStep, session.ID, nextNode.Title)
+		next = fmt.Sprintf("stripe coop step %d start --session=%s --note=%s", nextStep, session.ID, quoteArg("Beginning: "+nextNode.Title))
 	} else if session.IsComplete() {
 		next = fmt.Sprintf("stripe coop next-steps --session=%s", session.ID)
 	} else {

--- a/pkg/cmd/coop_step_test.go
+++ b/pkg/cmd/coop_step_test.go
@@ -259,29 +259,18 @@ func TestDoSkipFinalStepRoutesToNextSteps(t *testing.T) {
 }
 
 func TestCoopRunStoresParentSessionMetadata(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-
 	rc := &coopStartCmd{
 		language:      "node",
 		parentSession: "parent_session",
 		parentStep:    "deploy",
 	}
-	output := captureStdout(t, func() {
-		require.NoError(t, rc.runStartCmd(nil, []string{"one-time-payment"}))
-	})
-
-	var resp coopStartResponse
-	require.NoError(t, json.Unmarshal([]byte(output), &resp))
-	require.Contains(t, resp.Next, "--session="+resp.SessionID)
-	require.Contains(t, resp.Next, `--note="Beginning: Understand the project"`)
-
-	store, err := coop.NewStore(coopConfigFolder())
+	bp, err := coop.LoadBlueprint("one-time-payment")
 	require.NoError(t, err)
-	session, err := store.Read(resp.SessionID)
-	require.NoError(t, err)
+
+	session := rc.newSession(bp, "step_test_session")
 	assert.Equal(t, "parent_session", session.ParentSessionID)
 	assert.Equal(t, "deploy", session.ParentStepID)
+	assert.Equal(t, "node", session.Settings["language"])
 }
 
 func TestNextStepsDeployIncludesParentMetadata(t *testing.T) {

--- a/pkg/cmd/coop_step_test.go
+++ b/pkg/cmd/coop_step_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -256,6 +258,106 @@ func TestDoSkipFinalStepRoutesToNextSteps(t *testing.T) {
 	assert.Contains(t, output, `"next": "stripe coop next-steps --session=step_test_session"`)
 }
 
+func TestCoopRunStoresParentSessionMetadata(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	rc := &coopStartCmd{
+		language:      "node",
+		parentSession: "parent_session",
+		parentStep:    "deploy",
+	}
+	output := captureStdout(t, func() {
+		require.NoError(t, rc.runStartCmd(nil, []string{"one-time-payment"}))
+	})
+
+	var resp coopStartResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &resp))
+	require.Contains(t, resp.Next, "--session="+resp.SessionID)
+	require.Contains(t, resp.Next, `--note="Beginning: Understand the project"`)
+
+	store, err := coop.NewStore(coopConfigFolder())
+	require.NoError(t, err)
+	session, err := store.Read(resp.SessionID)
+	require.NoError(t, err)
+	assert.Equal(t, "parent_session", session.ParentSessionID)
+	assert.Equal(t, "deploy", session.ParentStepID)
+}
+
+func TestNextStepsDeployIncludesParentMetadata(t *testing.T) {
+	store, session := setupCompletedNextStepsSession(t)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			current, err := store.Read(session.ID)
+			if err == nil && current.NextSteps != nil && len(current.NextSteps.Suggestions) > 0 {
+				current.NextSteps.Selected = "deploy"
+				require.NoError(t, store.Write(current))
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	nc := &coopNextStepsCmd{session: session.ID}
+	output := captureStdout(t, func() {
+		require.NoError(t, nc.runNextStepsCmd(nil, nil))
+	})
+	<-done
+
+	var resp nextStepsResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &resp))
+	assert.Equal(t, session.ID, resp.SessionID)
+	assert.Equal(t, "stripe coop run deploy-stripe-projects --language=node --parent-session=step_test_session --parent-step=deploy", resp.Next)
+}
+
+func TestOutputCoopErrorReturnsRenderedError(t *testing.T) {
+	output := captureStderr(t, func() {
+		err := outputCoopError("No session found.", "stripe coop run <blueprint>")
+		var rendered coopRenderedError
+		require.True(t, errors.As(err, &rendered))
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &resp))
+	assert.False(t, resp.OK)
+	assert.Equal(t, "No session found.", resp.Error)
+	assert.Equal(t, "stripe coop run <blueprint>", resp.Hint)
+}
+
+func setupCompletedNextStepsSession(t *testing.T) (*coop.Store, *coop.Session) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	store, err := coop.NewStore(coopConfigFolder())
+	require.NoError(t, err)
+
+	session := &coop.Session{
+		ID:       "step_test_session",
+		Status:   coop.SessionActive,
+		Settings: map[string]string{"language": "node"},
+		Chapters: []coop.SessionChapter{
+			{
+				Key:   "ch1",
+				Title: "Chapter 1",
+				Nodes: []coop.SessionNode{
+					{Key: "n1", Title: "Step 1", State: coop.StepDone, Type: coop.NodeAPIRequest},
+					{Key: "n2", Title: "Step 2", State: coop.StepDone, Type: coop.NodeTestHelper},
+				},
+			},
+		},
+	}
+	for i := range session.Chapters {
+		for j := range session.Chapters[i].Nodes {
+			session.Chapters[i].Nodes[j].State = coop.StepDone
+		}
+	}
+	require.NoError(t, store.Write(session))
+	return store, session
+}
+
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 
@@ -268,6 +370,25 @@ func captureStdout(t *testing.T, fn func()) string {
 
 	require.NoError(t, w.Close())
 	os.Stdout = orig
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	return strings.TrimSpace(buf.String())
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	fn()
+
+	require.NoError(t, w.Close())
+	os.Stderr = orig
 
 	var buf bytes.Buffer
 	_, err = io.Copy(&buf, r)

--- a/pkg/cmd/coop_step_test.go
+++ b/pkg/cmd/coop_step_test.go
@@ -285,30 +285,11 @@ func TestCoopRunStoresParentSessionMetadata(t *testing.T) {
 }
 
 func TestNextStepsDeployIncludesParentMetadata(t *testing.T) {
-	store, session := setupCompletedNextStepsSession(t)
+	_, session := setupCompletedNextStepsSession(t)
+	suggestions := buildSuggestions(session, projectEnvironment{})
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for {
-			current, err := store.Read(session.ID)
-			if err == nil && current.NextSteps != nil && len(current.NextSteps.Suggestions) > 0 {
-				current.NextSteps.Selected = "deploy"
-				require.NoError(t, store.Write(current))
-				return
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
-	}()
+	resp := buildNextStepsResponse(session, suggestions, "deploy")
 
-	nc := &coopNextStepsCmd{session: session.ID}
-	output := captureStdout(t, func() {
-		require.NoError(t, nc.runNextStepsCmd(nil, nil))
-	})
-	<-done
-
-	var resp nextStepsResponse
-	require.NoError(t, json.Unmarshal([]byte(output), &resp))
 	assert.Equal(t, session.ID, resp.SessionID)
 	assert.Equal(t, "stripe coop run deploy-stripe-projects --language=node --parent-session=step_test_session --parent-step=deploy", resp.Next)
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -140,11 +140,14 @@ func Execute(ctx context.Context) {
 
 	if err := rootCmd.ExecuteContext(updatedCtx); err != nil {
 		errString := err.Error()
+		var renderedCoopError coopRenderedError
 
 		isLoginRequiredError := errString == validators.ErrAPIKeyNotConfigured.Error() || errString == validators.ErrDeviceNameNotConfigured.Error()
 		projectNameFlag := rootCmd.Flag("project-name").Value.String()
 
 		switch {
+		case errors.As(err, &renderedCoopError):
+			// Co-op agent-facing commands already rendered structured JSON.
 		case errors.Is(err, errNotAuthenticated):
 			// whoami already printed output; just exit non-zero
 		case requests.IsAPIKeyExpiredError(err):


### PR DESCRIPTION
## Summary
- Scope generated coop next commands to the active session
- Add parent session metadata for follow-up coop runs
- Return structured coop JSON errors instead of exiting directly from the helper
- Add command-layer coverage for handoff output

## Test plan
- go test ./pkg/cmd -run 'Coop|coop|Step|Next|Recover|Stop|Recommend'