### PR TITLE
[npm] Add a `repository.directory` field to unblock OIDC publishing from monorepo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,8 +145,8 @@ jobs:
       - name: Publish platform packages
         run: |
           for dir in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
-            NODE_AUTH_TOKEN="" npm publish ./npm/$dir --access public
+            npm publish ./npm/$dir --access public
           done
 
       - name: Publish wrapper package
-        run: NODE_AUTH_TOKEN="" npm publish ./npm/wrapper --access public
+        run: npm publish ./npm/wrapper --access public

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/stripe/stripe-cli.git"
+    "url": "git+https://github.com/stripe/stripe-cli.git",
+    "directory": "npm/darwin-arm64"
   },
   "os": [
     "darwin"

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/stripe/stripe-cli.git"
+    "url": "git+https://github.com/stripe/stripe-cli.git",
+    "directory": "npm/darwin-x64"
   },
   "os": [
     "darwin"

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/stripe/stripe-cli.git"
+    "url": "git+https://github.com/stripe/stripe-cli.git",
+    "directory": "npm/linux-arm64"
   },
   "os": [
     "linux"

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/stripe/stripe-cli.git"
+    "url": "git+https://github.com/stripe/stripe-cli.git",
+    "directory": "npm/linux-x64"
   },
   "os": [
     "linux"

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/stripe/stripe-cli.git"
+    "url": "git+https://github.com/stripe/stripe-cli.git",
+    "directory": "npm/win32-x64"
   },
   "os": [
     "win32"

--- a/npm/wrapper/package.json
+++ b/npm/wrapper/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/stripe/stripe-cli.git"
+    "url": "git+https://github.com/stripe/stripe-cli.git",
+    "directory": "npm/wrapper"
   },
   "bin": {
     "stripe": "bin/shim.js"


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Guidance around the internet is a little confusing, but we've been finding strange behavior in OIDC authentication from our `release.yml` workflow. We've already tried:

- Upgrading to `actions/setup-node@v6`, this unblocked the per-platform packages but not the main one
- Setting `NODE_AUTH_TOKEN=""`, this didn't help

I found some sources discussing that in monorepos, including the `repository.directory` field can be necessary in order to build a valid provenance file.  If this does resolve the problem, then I'm very confused about why it worked for the per-platform packages but not the main one.  My going theory is that npm does some string munging under the hood which made the other packages look close enough, but the `wrapper` in the main CLI's path failed that.

Safe to revert if necessary.