### PR TITLE
Deepen coop review criteria

### DIFF
--- a/pkg/cmd/coop_run.go
+++ b/pkg/cmd/coop_run.go
@@ -85,6 +85,7 @@ func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
 				Type:              string(n.Type),
 				Description:       n.Description,
 				ReviewPrompt:      n.ReviewPrompt,
+				ReviewRisk:        n.ReviewRisk,
 				ReviewGranularity: string(ch.ReviewGranularity),
 				AutoConfirm:       n.AutoConfirm,
 			})
@@ -139,6 +140,7 @@ type stepBrief struct {
 	Type              string `json:"type"`
 	Description       string `json:"description,omitempty"`
 	ReviewPrompt      string `json:"review_prompt,omitempty"`
+	ReviewRisk        string `json:"review_risk,omitempty"`
 	ReviewGranularity string `json:"review_granularity,omitempty"`
 	AutoConfirm       bool   `json:"auto_confirm,omitempty"`
 }
@@ -165,7 +167,7 @@ Each step has a description that tells you what to do. Follow the description â€
 - "cliCommand": Run a CLI command (e.g. stripe projects init, stripe projects deploy). Report the output.
 - "testHelper": Verify something works end-to-end. Run the flow and confirm the expected outcome.
 
-If a step includes review_prompt, that is what the human will use as the acceptance check. Make your implementation note and verifications directly answer it.
+If a step includes review_prompt, that is what the human will use as the acceptance check. If it includes review_risk, that is why the check matters. Make your implementation note and verifications directly answer both.
 
 Step 1 is always "Understand the project" â€” scan files, identify the tech stack, and summarize what you found. This helps you adapt the remaining steps to the developer's actual setup. Don't ask the developer questions you can answer by reading the code.
 

--- a/pkg/coop/blueprint.go
+++ b/pkg/coop/blueprint.go
@@ -17,6 +17,7 @@ type BlueprintNode struct {
 	Title        string      `json:"title"`
 	Description  string      `json:"description,omitempty"`
 	ReviewPrompt string      `json:"review_prompt,omitempty"`
+	ReviewRisk   string      `json:"review_risk,omitempty"`
 	AutoConfirm  bool        `json:"auto_confirm,omitempty"`
 	Request      *APIRequest `json:"request,omitempty"`
 	Events       []string    `json:"events,omitempty"`
@@ -168,6 +169,7 @@ func NewSessionFromBlueprint(bp *Blueprint, sessionID string, settings map[strin
 				Title:        n.Title,
 				Description:  n.Description,
 				ReviewPrompt: n.ReviewPrompt,
+				ReviewRisk:   n.ReviewRisk,
 				AutoConfirm:  n.AutoConfirm,
 				State:        StepPending,
 				Request:      n.Request,

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -55,6 +55,7 @@ func TestAllEmbeddedBlueprintsHaveQualityMetadata(t *testing.T) {
 					if !n.AutoConfirm {
 						assertQualityText(t, "node review prompt "+n.Key, n.ReviewPrompt, 20, weakPhrases)
 						assertObservableGuidance(t, n.Key, n.ReviewPrompt)
+						assertQualityText(t, "node review risk "+n.Key, n.ReviewRisk, 20, weakPhrases)
 					}
 
 					switch n.Type {
@@ -157,6 +158,7 @@ func TestNewSessionFromBlueprint(t *testing.T) {
 
 	assert.Equal(t, ReviewGranularityChapter, session.Chapters[2].ReviewGranularity)
 	assert.NotEmpty(t, session.Chapters[1].Nodes[0].ReviewPrompt)
+	assert.NotEmpty(t, session.Chapters[1].Nodes[0].ReviewRisk)
 }
 
 func TestListBlueprintsWithMetadata(t *testing.T) {

--- a/pkg/coop/blueprints/billing-portal.json
+++ b/pkg/coop/blueprints/billing-portal.json
@@ -14,7 +14,8 @@
           "type": "uiComponent",
           "key": "redirect-to-portal",
           "title": "Open billing portal",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         }
       ]
     }

--- a/pkg/coop/blueprints/checkout-studio.json
+++ b/pkg/coop/blueprints/checkout-studio.json
@@ -21,13 +21,15 @@
             "path": "/v1/checkout/sessions",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "uiComponent",
           "key": "setup-stripe-elements-html-snippet",
           "title": "Set up your frontend",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         }
       ]
     }

