### PR TITLE
Add contextual coop review actions

### DIFF
--- a/pkg/cmd/coop_run.go
+++ b/pkg/cmd/coop_run.go
@@ -85,6 +85,7 @@ func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
 				Type:              string(n.Type),
 				Description:       n.Description,
 				ReviewPrompt:      n.ReviewPrompt,
+				ReviewCommand:     n.ReviewCommand,
 				ReviewGranularity: string(ch.ReviewGranularity),
 				AutoConfirm:       n.AutoConfirm,
 			})
@@ -139,6 +140,7 @@ type stepBrief struct {
 	Type              string `json:"type"`
 	Description       string `json:"description,omitempty"`
 	ReviewPrompt      string `json:"review_prompt,omitempty"`
+	ReviewCommand     string `json:"review_command,omitempty"`
 	ReviewGranularity string `json:"review_granularity,omitempty"`
 	AutoConfirm       bool   `json:"auto_confirm,omitempty"`
 }
@@ -165,7 +167,7 @@ Each step has a description that tells you what to do. Follow the description â€
 - "cliCommand": Run a CLI command (e.g. stripe projects init, stripe projects deploy). Report the output.
 - "testHelper": Verify something works end-to-end. Run the flow and confirm the expected outcome.
 
-If a step includes review_prompt, that is what the human will use as the acceptance check. Make your implementation note and verifications directly answer it.
+If a step includes review_prompt, that is what the human will use as the acceptance check. If it includes review_command, run that exact command when verifying or explain why it does not apply. Make your implementation note and verifications directly answer these fields.
 
 Step 1 is always "Understand the project" â€” scan files, identify the tech stack, and summarize what you found. This helps you adapt the remaining steps to the developer's actual setup. Don't ask the developer questions you can answer by reading the code.
 

