### PR TITLE
Add terminal environment telemetry

### DIFF
--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -37,17 +37,20 @@ const DefaultTelemetryEndpoint = "https://r.stripe.com/0"
 
 // CLIAnalyticsEventMetadata is the structure that holds telemetry data context that is ultimately sent to the Stripe Analytics Service.
 type CLIAnalyticsEventMetadata struct {
-	InvocationID      string `url:"invocation_id"`            // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
-	UserAgent         string `url:"user_agent"`               // the application that is used to create this request
-	CommandPath       string `url:"command_path"`             // the command or gRPC method that initiated this request
-	CommandFlags      string `url:"command_flags"`            // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
-	PluginName        string `url:"plugin_name,omitempty"`    // the plugin being installed, when relevant
-	Merchant          string `url:"merchant"`                 // the merchant ID: ex. acct_xxxx
-	CLIVersion        string `url:"cli_version"`              // the version of the CLI
-	OS                string `url:"os"`                       // the OS of the system
-	GeneratedResource bool   `url:"generated_resource"`       // whether or not this was a generated resource
-	AIAgent           string `url:"ai_agent,omitempty"`       // the AI coding agent that invoked the CLI, if any
-	InstallMethod     string `url:"install_method,omitempty"` // how the CLI was installed
+	InvocationID      string `url:"invocation_id"`              // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
+	UserAgent         string `url:"user_agent"`                 // the application that is used to create this request
+	CommandPath       string `url:"command_path"`               // the command or gRPC method that initiated this request
+	CommandFlags      string `url:"command_flags"`              // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
+	PluginName        string `url:"plugin_name,omitempty"`      // the plugin being installed, when relevant
+	Merchant          string `url:"merchant"`                   // the merchant ID: ex. acct_xxxx
+	CLIVersion        string `url:"cli_version"`                // the version of the CLI
+	OS                string `url:"os"`                         // the OS of the system
+	GeneratedResource bool   `url:"generated_resource"`         // whether or not this was a generated resource
+	AIAgent           string `url:"ai_agent,omitempty"`         // the AI coding agent that invoked the CLI, if any
+	InstallMethod     string `url:"install_method,omitempty"`   // how the CLI was installed
+	InTmux            bool   `url:"in_tmux"`                    // whether the CLI was invoked from within tmux
+	InScreen          bool   `url:"in_screen"`                  // whether the CLI was invoked from within GNU Screen
+	TerminalProgram   string `url:"terminal_program,omitempty"` // the terminal program that invoked the CLI, if any
 }
 
 // TelemetryClient is an interface that can send two types of events: an API request, and just general events.
@@ -83,6 +86,9 @@ func NewEventMetadata() *CLIAnalyticsEventMetadata {
 			os.Executable,
 			func(p string) error { _, err := os.Stat(p); return err },
 		),