--- a/pkg/coop/blueprints/credit-burndown.json
+++ b/pkg/coop/blueprints/credit-burndown.json
@@ -18,7 +18,8 @@
             "path": "/v1/customers",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -28,7 +29,8 @@
             "path": "/v2/billing/pricing_plans",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -38,7 +40,8 @@
             "path": "/v1/billing/meters",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -48,7 +51,8 @@
             "path": "/v2/billing/rate_cards",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -58,7 +62,8 @@
             "path": "/v2/billing/metered_items",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -68,7 +73,8 @@
             "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -78,7 +84,8 @@
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -88,7 +95,8 @@
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -98,13 +106,15 @@
             "path": "/v1/checkout/sessions",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "uiComponent",
           "key": "completeCheckout",
           "title": "Complete the checkout",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         },
         {
           "type": "asyncHandler",
@@ -113,7 +123,8 @@
           "events": [
             "v2.billing.pricing_plan_subscription.servicing_activated"
           ],
-          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         },
         {
           "type": "apiRequest",
@@ -123,7 +134,8 @@
             "path": "/v1/payment_methods",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -133,7 +145,8 @@
             "path": "/v1/payment_methods/${node.grant-credits-chapter.createPaymentMethod.createPaymentMethodRequest:id}/attach",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -143,7 +156,8 @@
             "path": "/v1/invoices",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -153,7 +167,8 @@
             "path": "/v1/invoiceitems",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -163,7 +178,8 @@
             "path": "/v1/invoices/${node.grant-credits-chapter.createCreditInvoice.createCreditInvoiceRequest:id}/pay",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -173,7 +189,8 @@
             "path": "/v1/billing/credit_grants",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -183,7 +200,8 @@
             "path": "/v1/billing/alerts",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         }
       ]
     }

--- a/pkg/coop/blueprints/deploy-stripe-projects.json
+++ b/pkg/coop/blueprints/deploy-stripe-projects.json
@@ -42,7 +42,8 @@
           "key": "init-project",
           "title": "Initialize Stripe Project",
           "description": "Run `stripe projects init --help` to see available flags, then run `stripe projects init` with appropriate options for the detected framework. Report what was detected and what stripe.json contains.",
-          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
+          "review_prompt": "Confirm `stripe.json` exists, names the expected project, and matches the framework or build settings the agent reported.",
+          "review_risk": "An incorrect project link or build setting can deploy the wrong app shape even if initialization succeeds."
         }
       ]
     },
@@ -56,14 +57,16 @@
           "key": "stripe-keys",
           "title": "Set Stripe keys as project secrets",
           "description": "Run `stripe projects secrets --help` to discover the command interface. Set STRIPE_SECRET_KEY and STRIPE_PUBLISHABLE_KEY using the keys from `stripe whoami --json`. Tell the developer which keys you're using.",
-          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
+          "review_prompt": "Confirm Stripe keys were added as project secrets and no test or production secret values were committed to the repo.",
+          "review_risk": "Misplaced API keys can leak credentials or make the deployed app use the wrong Stripe environment."
         },
         {
           "type": "cliCommand",
           "key": "other-secrets",
           "title": "Set additional secrets",
           "description": "Scan .env, .env.local, .env.example for variables NOT already handled (not STRIPE_ keys). If NONE remain → SKIP. If found → use `stripe projects secrets set` to configure them. Ask the developer for production values only if they differ from what's in .env.",
-          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
+          "review_prompt": "Confirm each additional secret came from the expected environment variable and was configured through Stripe Projects, not committed.",
+          "review_risk": "Missing or incorrect non-Stripe secrets can make the deployed app fail only after launch."
         }
       ]
     },
