### PR TITLE
Harden coop blueprint metadata and docs

### DIFF
--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -31,7 +31,7 @@ No server, no HTTP, no WebSocket. Communication is through a shared JSON session
 ```
 pending ──→ active ──→ review ──→ done     (normal flow)
    │          │          │
-   │          │          └──→ active        (rejection: developer pressed 'r')
+   │          │          └──→ active        (rejection: developer entered feedback)
    │          │
    │          └──→ done                     (auto_confirm nodes skip review)
    │          └──→ skipped                  (agent decides step doesn't apply)
@@ -84,9 +84,12 @@ All agent commands output JSON with an `ok` field and a `next` field suggesting 
 | `↓`/`j` | Move cursor down |
 | `e` / `Enter` | Toggle detail panel for selected step |
 | `c` | Confirm step (review → done) |
-| `r` | Reject step (review → active, agent redoes it) |
+| `r` | Type rejection feedback for a review step |
+| `f` | Resume following the active/review step after manual navigation |
 | `o` | Open claim URL in browser (when sandbox is unclaimed) |
 | `q` / `Ctrl+C` | Quit TUI |
+
+When rejecting a step, `r` opens a feedback prompt. Press `Enter` to submit the note and move the step back to `active`; press `Esc` to cancel.
 
 In the completion view:
 | Key | Action |
@@ -110,12 +113,14 @@ $ stripe coop start one-time-payment --language=node
 #      stripe coop step 1 done --note="Found Next.js app"
 #      stripe coop step 2 start --note="Creating product"
 #      stripe coop step 2 done --file=server.js --lines=5-20 --note="Created product"
-#      stripe coop step 2 await   ← blocks until developer confirms
+#      stripe coop step 2 await --session=coop_abc123   ← blocks until developer confirms
 # 5. Developer sees progress live, presses 'c' to confirm
 # 6. Agent continues to next step
-# 7. After all steps: agent runs "stripe coop next-steps"
+# 7. After all steps: agent runs "stripe coop next-steps --session=coop_abc123"
 # 8. Developer picks what to do next from TUI suggestions
 ```
+
+Post-completion choices are written into the session file for the agent. Deploy follow-ups use `stripe coop run deploy-stripe-projects --parent-session=<id> --parent-step=<selection>` so the child session can return to the completed parent and mark that next step done.
 
 ## Auto-Confirm
 
@@ -139,7 +144,7 @@ The heartbeat file is cleaned up when `await` exits.
 
 | Issue | Detection | Fix |
 |-------|-----------|-----|
-| Step stuck in `active` | No heartbeat, step is active | `--fix` moves to `review` |
+| Step stuck in `active` | No heartbeat, step is active | Recovery reports the active step; it does not move in-progress work automatically |
 | Session done but not marked | All steps done, status=active | `--fix` marks completed |
 | No active step | No active/review steps found | Shows next pending step number |
 | Agent crashed | Heartbeat stale | TUI shows warning, user runs `recover --fix` |
