### PR TITLE
Support chapter-level coop review awaits

### DIFF
--- a/pkg/cmd/coop_step.go
+++ b/pkg/cmd/coop_step.go
@@ -138,7 +138,7 @@ func (sc *coopStepCmd) doStart(store *coop.Store, session *coop.Session, stepNum
 func (sc *coopStepCmd) doDone(store *coop.Store, session *coop.Session, stepNum int) error {
 	targetState := coop.StepReview
 	node, _ := session.NodeByNumber(stepNum)
-	if sc.autoConfirm || (node != nil && node.AutoConfirm) {
+	if sc.autoConfirm || (node != nil && node.AutoConfirm) || session.ReviewGranularityForStep(stepNum) == coop.ReviewGranularityAuto {
 		targetState = coop.StepDone
 	}
 
@@ -257,6 +257,32 @@ func (sc *coopStepCmd) doAwait(store *coop.Store, session *coop.Session, stepNum
 		})
 	}
 
+	if session.ReviewGranularityForStep(stepNum) == coop.ReviewGranularityChapter && node.State == coop.StepReview {
+		chapter, chapterIndex, _, err := session.ChapterByStepNumber(stepNum)
+		if err != nil {
+			return outputCoopError(err.Error(), fmt.Sprintf("stripe coop status --session=%s", session.ID))
+		}
+		if !session.ChapterReadyForReview(chapterIndex) {
+			next := ""
+			msg := fmt.Sprintf("Step %d is ready. Continue the chapter before asking for human review.", stepNum)
+			if nextStep := nextPendingStepInChapter(session, chapterIndex, stepNum); nextStep > 0 {
+				nextNode, _ := session.NodeByNumber(nextStep)
+				next = fmt.Sprintf("stripe coop step %d start --session=%s --note=%s", nextStep, session.ID, quoteArg("Beginning: "+nextNode.Title))
+			} else {
+				next = fmt.Sprintf("stripe coop status --session=%s", session.ID)
+			}
+			return outputJSON(coop.CommandResponse{
+				OK:        true,
+				SessionID: session.ID,
+				Step:      stepNum,
+				State:     string(coop.StepReview),
+				Message:   msg,
+				Next:      next,
+			})
+		}
+		return sc.awaitChapterReview(store, session, chapter.Title, chapterIndex, stepNum)
+	}
+
 	if node.State != coop.StepReview {
 		next := ""
 		msg := fmt.Sprintf("Step %d is already %s.", stepNum, node.State)
@@ -360,6 +386,86 @@ func (sc *coopStepCmd) doAwait(store *coop.Store, session *coop.Session, stepNum
 			Message:   fmt.Sprintf("Step %d is now %s", stepNum, node.State),
 		})
 	}