@@ -77,14 +80,16 @@
           "key": "first-deploy",
           "title": "Run first deployment",
           "description": "Run `stripe projects deploy --help` to check available flags, then run `stripe projects deploy`. Report the build output and deployment URL.",
-          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
+          "review_prompt": "Confirm the deployment command completed and the reported URL belongs to the intended project.",
+          "review_risk": "A successful build can still publish to the wrong target or leave the developer without the live URL they need to verify."
         },
         {
           "type": "testHelper",
           "key": "verify-live",
           "title": "Verify deployment is live",
           "description": "Ask the developer to visit the deployment URL and confirm it works. If it's a payment flow, suggest testing with card number 4242424242424242.",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Open the deployment URL and confirm the key payment or Stripe flow works with test data.",
+          "review_risk": "A deployment can pass build checks while the live environment is missing secrets, routes, or webhooks."
         }
       ]
     },
@@ -98,7 +103,8 @@
           "key": "register-endpoint",
           "title": "Register webhook endpoint",
           "description": "Look for webhook handling code (stripe.webhooks.constructEvent, /webhook routes). If found → construct the production URL (deployment URL + webhook path) and use `stripe projects webhooks --help` to discover how to register it. Set STRIPE_WEBHOOK_SECRET as a project secret and report the registered endpoint. If NOT found → SKIP.",
-          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
+          "review_prompt": "Confirm the production webhook endpoint matches the deployed route and that `STRIPE_WEBHOOK_SECRET` is configured as a project secret.",
+          "review_risk": "A wrong endpoint or missing webhook secret can silently break fulfillment in production."
         }
       ]
     }

--- a/pkg/coop/blueprints/destination-charge.json
+++ b/pkg/coop/blueprints/destination-charge.json
@@ -21,7 +21,8 @@
             "path": "/v1/payment_intents",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         }
       ]
     }

--- a/pkg/coop/blueprints/direct-charge.json
+++ b/pkg/coop/blueprints/direct-charge.json
@@ -18,7 +18,8 @@
             "path": "/v1/payment_intents",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         }
       ]
     }

--- a/pkg/coop/blueprints/flat-fee-and-overages.json
+++ b/pkg/coop/blueprints/flat-fee-and-overages.json
@@ -18,7 +18,8 @@
             "path": "/v1/customers",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -28,7 +29,8 @@
             "path": "/v2/billing/pricing_plans",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -38,7 +40,8 @@
             "path": "/v1/billing/meters",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -48,7 +51,8 @@
             "path": "/v2/billing/rate_cards",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -58,7 +62,8 @@
             "path": "/v2/billing/metered_items",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -68,7 +73,8 @@
             "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -78,7 +84,8 @@
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -88,7 +95,8 @@
             "path": "/v2/billing/licensed_items",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -98,7 +106,8 @@
             "path": "/v2/billing/license_fees",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -108,7 +117,8 @@
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -118,7 +128,8 @@
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -128,13 +139,15 @@
             "path": "/v1/checkout/sessions",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "uiComponent",
           "key": "completeCheckout",
           "title": "Complete the checkout",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         },
         {
           "type": "asyncHandler",
@@ -143,7 +156,8 @@
           "events": [
             "v2.billing.pricing_plan_subscription.servicing_activated"
           ],
-          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         }
       ]
     }

--- a/pkg/coop/blueprints/flat-subscription-with-entitlements.json
+++ b/pkg/coop/blueprints/flat-subscription-with-entitlements.json
@@ -18,7 +18,8 @@
             "path": "/v1/products",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -28,7 +29,8 @@
             "path": "/v1/entitlements/features",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -38,19 +40,22 @@
             "path": "/v1/products/${node.create-products-chapter.create-basic-product.create-basic-product-request:id}/features",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "testHelper",
           "key": "create-test-clock",
           "title": "Create a test clock",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run the described test flow and confirm the expected result is observable.",
