### PR TITLE
Isolate keyring in sandbox command tests

### DIFF
--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/99designs/keyring"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,7 @@ func setupSandboxTestConfig(t *testing.T) func() {
 
 	origProfilesFile := Config.ProfilesFile
 	origProfileName := Config.Profile.ProfileName
+	origKeyRing := config.KeyRing
 
 	viper.Reset()
 	os.WriteFile(profilesFile, []byte("[default]\n"), 0600)
@@ -36,6 +38,7 @@ func setupSandboxTestConfig(t *testing.T) func() {
 	Config.Profile.ProfileName = "default"
 	Config.Profile.TestModeAPIKey = ""
 	Config.InitConfig()
+	config.KeyRing = keyring.NewArrayKeyring([]keyring.Item{})
 
 	// Mock browser to prevent real browser launches
 	origOpen := openBrowserFunc
@@ -53,6 +56,7 @@ func setupSandboxTestConfig(t *testing.T) func() {
 	return func() {
 		Config.ProfilesFile = origProfilesFile
 		Config.Profile.ProfileName = origProfileName
+		config.KeyRing = origKeyRing
 		openBrowserFunc = origOpen
 		canOpenBrowserFunc = origCanOpen
 		restoreLoginBrowser()


### PR DESCRIPTION
Committed-By-Agent: codex

### Reviewers

r? @tomer-stripe 
cc @stripe/developer-products

### Summary

This fixes a local test isolation issue in the Stripe CLI sandbox command tests.

Most Stripe CLI users will not run into this. The affected path is for contributors or agents working on `stripe-cli` locally who run package tests such as:

```sh
go test ./pkg/cmd
```

That is a normal validation step when changing command code under `pkg/cmd/...`. It is also the kind of broad verification command an agent may run after touching command packages.

`pkg/cmd` includes `sandbox_test.go`. The sandbox tests mock Dashboard auth and return fixture credentials such as:

```text
rk_live_dashboard
```

That fixture value was introduced with the sandbox command tests in PR #1577 / commit `fa17253ae6156ecc90ea0feb860db2c44136ab49`. The fixture itself is fine. The problem is that `setupSandboxTestConfig()` only isolates the config file by switching to a temporary `config.toml`. It still calls `Config.InitConfig()`, which opens the real macOS Keychain service used by the Stripe CLI. Some sandbox fallback tests then run the normal login save path, so the fake live-mode credential can be written into the developer's real `StripeCLI / default.live_mode_api_key` Keychain item.

Observed locally: after running the `pkg/cmd` tests, my real Keychain item contained `rk_live_dashboard`. Later, `stripe directory search ...` used that value as the bearer token and got a 401 from the Stripe API.

This change makes `setupSandboxTestConfig()` replace `config.KeyRing` with an in-memory keyring for the duration of the sandbox command tests, then restore the original keyring during cleanup. That keeps the fake Dashboard credentials inside the test process.

### Local recovery

If a local test run already wrote the fixture value into the real macOS Keychain entry, this removes the affected live-mode key and then re-authenticates the CLI:

```sh
security delete-generic-password -s StripeCLI -a default.live_mode_api_key
stripe login
```

To inspect the local value without changing it, this prints the unredacted secret, so do not paste the output into issues, PRs, or Slack:

```sh
security find-generic-password -s StripeCLI -a default.live_mode_api_key -w
```

### Useful context

- Fixture introduction: https://github.com/stripe/stripe-cli/pull/1577
- Fixture value: https://github.com/stripe/stripe-cli/blob/fa17253ae6156ecc90ea0feb860db2c44136ab49/pkg/cmd/sandbox_test.go#L112-L120
- Test setup isolated `config.toml` but not `config.KeyRing`: https://github.com/stripe/stripe-cli/blob/fa17253ae6156ecc90ea0feb860db2c44136ab49/pkg/cmd/sandbox_test.go#L25-L37
- `InitConfig()` opens the keyring: https://github.com/stripe/stripe-cli/blob/fa17253ae6156ecc90ea0feb860db2c44136ab49/pkg/config/config.go#L182-L184
- Live-mode key save writes to the keyring: https://github.com/stripe/stripe-cli/blob/fa17253ae6156ecc90ea0feb860db2c44136ab49/pkg/config/profile.go#L452-L460

### Testing

- `go test ./pkg/cmd`
- `git diff --check`
