### PR TITLE
Add coop completion receipt

### DIFF
--- a/pkg/coop/tui/view.go
+++ b/pkg/coop/tui/view.go
@@ -656,6 +656,10 @@ func (m Model) renderCompletionBody() string {
 		content += "\n" + DimmedStyle.Render("    Press o to open in browser")
 	}
 
+	if receipt := m.renderCompletionReceipt(w); receipt != "" {
+		content += "\n\n" + receipt
+	}
+
 	content += "\n\n" + ChapterTitleStyle.Render("  Next steps")
 	ruleWidth := min(w-4, 50)
 	if ruleWidth < 0 {
@@ -692,6 +696,87 @@ func (m Model) renderCompletionBody() string {
 	}
 
 	return content
+}
+
+func (m Model) renderCompletionReceipt(width int) string {
+	if m.session == nil {
+		return ""
+	}
+
+	var content strings.Builder
+	built := m.completionBuiltItems()
+	if len(built) > 0 {
+		content.WriteString(ChapterTitleStyle.Render("  Built") + "\n")
+		for _, item := range built {
+			content.WriteString("  " + SuccessStyle.Render("✓") + " " + item + "\n")
+		}
+	}
+
+	checks := m.completionImportantChecks()
+	if len(checks) > 0 {
+		if content.Len() > 0 {
+			content.WriteString("\n")
+		}
+		content.WriteString(ChapterTitleStyle.Render("  Important checks") + "\n")
+		checkW := min(width-8, 72)
+		if checkW < 20 {
+			checkW = 20
+		}
+		for _, check := range checks {
+			wrapped := strings.Split(wordWrap(check, checkW), "\n")
+			for i, line := range wrapped {
+				prefix := "  - "
+				if i > 0 {
+					prefix = "    "
+				}
+				content.WriteString(prefix + line + "\n")
+			}
+		}
+	}
+
+	return strings.TrimRight(content.String(), "\n")
+}
+
+func (m Model) completionBuiltItems() []string {
+	var items []string
+	for _, ch := range m.session.Chapters {
+		if ch.Key == "context-chapter" {
+			continue
+		}
+		done := 0
+		relevant := 0
+		for _, node := range ch.Nodes {
+			if node.State == coop.StepSkipped {
+				continue
+			}
+			relevant++
+			if node.State == coop.StepDone {
+				done++
+			}
+		}
+		if relevant > 0 && done == relevant {
+			items = append(items, ch.Title)
+		}
+	}
+	return items
+}
+
+func (m Model) completionImportantChecks() []string {
+	var checks []string
+	seen := map[string]bool{}
+	for _, ch := range m.session.Chapters {
+		for _, node := range ch.Nodes {
+			if node.State != coop.StepDone || node.ReviewPrompt == "" || seen[node.ReviewPrompt] {
+				continue
+			}
+			seen[node.ReviewPrompt] = true
+			checks = append(checks, node.ReviewPrompt)
+			if len(checks) == 4 {
+				return checks
+			}
+		}
+	}
+	return checks
 }
 
 func (m Model) renderCompletionFooter() string {

--- a/pkg/coop/tui/view_test.go
+++ b/pkg/coop/tui/view_test.go
@@ -220,10 +220,67 @@ func TestRenderCompletionView(t *testing.T) {
 	view := m.renderCompletionView()
 
 	assert.Contains(t, view, "Integration complete")
+	assert.Contains(t, view, "Built")
+	assert.Contains(t, view, "Set up product")
+	assert.Contains(t, view, "Handle webhooks")
+	assert.Contains(t, view, "Important checks")
+	assert.Contains(t, view, "Confirm the saved price ID is reused by Checkout.")
 	assert.Contains(t, view, "Next steps")
 	assert.Contains(t, view, "STRIPE.md")
 	assert.Contains(t, view, "Deploy")
 	assert.Contains(t, view, "Finish")
+}
+
+func TestCompletionBuiltItemsFiltersContextSkippedAndIncomplete(t *testing.T) {
+	m := testModel()
+	m.session.Chapters = []coop.SessionChapter{
+		{
+			Key:   "context-chapter",
+			Title: "Project context",
+			Nodes: []coop.SessionNode{
+				{Title: "Understand project", State: coop.StepDone},
+			},
+		},
+		{
+			Key:   "built-with-skipped",
+			Title: "Built with skipped optional work",
+			Nodes: []coop.SessionNode{
+				{Title: "Required", State: coop.StepDone},
+				{Title: "Optional", State: coop.StepSkipped},
+			},
+		},
+		{
+			Key:   "incomplete",
+			Title: "Incomplete chapter",
+			Nodes: []coop.SessionNode{
+				{Title: "Done", State: coop.StepDone},
+				{Title: "Still active", State: coop.StepActive},
+			},
+		},
+	}
+
+	assert.Equal(t, []string{"Built with skipped optional work"}, m.completionBuiltItems())
+}
+
+func TestCompletionImportantChecksDedupesDoneOnlyAndCaps(t *testing.T) {
+	m := testModel()
+	m.session.Chapters = []coop.SessionChapter{
+		{
+			Key:   "checks",
+			Title: "Checks",
+			Nodes: []coop.SessionNode{
+				{Title: "First", State: coop.StepDone, ReviewPrompt: "Check one"},
+				{Title: "Duplicate", State: coop.StepDone, ReviewPrompt: "Check one"},
+				{Title: "Active", State: coop.StepActive, ReviewPrompt: "Do not include active"},
+				{Title: "Second", State: coop.StepDone, ReviewPrompt: "Check two"},
+				{Title: "Third", State: coop.StepDone, ReviewPrompt: "Check three"},
+				{Title: "Fourth", State: coop.StepDone, ReviewPrompt: "Check four"},
+				{Title: "Fifth", State: coop.StepDone, ReviewPrompt: "Do not include after cap"},
+			},
+		},
+	}
+
+	assert.Equal(t, []string{"Check one", "Check two", "Check three", "Check four"}, m.completionImportantChecks())
 }
 
 func TestGetCompletionSuggestionsDefault(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a completion receipt that summarizes built chapters and the most important checks
- keep context-gathering out of the built summary
- cover the receipt through the completion view tests

## Stack
- Previous: #1640
- This: #1641
- Next: #1642

## Tests
- `go test ./pkg/coop/...`
- `go test ./pkg/cmd -run 'Coop|coop'`