+          "review_risk": "Skipping this check can hide an integration that compiles but fails in the customer path."
         },
         {
           "type": "testHelper",
           "key": "create-customer",
           "title": "Create a customer",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run the described test flow and confirm the expected result is observable.",
+          "review_risk": "Skipping this check can hide an integration that compiles but fails in the customer path."
         },
         {
           "type": "apiRequest",
@@ -60,13 +65,15 @@
             "path": "/v1/checkout/sessions",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "uiComponent",
           "key": "complete-checkout",
           "title": "Complete the checkout process",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         },
         {
           "type": "asyncHandler",
@@ -75,7 +82,8 @@
           "events": [
             "customer.subscription.created"
           ],
-          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         },
         {
           "type": "asyncHandler",
@@ -84,13 +92,15 @@
           "events": [
             "entitlements.active_entitlement_summary.updated"
           ],
-          "review_prompt": "Run stripe trigger entitlements.active_entitlement_summary.updated and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger entitlements.active_entitlement_summary.updated and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         },
         {
           "type": "testHelper",
           "key": "advance-time",
           "title": "Advance time to billing date",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run the described test flow and confirm the expected result is observable.",
+          "review_risk": "Skipping this check can hide an integration that compiles but fails in the customer path."
         },
         {
           "type": "asyncHandler",
@@ -99,7 +109,8 @@
           "events": [
             "invoice.created"
           ],
-          "review_prompt": "Run stripe trigger invoice.created and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger invoice.created and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         },
         {
           "type": "apiRequest",
@@ -109,7 +120,8 @@
             "path": "/v1/invoices/${node.next-billing-cycle-chapter.wait-for-invoice-created.0:id}",
             "method": "get"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "asyncHandler",
@@ -118,13 +130,15 @@
           "events": [
             "test_helpers.test_clock.ready"
           ],
-          "review_prompt": "Run stripe trigger test_helpers.test_clock.ready and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger test_helpers.test_clock.ready and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         },
         {
           "type": "testHelper",
           "key": "delete-test-clock",
           "title": "Delete the test clock",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run the described test flow and confirm the expected result is observable.",
+          "review_risk": "Skipping this check can hide an integration that compiles but fails in the customer path."
         }
       ]
     }

--- a/pkg/coop/blueprints/invoice-payments.json
+++ b/pkg/coop/blueprints/invoice-payments.json
@@ -14,7 +14,8 @@
           "type": "testHelper",
           "key": "create-test-clock",
           "title": "Create a test clock",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run the described test flow and confirm the expected result is observable.",
+          "review_risk": "Skipping this check can hide an integration that compiles but fails in the customer path."
         },
         {
           "type": "apiRequest",
@@ -24,7 +25,8 @@
             "path": "/v1/products",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -34,7 +36,8 @@
             "path": "/v1/customers",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -44,7 +47,8 @@
             "path": "/v1/invoices",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -54,7 +58,8 @@
             "path": "/v1/invoiceitems",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -64,13 +69,15 @@
             "path": "/v1/invoices/${node.create-invoice-chapter.create-invoice.create-invoice-request:id}/send",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "uiComponent",
           "key": "view-invoice",
           "title": "View and pay the invoice",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         },
         {
           "type": "asyncHandler",
@@ -79,7 +86,8 @@
           "events": [
             "invoice.paid"
           ],
-          "review_prompt": "Run stripe trigger invoice.paid and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger invoice.paid and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         }
       ]
     }

--- a/pkg/coop/blueprints/managed-payments.json
+++ b/pkg/coop/blueprints/managed-payments.json
@@ -21,7 +21,8 @@
             "path": "/v1/products",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -31,7 +32,8 @@
             "path": "/v1/products",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -41,13 +43,15 @@
             "path": "/v1/checkout/sessions",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "uiComponent",
           "key": "complete-checkout",
           "title": "Complete a test payment",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         },
         {
           "type": "asyncHandler",
@@ -56,7 +60,8 @@
           "events": [
             "checkout.session.completed"
           ],
-          "review_prompt": "Run stripe trigger checkout.session.completed and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger checkout.session.completed and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         }
       ]
     }