+		InTmux:          useragent.DetectInTmux(os.Getenv),
+		InScreen:        useragent.DetectInScreen(os.Getenv),
+		TerminalProgram: useragent.DetectTerminalProgram(os.Getenv),
 	}
 }
 

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -100,12 +100,15 @@ func TestSendAPIRequestEvent(t *testing.T) {
 		require.Contains(t, bodyString, "command_path=stripe+test")
 		require.Contains(t, bodyString, "event_name=API+Request")
 		require.Contains(t, bodyString, "generated_resource=false")
+		require.Contains(t, bodyString, "in_screen=true")
+		require.Contains(t, bodyString, "in_tmux=true")
 		require.Contains(t, bodyString, "invocation_id=123456")
 		require.Contains(t, bodyString, "livemode=false")
 		require.Contains(t, bodyString, "merchant=acct_1234")
 		require.Contains(t, bodyString, "os=darwin")
 		require.Contains(t, bodyString, "plugin_name=apps")
 		require.Contains(t, bodyString, "request_id=req_zzz")
+		require.Contains(t, bodyString, "terminal_program=iTerm.app")
 		require.Contains(t, bodyString, "user_agent=Unit+Test")
 		// ai_agent should not be present when empty (omitempty)
 		require.NotContains(t, bodyString, "ai_agent")
@@ -122,6 +125,9 @@ func TestSendAPIRequestEvent(t *testing.T) {
 		PluginName:        "apps",
 		Merchant:          "acct_1234",
 		GeneratedResource: false,
+		InTmux:            true,
+		InScreen:          true,
+		TerminalProgram:   "iTerm.app",
 	}
 	processCtx := stripe.WithEventMetadata(context.Background(), telemetryMetadata)
 	analyticsClient := stripe.AnalyticsTelemetryClient{BaseURL: baseURL, HTTPClient: &http.Client{}}
@@ -159,10 +165,13 @@ func TestSendEvent(t *testing.T) {
 		require.Contains(t, bodyString, "event_name=foo")
 		require.Contains(t, bodyString, "event_value=bar")
 		require.Contains(t, bodyString, "generated_resource=false")
+		require.Contains(t, bodyString, "in_screen=true")
+		require.Contains(t, bodyString, "in_tmux=true")
 		require.Contains(t, bodyString, "invocation_id=123456")
 		require.Contains(t, bodyString, "merchant=acct_1234")
 		require.Contains(t, bodyString, "os=darwin")
 		require.Contains(t, bodyString, "plugin_name=apps")
+		require.Contains(t, bodyString, "terminal_program=iTerm.app")
 		require.Contains(t, bodyString, "user_agent=Unit+Test")
 		// ai_agent should not be present when empty (omitempty)
 		require.NotContains(t, bodyString, "ai_agent")
@@ -179,6 +188,9 @@ func TestSendEvent(t *testing.T) {
 		PluginName:        "apps",
 		Merchant:          "acct_1234",
 		GeneratedResource: false,
+		InTmux:            true,
+		InScreen:          true,
+		TerminalProgram:   "iTerm.app",
 	}
 	processCtx := stripe.WithEventMetadata(context.Background(), telemetryMetadata)
 	analyticsClient := stripe.AnalyticsTelemetryClient{BaseURL: baseURL, HTTPClient: &http.Client{}}

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -56,6 +56,39 @@ func DetectInstallMethod(
 	return "unknown"
 }
 
+// DetectInTmux detects whether the CLI was invoked from within a tmux session.
+func DetectInTmux(getEnv func(string) string) bool {
+	return getEnv("TMUX") != ""
+}
+
+// DetectInScreen detects whether the CLI was invoked from within a GNU Screen session.
+func DetectInScreen(getEnv func(string) string) bool {
+	return getEnv("STY") != ""
+}
+
+// DetectTerminalProgram detects the terminal program the CLI was invoked from, when available.
+func DetectTerminalProgram(getEnv func(string) string) string {
+	if program := getEnv("TERM_PROGRAM"); program != "" {
+		return program
+	}
+	if getEnv("WT_SESSION") != "" {
+		return "windows_terminal"
+	}
+	if getEnv("KITTY_WINDOW_ID") != "" {
+		return "kitty"
+	}
+	if getEnv("ALACRITTY_WINDOW_ID") != "" || getEnv("ALACRITTY_LOG") != "" {
+		return "alacritty"
+	}
+	if getEnv("WEZTERM_EXECUTABLE") != "" || getEnv("WEZTERM_PANE") != "" {
+		return "wezterm"
+	}
+	if getEnv("GHOSTTY_RESOURCES_DIR") != "" {
+		return "ghostty"
+	}
+	return ""
+}
+
 // DetectAIAgent detects if the CLI was invoked by a coding agent, based on well-known env vars.
 // It accepts an environment getter function to allow testing without modifying the actual environment.
 func DetectAIAgent(getEnv func(string) string) string {

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -68,8 +68,11 @@ func DetectInScreen(getEnv func(string) string) bool {
 
 // DetectTerminalProgram detects the terminal program the CLI was invoked from, when available.
 func DetectTerminalProgram(getEnv func(string) string) string {
-	if program := getEnv("TERM_PROGRAM"); program != "" {
-		return program
+	if terminal := getEnv("LC_TERMINAL"); terminal != "" {
+		return terminal
+	}
+	if getEnv("WARP_CLIENT_VERSION") != "" {
+		return "warp"
 	}
 	if getEnv("WT_SESSION") != "" {
 		return "windows_terminal"
@@ -85,6 +88,9 @@ func DetectTerminalProgram(getEnv func(string) string) string {
 	}
 	if getEnv("GHOSTTY_RESOURCES_DIR") != "" {
 		return "ghostty"
+	}
+	if program := getEnv("TERM_PROGRAM"); program != "" {
+		return program
 	}
 	return ""
 }

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -106,7 +106,8 @@ func TestDetectTerminalProgram(t *testing.T) {
 		envs     map[string]string
 		expected string
 	}{
-		{"term program", map[string]string{"TERM_PROGRAM": "iTerm.app"}, "iTerm.app"},
+		{"lc terminal", map[string]string{"LC_TERMINAL": "iTerm2"}, "iTerm2"},
+		{"warp", map[string]string{"WARP_CLIENT_VERSION": "v0.2026.06.01"}, "warp"},
 		{"windows terminal", map[string]string{"WT_SESSION": "abc"}, "windows_terminal"},
 		{"kitty", map[string]string{"KITTY_WINDOW_ID": "1"}, "kitty"},
 		{"alacritty window id", map[string]string{"ALACRITTY_WINDOW_ID": "123"}, "alacritty"},
@@ -114,6 +115,8 @@ func TestDetectTerminalProgram(t *testing.T) {
 		{"wezterm executable", map[string]string{"WEZTERM_EXECUTABLE": "/Applications/WezTerm.app"}, "wezterm"},
 		{"wezterm pane", map[string]string{"WEZTERM_PANE": "1"}, "wezterm"},
 		{"ghostty", map[string]string{"GHOSTTY_RESOURCES_DIR": "/Applications/Ghostty.app/Contents/Resources"}, "ghostty"},
+		{"term program fallback", map[string]string{"TERM_PROGRAM": "Apple_Terminal"}, "Apple_Terminal"},
+		{"specific env wins over term program", map[string]string{"TERM_PROGRAM": "tmux", "LC_TERMINAL": "iTerm2"}, "iTerm2"},
 		{"unknown", map[string]string{}, ""},
 	}
 

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -63,3 +63,70 @@ func TestDetectInstallMethod(t *testing.T) {
 		})
 	}
 }
+
+func TestDetectInTmux(t *testing.T) {
+	tests := []struct {
+		name     string
+		envs     map[string]string
+		expected bool
+	}{
+		{"tmux", map[string]string{"TMUX": "/tmp/tmux-501/default,123,0"}, true},
+		{"not tmux", map[string]string{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetectInTmux(mapEnv(tt.envs))
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetectInScreen(t *testing.T) {
+	tests := []struct {
+		name     string
+		envs     map[string]string
+		expected bool
+	}{
+		{"screen", map[string]string{"STY": "1234.pts-0.host"}, true},
+		{"not screen", map[string]string{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetectInScreen(mapEnv(tt.envs))
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetectTerminalProgram(t *testing.T) {
+	tests := []struct {
+		name     string
+		envs     map[string]string
+		expected string
+	}{
+		{"term program", map[string]string{"TERM_PROGRAM": "iTerm.app"}, "iTerm.app"},
+		{"windows terminal", map[string]string{"WT_SESSION": "abc"}, "windows_terminal"},
+		{"kitty", map[string]string{"KITTY_WINDOW_ID": "1"}, "kitty"},
+		{"alacritty window id", map[string]string{"ALACRITTY_WINDOW_ID": "123"}, "alacritty"},
+		{"alacritty log", map[string]string{"ALACRITTY_LOG": "/tmp/alacritty.log"}, "alacritty"},
+		{"wezterm executable", map[string]string{"WEZTERM_EXECUTABLE": "/Applications/WezTerm.app"}, "wezterm"},
+		{"wezterm pane", map[string]string{"WEZTERM_PANE": "1"}, "wezterm"},
+		{"ghostty", map[string]string{"GHOSTTY_RESOURCES_DIR": "/Applications/Ghostty.app/Contents/Resources"}, "ghostty"},
+		{"unknown", map[string]string{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetectTerminalProgram(mapEnv(tt.envs))
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func mapEnv(envs map[string]string) func(string) string {
+	return func(key string) string {
+		return envs[key]
+	}
+}


### PR DESCRIPTION
## Summary
- add telemetry fields for whether the CLI runs inside tmux or GNU Screen
- add terminal program detection using TERM_PROGRAM and common terminal-specific fallback env vars
- include the new metadata on CLI telemetry events and API request telemetry

## Testing
- go test ./pkg/useragent
- go test ./pkg/stripe
- git -c core.fsmonitor=false diff --check
- env -u CODEX_SANDBOX -u CODEX_THREAD_ID -u CODEX_SANDBOX_NETWORK_DISABLED -u CODEX_CI go test ./...

Note: plain `go test ./...` fails in this Codex shell because `pkg/stripeauth` has an existing user-agent regex expectation that does not allow the environment-added `AIAgent/codex_cli` suffix.