+}
+
+func (sc *coopStepCmd) awaitChapterReview(store *coop.Store, session *coop.Session, chapterTitle string, chapterIndex, stepNum int) error {
+	store.WriteHeartbeat(session.ID)
+	defer store.RemoveHeartbeat(session.ID)
+
+	deadline := time.Now().Add(10 * time.Minute)
+	for {
+		if time.Now().After(deadline) {
+			return outputJSON(coop.CommandResponse{
+				OK:        true,
+				SessionID: session.ID,
+				Step:      stepNum,
+				State:     "timeout",
+				Message:   "Timed out waiting for developer confirmation (10 minutes). The developer may still be reviewing. Re-run this command to wait again.",
+				Next:      fmt.Sprintf("stripe coop step %d await --session=%s", stepNum, session.ID),
+			})
+		}
+
+		time.Sleep(500 * time.Millisecond)
+		store.WriteHeartbeat(session.ID)
+
+		var err error
+		session, err = store.Read(session.ID)
+		if err != nil {
+			return fmt.Errorf("reading session: %w", err)
+		}
+
+		if session.ChapterHasReview(chapterIndex) {
+			continue
+		}
+
+		if activeStep := session.FirstActiveStepInChapter(chapterIndex); activeStep > 0 {
+			activeNode, _ := session.NodeByNumber(activeStep)
+			msg := fmt.Sprintf("Chapter %q requested changes.", chapterTitle)
+			if activeNode != nil && activeNode.RejectionNote != "" {
+				msg += fmt.Sprintf("\nFeedback: %s", activeNode.RejectionNote)
+			}
+			msg += "\nRedo the chapter from the first affected step."
+			return outputJSON(coop.CommandResponse{
+				OK:        true,
+				SessionID: session.ID,
+				Step:      activeStep,
+				State:     "rejected",
+				Message:   msg,
+				Next:      fmt.Sprintf("stripe coop step %d start --session=%s --note=%s", activeStep, session.ID, quoteArg("Redoing: "+activeNode.Title)),
+			})
+		}
+
+		next := ""
+		msg := fmt.Sprintf("Chapter %q confirmed by developer. Proceed to next step.", chapterTitle)
+		if nextStep := session.NextPendingStep(stepNum); nextStep > 0 {
+			nextNode, _ := session.NodeByNumber(nextStep)
+			next = fmt.Sprintf("stripe coop step %d start --session=%s --note=%s", nextStep, session.ID, quoteArg("Beginning: "+nextNode.Title))
+		} else if session.IsComplete() {
+			msg = fmt.Sprintf("Chapter %q confirmed. All steps complete! You MUST run the next command immediately — it shows the developer their options and blocks until they choose.", chapterTitle)
+			next = fmt.Sprintf("stripe coop next-steps --session=%s", session.ID)
+		}
+		return outputJSON(coop.CommandResponse{
+			OK:        true,
+			SessionID: session.ID,
+			Step:      stepNum,
+			State:     "confirmed",
+			Message:   msg,
+			Next:      next,
+		})
+	}
+}
+
+func nextPendingStepInChapter(session *coop.Session, chapterIndex, afterStep int) int {
+	step := 0
+	for i := range session.Chapters {
+		for j := range session.Chapters[i].Nodes {
+			step++
+			if i == chapterIndex && step > afterStep && session.Chapters[i].Nodes[j].State == coop.StepPending {
+				return step
+			}
+		}
+	}
+	return 0
 }
 
 // readFromStdin reads implementation data from stdin as JSON.

--- a/pkg/cmd/coop_step_test.go
+++ b/pkg/cmd/coop_step_test.go
@@ -95,6 +95,22 @@ func TestDoDoneAutoConfirmNode(t *testing.T) {
 	assert.Equal(t, coop.StepDone, node.State)
 }
 