--- a/pkg/coop/blueprints/metered-subscription.json
+++ b/pkg/coop/blueprints/metered-subscription.json
@@ -18,7 +18,8 @@
             "path": "/v1/billing/meters",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -28,7 +29,8 @@
             "path": "/v1/products",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -38,7 +40,8 @@
             "path": "/v1/prices",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -48,7 +51,8 @@
             "path": "/v1/entitlements/features",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -58,19 +62,22 @@
             "path": "/v1/products/${node.metering-setup-chapter.create-usage-product.create-usage-product-request:id}/features",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "testHelper",
           "key": "create-test-clock",
           "title": "Create a test clock",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run the described test flow and confirm the expected result is observable.",
+          "review_risk": "Skipping this check can hide an integration that compiles but fails in the customer path."
         },
         {
           "type": "testHelper",
           "key": "create-customer",
           "title": "Create a customer",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run the described test flow and confirm the expected result is observable.",
+          "review_risk": "Skipping this check can hide an integration that compiles but fails in the customer path."
         },
         {
           "type": "apiRequest",
@@ -80,13 +87,15 @@
             "path": "/v1/checkout/sessions",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "uiComponent",
           "key": "complete-checkout",
           "title": "Complete the checkout process",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         },
         {
           "type": "asyncHandler",
@@ -95,7 +104,8 @@
           "events": [
             "entitlements.active_entitlement_summary.updated"
           ],
-          "review_prompt": "Run stripe trigger entitlements.active_entitlement_summary.updated and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger entitlements.active_entitlement_summary.updated and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         },
         {
           "type": "asyncHandler",
@@ -104,7 +114,8 @@
           "events": [
             "customer.subscription.created"
           ],
-          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         },
         {
           "type": "apiRequest",
@@ -114,13 +125,15 @@
             "path": "/v1/billing/meter_events",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "testHelper",
           "key": "advance-time",
           "title": "Advance time to billing date",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run the described test flow and confirm the expected result is observable.",
+          "review_risk": "Skipping this check can hide an integration that compiles but fails in the customer path."
         },
         {
           "type": "asyncHandler",
@@ -129,7 +142,8 @@
           "events": [
             "invoice.created"
           ],
-          "review_prompt": "Run stripe trigger invoice.created and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger invoice.created and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         },
         {
           "type": "apiRequest",
@@ -139,7 +153,8 @@
             "path": "/v1/invoices/${node.usage-chapter.wait-for-invoice-created.0:id}",
             "method": "get"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "asyncHandler",
@@ -148,13 +163,15 @@
           "events": [
             "test_helpers.test_clock.ready"
           ],
-          "review_prompt": "Run stripe trigger test_helpers.test_clock.ready and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger test_helpers.test_clock.ready and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         },
         {
           "type": "testHelper",
           "key": "delete-test-clock",
           "title": "Delete the test clock",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run the described test flow and confirm the expected result is observable.",
+          "review_risk": "Skipping this check can hide an integration that compiles but fails in the customer path."
         }
       ]
     }

--- a/pkg/coop/blueprints/one-time-payment.json
+++ b/pkg/coop/blueprints/one-time-payment.json
@@ -21,7 +21,8 @@
           },
           "title": "Create a product",
           "type": "apiRequest",
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the product has a default price and that the product or price ID is stored in code for the Checkout Session step.",
+          "review_risk": "If the price ID is missing or stale, Checkout can charge the wrong amount or fail later in the flow."
         }
       ],
       "required": true,
