### PR TITLE
Add sectioned coop detail view

### DIFF
--- a/pkg/coop/tui/model.go
+++ b/pkg/coop/tui/model.go
@@ -22,6 +22,7 @@ type Model struct {
 
 	cursor    int
 	expanded  bool
+	detailTab int
 	width     int
 	height    int
 	userMoved bool
@@ -305,6 +306,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "e", "?":
 		m.expanded = !m.expanded
+		if m.expanded {
+			m.setStatus("Details opened", 2*time.Second)
+		} else {
+			m.setStatus("Details collapsed", 2*time.Second)
+		}
 		m.syncViewport()
 		if m.expanded {
 			return m, m.fetchSnippetIfNeeded()
@@ -312,6 +318,20 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "enter":
 		return m.handleEnter()
+	case "tab":
+		if m.expanded {
+			m.detailTab = (m.detailTab + 1) % len(detailSections)
+			m.syncViewport()
+			return m, m.fetchSnippetIfNeeded()
+		}
+		return m, nil
+	case "esc":
+		if m.expanded {
+			m.expanded = false
+			m.setStatus("Details collapsed", 2*time.Second)
+			m.syncViewport()
+		}
+		return m, nil
 	case "f":
 		m.userMoved = false
 		m.autoScroll()
@@ -392,6 +412,11 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.expanded = !m.expanded
+	if m.expanded {
+		m.setStatus("Details opened", 2*time.Second)
+	} else {
+		m.setStatus("Details collapsed", 2*time.Second)
+	}
 	m.syncViewport()
 	if m.expanded {
 		return m, m.fetchSnippetIfNeeded()

--- a/pkg/coop/tui/model_test.go
+++ b/pkg/coop/tui/model_test.go
@@ -80,6 +80,27 @@ func TestUpdateKeyExpandToggle(t *testing.T) {
 	assert.False(t, updated.expanded)
 }
 
+func TestUpdateKeyTabCyclesDetailSection(t *testing.T) {
+	m := readyModel()
+	m.expanded = true
+	m.detailTab = 0
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	updated := result.(Model)
+
+	assert.Equal(t, 1, updated.detailTab)
+}
+
+func TestUpdateKeyEscClosesDetails(t *testing.T) {
+	m := readyModel()
+	m.expanded = true
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updated := result.(Model)
+
+	assert.False(t, updated.expanded)
+}
+
 func TestUpdateKeyConfirm(t *testing.T) {
 	dir := t.TempDir()
 	store, _ := coop.NewStoreAt(dir)

--- a/pkg/coop/tui/view.go
+++ b/pkg/coop/tui/view.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stripe/stripe-cli/pkg/coop"
 )
 
+var detailSections = []string{"Summary", "Files", "Checks", "Reference"}
+
 func (m Model) renderWaitingView() string {
 	w := m.contentWidth() - 8
 	if w < 25 {
@@ -230,29 +232,27 @@ func (m Model) renderDetail() string {
 	w, innerW := m.detailWidths()
 
 	var md strings.Builder
+	section := detailSections[m.detailTab%len(detailSections)]
+	md.WriteString("**Details: " + node.Title + "**\n\n")
+	md.WriteString(m.renderDetailTabs(section) + "\n\n")
 
-	if node.Description != "" {
-		md.WriteString("**Summary**\n\n")
-		md.WriteString(node.Description + "\n\n")
-	}
-
-	if node.ReviewPrompt != "" {
-		md.WriteString("**What to check**\n\n")
-		md.WriteString(node.ReviewPrompt + "\n\n")
+	switch section {
+	case "Summary":
+		m.writeSummaryDetail(&md, node)
+	case "Files":
+		m.writeImplementationDetail(&md, node, false)
+	case "Checks":
+		m.writeAsyncHandlerCheckDetail(&md, node)
+		m.writeVerificationDetail(&md, node)
+	case "Reference":
+		currentSnippet := m.sdkSnippetStep == m.cursor && m.sdkSnippet != ""
+		m.writeSDKReferenceDetail(&md, node, currentSnippet)
+		m.writeAsyncHandlerReferenceDetail(&md, node)
 	}
 
 	if node.State == coop.StepSkipped && node.Activity != "" {
-		md.WriteString("*Skipped: " + node.Activity + "*\n")
-		rendered := m.renderMarkdown(md.String(), innerW)
-		return "    " + DetailBoxStyle.Width(w).Render(rendered)
+		md.WriteString("*Skipped: " + node.Activity + "*\n\n")
 	}
-
-	m.writeAsyncHandlerDetail(&md, node)
-
-	currentSnippet := m.sdkSnippetStep == m.cursor && m.sdkSnippet != ""
-	m.writeSDKReferenceDetail(&md, node, currentSnippet)
-	m.writeImplementationDetail(&md, node, currentSnippet)
-	m.writeVerificationDetail(&md, node)
 
 	content := md.String()
 	suffix := m.renderDetailSuffix(node)
@@ -262,6 +262,18 @@ func (m Model) renderDetail() string {
 
 	rendered := m.renderMarkdown(content, innerW)
 	return "    " + DetailBoxStyle.Width(w).Render(rendered+suffix)
+}
+
+func (m Model) renderDetailTabs(active string) string {
+	var parts []string
+	for _, section := range detailSections {
+		if section == active {
+			parts = append(parts, "["+section+"]")
+		} else {
+			parts = append(parts, section)
+		}
+	}
+	return strings.Join(parts, "  ")
 }
 
 func (m Model) detailWidths() (int, int) {
@@ -284,7 +296,21 @@ func (m Model) detailLanguage() string {
 	return lang
 }
 
-func (m Model) writeAsyncHandlerDetail(md *strings.Builder, node *coop.SessionNode) {
+func (m Model) writeSummaryDetail(md *strings.Builder, node *coop.SessionNode) {
+	if node.Description != "" {
+		md.WriteString("**Summary**\n\n")
+		md.WriteString(node.Description + "\n\n")
+	}
+	if node.ReviewPrompt != "" {
+		md.WriteString("**You check**\n\n")
+		md.WriteString(node.ReviewPrompt + "\n\n")
+	}
+	if node.Description == "" && node.ReviewPrompt == "" {
+		md.WriteString("*No summary available for this step.*\n\n")
+	}
+}
+
+func (m Model) writeAsyncHandlerCheckDetail(md *strings.Builder, node *coop.SessionNode) {
 	if node.Type != coop.NodeAsyncHandler || len(node.Events) == 0 {
 		return
 	}
@@ -292,6 +318,14 @@ func (m Model) writeAsyncHandlerDetail(md *strings.Builder, node *coop.SessionNo
 	md.WriteString("1. `stripe listen --forward-to localhost:<port>/webhook`\n")
 	md.WriteString("2. `stripe trigger " + node.Events[0] + "`\n")
 	md.WriteString("3. Confirm your handler processes the event\n\n")
+}
+
+func (m Model) writeAsyncHandlerReferenceDetail(md *strings.Builder, node *coop.SessionNode) {
+	if node.Type != coop.NodeAsyncHandler || len(node.Events) == 0 {
+		return
+	}
+	md.WriteString("**Webhook trigger:**\n\n")
+	md.WriteString("`stripe trigger " + node.Events[0] + "`\n\n")
 }
 
 func (m Model) writeSDKReferenceDetail(md *strings.Builder, node *coop.SessionNode, currentSnippet bool) {
@@ -417,6 +451,9 @@ func (m Model) renderFooter() string {
 		parts = append(parts, "↑↓ navigate")
 	}
 	parts = append(parts, "enter/e details")
+	if m.expanded {
+		parts = append(parts, "tab section", "esc close")
+	}
 	if m.session != nil && m.session.ClaimURL != "" {
 		parts = append(parts, "o open claim URL")
 	}

--- a/pkg/coop/tui/view_test.go
+++ b/pkg/coop/tui/view_test.go
@@ -112,9 +112,10 @@ func TestRenderDetail(t *testing.T) {
 	m := testModel()
 	m.cursor = 0
 	m.expanded = true
+	m.detailTab = 1
 	detail := m.renderDetail()
 
-	// Should show implementation info via glamour
+	assert.Contains(t, detail, "Files")
 	assert.Contains(t, detail, "Agent wrote")
 	assert.Contains(t, detail, "server.js:5-20")
 	assert.Contains(t, detail, "Created product")
@@ -124,8 +125,10 @@ func TestRenderDetailWebhook(t *testing.T) {
 	m := testModel()
 	m.cursor = 2 // asyncHandler node
 	m.expanded = true
+	m.detailTab = 2
 	detail := m.renderDetail()
 
+	assert.Contains(t, detail, "Checks")
 	assert.Contains(t, detail, "How to verify")
 	assert.Contains(t, detail, "stripe listen")
 	assert.Contains(t, detail, "stripe trigger checkout.session.completed")
@@ -135,6 +138,7 @@ func TestRenderDetailWithSDKSnippet(t *testing.T) {
 	m := testModel()
 	m.cursor = 0
 	m.expanded = true
+	m.detailTab = 3
 	m.sdkSnippet = "const product = await stripe.products.create({});"
 	m.sdkSnippetStep = 0
 	detail := m.renderDetail()


### PR DESCRIPTION
## Summary
- split expanded step details into Summary, Files, Checks, and Reference sections
- add `tab` section cycling and `esc` close behavior when details are expanded
- keep footer hints contextual to the expanded/collapsed state

## Stack
- Previous: #1639
- This: #1640
- Next: #1641

## Tests
- `go test ./pkg/coop/...`
- `go test ./pkg/cmd -run 'Coop|coop'`