@@ -231,3 +236,7 @@ pkg/cmd/
   coop_recover.go   — Diagnose and fix stuck sessions
   coop_recommend.go — Blueprint discovery
 ```
+
+## Local Harness Artifacts
+
+The repository-level `bin/` directory remains ignored. Tmux harness isolation files under `bin/` are treated as local development artifacts unless a specific script or fixture is moved into a tracked source path with tests. Do not commit the ignored `bin/` directory wholesale.

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -1,6 +1,7 @@
 package coop
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,80 @@ func TestLoadBlueprint(t *testing.T) {
 	assert.Len(t, bp.Chapters, 4)
 	assert.Equal(t, "setup-chapter", bp.Chapters[0].Key)
 	assert.Equal(t, NodeAPIRequest, bp.Chapters[0].Nodes[0].Type)
+}
+
+func TestAllEmbeddedBlueprintsHaveQualityMetadata(t *testing.T) {
+	ids, err := ListBlueprints()
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+
+	weakPhrases := []string{
+		"do the thing",
+		"verify it works",
+		"todo",
+		"tbd",
+		"placeholder",
+		"lorem ipsum",
+	}
+
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			bp, err := LoadBlueprint(id)
+			require.NoError(t, err)
+
+			assertQualityText(t, "blueprint title", bp.Title, 4, weakPhrases)
+			if bp.Description != "" {
+				assertQualityText(t, "blueprint description", bp.Description, 20, weakPhrases)
+			}
+			assert.True(t, bp.Description != "" || len(bp.Products) > 0, "blueprint should include description or product metadata")
+
+			for _, ch := range bp.Chapters {
+				assertQualityText(t, "chapter title "+ch.Key, ch.Title, 4, weakPhrases)
+				for _, n := range ch.Nodes {
+					assertQualityText(t, "node title "+n.Key, n.Title, 4, weakPhrases)
+					assert.NotEqual(t, "api request", strings.ToLower(strings.TrimSpace(n.Title)), "node %q should have a product-specific title", n.Key)
+					if n.Description != "" {
+						assertQualityText(t, "node description "+n.Key, n.Description, 20, weakPhrases)
+					}
+
+					switch n.Type {
+					case NodeAPIRequest:
+						require.NotNil(t, n.Request, "apiRequest node %q should have request metadata", n.Key)
+					case NodeAsyncHandler:
+						assert.NotEmpty(t, n.Events, "asyncHandler node %q should name webhook events to verify", n.Key)
+					case NodeCLICommand, NodeTestHelper, NodeSetUpWebhooks:
+						if n.Description != "" {
+							assertObservableGuidance(t, n.Key, n.Description)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func assertQualityText(t *testing.T, label, value string, minLen int, weakPhrases []string) {
+	t.Helper()
+	trimmed := strings.TrimSpace(value)
+	require.NotEmpty(t, trimmed, "%s should not be empty", label)
+	assert.GreaterOrEqual(t, len(trimmed), minLen, "%s should be specific enough", label)
+
+	lower := strings.ToLower(trimmed)
+	for _, phrase := range weakPhrases {
+		assert.NotContains(t, lower, phrase, "%s contains weak placeholder text", label)
+	}
+}
+
+func assertObservableGuidance(t *testing.T, key, description string) {
+	t.Helper()
+	lower := strings.ToLower(description)
+	observableTerms := []string{"verify", "confirm", "report", "check", "run", "summarize", "ask"}
+	for _, term := range observableTerms {
+		if strings.Contains(lower, term) {
+			return
+		}
+	}
+	assert.Failf(t, "weak verification guidance", "node %q should name an observable check or reported outcome", key)
 }
 
 func TestLoadBlueprintNotFound(t *testing.T) {

--- a/pkg/coop/blueprints/checkout-studio.json
+++ b/pkg/coop/blueprints/checkout-studio.json
@@ -1,9 +1,12 @@
 {
   "id": "checkout-studio",
   "title": "Build your Integration",
-  "description": "",
+  "description": "Create a Checkout Session and add the frontend entry point for a hosted Checkout payment flow.",
   "type": "learning",
-  "products": [],
+  "products": [
+    "Checkout",
+    "Payments"
+  ],
   "settings": [],
   "chapters": [
     {

--- a/pkg/coop/blueprints/deploy-stripe-projects.json
+++ b/pkg/coop/blueprints/deploy-stripe-projects.json
@@ -90,7 +90,7 @@
           "type": "cliCommand",
           "key": "register-endpoint",
           "title": "Register webhook endpoint",
-          "description": "Look for webhook handling code (stripe.webhooks.constructEvent, /webhook routes). If found → construct the production URL (deployment URL + webhook path) and use `stripe projects webhooks --help` to discover how to register it. Set STRIPE_WEBHOOK_SECRET as a project secret. If NOT found → SKIP."
+          "description": "Look for webhook handling code (stripe.webhooks.constructEvent, /webhook routes). If found → construct the production URL (deployment URL + webhook path) and use `stripe projects webhooks --help` to discover how to register it. Set STRIPE_WEBHOOK_SECRET as a project secret and report the registered endpoint. If NOT found → SKIP."
         }
       ]
     }

--- a/pkg/coop/blueprints/destination-charge.json
+++ b/pkg/coop/blueprints/destination-charge.json
@@ -1,9 +1,12 @@
 {
   "id": "destination-charge",
   "title": "Create a destination charge",
-  "description": "",
+  "description": "Create a Connect destination charge by collecting payment on the platform and transferring funds to a connected account.",
   "type": "learning",
-  "products": [],
+  "products": [
+    "Connect",
+    "Payments"
+  ],
   "settings": [],
   "chapters": [
     {

--- a/pkg/coop/blueprints/managed-payments.json
+++ b/pkg/coop/blueprints/managed-payments.json
@@ -1,9 +1,12 @@
 {
   "id": "managed-payments",
   "title": "Set up Managed Payments",
-  "description": "",
+  "description": "Set up Checkout for managed payments with subscription and one-time product options, then listen for completed checkout events.",
   "type": "learning",
-  "products": [],
+  "products": [
+    "Checkout",
+    "Payments"
+  ],
   "settings": [],
   "chapters": [
     {
@@ -13,7 +16,7 @@
         {
           "type": "apiRequest",
           "key": "create-subscription-product",
-          "title": "API request",
+          "title": "Create subscription product",
           "request": {
             "path": "/v1/products",
             "method": "post"
@@ -22,7 +25,7 @@
         {
           "type": "apiRequest",
           "key": "create-one-time-product",
-          "title": "API request",
+          "title": "Create one-time product",
           "request": {
             "path": "/v1/products",
             "method": "post"
@@ -31,7 +34,7 @@
         {
           "type": "apiRequest",
           "key": "create-checkout-session",
-          "title": "API request",
+          "title": "Create managed Checkout Session",
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
@@ -45,7 +48,10 @@
         {
           "type": "asyncHandler",
           "key": "wait-for-checkout-completed",
-          "title": "Listen for checkout.session.completed"
+          "title": "Listen for checkout.session.completed",
+          "events": [
+            "checkout.session.completed"
+          ]
         }
       ]
     }

--- a/pkg/coop/blueprints/usage-based-billing.json
+++ b/pkg/coop/blueprints/usage-based-billing.json
@@ -152,7 +152,10 @@
         {
           "type": "asyncHandler",
           "key": "waitForCreditGrantCreated",
-          "title": "Wait for credit grant created event"
+          "title": "Wait for credit grant created event",
+          "events": [
+            "v2.billing.credit_grant.created"
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Add deterministic blueprint metadata quality checks
- Fill in weak blueprint metadata caught by the tests
- Update coop docs for rejection, follow mode, next-step handoffs, and local harness artifacts

## Test plan
- go test ./pkg/coop/...