### PR TITLE
Save UAT and account information in profile

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -414,6 +414,7 @@ func (c *Config) RemoveAuthFields(profileName string) error {
 				p := &Profile{ProfileName: field}
 				runtimeViper = p.deleteAuthFields(runtimeViper)
 				deleteLivemodeKey(LiveModeAPIKeyName, field)
+				deleteLivemodeKey(UATName, field)
 			}
 		}
 	}
@@ -431,6 +432,7 @@ func (c *Config) RemoveAllAuthFields() error {
 			p := &Profile{ProfileName: field}
 			runtimeViper = p.deleteAuthFields(runtimeViper)
 			deleteLivemodeKey(LiveModeAPIKeyName, field)
+			deleteLivemodeKey(UATName, field)
 		}
 	}
 

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -33,6 +33,9 @@ type Profile struct {
 	AccountID              string
 	SandboxClaimURL        string
 	SandboxExpiresAt       string
+	UAT                    string
+	LiveContext            string
+	TestWorkspaceID        string
 }
 
 // config key names
@@ -49,6 +52,9 @@ const (
 	LiveModeKeyExpiresAtName   = "live_mode_key_expires_at"
 	SandboxClaimURLName        = "sandbox_claim_url"
 	SandboxExpiresAtName       = "sandbox_expires_at"
+	UATName                    = "uat"
+	LiveContextName            = "live_context"
+	TestWorkspaceIDName        = "test_workspace_id"
 )
 
 const (
@@ -487,6 +493,18 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 
 	if p.SandboxExpiresAt != "" {
 		runtimeViper.Set(p.GetConfigField(SandboxExpiresAtName), strings.TrimSpace(p.SandboxExpiresAt))
+	}
+
+	if p.UAT != "" {
+		p.saveLivemodeValue(UATName, strings.TrimSpace(p.UAT), "UAT")
+	}
+
+	if p.LiveContext != "" {
+		runtimeViper.Set(p.GetConfigField(LiveContextName), strings.TrimSpace(p.LiveContext))
+	}
+
+	if p.TestWorkspaceID != "" {
+		runtimeViper.Set(p.GetConfigField(TestWorkspaceIDName), strings.TrimSpace(p.TestWorkspaceID))
 	}
 
 	runtimeViper.MergeInConfig()

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -136,6 +136,8 @@ var authFieldNames = []string{
 	LiveModeAPIKeyName,
 	LiveModePubKeyName,
 	LiveModeKeyExpiresAtName,
+	LiveContextName,
+	TestWorkspaceIDName,
 	"profile_name",
 	// sandbox-specific fields from stripe sandbox create
 	SandboxClaimURLName,

--- a/pkg/login/keys/configurer.go
+++ b/pkg/login/keys/configurer.go
@@ -41,6 +41,9 @@ func (c *RAKConfigurer) SaveLoginDetails(response *PollAPIKeyResponse) error {
 	c.cfg.Profile.LiveModePublishableKey = response.LiveModePublishableKey
 	c.cfg.Profile.TestModeAPIKey = response.TestModeAPIKey
 	c.cfg.Profile.TestModePublishableKey = response.TestModePublishableKey
+	c.cfg.Profile.UAT = response.UAT
+	c.cfg.Profile.LiveContext = response.LiveContext
+	c.cfg.Profile.TestWorkspaceID = response.TestWorkspaceID
 	// TODO: AccountDisplayName appears to be empty for test mode accounts; is there a better default?
 	if response.AccountDisplayName != "" {
 		c.cfg.Profile.DisplayName = response.AccountDisplayName

--- a/pkg/login/keys/polling.go
+++ b/pkg/login/keys/polling.go
@@ -26,6 +26,9 @@ type PollAPIKeyResponse struct {
 	LiveModePublishableKey string `json:"livemode_key_publishable"`
 	TestModeAPIKey         string `json:"testmode_key_secret"`
 	TestModePublishableKey string `json:"testmode_key_publishable"`
+	UAT                    string `json:"uat"`
+	LiveContext            string `json:"live_context"`
+	TestWorkspaceID        string `json:"test_workspace_id"`
 }
 
 // PollForKey polls Stripe at the specified interval until either the API key is available or we've reached the max attempts.


### PR DESCRIPTION
### Summary

This saves the UAT and account information to the profile during login, only if this data is returned by the server during `stripe login` (requires a flag to be enabled). 