### PR TITLE
Add coop review metadata

### DIFF
--- a/pkg/cmd/coop_run.go
+++ b/pkg/cmd/coop_run.go
@@ -80,11 +80,13 @@ func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
 		for _, n := range ch.Nodes {
 			stepNum++
 			steps = append(steps, stepBrief{
-				Number:      stepNum,
-				Title:       n.Title,
-				Type:        string(n.Type),
-				Description: n.Description,
-				AutoConfirm: n.AutoConfirm,
+				Number:            stepNum,
+				Title:             n.Title,
+				Type:              string(n.Type),
+				Description:       n.Description,
+				ReviewPrompt:      n.ReviewPrompt,
+				ReviewGranularity: string(ch.ReviewGranularity),
+				AutoConfirm:       n.AutoConfirm,
 			})
 		}
 	}
@@ -132,11 +134,13 @@ type coopStartResponse struct {
 }
 
 type stepBrief struct {
-	Number      int    `json:"number"`
-	Title       string `json:"title"`
-	Type        string `json:"type"`
-	Description string `json:"description,omitempty"`
-	AutoConfirm bool   `json:"auto_confirm,omitempty"`
+	Number            int    `json:"number"`
+	Title             string `json:"title"`
+	Type              string `json:"type"`
+	Description       string `json:"description,omitempty"`
+	ReviewPrompt      string `json:"review_prompt,omitempty"`
+	ReviewGranularity string `json:"review_granularity,omitempty"`
+	AutoConfirm       bool   `json:"auto_confirm,omitempty"`
 }
 
 func agentInstructions(bp *coop.Blueprint, session *coop.Session) string {
@@ -161,6 +165,8 @@ Each step has a description that tells you what to do. Follow the description �
 - "cliCommand": Run a CLI command (e.g. stripe projects init, stripe projects deploy). Report the output.
 - "testHelper": Verify something works end-to-end. Run the flow and confirm the expected outcome.
 
+If a step includes review_prompt, that is what the human will use as the acceptance check. Make your implementation note and verifications directly answer it.
+
 Step 1 is always "Understand the project" — scan files, identify the tech stack, and summarize what you found. This helps you adapt the remaining steps to the developer's actual setup. Don't ask the developer questions you can answer by reading the code.
 
 Step lifecycle commands (use this session id: %s):
@@ -168,11 +174,11 @@ Step lifecycle commands (use this session id: %s):
 2. Write the code and run it to verify it works
 3. stripe coop step <n> verify --session=%s --check="<what you verified>" --passed
 4. stripe coop step <n> done --session=%s --file=<main file> --lines=<range> --snippet="<key code>" --note="<summary>"
-5. stripe coop step <n> await --session=%s   ← BLOCKS until the human confirms or rejects
+5. stripe coop step <n> await --session=%s   ← BLOCKS until the human confirms or requests changes
 6. If confirmed: move to next step. If rejected: redo the step (check the message for feedback).
 7. When the final step is confirmed: IMMEDIATELY run "stripe coop next-steps --session=%s". Do not stop or ask — just run it. It shows the developer their options in the TUI and blocks until they choose.
 
-The "await" command is critical — it blocks until the developer acts. Do NOT proceed to the next step without running await first. Set a 5-minute timeout on the shell command (it will re-prompt you if it times out). If rejected, ask the developer what they'd like you to change before redoing the step.
+The "await" command is critical — it blocks until the developer acts, or returns the next step if this step belongs to a chapter-level review that is not ready yet. Do NOT proceed to the next step without running await first. Set a 5-minute timeout on the shell command (it will re-prompt you if it times out). If changes are requested, ask the developer what they'd like you to change before redoing the step.
 
 Some steps are marked auto_confirm — await returns immediately for these (no human review needed). You still must call await for every step; the system handles the rest.
 

--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -31,7 +31,7 @@ No server, no HTTP, no WebSocket. Communication is through a shared JSON session
 ```
 pending ──→ active ──→ review ──→ done     (normal flow)
    │          │          │
-   │          │          └──→ active        (rejection: developer entered feedback)
+   │          │          └──→ active        (request changes: developer entered feedback)
    │          │
    │          └──→ done                     (auto_confirm nodes skip review)
    │          └──→ skipped                  (agent decides step doesn't apply)
@@ -71,7 +71,7 @@ active ──→ completed    (all steps done/skipped, or "stripe coop stop")
 | `stripe coop step <n> done` | Mark step as complete (→ review or → done if auto_confirm) |
 | `stripe coop step <n> verify` | Add a verification check |
 | `stripe coop step <n> skip` | Skip a step |
-| `stripe coop step <n> await` | Block until developer confirms/rejects |
+| `stripe coop step <n> await` | Block until developer confirms or requests changes |
 | `stripe coop next-steps` | Show post-completion options (blocks until selection) |
 
 All agent commands output JSON with an `ok` field and a `next` field suggesting the next command.
@@ -83,13 +83,13 @@ All agent commands output JSON with an `ok` field and a `next` field suggesting 
 | `↑`/`k` | Move cursor up |
 | `↓`/`j` | Move cursor down |
 | `e` / `Enter` | Toggle detail panel for selected step |
-| `c` | Confirm step (review → done) |
-| `r` | Type rejection feedback for a review step |
+| `c` | Confirm the selected review item |
+| `r` | Request changes for the selected review item |
 | `f` | Resume following the active/review step after manual navigation |
 | `o` | Open claim URL in browser (when sandbox is unclaimed) |
 | `q` / `Ctrl+C` | Quit TUI |
 
-When rejecting a step, `r` opens a feedback prompt. Press `Enter` to submit the note and move the step back to `active`; press `Esc` to cancel.
+When requesting changes, `r` opens a feedback prompt. Press `Enter` to submit a note and move the reviewed step or chapter back to `active`; press `Esc` to cancel.
 
 In the completion view:
 | Key | Action |
@@ -161,8 +161,11 @@ Each node has:
 - `type` — `apiRequest`, `asyncHandler`, `uiComponent`, `cliCommand`, `testHelper`
 - `auto_confirm` — skip human review for this step
 - `description` — what the agent should do (source of truth)
+- `review_prompt` — what the human should check before confirming
 - `request` — API request details (for `apiRequest` nodes with SDK snippet support)
 - `events` — webhook events (for `asyncHandler` nodes)
+
+Chapters may set `review_granularity` to `chapter` to group multiple reviewable nodes into one human approval milestone.
 
 ### Custom Agent Prompt
 
@@ -190,7 +193,7 @@ Without `prompt`, the agent gets: "You are building a working Stripe integration
 | Problem | Cause | Solution |
 |---------|-------|----------|
 | TUI shows "Agent appears idle" | Agent crashed or stopped | Check the agent pane; restart with `stripe coop start` |
-| Agent stuck on "await" | Developer hasn't confirmed | Press `c` in TUI to confirm, or `r` to reject |
+| Agent stuck on "await" | Developer hasn't confirmed | Press `c` in TUI to confirm, or `r` to request changes |
 | "Version conflict" error | TUI and agent wrote simultaneously | Agent retries the command (safe to re-run) |
 | TUI shows wrong session | Multiple sessions exist | Use `stripe coop join <session-id>` with the correct ID |
 | Steps not updating in TUI | Agent created a duplicate session | Check `stripe coop status` for the correct session ID |

--- a/pkg/coop/blueprint.go
+++ b/pkg/coop/blueprint.go
@@ -12,22 +12,24 @@ var blueprintFS embed.FS
 
 // BlueprintNode is a node definition within a blueprint chapter.
 type BlueprintNode struct {
-	Type        NodeType    `json:"type"`
-	Key         string      `json:"key"`
-	Title       string      `json:"title"`
-	Description string      `json:"description,omitempty"`
-	AutoConfirm bool        `json:"auto_confirm,omitempty"`
-	Request     *APIRequest `json:"request,omitempty"`
-	Events      []string    `json:"events,omitempty"`
+	Type         NodeType    `json:"type"`
+	Key          string      `json:"key"`
+	Title        string      `json:"title"`
+	Description  string      `json:"description,omitempty"`
+	ReviewPrompt string      `json:"review_prompt,omitempty"`
+	AutoConfirm  bool        `json:"auto_confirm,omitempty"`
+	Request      *APIRequest `json:"request,omitempty"`
+	Events       []string    `json:"events,omitempty"`
 }
 
 // BlueprintChapter is a chapter definition within a blueprint.
 type BlueprintChapter struct {
-	Key         string          `json:"key"`
-	Title       string          `json:"title"`
-	Description string          `json:"description,omitempty"`
-	Required    bool            `json:"required,omitempty"`
-	Nodes       []BlueprintNode `json:"nodes"`
+	Key               string            `json:"key"`
+	Title             string            `json:"title"`
+	Description       string            `json:"description,omitempty"`
+	ReviewGranularity ReviewGranularity `json:"review_granularity,omitempty"`
+	Required          bool              `json:"required,omitempty"`
+	Nodes             []BlueprintNode   `json:"nodes"`
 }
 
 // Blueprint is the CLI-friendly representation of a Workbench Blueprint.
@@ -161,20 +163,22 @@ func NewSessionFromBlueprint(bp *Blueprint, sessionID string, settings map[strin
 		nodes := make([]SessionNode, len(ch.Nodes))
 		for j, n := range ch.Nodes {
 			nodes[j] = SessionNode{
-				Key:         n.Key,
-				Type:        n.Type,
-				Title:       n.Title,
-				Description: n.Description,
-				AutoConfirm: n.AutoConfirm,
-				State:       StepPending,
-				Request:     n.Request,
-				Events:      n.Events,
+				Key:          n.Key,
+				Type:         n.Type,
+				Title:        n.Title,
+				Description:  n.Description,
+				ReviewPrompt: n.ReviewPrompt,
+				AutoConfirm:  n.AutoConfirm,
+				State:        StepPending,
+				Request:      n.Request,
+				Events:       n.Events,
 			}
 		}
 		chapters = append(chapters, SessionChapter{
-			Key:   ch.Key,
-			Title: ch.Title,
-			Nodes: nodes,
+			Key:               ch.Key,
+			Title:             ch.Title,
+			ReviewGranularity: ch.ReviewGranularity,
+			Nodes:             nodes,
 		})
 	}
 

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -52,6 +52,10 @@ func TestAllEmbeddedBlueprintsHaveQualityMetadata(t *testing.T) {
 					if n.Description != "" {
 						assertQualityText(t, "node description "+n.Key, n.Description, 20, weakPhrases)
 					}
+					if !n.AutoConfirm {
+						assertQualityText(t, "node review prompt "+n.Key, n.ReviewPrompt, 20, weakPhrases)
+						assertObservableGuidance(t, n.Key, n.ReviewPrompt)
+					}
 
 					switch n.Type {
 					case NodeAPIRequest:
@@ -84,7 +88,7 @@ func assertQualityText(t *testing.T, label, value string, minLen int, weakPhrase
 func assertObservableGuidance(t *testing.T, key, description string) {
 	t.Helper()
 	lower := strings.ToLower(description)
-	observableTerms := []string{"verify", "confirm", "report", "check", "run", "summarize", "ask"}
+	observableTerms := []string{"verify", "confirm", "report", "check", "run", "summarize", "ask", "open"}
 	for _, term := range observableTerms {
 		if strings.Contains(lower, term) {
 			return
@@ -150,6 +154,9 @@ func TestNewSessionFromBlueprint(t *testing.T) {
 
 	// Total steps = blueprint steps (6) + context step (1)
 	assert.Equal(t, 7, session.TotalSteps())
+
+	assert.Equal(t, ReviewGranularityChapter, session.Chapters[2].ReviewGranularity)
+	assert.NotEmpty(t, session.Chapters[1].Nodes[0].ReviewPrompt)
 }
 
 func TestListBlueprintsWithMetadata(t *testing.T) {

--- a/pkg/coop/blueprints/billing-portal.json
+++ b/pkg/coop/blueprints/billing-portal.json
@@ -13,7 +13,8 @@
         {
           "type": "uiComponent",
           "key": "redirect-to-portal",
-          "title": "Open billing portal"
+          "title": "Open billing portal",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         }
       ]
     }

--- a/pkg/coop/blueprints/checkout-studio.json
+++ b/pkg/coop/blueprints/checkout-studio.json
@@ -20,12 +20,14 @@
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "uiComponent",
           "key": "setup-stripe-elements-html-snippet",
-          "title": "Set up your frontend"
+          "title": "Set up your frontend",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         }
       ]
     }

--- a/pkg/coop/blueprints/credit-burndown.json
+++ b/pkg/coop/blueprints/credit-burndown.json
@@ -17,7 +17,8 @@
           "request": {
             "path": "/v1/customers",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -26,7 +27,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -35,7 +37,8 @@
           "request": {
             "path": "/v1/billing/meters",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -44,7 +47,8 @@
           "request": {
             "path": "/v2/billing/rate_cards",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -53,7 +57,8 @@
           "request": {
             "path": "/v2/billing/metered_items",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -62,7 +67,8 @@
           "request": {
             "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -71,7 +77,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -80,7 +87,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -89,12 +97,14 @@
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "uiComponent",
           "key": "completeCheckout",
-          "title": "Complete the checkout"
+          "title": "Complete the checkout",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
           "type": "asyncHandler",
@@ -102,7 +112,8 @@
           "title": "Wait for servicing activated event",
           "events": [
             "v2.billing.pricing_plan_subscription.servicing_activated"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
         },
         {
           "type": "apiRequest",
@@ -111,7 +122,8 @@
           "request": {
             "path": "/v1/payment_methods",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -120,7 +132,8 @@
           "request": {
             "path": "/v1/payment_methods/${node.grant-credits-chapter.createPaymentMethod.createPaymentMethodRequest:id}/attach",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -129,7 +142,8 @@
           "request": {
             "path": "/v1/invoices",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -138,7 +152,8 @@
           "request": {
             "path": "/v1/invoiceitems",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -147,7 +162,8 @@
           "request": {
             "path": "/v1/invoices/${node.grant-credits-chapter.createCreditInvoice.createCreditInvoiceRequest:id}/pay",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -156,7 +172,8 @@
           "request": {
             "path": "/v1/billing/credit_grants",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -165,7 +182,8 @@
           "request": {
             "path": "/v1/billing/alerts",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         }
       ]
     }

--- a/pkg/coop/blueprints/deploy-stripe-projects.json
+++ b/pkg/coop/blueprints/deploy-stripe-projects.json
@@ -4,7 +4,9 @@
   "description": "Configure and deploy your local project using the Stripe Projects CLI plugin.",
   "prompt": "The developer wants to configure their local project for deployment using the Stripe Projects CLI plugin. You will walk them through the setup using `stripe projects` commands. Use `stripe projects --help` and `stripe projects <subcommand> --help` to discover available options. All stripe CLI commands output JSON when passed --json. Report command output to the developer via the coop step commands.\n\nIMPORTANT: If any step fails because the account is a claimable sandbox (errors mentioning 'claim', 'unclaimed', or permission issues), tell the developer they need to claim their sandbox first. Show them the claim URL from `stripe coop status` (the claim_url field) or from `stripe whoami`. Once they've claimed it, tell them to re-run the session with: stripe coop start deploy",
   "type": "learning",
-  "products": ["Projects"],
+  "products": [
+    "Projects"
+  ],
   "settings": [],
   "chapters": [
     {
@@ -39,7 +41,8 @@
           "type": "cliCommand",
           "key": "init-project",
           "title": "Initialize Stripe Project",
-          "description": "Run `stripe projects init --help` to see available flags, then run `stripe projects init` with appropriate options for the detected framework. Report what was detected and what stripe.json contains."
+          "description": "Run `stripe projects init --help` to see available flags, then run `stripe projects init` with appropriate options for the detected framework. Report what was detected and what stripe.json contains.",
+          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
         }
       ]
     },
@@ -52,13 +55,15 @@
           "type": "cliCommand",
           "key": "stripe-keys",
           "title": "Set Stripe keys as project secrets",
-          "description": "Run `stripe projects secrets --help` to discover the command interface. Set STRIPE_SECRET_KEY and STRIPE_PUBLISHABLE_KEY using the keys from `stripe whoami --json`. Tell the developer which keys you're using."
+          "description": "Run `stripe projects secrets --help` to discover the command interface. Set STRIPE_SECRET_KEY and STRIPE_PUBLISHABLE_KEY using the keys from `stripe whoami --json`. Tell the developer which keys you're using.",
+          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
         },
         {
           "type": "cliCommand",
           "key": "other-secrets",
           "title": "Set additional secrets",
-          "description": "Scan .env, .env.local, .env.example for variables NOT already handled (not STRIPE_ keys). If NONE remain → SKIP. If found → use `stripe projects secrets set` to configure them. Ask the developer for production values only if they differ from what's in .env."
+          "description": "Scan .env, .env.local, .env.example for variables NOT already handled (not STRIPE_ keys). If NONE remain → SKIP. If found → use `stripe projects secrets set` to configure them. Ask the developer for production values only if they differ from what's in .env.",
+          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
         }
       ]
     },
@@ -71,13 +76,15 @@
           "type": "cliCommand",
           "key": "first-deploy",
           "title": "Run first deployment",
-          "description": "Run `stripe projects deploy --help` to check available flags, then run `stripe projects deploy`. Report the build output and deployment URL."
+          "description": "Run `stripe projects deploy --help` to check available flags, then run `stripe projects deploy`. Report the build output and deployment URL.",
+          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
         },
         {
           "type": "testHelper",
           "key": "verify-live",
           "title": "Verify deployment is live",
-          "description": "Ask the developer to visit the deployment URL and confirm it works. If it's a payment flow, suggest testing with card number 4242424242424242."
+          "description": "Ask the developer to visit the deployment URL and confirm it works. If it's a payment flow, suggest testing with card number 4242424242424242.",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
         }
       ]
     },
@@ -90,7 +97,8 @@
           "type": "cliCommand",
           "key": "register-endpoint",
           "title": "Register webhook endpoint",
-          "description": "Look for webhook handling code (stripe.webhooks.constructEvent, /webhook routes). If found → construct the production URL (deployment URL + webhook path) and use `stripe projects webhooks --help` to discover how to register it. Set STRIPE_WEBHOOK_SECRET as a project secret and report the registered endpoint. If NOT found → SKIP."
+          "description": "Look for webhook handling code (stripe.webhooks.constructEvent, /webhook routes). If found → construct the production URL (deployment URL + webhook path) and use `stripe projects webhooks --help` to discover how to register it. Set STRIPE_WEBHOOK_SECRET as a project secret and report the registered endpoint. If NOT found → SKIP.",
+          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
         }
       ]
     }

--- a/pkg/coop/blueprints/destination-charge.json
+++ b/pkg/coop/blueprints/destination-charge.json
@@ -20,7 +20,8 @@
           "request": {
             "path": "/v1/payment_intents",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         }
       ]
     }

--- a/pkg/coop/blueprints/direct-charge.json
+++ b/pkg/coop/blueprints/direct-charge.json
@@ -17,7 +17,8 @@
           "request": {
             "path": "/v1/payment_intents",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         }
       ]
     }

--- a/pkg/coop/blueprints/flat-fee-and-overages.json
+++ b/pkg/coop/blueprints/flat-fee-and-overages.json
@@ -17,7 +17,8 @@
           "request": {
             "path": "/v1/customers",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -26,7 +27,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -35,7 +37,8 @@
           "request": {
             "path": "/v1/billing/meters",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -44,7 +47,8 @@
           "request": {
             "path": "/v2/billing/rate_cards",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -53,7 +57,8 @@
           "request": {
             "path": "/v2/billing/metered_items",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -62,7 +67,8 @@
           "request": {
             "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -71,7 +77,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -80,7 +87,8 @@
           "request": {
             "path": "/v2/billing/licensed_items",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -89,7 +97,8 @@
           "request": {
             "path": "/v2/billing/license_fees",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -98,7 +107,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -107,7 +117,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -116,12 +127,14 @@
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "uiComponent",
           "key": "completeCheckout",
-          "title": "Complete the checkout"
+          "title": "Complete the checkout",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
           "type": "asyncHandler",
@@ -129,7 +142,8 @@
           "title": "Wait for servicing activated event",
           "events": [
             "v2.billing.pricing_plan_subscription.servicing_activated"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
         }
       ]
     }

--- a/pkg/coop/blueprints/flat-subscription-with-entitlements.json
+++ b/pkg/coop/blueprints/flat-subscription-with-entitlements.json
@@ -17,7 +17,8 @@
           "request": {
             "path": "/v1/products",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -26,7 +27,8 @@
           "request": {
             "path": "/v1/entitlements/features",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -35,17 +37,20 @@
           "request": {
             "path": "/v1/products/${node.create-products-chapter.create-basic-product.create-basic-product-request:id}/features",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "testHelper",
           "key": "create-test-clock",
-          "title": "Create a test clock"
+          "title": "Create a test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
         },
         {
           "type": "testHelper",
           "key": "create-customer",
-          "title": "Create a customer"
+          "title": "Create a customer",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
         },
         {
           "type": "apiRequest",
@@ -54,12 +59,14 @@
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "uiComponent",
           "key": "complete-checkout",
-          "title": "Complete the checkout process"
+          "title": "Complete the checkout process",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
           "type": "asyncHandler",
@@ -67,7 +74,8 @@
           "title": "Track subscription creation",
           "events": [
             "customer.subscription.created"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly."
         },
         {
           "type": "asyncHandler",
@@ -75,12 +83,14 @@
           "title": "Check customer entitlements",
           "events": [
             "entitlements.active_entitlement_summary.updated"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger entitlements.active_entitlement_summary.updated and confirm the handler processes the signed event correctly."
         },
         {
           "type": "testHelper",
           "key": "advance-time",
-          "title": "Advance time to billing date"
+          "title": "Advance time to billing date",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
         },
         {
           "type": "asyncHandler",
@@ -88,7 +98,8 @@
           "title": "View the invoice created",
           "events": [
             "invoice.created"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger invoice.created and confirm the handler processes the signed event correctly."
         },
         {
           "type": "apiRequest",
@@ -97,7 +108,8 @@
           "request": {
             "path": "/v1/invoices/${node.next-billing-cycle-chapter.wait-for-invoice-created.0:id}",
             "method": "get"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "asyncHandler",
@@ -105,12 +117,14 @@
           "title": "Wait for test clock to be ready.",
           "events": [
             "test_helpers.test_clock.ready"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger test_helpers.test_clock.ready and confirm the handler processes the signed event correctly."
         },
         {
           "type": "testHelper",
           "key": "delete-test-clock",
-          "title": "Delete the test clock"
+          "title": "Delete the test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
         }
       ]
     }

--- a/pkg/coop/blueprints/invoice-payments.json
+++ b/pkg/coop/blueprints/invoice-payments.json
@@ -13,7 +13,8 @@
         {
           "type": "testHelper",
           "key": "create-test-clock",
-          "title": "Create a test clock"
+          "title": "Create a test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
         },
         {
           "type": "apiRequest",
@@ -22,7 +23,8 @@
           "request": {
             "path": "/v1/products",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -31,7 +33,8 @@
           "request": {
             "path": "/v1/customers",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -40,7 +43,8 @@
           "request": {
             "path": "/v1/invoices",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -49,7 +53,8 @@
           "request": {
             "path": "/v1/invoiceitems",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -58,12 +63,14 @@
           "request": {
             "path": "/v1/invoices/${node.create-invoice-chapter.create-invoice.create-invoice-request:id}/send",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "uiComponent",
           "key": "view-invoice",
-          "title": "View and pay the invoice"
+          "title": "View and pay the invoice",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
           "type": "asyncHandler",
@@ -71,7 +78,8 @@
           "title": "Handle invoice payment events",
           "events": [
             "invoice.paid"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger invoice.paid and confirm the handler processes the signed event correctly."
         }
       ]
     }

--- a/pkg/coop/blueprints/managed-payments.json
+++ b/pkg/coop/blueprints/managed-payments.json
@@ -20,7 +20,8 @@
           "request": {
             "path": "/v1/products",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -29,7 +30,8 @@
           "request": {
             "path": "/v1/products",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -38,12 +40,14 @@
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "uiComponent",
           "key": "complete-checkout",
-          "title": "Complete a test payment"
+          "title": "Complete a test payment",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
           "type": "asyncHandler",
@@ -51,7 +55,8 @@
           "title": "Listen for checkout.session.completed",
           "events": [
             "checkout.session.completed"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger checkout.session.completed and confirm the handler processes the signed event correctly."
         }
       ]
     }

--- a/pkg/coop/blueprints/metered-subscription.json
+++ b/pkg/coop/blueprints/metered-subscription.json
@@ -17,7 +17,8 @@
           "request": {
             "path": "/v1/billing/meters",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -26,7 +27,8 @@
           "request": {
             "path": "/v1/products",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -35,7 +37,8 @@
           "request": {
             "path": "/v1/prices",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -44,7 +47,8 @@
           "request": {
             "path": "/v1/entitlements/features",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -53,17 +57,20 @@
           "request": {
             "path": "/v1/products/${node.metering-setup-chapter.create-usage-product.create-usage-product-request:id}/features",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "testHelper",
           "key": "create-test-clock",
-          "title": "Create a test clock"
+          "title": "Create a test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
         },
         {
           "type": "testHelper",
           "key": "create-customer",
-          "title": "Create a customer"
+          "title": "Create a customer",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
         },
         {
           "type": "apiRequest",
@@ -72,12 +79,14 @@
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "uiComponent",
           "key": "complete-checkout",
-          "title": "Complete the checkout process"
+          "title": "Complete the checkout process",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
           "type": "asyncHandler",
@@ -85,7 +94,8 @@
           "title": "Check customer entitlements",
           "events": [
             "entitlements.active_entitlement_summary.updated"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger entitlements.active_entitlement_summary.updated and confirm the handler processes the signed event correctly."
         },
         {
           "type": "asyncHandler",
@@ -93,7 +103,8 @@
           "title": "Track subscription creation",
           "events": [
             "customer.subscription.created"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly."
         },
         {
           "type": "apiRequest",
@@ -102,12 +113,14 @@
           "request": {
             "path": "/v1/billing/meter_events",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "testHelper",
           "key": "advance-time",
-          "title": "Advance time to billing date"
+          "title": "Advance time to billing date",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
         },
         {
           "type": "asyncHandler",
@@ -115,7 +128,8 @@
           "title": "Wait for the invoice to be created",
           "events": [
             "invoice.created"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger invoice.created and confirm the handler processes the signed event correctly."
         },
         {
           "type": "apiRequest",
@@ -124,7 +138,8 @@
           "request": {
             "path": "/v1/invoices/${node.usage-chapter.wait-for-invoice-created.0:id}",
             "method": "get"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "asyncHandler",
@@ -132,12 +147,14 @@
           "title": "Wait for test clock to be ready.",
           "events": [
             "test_helpers.test_clock.ready"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger test_helpers.test_clock.ready and confirm the handler processes the signed event correctly."
         },
         {
           "type": "testHelper",
           "key": "delete-test-clock",
-          "title": "Delete the test clock"
+          "title": "Delete the test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
         }
       ]
     }

--- a/pkg/coop/blueprints/one-time-payment.json
+++ b/pkg/coop/blueprints/one-time-payment.json
@@ -20,7 +20,8 @@
             "path": "/v1/products"
           },
           "title": "Create a product",
-          "type": "apiRequest"
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         }
       ],
       "required": true,
@@ -29,6 +30,7 @@
     {
       "description": "Build a server endpoint that creates a Checkout Session and redirects the customer.",
       "key": "checkout-chapter",
+      "review_granularity": "chapter",
       "nodes": [
         {
           "description": "Create a Checkout Session with the price from the previous step.",
@@ -50,19 +52,22 @@
             "path": "/v1/checkout/sessions"
           },
           "title": "Create a Checkout Session",
-          "type": "apiRequest"
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "description": "Add a button or link that redirects the customer to the Checkout page.",
           "key": "redirect-to-checkout",
           "title": "Redirect to Checkout",
-          "type": "uiComponent"
+          "type": "uiComponent",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
           "description": "Create a page to show after the customer completes payment.",
           "key": "add-success-page",
           "title": "Add a success page",
-          "type": "uiComponent"
+          "type": "uiComponent",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         }
       ],
       "title": "Create a Checkout Session"
@@ -78,7 +83,8 @@
           ],
           "key": "handle-checkout-completed",
           "title": "Handle checkout.session.completed",
-          "type": "asyncHandler"
+          "type": "asyncHandler",
+          "review_prompt": "Run stripe trigger checkout.session.completed and confirm the handler processes the signed event correctly."
         }
       ],
       "title": "Handle post-payment events"
@@ -91,7 +97,8 @@
           "description": "Run through the complete payment flow using a test card number.",
           "key": "test-payment-flow",
           "title": "Make a test payment",
-          "type": "testHelper"
+          "type": "testHelper",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
         }
       ],
       "title": "Test the integration"

--- a/pkg/coop/blueprints/pay-as-you-go.json
+++ b/pkg/coop/blueprints/pay-as-you-go.json
@@ -17,7 +17,8 @@
           "request": {
             "path": "/v1/customers",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -26,7 +27,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -35,7 +37,8 @@
           "request": {
             "path": "/v1/billing/meters",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -44,7 +47,8 @@
           "request": {
             "path": "/v2/billing/rate_cards",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -53,7 +57,8 @@
           "request": {
             "path": "/v2/billing/metered_items",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -62,7 +67,8 @@
           "request": {
             "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -71,7 +77,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -80,7 +87,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -89,12 +97,14 @@
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "uiComponent",
           "key": "completeCheckout",
-          "title": "Complete the checkout"
+          "title": "Complete the checkout",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
           "type": "asyncHandler",
@@ -102,7 +112,8 @@
           "title": "Wait for servicing activated event",
           "events": [
             "v2.billing.pricing_plan_subscription.servicing_activated"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
         }
       ]
     }

--- a/pkg/coop/blueprints/setup-future-payments.json
+++ b/pkg/coop/blueprints/setup-future-payments.json
@@ -17,7 +17,8 @@
             "path": "/v1/customers"
           },
           "title": "Create a customer",
-          "type": "apiRequest"
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "description": "Create a Checkout Session with mode=setup to save a payment method.",
@@ -37,7 +38,8 @@
             "path": "/v1/checkout/sessions"
           },
           "title": "Create a Checkout Session (setup mode)",
-          "type": "apiRequest"
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         }
       ],
       "required": true,
@@ -51,7 +53,8 @@
           "description": "Redirect the customer to the Checkout Session URL.",
           "key": "redirect-to-setup",
           "title": "Redirect to setup page",
-          "type": "uiComponent"
+          "type": "uiComponent",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
           "description": "Listen for the setup_intent.succeeded event to confirm the payment method was saved.",
@@ -60,7 +63,8 @@
           ],
           "key": "handle-setup-completed",
           "title": "Handle setup_intent.succeeded",
-          "type": "asyncHandler"
+          "type": "asyncHandler",
+          "review_prompt": "Run stripe trigger setup_intent.succeeded and confirm the handler processes the signed event correctly."
         }
       ],
       "title": "Complete the setup"
@@ -86,7 +90,8 @@
             "path": "/v1/payment_intents"
           },
           "title": "Create a PaymentIntent off-session",
-          "type": "apiRequest"
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         }
       ],
       "title": "Charge the saved card"

--- a/pkg/coop/blueprints/subscription-with-trial.json
+++ b/pkg/coop/blueprints/subscription-with-trial.json
@@ -17,12 +17,14 @@
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "uiComponent",
           "key": "complete-checkout",
-          "title": "Complete checkout"
+          "title": "Complete checkout",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
           "type": "asyncHandler",
@@ -30,7 +32,8 @@
           "title": "Wait for checkout.session.completed event",
           "events": [
             "checkout.session.completed"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger checkout.session.completed and confirm the handler processes the signed event correctly."
         },
         {
           "type": "asyncHandler",
@@ -38,7 +41,8 @@
           "title": "Wait for customer.subscription.created event",
           "events": [
             "customer.subscription.created"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly."
         }
       ]
     }

--- a/pkg/coop/blueprints/usage-based-billing.json
+++ b/pkg/coop/blueprints/usage-based-billing.json
@@ -17,7 +17,8 @@
           "request": {
             "path": "/v1/customers",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -26,7 +27,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -35,7 +37,8 @@
           "request": {
             "path": "/v1/billing/meters",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -44,7 +47,8 @@
           "request": {
             "path": "/v2/billing/rate_cards",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -53,7 +57,8 @@
           "request": {
             "path": "/v2/billing/metered_items",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -62,7 +67,8 @@
           "request": {
             "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -71,7 +77,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -80,7 +87,8 @@
           "request": {
             "path": "/v2/billing/licensed_items",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -89,7 +97,8 @@
           "request": {
             "path": "/v2/billing/license_fees",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -98,7 +107,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -107,7 +117,8 @@
           "request": {
             "path": "/v2/billing/service_actions",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -116,7 +127,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -125,7 +137,8 @@
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -134,12 +147,14 @@
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "uiComponent",
           "key": "completeCheckout",
-          "title": "Complete the checkout"
+          "title": "Complete the checkout",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
           "type": "asyncHandler",
@@ -147,7 +162,8 @@
           "title": "Wait for servicing activated event",
           "events": [
             "v2.billing.pricing_plan_subscription.servicing_activated"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
         },
         {
           "type": "asyncHandler",
@@ -155,7 +171,8 @@
           "title": "Wait for credit grant created event",
           "events": [
             "v2.billing.credit_grant.created"
-          ]
+          ],
+          "review_prompt": "Run stripe trigger v2.billing.credit_grant.created and confirm the handler processes the signed event correctly."
         }
       ]
     }

--- a/pkg/coop/blueprints/usage-recording.json
+++ b/pkg/coop/blueprints/usage-recording.json
@@ -17,7 +17,8 @@
           "request": {
             "path": "/v1/billing/meters",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         },
         {
           "type": "apiRequest",
@@ -26,7 +27,8 @@
           "request": {
             "path": "/v1/billing/meter_events",
             "method": "post"
-          }
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
         }
       ]
     }

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -28,6 +28,15 @@ const (
 	NodeSetUpWebhooks NodeType = "setUpWebhooks"
 )
 
+// ReviewGranularity controls where human approval happens.
+type ReviewGranularity string
+
+const (
+	ReviewGranularityStep    ReviewGranularity = "step"
+	ReviewGranularityChapter ReviewGranularity = "chapter"
+	ReviewGranularityAuto    ReviewGranularity = "auto"
+)
+
 // SessionStatus represents the overall session lifecycle.
 type SessionStatus string
 
@@ -65,6 +74,7 @@ type SessionNode struct {
 	Type           NodeType        `json:"type"`
 	Title          string          `json:"title"`
 	Description    string          `json:"description,omitempty"`
+	ReviewPrompt   string          `json:"review_prompt,omitempty"`
 	AutoConfirm    bool            `json:"auto_confirm,omitempty"`
 	State          StepState       `json:"state"`
 	Activity       string          `json:"activity,omitempty"`
@@ -79,9 +89,10 @@ type SessionNode struct {
 
 // SessionChapter groups nodes under a titled section.
 type SessionChapter struct {
-	Key   string        `json:"key"`
-	Title string        `json:"title"`
-	Nodes []SessionNode `json:"nodes"`
+	Key               string            `json:"key"`
+	Title             string            `json:"title"`
+	ReviewGranularity ReviewGranularity `json:"review_granularity,omitempty"`
+	Nodes             []SessionNode     `json:"nodes"`
 }
 
 // Session is the shared state file between agent and TUI.


### PR DESCRIPTION
## Summary
- Add `review_prompt` metadata to coop blueprint/session nodes.
- Add `review_granularity` metadata plumbing.
- Populate review prompts across embedded blueprints.
- Expose review metadata in `coop run` output and docs.

## Tests
- `go test ./pkg/coop/...`
- `go test ./pkg/cmd -run 'Coop|coop'`