@@ -53,21 +54,24 @@
           },
           "title": "Create a Checkout Session",
           "type": "apiRequest",
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the Checkout Session uses the price created in product setup and has the intended success and cancel URLs.",
+          "review_risk": "A mismatched price or redirect URL creates a payment flow that works technically but sends customers to the wrong purchase or page."
         },
         {
           "description": "Add a button or link that redirects the customer to the Checkout page.",
           "key": "redirect-to-checkout",
           "title": "Redirect to Checkout",
           "type": "uiComponent",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the checkout button redirects to Stripe Checkout instead of staying on a local route.",
+          "review_risk": "If the button points at the wrong route, customers cannot reach the hosted Checkout flow even when the backend works."
         },
         {
           "description": "Create a page to show after the customer completes payment.",
           "key": "add-success-page",
           "title": "Add a success page",
           "type": "uiComponent",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Complete a test Checkout Session and confirm the success page renders after returning from Stripe.",
+          "review_risk": "A broken return page makes completed payments look failed to customers and increases support burden."
         }
       ],
       "title": "Create a Checkout Session"
@@ -84,7 +88,8 @@
           "key": "handle-checkout-completed",
           "title": "Handle checkout.session.completed",
           "type": "asyncHandler",
-          "review_prompt": "Run stripe trigger checkout.session.completed and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run `stripe trigger checkout.session.completed` and confirm fulfillment happens only after verifying the Stripe signature.",
+          "review_risk": "Webhook signature mistakes can fulfill orders from spoofed events or miss real completed payments."
         }
       ],
       "title": "Handle post-payment events"
@@ -98,7 +103,8 @@
           "key": "test-payment-flow",
           "title": "Make a test payment",
           "type": "testHelper",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run the full test-card payment flow and confirm it reaches Checkout, returns to success, and records fulfillment.",
+          "review_risk": "The individual pieces can pass independently while the end-to-end customer path still fails."
         }
       ],
       "title": "Test the integration"

--- a/pkg/coop/blueprints/pay-as-you-go.json
+++ b/pkg/coop/blueprints/pay-as-you-go.json
@@ -18,7 +18,8 @@
             "path": "/v1/customers",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -28,7 +29,8 @@
             "path": "/v2/billing/pricing_plans",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -38,7 +40,8 @@
             "path": "/v1/billing/meters",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -48,7 +51,8 @@
             "path": "/v2/billing/rate_cards",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -58,7 +62,8 @@
             "path": "/v2/billing/metered_items",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -68,7 +73,8 @@
             "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -78,7 +84,8 @@
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -88,7 +95,8 @@
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -98,13 +106,15 @@
             "path": "/v1/checkout/sessions",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "uiComponent",
           "key": "completeCheckout",
           "title": "Complete the checkout",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         },
         {
           "type": "asyncHandler",
@@ -113,7 +123,8 @@
           "events": [
             "v2.billing.pricing_plan_subscription.servicing_activated"
           ],
-          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         }
       ]
     }

--- a/pkg/coop/blueprints/setup-future-payments.json
+++ b/pkg/coop/blueprints/setup-future-payments.json
@@ -18,7 +18,8 @@
           },
           "title": "Create a customer",
           "type": "apiRequest",
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "description": "Create a Checkout Session with mode=setup to save a payment method.",
@@ -39,7 +40,8 @@
           },
           "title": "Create a Checkout Session (setup mode)",
           "type": "apiRequest",
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         }
       ],
       "required": true,
@@ -54,7 +56,8 @@
           "key": "redirect-to-setup",
           "title": "Redirect to setup page",
           "type": "uiComponent",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         },
         {
           "description": "Listen for the setup_intent.succeeded event to confirm the payment method was saved.",
@@ -64,7 +67,8 @@
           "key": "handle-setup-completed",
           "title": "Handle setup_intent.succeeded",
           "type": "asyncHandler",
-          "review_prompt": "Run stripe trigger setup_intent.succeeded and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger setup_intent.succeeded and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         }
       ],
       "title": "Complete the setup"
@@ -91,7 +95,8 @@
           },
           "title": "Create a PaymentIntent off-session",
           "type": "apiRequest",
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         }
       ],
       "title": "Charge the saved card"