+func TestDoDoneReviewGranularityAuto(t *testing.T) {
+	store, session := setupStepTest(t)
+	session.Chapters[0].ReviewGranularity = coop.ReviewGranularityAuto
+	require.NoError(t, session.TransitionStep(1, coop.StepActive))
+
+	sc := &coopStepCmd{}
+	output := captureStdout(t, func() {
+		require.NoError(t, sc.doDone(store, session, 1))
+	})
+
+	node, _ := session.NodeByNumber(1)
+	assert.Equal(t, coop.StepDone, node.State)
+	assert.Contains(t, output, `"state": "done"`)
+	assert.NotContains(t, output, `"state": "review"`)
+}
+
 func TestSkipDoneStepFails(t *testing.T) {
 	_, session := setupStepTest(t)
 
@@ -256,6 +272,113 @@ func TestDoSkipFinalStepRoutesToNextSteps(t *testing.T) {
 
 	assert.Contains(t, output, `"state": "skipped"`)
 	assert.Contains(t, output, `"next": "stripe coop next-steps --session=step_test_session"`)
+}
+
+func TestDoAwaitChapterReviewContinuesUntilChapterReady(t *testing.T) {
+	store, session := setupStepTest(t)
+	session.Chapters[0].ReviewGranularity = coop.ReviewGranularityChapter
+	require.NoError(t, session.TransitionStep(1, coop.StepActive))
+	require.NoError(t, session.TransitionStep(1, coop.StepReview))
+	require.NoError(t, store.Write(session))
+
+	sc := &coopStepCmd{}
+	output := captureStdout(t, func() {
+		require.NoError(t, sc.doAwait(store, session, 1))
+	})
+
+	assert.Contains(t, output, `"state": "review"`)
+	assert.Contains(t, output, `stripe coop step 2 start`)
+}
+
+func TestNextPendingStepInChapterDoesNotLeaveChapter(t *testing.T) {
+	session := &coop.Session{
+		Chapters: []coop.SessionChapter{
+			{Nodes: []coop.SessionNode{
+				{Key: "a", State: coop.StepReview},
+				{Key: "b", State: coop.StepDone},
+			}},
+			{Nodes: []coop.SessionNode{
+				{Key: "c", State: coop.StepPending},
+			}},
+		},
+	}
+
+	assert.Equal(t, 0, nextPendingStepInChapter(session, 0, 1))
+	assert.Equal(t, 3, nextPendingStepInChapter(session, 1, 2))
+	assert.Equal(t, 0, nextPendingStepInChapter(session, 99, 1))
+}
+
+func TestDoAwaitChapterReviewConfirmed(t *testing.T) {
+	store, session := setupStepTest(t)
+	session.Chapters[0].ReviewGranularity = coop.ReviewGranularityChapter
+	require.NoError(t, session.TransitionStep(1, coop.StepActive))
+	require.NoError(t, session.TransitionStep(1, coop.StepReview))
+	require.NoError(t, session.TransitionStep(2, coop.StepActive))
+	require.NoError(t, session.TransitionStep(2, coop.StepDone))
+	require.NoError(t, session.TransitionStep(3, coop.StepActive))
+	require.NoError(t, session.TransitionStep(3, coop.StepReview))
+	require.NoError(t, store.Write(session))
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		must := func(err error) {
+			if err != nil {
+				panic(err)
+			}
+		}
+		updated, err := store.Read(session.ID)
+		must(err)
+		must(updated.TransitionStep(1, coop.StepDone))
+		must(updated.TransitionStep(3, coop.StepDone))
+		must(store.Write(updated))
+	}()
+
+	sc := &coopStepCmd{}
+	output := captureStdout(t, func() {
+		require.NoError(t, sc.doAwait(store, session, 1))
+	})
+
+	assert.Contains(t, output, `"state": "confirmed"`)
+	assert.Contains(t, output, `stripe coop next-steps --session=step_test_session`)
+}
+
+func TestDoAwaitChapterReviewRejected(t *testing.T) {
+	store, session := setupStepTest(t)
+	session.Chapters[0].ReviewGranularity = coop.ReviewGranularityChapter
+	require.NoError(t, session.TransitionStep(1, coop.StepActive))
+	require.NoError(t, session.TransitionStep(1, coop.StepReview))
+	require.NoError(t, session.TransitionStep(2, coop.StepActive))
+	require.NoError(t, session.TransitionStep(2, coop.StepDone))
+	require.NoError(t, session.TransitionStep(3, coop.StepActive))
+	require.NoError(t, session.TransitionStep(3, coop.StepReview))
+	require.NoError(t, store.Write(session))
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		must := func(err error) {
+			if err != nil {
+				panic(err)
+			}
+		}
+		updated, err := store.Read(session.ID)
+		must(err)
+		must(updated.TransitionStep(1, coop.StepDone))
+		must(updated.TransitionStep(3, coop.StepActive))
+		node, err := updated.NodeByNumber(3)
+		must(err)
+		node.RejectionNote = "Webhook does not verify signatures"
+		must(store.Write(updated))
+	}()
+
+	sc := &coopStepCmd{}
+	output := captureStdout(t, func() {
+		require.NoError(t, sc.doAwait(store, session, 1))
+	})
+
+	assert.Contains(t, output, `"state": "rejected"`)
+	assert.Contains(t, output, `"step": 3`)
+	assert.Contains(t, output, `Webhook does not verify signatures`)
+	assert.Contains(t, output, `stripe coop step 3 start`)
 }
 
 func TestCoopRunStoresParentSessionMetadata(t *testing.T) {

--- a/pkg/coop/session.go
+++ b/pkg/coop/session.go
@@ -39,6 +39,100 @@ func (s *Session) NodeByNumber(n int) (*SessionNode, error) {
 	return nil, fmt.Errorf("step %d out of range (session has %d steps)", n, s.TotalSteps())
 }
 
+// ChapterByStepNumber returns the chapter containing a 1-based step number.
+func (s *Session) ChapterByStepNumber(n int) (*SessionChapter, int, int, error) {
+	if n < 1 {
+		return nil, -1, -1, fmt.Errorf("step number must be >= 1, got %d", n)
+	}
+	idx := 0
+	for i := range s.Chapters {
+		for j := range s.Chapters[i].Nodes {
+			idx++
+			if idx == n {
+				return &s.Chapters[i], i, j, nil
+			}
+		}
+	}
+	return nil, -1, -1, fmt.Errorf("step %d out of range (session has %d steps)", n, s.TotalSteps())
+}
+
+// ReviewGranularityForStep returns the effective review granularity for a step.
+func (s *Session) ReviewGranularityForStep(n int) ReviewGranularity {
+	ch, _, _, err := s.ChapterByStepNumber(n)
+	if err != nil || ch.ReviewGranularity == "" {
+		return ReviewGranularityStep
+	}
+	return ch.ReviewGranularity
+}
+
+// ChapterReadyForReview returns true when every reviewable node in a chapter is
+// no longer pending or active.
+func (s *Session) ChapterReadyForReview(chapterIndex int) bool {
+	if chapterIndex < 0 || chapterIndex >= len(s.Chapters) {
+		return false
+	}
+	hasReviewable := false
+	for _, n := range s.Chapters[chapterIndex].Nodes {
+		if n.AutoConfirm {
+			continue
+		}
+		hasReviewable = true
+		switch n.State {
+		case StepReview, StepDone, StepSkipped:
+		default:
+			return false
+		}
+	}
+	return hasReviewable
+}
+
+// ChapterHasReview returns true if any node in the chapter is waiting for human review.
+func (s *Session) ChapterHasReview(chapterIndex int) bool {
+	if chapterIndex < 0 || chapterIndex >= len(s.Chapters) {
+		return false
+	}
+	for _, n := range s.Chapters[chapterIndex].Nodes {
+		if n.State == StepReview {
+			return true
+		}
+	}
+	return false
+}
+
+// FirstReviewStepInChapter returns the 1-based step number of the first review node.
+func (s *Session) FirstReviewStepInChapter(chapterIndex int) int {
+	if chapterIndex < 0 || chapterIndex >= len(s.Chapters) {
+		return 0
+	}
+	step := 0
+	for i := range s.Chapters {
+		for j := range s.Chapters[i].Nodes {
+			step++
+			if i == chapterIndex && s.Chapters[i].Nodes[j].State == StepReview {
+				return step
+			}
+		}
+	}
+	return 0
+}
+
+// FirstActiveStepInChapter returns the 1-based step number of the first active node.
+func (s *Session) FirstActiveStepInChapter(chapterIndex int) int {
+	if chapterIndex < 0 || chapterIndex >= len(s.Chapters) {
+		return 0
+	}
+	step := 0
+	for i := range s.Chapters {
+		for j := range s.Chapters[i].Nodes {
+			step++
+			if i == chapterIndex && s.Chapters[i].Nodes[j].State == StepActive {
+				return step
+			}
+		}
+	}
+	return 0
+}
+
 // ActiveNode returns the first node in active state, or nil.
 func (s *Session) ActiveNode() (*SessionNode, int) {
 	idx := 0

--- a/pkg/coop/session_test.go
+++ b/pkg/coop/session_test.go
@@ -229,6 +229,91 @@ func TestNodeByNumberAcrossChapters(t *testing.T) {
 	assert.Equal(t, 6, s.TotalSteps())
 }
 
+func TestChapterByStepNumber(t *testing.T) {
+	s := newTestSession()
+
+	ch, chapterIndex, nodeIndex, err := s.ChapterByStepNumber(3)
+	require.NoError(t, err)
+	assert.Equal(t, "chapter-2", ch.Key)
+	assert.Equal(t, 1, chapterIndex)
+	assert.Equal(t, 0, nodeIndex)
+
+	ch, chapterIndex, nodeIndex, err = s.ChapterByStepNumber(0)
+	assert.Nil(t, ch)
+	assert.Equal(t, -1, chapterIndex)
+	assert.Equal(t, -1, nodeIndex)
+	assert.Error(t, err)
+
+	ch, chapterIndex, nodeIndex, err = s.ChapterByStepNumber(4)
+	assert.Nil(t, ch)
+	assert.Equal(t, -1, chapterIndex)
+	assert.Equal(t, -1, nodeIndex)
+	assert.Error(t, err)
+}
+
+func TestReviewGranularityForStep(t *testing.T) {
+	s := newTestSession()
+	s.Chapters[0].ReviewGranularity = ReviewGranularityChapter
+	s.Chapters[1].ReviewGranularity = ReviewGranularityAuto
+
+	assert.Equal(t, ReviewGranularityChapter, s.ReviewGranularityForStep(1))
+	assert.Equal(t, ReviewGranularityChapter, s.ReviewGranularityForStep(2))
+	assert.Equal(t, ReviewGranularityAuto, s.ReviewGranularityForStep(3))
+	assert.Equal(t, ReviewGranularityStep, s.ReviewGranularityForStep(4))
+}
+
+func TestChapterReadyForReview(t *testing.T) {
+	s := newTestSession()
+	assert.False(t, s.ChapterReadyForReview(-1))
+	assert.False(t, s.ChapterReadyForReview(99))
+
+	s.Chapters[0].Nodes[0].State = StepReview
+	s.Chapters[0].Nodes[1].State = StepPending
+	assert.False(t, s.ChapterReadyForReview(0))
+
+	s.Chapters[0].Nodes[1].State = StepSkipped
+	assert.True(t, s.ChapterReadyForReview(0))
+
+	s.Chapters[0].Nodes[0].State = StepActive
+	assert.False(t, s.ChapterReadyForReview(0))
+}
+
+func TestChapterReadyForReviewIgnoresAutoConfirmNodes(t *testing.T) {
+	s := &Session{
+		Chapters: []SessionChapter{
+			{Nodes: []SessionNode{
+				{Key: "a", State: StepReview},
+				{Key: "auto", State: StepPending, AutoConfirm: true},
+			}},
+			{Nodes: []SessionNode{
+				{Key: "only-auto", State: StepPending, AutoConfirm: true},
+			}},
+		},
+	}
+
+	assert.True(t, s.ChapterReadyForReview(0))
+	assert.False(t, s.ChapterReadyForReview(1))
+}
+
+func TestChapterReviewStateHelpers(t *testing.T) {
+	s := newTestSession()
+	s.Chapters[0].Nodes[0].State = StepDone
+	s.Chapters[0].Nodes[1].State = StepReview
+	s.Chapters[1].Nodes[0].State = StepActive
+
+	assert.True(t, s.ChapterHasReview(0))
+	assert.False(t, s.ChapterHasReview(1))
+	assert.False(t, s.ChapterHasReview(-1))
+
+	assert.Equal(t, 2, s.FirstReviewStepInChapter(0))
+	assert.Equal(t, 0, s.FirstReviewStepInChapter(1))
+	assert.Equal(t, 0, s.FirstReviewStepInChapter(99))
+
+	assert.Equal(t, 0, s.FirstActiveStepInChapter(0))
+	assert.Equal(t, 3, s.FirstActiveStepInChapter(1))
+	assert.Equal(t, 0, s.FirstActiveStepInChapter(-1))
+}
+
 func TestActiveNodeReturnsFirst(t *testing.T) {
 	s := newTestSession()
 	s.TransitionStep(1, StepActive)


### PR DESCRIPTION
## Summary
- Add session helpers for chapter review state.
- Make `coop step await` continue through unfinished chapter-review groups.
- Block once the chapter review milestone is ready.
- Add command and session-helper coverage for chapter-review await behavior.

## Tests
- `go test ./pkg/coop/...`
- `go test ./pkg/cmd -run 'Coop|coop'`
