### PR TITLE
Revert "Fix release workflow: set NODE_AUTH_TOKEN for npm publish"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,8 +145,8 @@ jobs:
       - name: Publish platform packages
         run: |
           for dir in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
-            NODE_AUTH_TOKEN="" npm publish ./npm/$dir --access public
+            npm publish ./npm/$dir --access public
           done
 
       - name: Publish wrapper package
-        run: NODE_AUTH_TOKEN="" npm publish ./npm/wrapper --access public
+        run: npm publish ./npm/wrapper --access public


### PR DESCRIPTION
Reverts stripe/stripe-cli#1646 because it didn't fix the CI release