--- a/pkg/cmd/coop_step_test.go
+++ b/pkg/cmd/coop_step_test.go
@@ -241,8 +241,10 @@ func TestAgentPromptsUseSandboxCommand(t *testing.T) {
 
 	bp := &coop.Blueprint{Title: "Test integration"}
 	session := &coop.Session{}
-	assert.Contains(t, agentInstructions(bp, session), "stripe sandbox create --from-git")
-	assert.NotContains(t, agentInstructions(bp, session), "stripe sandboxes create")
+	instructions := agentInstructions(bp, session)
+	assert.Contains(t, instructions, "stripe sandbox create --from-git")
+	assert.Contains(t, instructions, "review_command")
+	assert.NotContains(t, instructions, "stripe sandboxes create")
 }
 
 func TestBlueprintMatchScoreRanksRelevantBlueprints(t *testing.T) {
@@ -394,6 +396,7 @@ func TestCoopRunStoresParentSessionMetadata(t *testing.T) {
 	assert.Equal(t, "parent_session", session.ParentSessionID)
 	assert.Equal(t, "deploy", session.ParentStepID)
 	assert.Equal(t, "node", session.Settings["language"])
+	assert.Equal(t, "stripe trigger checkout.session.completed", session.Chapters[3].Nodes[0].ReviewCommand)
 }
 
 func TestNextStepsDeployIncludesParentMetadata(t *testing.T) {

--- a/pkg/coop/blueprint.go
+++ b/pkg/coop/blueprint.go
@@ -12,14 +12,15 @@ var blueprintFS embed.FS
 
 // BlueprintNode is a node definition within a blueprint chapter.
 type BlueprintNode struct {
-	Type         NodeType    `json:"type"`
-	Key          string      `json:"key"`
-	Title        string      `json:"title"`
-	Description  string      `json:"description,omitempty"`
-	ReviewPrompt string      `json:"review_prompt,omitempty"`
-	AutoConfirm  bool        `json:"auto_confirm,omitempty"`
-	Request      *APIRequest `json:"request,omitempty"`
-	Events       []string    `json:"events,omitempty"`
+	Type          NodeType    `json:"type"`
+	Key           string      `json:"key"`
+	Title         string      `json:"title"`
+	Description   string      `json:"description,omitempty"`
+	ReviewPrompt  string      `json:"review_prompt,omitempty"`
+	ReviewCommand string      `json:"review_command,omitempty"`
+	AutoConfirm   bool        `json:"auto_confirm,omitempty"`
+	Request       *APIRequest `json:"request,omitempty"`
+	Events        []string    `json:"events,omitempty"`
 }
 
 // BlueprintChapter is a chapter definition within a blueprint.
@@ -163,15 +164,16 @@ func NewSessionFromBlueprint(bp *Blueprint, sessionID string, settings map[strin
 		nodes := make([]SessionNode, len(ch.Nodes))
 		for j, n := range ch.Nodes {
 			nodes[j] = SessionNode{
-				Key:          n.Key,
-				Type:         n.Type,
-				Title:        n.Title,
-				Description:  n.Description,
-				ReviewPrompt: n.ReviewPrompt,
-				AutoConfirm:  n.AutoConfirm,
-				State:        StepPending,
-				Request:      n.Request,
-				Events:       n.Events,
+				Key:           n.Key,
+				Type:          n.Type,
+				Title:         n.Title,
+				Description:   n.Description,
+				ReviewPrompt:  n.ReviewPrompt,
+				ReviewCommand: n.ReviewCommand,
+				AutoConfirm:   n.AutoConfirm,
+				State:         StepPending,
+				Request:       n.Request,
+				Events:        n.Events,
 			}
 		}
 		chapters = append(chapters, SessionChapter{

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -157,6 +157,7 @@ func TestNewSessionFromBlueprint(t *testing.T) {
 
 	assert.Equal(t, ReviewGranularityChapter, session.Chapters[2].ReviewGranularity)
 	assert.NotEmpty(t, session.Chapters[1].Nodes[0].ReviewPrompt)
+	assert.Equal(t, "stripe trigger checkout.session.completed", session.Chapters[3].Nodes[0].ReviewCommand)
 }
 
 func TestListBlueprintsWithMetadata(t *testing.T) {

--- a/pkg/coop/blueprints/one-time-payment.json
+++ b/pkg/coop/blueprints/one-time-payment.json
@@ -84,7 +84,8 @@
           "key": "handle-checkout-completed",
           "title": "Handle checkout.session.completed",
           "type": "asyncHandler",
-          "review_prompt": "Run stripe trigger checkout.session.completed and confirm the handler processes the signed event correctly."
+          "review_prompt": "Run `stripe trigger checkout.session.completed` and confirm fulfillment happens only after verifying the Stripe signature.",
+          "review_command": "stripe trigger checkout.session.completed"
         }
       ],
       "title": "Handle post-payment events"

--- a/pkg/coop/tui/helpers.go
+++ b/pkg/coop/tui/helpers.go
@@ -11,9 +11,14 @@ import (
 )
 
 var openBrowserFn = openBrowserDefault
+var copyTextFn = copyTextDefault
 
 func openBrowser(url string) {
 	openBrowserFn(url)
+}
+
+func copyText(text string) error {
+	return copyTextFn(text)
 }
 
 func openBrowserDefault(url string) {
@@ -25,6 +30,22 @@ func openBrowserDefault(url string) {
 	case "windows":
 		exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start() //nolint:gosec
 	}
+}
+
+func copyTextDefault(text string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy") //nolint:gosec
+	case "linux":
+		cmd = exec.Command("wl-copy") //nolint:gosec
+	case "windows":
+		cmd = exec.Command("clip") //nolint:gosec
+	default:
+		return fmt.Errorf("clipboard unsupported on %s", runtime.GOOS)
+	}
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
 }
 
 func (m Model) contentWidth() int {

--- a/pkg/coop/tui/model.go
+++ b/pkg/coop/tui/model.go
@@ -234,6 +234,9 @@ func (m *Model) syncViewport() {
 	content := m.renderStepList()
 	if m.session.IsComplete() {
 		content = m.renderCompletionBody()
+		m.viewport.SetContent(content)
+		m.viewport.SetYOffset(0)
+		return
 	}
 	m.viewport.SetContent(content)
 	m.scrollToCursor()
@@ -255,10 +258,14 @@ func (m *Model) scrollToCursor() {
 
 	vpTop := m.viewport.YOffset
 	vpBottom := vpTop + m.viewport.Height
+	scrollThreshold := vpBottom - 2
+	if m.session != nil && m.session.IsComplete() {
+		scrollThreshold = vpBottom
+	}
 
 	if targetLine < vpTop {
 		m.viewport.SetYOffset(targetLine)
-	} else if targetLine >= vpBottom-2 {
+	} else if targetLine >= scrollThreshold {
 		offset := targetLine - m.viewport.Height/2
 		if offset < 0 {
 			offset = 0
@@ -344,6 +351,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "o":
 		if m.session != nil && m.session.ClaimURL != "" {
 			openBrowser(m.session.ClaimURL)
+		}
+		return m, nil
+	case "y":
+		if command := m.selectedReviewCommand(); command != "" {
+			if err := copyText(command); err != nil {
+				m.setStatus("Could not copy command: "+err.Error(), 4*time.Second)
+			} else {
+				m.setStatus("Copied review command.", 3*time.Second)
+			}
+			m.syncViewport()
 		}
 		return m, nil
 	case "r":
@@ -603,6 +620,14 @@ func (m Model) reviewIsActionable(stepNum int) bool {
 	}
 	_, chapterIndex, _, err := m.session.ChapterByStepNumber(stepNum)
 	return err == nil && m.session.ChapterReadyForReview(chapterIndex)
+}
+
+func (m Model) selectedReviewCommand() string {
+	target, ok := m.selectedReviewTarget()
+	if !ok {
+		return ""
+	}
+	return m.reviewCommandLabel(target.steps)
 }
 
 func (m *Model) setStatus(message string, ttl time.Duration) {

--- a/pkg/coop/tui/model_test.go
+++ b/pkg/coop/tui/model_test.go
@@ -415,7 +415,7 @@ func TestCompletionViewKeyDown(t *testing.T) {
 	assert.Equal(t, 1, updated.cursor)
 }
 
-func TestCompletionViewportScrollsToCursor(t *testing.T) {
+func TestCompletionViewportKeepsReceiptAtTop(t *testing.T) {
 	m := readyModel()
 	m.height = 10
 	m.viewport.Height = 3
@@ -437,7 +437,8 @@ func TestCompletionViewportScrollsToCursor(t *testing.T) {
 
 	m.syncViewport()
 
-	assert.Greater(t, m.viewport.YOffset, 0)
+	assert.Equal(t, 0, m.viewport.YOffset)
+	assert.Contains(t, m.viewport.View(), "Integration complete")
 }
 
 func TestCompletionViewKeyDownWraps(t *testing.T) {
@@ -612,6 +613,26 @@ func TestHandleKeyOpenBrowser(t *testing.T) {
 	updated := result.(Model)
 	assert.NotNil(t, updated)
 	assert.Equal(t, "https://example.com", opened)
+}
+
+func TestHandleKeyCopyReviewCommand(t *testing.T) {
+	orig := copyTextFn
+	var copied string
+	copyTextFn = func(text string) error {
+		copied = text
+		return nil
+	}
+	defer func() { copyTextFn = orig }()
+
+	m := readyModel()
+	m.session.Chapters[1].Nodes[0].State = coop.StepReview
+	m.cursor = 2
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	updated := result.(Model)
+
+	assert.Equal(t, "stripe trigger checkout.session.completed", copied)
+	assert.Contains(t, updated.statusMessage, "Copied")
 }
 
 func TestHandleKeyQuestionMark(t *testing.T) {

--- a/pkg/coop/tui/view.go
+++ b/pkg/coop/tui/view.go
@@ -242,6 +242,7 @@ func (m Model) renderDetail() string {
 	case "Files":
 		m.writeImplementationDetail(&md, node, false)
 	case "Checks":
+		m.writeReviewCommandDetail(&md, node)
 		m.writeAsyncHandlerCheckDetail(&md, node)
 		m.writeVerificationDetail(&md, node)
 	case "Reference":
@@ -326,6 +327,15 @@ func (m Model) writeAsyncHandlerReferenceDetail(md *strings.Builder, node *coop.
 	}
 	md.WriteString("**Webhook trigger:**\n\n")
 	md.WriteString("`stripe trigger " + node.Events[0] + "`\n\n")
+}
+
+func (m Model) writeReviewCommandDetail(md *strings.Builder, node *coop.SessionNode) {
+	command := reviewCommandForNode(node)
+	if command == "" {
+		return
+	}
+	md.WriteString("**Review command:**\n\n")
+	md.WriteString("`" + strings.ReplaceAll(command, "`", "'") + "`\n\n")
 }
 
 func (m Model) writeSDKReferenceDetail(md *strings.Builder, node *coop.SessionNode, currentSnippet bool) {
@@ -441,30 +451,33 @@ func (m Model) renderFooter() string {
 	}
 
 	if m.rejecting {
-		return footer + FooterStyle.Render("  enter send feedback  ·  esc cancel")
+		return footer + FooterStyle.Render("  enter send · esc cancel")
 	}
 
 	var parts []string
 	if m.userMoved {
-		parts = append(parts, "Viewing earlier steps", "f follow latest")
+		parts = append(parts, "earlier", "f follow")
 	} else {
-		parts = append(parts, "↑↓ navigate")
+		parts = append(parts, "↑↓")
 	}
-	parts = append(parts, "enter/e details")
+	parts = append(parts, "enter/e")
 	if m.expanded {
-		parts = append(parts, "tab section", "esc close")
+		parts = append(parts, "tab", "esc")
 	}
 	if m.session != nil && m.session.ClaimURL != "" {
-		parts = append(parts, "o open claim URL")
+		parts = append(parts, "o claim")
 	}
 	if m.session != nil {
 		if _, ok := m.selectedReviewTarget(); ok {
+			if m.selectedReviewCommand() != "" {
+				parts = append(parts, "y copy")
+			}
 			parts = append(parts, SuccessStyle.Render("c confirm"))
-			parts = append(parts, ErrorStyle.Render("r request changes"))
+			parts = append(parts, ErrorStyle.Render("r changes"))
 		}
 	}
 	parts = append(parts, "q quit")
-	footer += FooterStyle.Render("  " + strings.Join(parts, "  ·  "))
+	footer += FooterStyle.Render("  " + strings.Join(parts, " · "))
 	return footer
 }
 
@@ -494,10 +507,13 @@ func (m Model) renderReviewCard() string {
 	if check != "" {
 		lines = append(lines, MutedStyle.Render("You check: ")+check)
 	}
+	if command := m.reviewCommandLabel(target.steps); command != "" {
+		lines = append(lines, MutedStyle.Render("Run: ")+command)
+	}
 	if m.rejecting {
 		input := m.rejectionInput
 		if input == "" {
-			input = DimmedStyle.Render("Describe what should change")
+			input = DimmedStyle.Render(m.requestChangesPlaceholder(target))
 		}
 		lines = append(lines, ErrorStyle.Render("Request changes: ")+input)
 		if m.rejectionError != "" {
@@ -510,6 +526,29 @@ func (m Model) renderReviewCard() string {
 		wrapped = append(wrapped, strings.Split(wordWrap(line, w-4), "\n")...)
 	}
 	return ReviewCardStyle.Width(w).Render(strings.Join(wrapped, "\n"))
+}
+
+func (m Model) requestChangesPlaceholder(target reviewTarget) string {
+	if target.kind == "chapter" {
+		return "Describe what should change in this chapter"
+	}
+	for _, step := range target.steps {
+		node, err := m.session.NodeByNumber(step)
+		if err != nil {
+			continue
+		}
+		switch node.Type {
+		case coop.NodeAsyncHandler, coop.NodeSetUpWebhooks:
+			return "Describe what should change in signature verification or event handling"
+		case coop.NodeAPIRequest:
+			return "Describe what should change in the API call, IDs, or stored values"
+		case coop.NodeUIComponent:
+			return "Describe what should change in the user-facing flow"
+		case coop.NodeTestHelper:
+			return "Describe the failing path or expected result"
+		}
+	}
+	return "Describe what should change"
 }
 
 func (m Model) reviewChangedLabel(steps []int) string {
@@ -577,6 +616,40 @@ func (m Model) reviewPromptLabel(steps []int) string {
 		return strings.Join(prompts[:2], " ") + " Open details for the remaining checks."
 	}
 	return strings.Join(prompts, " ")
+}
+
+func (m Model) reviewCommandLabel(steps []int) string {
+	var commands []string
+	seen := map[string]bool{}
+	for _, step := range steps {
+		node, err := m.session.NodeByNumber(step)
+		if err != nil {
+			continue
+		}
+		command := reviewCommandForNode(node)
+		if command == "" || seen[command] {
+			continue
+		}
+		seen[command] = true
+		commands = append(commands, command)
+	}
+	if len(commands) == 0 {
+		return ""
+	}
+	if len(commands) > 2 {
+		return strings.Join(commands[:2], " && ") + fmt.Sprintf(" && # +%d more", len(commands)-2)
+	}
+	return strings.Join(commands, " && ")
+}
+
+func reviewCommandForNode(node *coop.SessionNode) string {
+	if node.ReviewCommand != "" {
+		return node.ReviewCommand
+	}
+	if node.Type == coop.NodeAsyncHandler && len(node.Events) > 0 {
+		return "stripe trigger " + node.Events[0]
+	}
+	return ""
 }
 
 func (m Model) actionableReviewCount() int {
@@ -707,8 +780,16 @@ func (m Model) renderCompletionReceipt(width int) string {
 	built := m.completionBuiltItems()
 	if len(built) > 0 {
 		content.WriteString(ChapterTitleStyle.Render("  Built") + "\n")
-		for _, item := range built {
-			content.WriteString("  " + SuccessStyle.Render("✓") + " " + item + "\n")
+		builtW := min(width-4, 76)
+		if builtW < 20 {
+			builtW = 20
+		}
+		for i, line := range strings.Split(wordWrap(strings.Join(built, " · "), builtW), "\n") {
+			prefix := "  " + SuccessStyle.Render("✓") + " "
+			if i > 0 {
+				prefix = "    "
+			}
+			content.WriteString(prefix + line + "\n")
 		}
 	}
 
@@ -771,7 +852,7 @@ func (m Model) completionImportantChecks() []string {
 			}
 			seen[node.ReviewPrompt] = true
 			checks = append(checks, node.ReviewPrompt)
-			if len(checks) == 4 {
+			if len(checks) == 2 {
 				return checks
 			}
 		}

--- a/pkg/coop/tui/view_test.go
+++ b/pkg/coop/tui/view_test.go
@@ -129,6 +129,7 @@ func TestRenderDetailWebhook(t *testing.T) {
 	detail := m.renderDetail()
 
 	assert.Contains(t, detail, "Checks")
+	assert.Contains(t, detail, "Review command")
 	assert.Contains(t, detail, "How to verify")
 	assert.Contains(t, detail, "stripe listen")
 	assert.Contains(t, detail, "stripe trigger checkout.session.completed")
@@ -153,8 +154,8 @@ func TestRenderFooter(t *testing.T) {
 	footer := m.renderFooter()
 
 	// Step 0 is done — no review actions
-	assert.Contains(t, footer, "navigate")
-	assert.Contains(t, footer, "details")
+	assert.Contains(t, footer, "↑↓")
+	assert.Contains(t, footer, "enter/e")
 	assert.NotContains(t, footer, "confirm")
 }
 
@@ -165,7 +166,7 @@ func TestRenderFooterReviewStep(t *testing.T) {
 	footer := m.renderFooter()
 
 	assert.Contains(t, footer, "confirm")
-	assert.Contains(t, footer, "request changes")
+	assert.Contains(t, footer, "changes")
 	assert.Contains(t, footer, "Review:")
 	assert.Contains(t, footer, "Agent changed")
 	assert.Contains(t, footer, "You check")
@@ -200,6 +201,17 @@ func TestRenderReviewCardFallbackCheck(t *testing.T) {
 	card := m.renderReviewCard()
 
 	assert.Contains(t, card, "Confirm the completed work matches this step")
+}
+
+func TestRenderFooterReviewCommand(t *testing.T) {
+	m := testModel()
+	m.session.Chapters[1].Nodes[0].State = coop.StepReview
+	m.cursor = 2
+	footer := m.renderFooter()
+
+	assert.Contains(t, footer, "Run:")
+	assert.Contains(t, footer, "stripe trigger checkout.session.completed")
+	assert.Contains(t, footer, "y copy")
 }
 
 func TestRenderFooterReviewNotice(t *testing.T) {
@@ -280,7 +292,7 @@ func TestCompletionImportantChecksDedupesDoneOnlyAndCaps(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, []string{"Check one", "Check two", "Check three", "Check four"}, m.completionImportantChecks())
+	assert.Equal(t, []string{"Check one", "Check two"}, m.completionImportantChecks())
 }
 
 func TestGetCompletionSuggestionsDefault(t *testing.T) {
@@ -429,9 +441,21 @@ func TestRenderFooterRejectionInput(t *testing.T) {
 
 	footer := m.renderFooter()
 
-	assert.Contains(t, footer, "enter send feedback")
+	assert.Contains(t, footer, "enter send")
 	assert.Contains(t, footer, "esc cancel")
 	assert.Contains(t, footer, "Missing webhook test")
+}
+
+func TestRenderFooterRejectionPlaceholder(t *testing.T) {
+	m := testModel()
+	m.session.Chapters[1].Nodes[0].State = coop.StepReview
+	m.cursor = 2
+	m.rejecting = true
+
+	footer := m.renderFooter()
+
+	assert.Contains(t, footer, "signature verification")
+	assert.Contains(t, footer, "event handling")
 }
 
 func TestStepIconAllStates(t *testing.T) {

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -75,6 +75,7 @@ type SessionNode struct {
 	Title          string          `json:"title"`
 	Description    string          `json:"description,omitempty"`
 	ReviewPrompt   string          `json:"review_prompt,omitempty"`
+	ReviewCommand  string          `json:"review_command,omitempty"`
 	AutoConfirm    bool            `json:"auto_confirm,omitempty"`
 	State          StepState       `json:"state"`
 	Activity       string          `json:"activity,omitempty"`


### PR DESCRIPTION
## Summary
- add `review_command` metadata and surface it in agent step briefs, review cards, details, and footer actions
- add `y` to copy the current review command when available
- use context-specific request-change placeholders for API, webhook, UI, and test-helper reviews
- compact review and completion footers/receipts based on live default-terminal checks

## Stack
- Previous: #1641
- This: #1642
- Top of the active follow-up stack.

## Tests
- `jq -e . pkg/coop/blueprints/*.json`
- `go test ./pkg/coop/...`
- `go test ./pkg/cmd -run 'Coop|coop'`\n- `go build ./cmd/stripe`\n- end-to-end temp-session check with `stripe coop run`, `stripe coop step`, and `stripe coop join`\n