### PR TITLE
Refresh coop TUI review surface

### DIFF
--- a/pkg/cmd/coop_env.go
+++ b/pkg/cmd/coop_env.go
@@ -55,8 +55,8 @@ func buildSuggestions(session *coop.Session, env projectEnvironment) []suggestio
 
 	suggestions = append(suggestions, suggestion{
 		ID:          "done",
-		Title:       "I'm done",
-		Description: "End the co-op session",
+		Title:       "Finish",
+		Description: "Close this session",
 		Available:   true,
 	})
 

--- a/pkg/coop/tui/model.go
+++ b/pkg/coop/tui/model.go
@@ -26,9 +26,11 @@ type Model struct {
 	height    int
 	userMoved bool
 
-	rejecting      bool
-	rejectionInput string
-	statusMessage  string
+	rejecting       bool
+	rejectionInput  string
+	rejectionError  string
+	statusMessage   string
+	statusExpiresAt time.Time
 
 	viewport viewport.Model
 	ready    bool
@@ -103,6 +105,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tickMsg:
+		m.clearExpiredStatus(time.Now())
 		return m, m.checkForUpdates()
 
 	case sessionDiscoveredMsg:
@@ -114,7 +117,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.userMoved = false
 		m.rejecting = false
 		m.rejectionInput = ""
+		m.rejectionError = ""
 		m.statusMessage = ""
+		m.statusExpiresAt = time.Time{}
 		m.sdkSnippet = ""
 		m.sdkSnippetStep = -1
 		m.sdkLoading = false
@@ -137,6 +142,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.cursor = 0
 			m.expanded = false
 			m.userMoved = false
+			m.statusMessage = ""
+			m.statusExpiresAt = time.Time{}
+			m.rejecting = false
+			m.rejectionInput = ""
+			m.rejectionError = ""
+			if m.ready {
+				m.viewport.SetYOffset(0)
+			}
 		}
 		m.resizeViewport()
 		if !m.userMoved {
@@ -260,9 +273,9 @@ func (m *Model) autoScroll() {
 	idx := 0
 	for i := range m.session.Chapters {
 		for j := range m.session.Chapters[i].Nodes {
-			if m.session.Chapters[i].Nodes[j].State == coop.StepReview {
+			if m.session.Chapters[i].Nodes[j].State == coop.StepReview && m.reviewIsActionable(idx+1) {
 				m.cursor = idx
-				m.expanded = true // auto-expand so developer sees what to confirm
+				m.expanded = false
 				return
 			}
 			idx++
@@ -302,6 +315,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "f":
 		m.userMoved = false
 		m.autoScroll()
+		m.setStatus("Following the current review step", 3*time.Second)
 		m.syncViewport()
 		return m, nil
 	case "c":
@@ -394,6 +408,9 @@ func (m *Model) enterWaitingMode(message string) {
 	m.userMoved = false
 	m.rejecting = false
 	m.rejectionInput = ""
+	m.rejectionError = ""
+	m.statusMessage = ""
+	m.statusExpiresAt = time.Time{}
 	m.existingIDs = make(map[string]bool)
 	if ids, err := m.store.List(); err == nil {
 		for _, id := range ids {
@@ -406,33 +423,44 @@ func (m *Model) handleConfirm() {
 	if m.session == nil {
 		return
 	}
-	node, _ := m.session.NodeByNumber(m.cursor + 1)
-	if node != nil && node.State == coop.StepReview {
-		m.session.TransitionStep(m.cursor+1, coop.StepDone)
-		if err := m.store.Write(m.session); err != nil {
-			m.err = fmt.Errorf("failed to save confirmation: %w", err)
-		}
-		m.lastVersion = m.session.Version
-		m.statusMessage = "Waiting for agent to continue..."
-		if m.session.IsComplete() {
-			m.cursor = 0
-			m.expanded = false
-		}
-		m.resizeViewport()
-		m.syncViewport()
+	target, ok := m.selectedReviewTarget()
+	if !ok {
+		return
 	}
+	for _, step := range target.steps {
+		if err := m.session.TransitionStep(step, coop.StepDone); err != nil {
+			m.err = fmt.Errorf("failed to confirm review: %w", err)
+			return
+		}
+	}
+	if err := m.store.Write(m.session); err != nil {
+		m.err = fmt.Errorf("failed to save confirmation: %w", err)
+	}
+	m.lastVersion = m.session.Version
+	m.setStatus("Confirmed. Waiting for agent...", 5*time.Second)
+	m.rejecting = false
+	m.rejectionInput = ""
+	m.rejectionError = ""
+	if m.session.IsComplete() {
+		m.cursor = 0
+		m.expanded = false
+		m.statusMessage = ""
+		m.statusExpiresAt = time.Time{}
+	}
+	m.resizeViewport()
+	m.syncViewport()
 }
 
 func (m *Model) startReject() {
 	if m.session == nil {
 		return
 	}
-	node, _ := m.session.NodeByNumber(m.cursor + 1)
-	if node != nil && node.State == coop.StepReview {
+	if _, ok := m.selectedReviewTarget(); ok {
 		m.rejecting = true
 		m.rejectionInput = ""
-		m.expanded = true
+		m.rejectionError = ""
 		m.statusMessage = ""
+		m.statusExpiresAt = time.Time{}
 		m.syncViewport()
 	}
 }
@@ -442,7 +470,8 @@ func (m Model) handleRejectionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc", "ctrl+c":
 		m.rejecting = false
 		m.rejectionInput = ""
-		m.statusMessage = "Rejection canceled."
+		m.rejectionError = ""
+		m.setStatus("Request changes canceled.", 3*time.Second)
 		m.syncViewport()
 		return m, nil
 	case "enter":
@@ -458,6 +487,7 @@ func (m Model) handleRejectionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	if msg.Type == tea.KeyRunes {
 		m.rejectionInput += string(msg.Runes)
+		m.rejectionError = ""
 		m.syncViewport()
 	}
 	return m, nil
@@ -467,22 +497,101 @@ func (m *Model) handleReject(note string) {
 	if m.session == nil {
 		return
 	}
-	node, _ := m.session.NodeByNumber(m.cursor + 1)
-	if node != nil && node.State == coop.StepReview {
-		m.session.TransitionStep(m.cursor+1, coop.StepActive)
-		if note == "" {
-			note = "Rejected by developer. Please redo this step."
+	if note == "" {
+		m.rejectionError = "Add a short note so the agent knows what to change."
+		m.syncViewport()
+		return
+	}
+	target, ok := m.selectedReviewTarget()
+	if !ok {
+		return
+	}
+	for _, step := range target.steps {
+		if err := m.session.TransitionStep(step, coop.StepActive); err != nil {
+			m.err = fmt.Errorf("failed to request changes: %w", err)
+			return
 		}
+		node, _ := m.session.NodeByNumber(step)
 		node.RejectionNote = note
 		node.Implementation = nil
 		node.Verifications = nil
-		if err := m.store.Write(m.session); err != nil {
-			m.err = fmt.Errorf("failed to save rejection: %w", err)
+	}
+	if err := m.store.Write(m.session); err != nil {
+		m.err = fmt.Errorf("failed to save request changes: %w", err)
+	}
+	m.lastVersion = m.session.Version
+	m.rejecting = false
+	m.rejectionInput = ""
+	m.rejectionError = ""
+	m.setStatus("Feedback sent. Waiting for agent...", 5*time.Second)
+	m.syncViewport()
+}
+
+type reviewTarget struct {
+	title string
+	kind  string
+	steps []int
+}
+
+func (m Model) selectedReviewTarget() (reviewTarget, bool) {
+	if m.session == nil {
+		return reviewTarget{}, false
+	}
+	stepNum := m.cursor + 1
+	node, err := m.session.NodeByNumber(stepNum)
+	if err != nil || node.State != coop.StepReview {
+		return reviewTarget{}, false
+	}
+	if m.session.ReviewGranularityForStep(stepNum) != coop.ReviewGranularityChapter {
+		return reviewTarget{title: node.Title, kind: "step", steps: []int{stepNum}}, true
+	}
+	ch, chapterIndex, _, err := m.session.ChapterByStepNumber(stepNum)
+	if err != nil || !m.session.ChapterReadyForReview(chapterIndex) {
+		return reviewTarget{}, false
+	}
+	var steps []int
+	idx := 0
+	for i := range m.session.Chapters {
+		for j := range m.session.Chapters[i].Nodes {
+			idx++
+			if i == chapterIndex && m.session.Chapters[i].Nodes[j].State == coop.StepReview {
+				steps = append(steps, idx)
+			}
 		}
-		m.lastVersion = m.session.Version
-		m.rejecting = false
-		m.rejectionInput = ""
-		m.statusMessage = "Waiting for agent to address your feedback..."
-		m.syncViewport()
+	}
+	if len(steps) == 0 {
+		return reviewTarget{}, false
+	}
+	return reviewTarget{title: ch.Title, kind: "chapter", steps: steps}, true
+}
+
+func (m Model) reviewIsActionable(stepNum int) bool {
+	if m.session == nil {
+		return false
+	}
+	node, err := m.session.NodeByNumber(stepNum)
+	if err != nil || node.State != coop.StepReview {
+		return false
+	}
+	if m.session.ReviewGranularityForStep(stepNum) != coop.ReviewGranularityChapter {
+		return true
+	}
+	_, chapterIndex, _, err := m.session.ChapterByStepNumber(stepNum)
+	return err == nil && m.session.ChapterReadyForReview(chapterIndex)
+}
+
+func (m *Model) setStatus(message string, ttl time.Duration) {
+	m.statusMessage = message
+	if ttl <= 0 {
+		m.statusExpiresAt = time.Time{}
+		return
+	}
+	m.statusExpiresAt = time.Now().Add(ttl)
+}
+
+func (m *Model) clearExpiredStatus(now time.Time) {
+	if !m.statusExpiresAt.IsZero() && now.After(m.statusExpiresAt) {
+		m.statusMessage = ""
+		m.statusExpiresAt = time.Time{}
 	}
 }

--- a/pkg/coop/tui/model_test.go
+++ b/pkg/coop/tui/model_test.go
@@ -136,6 +136,105 @@ func TestUpdateKeyReject(t *testing.T) {
 	assert.False(t, updated.rejecting)
 }
 
+func TestUpdateKeyRejectRequiresNote(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.session.Chapters[0].Nodes[0].State = coop.StepReview
+	m.cursor = 0
+	store.Write(m.session)
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	updated := result.(Model)
+	result, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = result.(Model)
+
+	node, _ := updated.session.NodeByNumber(1)
+	assert.Equal(t, coop.StepReview, node.State)
+	assert.True(t, updated.rejecting)
+	assert.Contains(t, updated.rejectionError, "short note")
+}
+
+func TestUpdateKeyConfirmChapterReview(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.session.Chapters[0].ReviewGranularity = coop.ReviewGranularityChapter
+	m.session.Chapters[0].Nodes[0].State = coop.StepReview
+	m.session.Chapters[0].Nodes[1].State = coop.StepReview
+	m.cursor = 0
+	store.Write(m.session)
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	updated := result.(Model)
+
+	node1, _ := updated.session.NodeByNumber(1)
+	node2, _ := updated.session.NodeByNumber(2)
+	assert.Equal(t, coop.StepDone, node1.State)
+	assert.Equal(t, coop.StepDone, node2.State)
+}
+
+func TestSelectedReviewTargetChapterRequiresReadyChapter(t *testing.T) {
+	m := readyModel()
+	m.session.Chapters[0].ReviewGranularity = coop.ReviewGranularityChapter
+	m.session.Chapters[0].Nodes[0].State = coop.StepReview
+	m.session.Chapters[0].Nodes[1].State = coop.StepPending
+	m.cursor = 0
+
+	_, ok := m.selectedReviewTarget()
+	assert.False(t, ok)
+	assert.False(t, m.reviewIsActionable(1))
+
+	m.session.Chapters[0].Nodes[1].State = coop.StepReview
+	target, ok := m.selectedReviewTarget()
+
+	assert.True(t, ok)
+	assert.Equal(t, "chapter", target.kind)
+	assert.Equal(t, "Set up product", target.title)
+	assert.Equal(t, []int{1, 2}, target.steps)
+	assert.True(t, m.reviewIsActionable(1))
+}
+
+func TestUpdateKeyRejectChapterReview(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.session.Chapters[0].ReviewGranularity = coop.ReviewGranularityChapter
+	m.session.Chapters[0].Nodes[0].State = coop.StepReview
+	m.session.Chapters[0].Nodes[0].Implementation = &coop.Implementation{File: "product.js"}
+	m.session.Chapters[0].Nodes[0].Verifications = []coop.Verification{{Check: "product test", Passed: true}}
+	m.session.Chapters[0].Nodes[1].State = coop.StepReview
+	m.session.Chapters[0].Nodes[1].Implementation = &coop.Implementation{File: "checkout.js"}
+	m.session.Chapters[0].Nodes[1].Verifications = []coop.Verification{{Check: "checkout test", Passed: true}}
+	m.cursor = 0
+	store.Write(m.session)
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	updated := result.(Model)
+	result, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Rework both steps")})
+	updated = result.(Model)
+	result, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = result.(Model)
+
+	node1, _ := updated.session.NodeByNumber(1)
+	node2, _ := updated.session.NodeByNumber(2)
+	assert.Equal(t, coop.StepActive, node1.State)
+	assert.Equal(t, coop.StepActive, node2.State)
+	assert.Equal(t, "Rework both steps", node1.RejectionNote)
+	assert.Equal(t, "Rework both steps", node2.RejectionNote)
+	assert.Nil(t, node1.Implementation)
+	assert.Nil(t, node2.Implementation)
+	assert.Nil(t, node1.Verifications)
+	assert.Nil(t, node2.Verifications)
+	assert.False(t, updated.rejecting)
+}
+
 func TestUpdateKeyRejectCancel(t *testing.T) {
 	m := readyModel()
 	m.session.Chapters[0].Nodes[0].State = coop.StepReview
@@ -260,6 +359,25 @@ func TestFollowKeyResumesAutoFollow(t *testing.T) {
 	assert.Equal(t, 1, updated.cursor)
 }
 
+func TestActionableReviewCountCollapsesChapterReview(t *testing.T) {
+	m := readyModel()
+	m.session.Chapters[0].ReviewGranularity = coop.ReviewGranularityChapter
+	m.session.Chapters[0].Nodes[0].State = coop.StepReview
+	m.session.Chapters[0].Nodes[1].State = coop.StepReview
+	m.session.Chapters[1].Nodes[0].State = coop.StepReview
+
+	assert.Equal(t, 2, m.actionableReviewCount())
+}
+
+func TestActionableReviewCountIgnoresUnreadyChapterReview(t *testing.T) {
+	m := readyModel()
+	m.session.Chapters[0].ReviewGranularity = coop.ReviewGranularityChapter
+	m.session.Chapters[0].Nodes[0].State = coop.StepReview
+	m.session.Chapters[0].Nodes[1].State = coop.StepPending
+
+	assert.Equal(t, 0, m.actionableReviewCount())
+}
+
 func TestCompletionViewKeyDown(t *testing.T) {
 	m := readyModel()
 	// Make session complete
@@ -291,7 +409,7 @@ func TestCompletionViewportScrollsToCursor(t *testing.T) {
 			{ID: "b", Title: "Second", Description: "Long second option"},
 			{ID: "c", Title: "Third", Description: "Long third option"},
 			{ID: "d", Title: "Fourth", Description: "Long fourth option"},
-			{ID: "done", Title: "I'm done", Description: "End the session"},
+			{ID: "done", Title: "Finish", Description: "Close this session"},
 		},
 	}
 	m.cursor = 4
@@ -330,7 +448,7 @@ func TestCompletionEnterSelectsDone(t *testing.T) {
 	}
 	m.session.ID = "done_selection"
 	store.Write(m.session)
-	// "I'm done" is the last suggestion
+	// "Finish" is the last suggestion
 	suggestions := m.getCompletionSuggestions()
 	m.cursor = len(suggestions) - 1
 
@@ -484,20 +602,21 @@ func TestHandleKeyQuestionMark(t *testing.T) {
 	assert.True(t, updated.expanded)
 }
 
-func TestAutoScrollExpandsOnReview(t *testing.T) {
+func TestAutoScrollFocusesReviewWithoutExpanding(t *testing.T) {
 	m := readyModel()
 	m.session.Chapters[0].Nodes[0].State = coop.StepReview
 	m.expanded = false
 
 	m.autoScroll()
 
-	assert.True(t, m.expanded)
+	assert.False(t, m.expanded)
 	assert.Equal(t, 0, m.cursor)
 }
 
 func TestCompletionTransitionResetsCursor(t *testing.T) {
 	m := readyModel()
 	m.cursor = 2
+	m.viewport.SetYOffset(5)
 
 	// Simulate session becoming complete
 	newSession := &coop.Session{
@@ -518,6 +637,29 @@ func TestCompletionTransitionResetsCursor(t *testing.T) {
 
 	assert.Equal(t, 0, updated.cursor)
 	assert.False(t, updated.expanded)
+	assert.Equal(t, 0, updated.viewport.YOffset)
+}
+
+func TestStatusExpiresOnTick(t *testing.T) {
+	m := readyModel()
+	m.setStatus("Temporary status", time.Second)
+
+	assert.Equal(t, "Temporary status", m.statusMessage)
+
+	m.clearExpiredStatus(time.Now().Add(2 * time.Second))
+
+	assert.Equal(t, "", m.statusMessage)
+	assert.True(t, m.statusExpiresAt.IsZero())
+}
+
+func TestStatusWithoutTTLDoesNotExpire(t *testing.T) {
+	m := readyModel()
+	m.setStatus("Persistent status", 0)
+
+	m.clearExpiredStatus(time.Now().Add(2 * time.Second))
+
+	assert.Equal(t, "Persistent status", m.statusMessage)
+	assert.True(t, m.statusExpiresAt.IsZero())
 }
 
 func TestShouldTransitionToNewSession(t *testing.T) {
@@ -539,7 +681,7 @@ func TestShouldTransitionToNewSession(t *testing.T) {
 		}
 	}
 
-	// Find "I'm done" — should NOT transition
+	// Find "Finish" — should NOT transition
 	for i, s := range suggestions {
 		if s.id == "done" {
 			m.cursor = i

--- a/pkg/coop/tui/theme.go
+++ b/pkg/coop/tui/theme.go
@@ -72,6 +72,11 @@ var (
 			Padding(0, 1).
 			MarginTop(1)
 
+	ReviewCardStyle = lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder()).
+			BorderForeground(HueOrange400).
+			Padding(0, 1)
+
 	FooterStyle = lipgloss.NewStyle().
 			Foreground(HueGray500)
 

--- a/pkg/coop/tui/view.go
+++ b/pkg/coop/tui/view.go
@@ -19,10 +19,10 @@ func (m Model) renderWaitingView() string {
 
 	waitingText := m.waitingMessage
 	if waitingText == "" {
-		waitingText = "Waiting for agent to explore your codebase and pick an integration..."
+		waitingText = "Waiting for agent"
 	}
 	waitingLines := strings.Split(wordWrap(waitingText, w), "\n")
-	subtitleLines := strings.Split(wordWrap("The agent will ask what you want to build, then start a session. You'll see progress here.", w), "\n")
+	subtitleLines := strings.Split(wordWrap("The agent is scanning the project and will start a session here. You can leave this open.", w), "\n")
 
 	var content string
 	content = HeaderStyle.Render("● Stripe Co-op") + "\n\n"
@@ -167,6 +167,9 @@ func (m Model) renderStepLine(node coop.SessionNode, idx int) string {
 	}
 
 	line := fmt.Sprintf("  %s%s %s", cursor, icon, title)
+	if label, style := m.stepStatusLabel(node); label != "" {
+		line += "  " + style(label)
+	}
 
 	if annText != "" {
 		wrapW := m.contentWidth() - 8
@@ -180,6 +183,23 @@ func (m Model) renderStepLine(node coop.SessionNode, idx int) string {
 	}
 
 	return line
+}
+
+func (m Model) stepStatusLabel(node coop.SessionNode) (string, func(string) string) {
+	switch node.State {
+	case coop.StepDone:
+		return "Done", func(s string) string { return SuccessStyle.Render(s) }
+	case coop.StepActive:
+		return "Agent working", func(s string) string { return MutedStyle.Render(s) }
+	case coop.StepReview:
+		return "Needs review", func(s string) string { return AttentionStyle.Render(s) }
+	case coop.StepSkipped:
+		return "Skipped", func(s string) string { return DimmedStyle.Render(s) }
+	case coop.StepPending:
+		return "Pending", func(s string) string { return MutedStyle.Render(s) }
+	default:
+		return "", func(s string) string { return s }
+	}
 }
 
 func (m Model) stepIcon(node coop.SessionNode) string {
@@ -212,7 +232,13 @@ func (m Model) renderDetail() string {
 	var md strings.Builder
 
 	if node.Description != "" {
+		md.WriteString("**Summary**\n\n")
 		md.WriteString(node.Description + "\n\n")
+	}
+
+	if node.ReviewPrompt != "" {
+		md.WriteString("**What to check**\n\n")
+		md.WriteString(node.ReviewPrompt + "\n\n")
 	}
 
 	if node.State == coop.StepSkipped && node.Activity != "" {
@@ -330,14 +356,7 @@ func (m Model) writeVerificationDetail(md *strings.Builder, node *coop.SessionNo
 func (m Model) renderDetailSuffix(node *coop.SessionNode) string {
 	var suffix string
 	if node.State == coop.StepReview {
-		suffix = "\n" + AttentionStyle.Render("  Waiting for you: press c to confirm or r to reject")
-	}
-	if m.rejecting {
-		input := m.rejectionInput
-		if input == "" {
-			input = "<type feedback>"
-		}
-		suffix += "\n" + ErrorStyle.Render("  Rejection note: ") + input
+		suffix = "\n" + AttentionStyle.Render("  Waiting for you: press c to confirm or r to request changes")
 	}
 	return suffix
 }
@@ -378,33 +397,175 @@ func (m Model) renderFooter() string {
 	}
 
 	if m.session != nil {
-		summary := m.session.StepSummary()
-		if summary[coop.StepReview] > 0 {
-			footer += AttentionStyle.Render(fmt.Sprintf("  Waiting for you: %d step(s) need confirmation", summary[coop.StepReview])) + "\n"
+		if count := m.actionableReviewCount(); count > 0 {
+			footer += AttentionStyle.Render(fmt.Sprintf("  Waiting for you: %d item(s) need review", count)) + "\n"
 		}
 	}
 
-	if m.rejecting {
-		return footer + FooterStyle.Render("  type feedback  ·  enter reject  ·  esc cancel")
+	if card := m.renderReviewCard(); card != "" {
+		footer += card + "\n"
 	}
 
-	parts := []string{"↑↓ navigate", "enter/e details"}
-	if m.userMoved {
-		parts = append(parts, "f follow")
+	if m.rejecting {
+		return footer + FooterStyle.Render("  enter send feedback  ·  esc cancel")
 	}
+
+	var parts []string
+	if m.userMoved {
+		parts = append(parts, "Viewing earlier steps", "f follow latest")
+	} else {
+		parts = append(parts, "↑↓ navigate")
+	}
+	parts = append(parts, "enter/e details")
 	if m.session != nil && m.session.ClaimURL != "" {
 		parts = append(parts, "o open claim URL")
 	}
 	if m.session != nil {
-		node, _ := m.session.NodeByNumber(m.cursor + 1)
-		if node != nil && node.State == coop.StepReview {
+		if _, ok := m.selectedReviewTarget(); ok {
 			parts = append(parts, SuccessStyle.Render("c confirm"))
-			parts = append(parts, ErrorStyle.Render("r reject"))
+			parts = append(parts, ErrorStyle.Render("r request changes"))
 		}
 	}
 	parts = append(parts, "q quit")
 	footer += FooterStyle.Render("  " + strings.Join(parts, "  ·  "))
 	return footer
+}
+
+func (m Model) renderReviewCard() string {
+	target, ok := m.selectedReviewTarget()
+	if !ok {
+		return ""
+	}
+	w := min(m.contentWidth()-4, 84)
+	if w < 30 {
+		w = m.contentWidth()
+	}
+
+	var lines []string
+	prefix := "Review"
+	if target.kind == "chapter" {
+		prefix = "Review chapter"
+	}
+	lines = append(lines, AttentionStyle.Render(prefix+": ")+target.title)
+	if changed := m.reviewChangedLabel(target.steps); changed != "" {
+		lines = append(lines, MutedStyle.Render("Changed: ")+changed)
+	}
+	if verified := m.reviewVerificationLabel(target.steps); verified != "" {
+		lines = append(lines, MutedStyle.Render("Verified: ")+verified)
+	}
+	check := m.reviewPromptLabel(target.steps)
+	if check != "" {
+		lines = append(lines, MutedStyle.Render("Check: ")+check)
+	}
+	if m.rejecting {
+		input := m.rejectionInput
+		if input == "" {
+			input = DimmedStyle.Render("Describe what should change")
+		}
+		lines = append(lines, ErrorStyle.Render("Request changes: ")+input)
+		if m.rejectionError != "" {
+			lines = append(lines, ErrorStyle.Render(m.rejectionError))
+		}
+	}
+
+	var wrapped []string
+	for _, line := range lines {
+		wrapped = append(wrapped, strings.Split(wordWrap(line, w-4), "\n")...)
+	}
+	return ReviewCardStyle.Width(w).Render(strings.Join(wrapped, "\n"))
+}
+
+func (m Model) reviewChangedLabel(steps []int) string {
+	var labels []string
+	seen := map[string]bool{}
+	for _, step := range steps {
+		node, err := m.session.NodeByNumber(step)
+		if err != nil || node.Implementation == nil || node.Implementation.File == "" {
+			continue
+		}
+		label := implementationFileLabel(node.Implementation)
+		if !seen[label] {
+			seen[label] = true
+			labels = append(labels, label)
+		}
+	}
+	if len(labels) == 0 {
+		return ""
+	}
+	if len(labels) > 3 {
+		return strings.Join(labels[:3], ", ") + fmt.Sprintf(" +%d more", len(labels)-3)
+	}
+	return strings.Join(labels, ", ")
+}
+
+func (m Model) reviewVerificationLabel(steps []int) string {
+	passed := 0
+	total := 0
+	for _, step := range steps {
+		node, err := m.session.NodeByNumber(step)
+		if err != nil {
+			continue
+		}
+		for _, v := range node.Verifications {
+			total++
+			if v.Passed {
+				passed++
+			}
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+	if passed == total {
+		return fmt.Sprintf("%d check(s) passed", passed)
+	}
+	return fmt.Sprintf("%d/%d check(s) passed", passed, total)
+}
+
+func (m Model) reviewPromptLabel(steps []int) string {
+	var prompts []string
+	seen := map[string]bool{}
+	for _, step := range steps {
+		node, err := m.session.NodeByNumber(step)
+		if err != nil || node.ReviewPrompt == "" || seen[node.ReviewPrompt] {
+			continue
+		}
+		seen[node.ReviewPrompt] = true
+		prompts = append(prompts, node.ReviewPrompt)
+	}
+	if len(prompts) == 0 {
+		return "Confirm the completed work matches this step and its verification evidence."
+	}
+	if len(prompts) > 2 {
+		return strings.Join(prompts[:2], " ") + " Open details for the remaining checks."
+	}
+	return strings.Join(prompts, " ")
+}
+
+func (m Model) actionableReviewCount() int {
+	if m.session == nil {
+		return 0
+	}
+	count := 0
+	countedChapters := map[int]bool{}
+	step := 0
+	for i := range m.session.Chapters {
+		for j := range m.session.Chapters[i].Nodes {
+			step++
+			if m.session.Chapters[i].Nodes[j].State != coop.StepReview || !m.reviewIsActionable(step) {
+				continue
+			}
+			if m.session.ReviewGranularityForStep(step) == coop.ReviewGranularityChapter {
+				if !countedChapters[i] {
+					count++
+					countedChapters[i] = true
+				}
+				continue
+			}
+			count++
+		}
+	}
+	return count
 }
 
 func (m Model) agentIdle() bool {
@@ -458,7 +619,7 @@ func (m Model) renderCompletionBody() string {
 		content += "\n" + DimmedStyle.Render("    Press o to open in browser")
 	}
 
-	content += "\n\n" + ChapterTitleStyle.Render("  What's next?")
+	content += "\n\n" + ChapterTitleStyle.Render("  Next steps")
 	ruleWidth := min(w-4, 50)
 	if ruleWidth < 0 {
 		ruleWidth = 0
@@ -547,7 +708,7 @@ func (m Model) getCompletionSuggestions() []completionSuggestion {
 	}
 
 	suggestions = append(suggestions, completionSuggestion{id: "add-integration", title: "Add another Stripe feature", desc: "Subscriptions, Connect, billing portal, and more"})
-	suggestions = append(suggestions, completionSuggestion{id: "done", title: "I'm done", desc: "End the session"})
+	suggestions = append(suggestions, completionSuggestion{id: "done", title: "Finish", desc: "Close this session"})
 
 	return suggestions
 }

--- a/pkg/coop/tui/view_test.go
+++ b/pkg/coop/tui/view_test.go
@@ -147,7 +147,7 @@ func TestRenderFooter(t *testing.T) {
 	m.cursor = 0
 	footer := m.renderFooter()
 
-	// Step 0 is done — no confirm/reject
+	// Step 0 is done — no review actions
 	assert.Contains(t, footer, "navigate")
 	assert.Contains(t, footer, "details")
 	assert.NotContains(t, footer, "confirm")
@@ -160,7 +160,39 @@ func TestRenderFooterReviewStep(t *testing.T) {
 	footer := m.renderFooter()
 
 	assert.Contains(t, footer, "confirm")
-	assert.Contains(t, footer, "reject")
+	assert.Contains(t, footer, "request changes")
+	assert.Contains(t, footer, "Review:")
+}
+
+func TestRenderReviewCardEvidence(t *testing.T) {
+	m := testModel()
+	m.session.Chapters[0].Nodes[0].State = coop.StepReview
+	m.session.Chapters[0].Nodes[0].ReviewPrompt = "Confirm Checkout uses the saved price ID."
+	m.session.Chapters[0].Nodes[0].Verifications = []coop.Verification{
+		{Check: "unit test", Passed: true},
+		{Check: "manual test", Passed: false},
+	}
+	m.cursor = 0
+
+	card := m.renderReviewCard()
+
+	assert.Contains(t, card, "Review: Create product")
+	assert.Contains(t, card, "Changed:")
+	assert.Contains(t, card, "server.js:5-20")
+	assert.Contains(t, card, "Verified:")
+	assert.Contains(t, card, "1/2 check(s) passed")
+	assert.Contains(t, card, "Check:")
+	assert.Contains(t, card, "Confirm Checkout uses the saved price ID.")
+}
+
+func TestRenderReviewCardFallbackCheck(t *testing.T) {
+	m := testModel()
+	m.session.Chapters[1].Nodes[0].State = coop.StepReview
+	m.cursor = 2
+
+	card := m.renderReviewCard()
+
+	assert.Contains(t, card, "Confirm the completed work matches this step")
 }
 
 func TestRenderFooterReviewNotice(t *testing.T) {
@@ -169,7 +201,7 @@ func TestRenderFooterReviewNotice(t *testing.T) {
 	footer := m.renderFooter()
 
 	assert.Contains(t, footer, "Waiting for you")
-	assert.Contains(t, footer, "need confirmation")
+	assert.Contains(t, footer, "need review")
 }
 
 func TestRenderCompletionView(t *testing.T) {
@@ -181,10 +213,10 @@ func TestRenderCompletionView(t *testing.T) {
 	view := m.renderCompletionView()
 
 	assert.Contains(t, view, "Integration complete")
-	assert.Contains(t, view, "What's next")
+	assert.Contains(t, view, "Next steps")
 	assert.Contains(t, view, "STRIPE.md")
 	assert.Contains(t, view, "Deploy")
-	assert.Contains(t, view, "I'm done")
+	assert.Contains(t, view, "Finish")
 }
 
 func TestGetCompletionSuggestionsDefault(t *testing.T) {
@@ -193,7 +225,7 @@ func TestGetCompletionSuggestionsDefault(t *testing.T) {
 
 	assert.Len(t, suggestions, 4)
 	assert.Equal(t, "Write a STRIPE.md summary", suggestions[0].title)
-	assert.Equal(t, "I'm done", suggestions[3].title)
+	assert.Equal(t, "Finish", suggestions[3].title)
 }
 
 func TestGetCompletionSuggestionsFromSession(t *testing.T) {
@@ -332,11 +364,10 @@ func TestRenderFooterRejectionInput(t *testing.T) {
 	m.rejectionInput = "Missing webhook test"
 
 	footer := m.renderFooter()
-	detail := m.renderDetail()
 
-	assert.Contains(t, footer, "enter reject")
+	assert.Contains(t, footer, "enter send feedback")
 	assert.Contains(t, footer, "esc cancel")
-	assert.Contains(t, detail, "Missing webhook test")
+	assert.Contains(t, footer, "Missing webhook test")
 }
 
 func TestStepIconAllStates(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace review auto-expand with a compact pinned review card.
- Scope request-changes input to the review card and require a note.
- Clarify follow mode, waiting state, completion copy, and status messages.
- Fix completion viewport reset so the success summary is visible.
- Add targeted coverage for chapter review actionability, review-card evidence, request-changes behavior, actionable review counts, and status expiry.

## Tests
- `go test ./pkg/coop/...`
- `go test ./pkg/cmd -run 'Coop|coop'`
- `bin/test_coop_tui.sh` passed locally: 53/53. The harness file is ignored by git, so the local harness update is not committed.