--- a/pkg/coop/blueprints/subscription-with-trial.json
+++ b/pkg/coop/blueprints/subscription-with-trial.json
@@ -18,13 +18,15 @@
             "path": "/v1/checkout/sessions",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "uiComponent",
           "key": "complete-checkout",
           "title": "Complete checkout",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         },
         {
           "type": "asyncHandler",
@@ -33,7 +35,8 @@
           "events": [
             "checkout.session.completed"
           ],
-          "review_prompt": "Run stripe trigger checkout.session.completed and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger checkout.session.completed and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         },
         {
           "type": "asyncHandler",
@@ -42,7 +45,8 @@
           "events": [
             "customer.subscription.created"
           ],
-          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         }
       ]
     }

--- a/pkg/coop/blueprints/usage-based-billing.json
+++ b/pkg/coop/blueprints/usage-based-billing.json
@@ -18,7 +18,8 @@
             "path": "/v1/customers",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -28,7 +29,8 @@
             "path": "/v2/billing/pricing_plans",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -38,7 +40,8 @@
             "path": "/v1/billing/meters",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -48,7 +51,8 @@
             "path": "/v2/billing/rate_cards",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -58,7 +62,8 @@
             "path": "/v2/billing/metered_items",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -68,7 +73,8 @@
             "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -78,7 +84,8 @@
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -88,7 +95,8 @@
             "path": "/v2/billing/licensed_items",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -98,7 +106,8 @@
             "path": "/v2/billing/license_fees",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -108,7 +117,8 @@
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -118,7 +128,8 @@
             "path": "/v2/billing/service_actions",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -128,7 +139,8 @@
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -138,7 +150,8 @@
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -148,13 +161,15 @@
             "path": "/v1/checkout/sessions",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "uiComponent",
           "key": "completeCheckout",
           "title": "Complete the checkout",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+          "review_prompt": "Open the app and confirm the user-facing flow works as described.",
+          "review_risk": "A UI mismatch can make a working backend unreachable or send users through the wrong flow."
         },
         {
           "type": "asyncHandler",
@@ -163,7 +178,8 @@
           "events": [
             "v2.billing.pricing_plan_subscription.servicing_activated"
           ],
-          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         },
         {
           "type": "asyncHandler",
@@ -172,7 +188,8 @@
           "events": [
             "v2.billing.credit_grant.created"
           ],
-          "review_prompt": "Run stripe trigger v2.billing.credit_grant.created and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run stripe trigger v2.billing.credit_grant.created and confirm the handler processes the signed event correctly.",
+          "review_risk": "Webhook mistakes can fulfill work from spoofed or unhandled events."
         }
       ]
     }

--- a/pkg/coop/blueprints/usage-recording.json
+++ b/pkg/coop/blueprints/usage-recording.json
@@ -18,7 +18,8 @@
             "path": "/v1/billing/meters",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         },
         {
           "type": "apiRequest",
@@ -28,7 +29,8 @@
             "path": "/v1/billing/meter_events",
             "method": "post"
           },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "review_risk": "A wrong API call or stale Stripe ID can make later steps work against the wrong resource."
         }
       ]
     }

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -75,6 +75,7 @@ type SessionNode struct {
 	Title          string          `json:"title"`
 	Description    string          `json:"description,omitempty"`
 	ReviewPrompt   string          `json:"review_prompt,omitempty"`
+	ReviewRisk     string          `json:"review_risk,omitempty"`
 	AutoConfirm    bool            `json:"auto_confirm,omitempty"`
 	State          StepState       `json:"state"`
 	Activity       string          `json:"activity,omitempty"`


### PR DESCRIPTION
## Summary
- add `review_risk` metadata to coop blueprint/session state and agent step briefs
- strengthen the one-time-payment and deploy blueprint review prompts with product-specific checks
- require review prompts and risks to stay concrete through blueprint quality tests

## Stack
- Previous: #1637
- This: #1638
- Next: #1639

## Tests
- `jq -e . pkg/coop/blueprints/*.json`
- `go test ./pkg/coop/...`
- `go test ./pkg/cmd -run 'Coop|coop'`
