### PR TITLE
[npm] Removing `registry-url` from our `actions/setup-node` config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,9 +141,6 @@ jobs:
             cp README.md npm/$dir/README.md
           done
 
-      - name: Upgrade npm to ensure OIDC support
-        run: npm i -g npm@latest
-
       - name: Publish platform packages
         run: |
           for dir in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
       - name: Derive version from tag
@@ -145,8 +144,8 @@ jobs:
       - name: Publish platform packages
         run: |
           for dir in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
-            npm publish ./npm/$dir --access public
+            npm publish ./npm/$dir
           done
 
       - name: Publish wrapper package
-        run: npm publish ./npm/wrapper --access public
+        run: npm publish ./npm/wrapper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
             cp README.md npm/$dir/README.md
           done
 
+      - name: Upgrade npm to ensure OIDC support
+        run: npm i -g npm@latest
+
       - name: Publish platform packages
         run: |
           for dir in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -9,6 +9,11 @@
     "url": "git+https://github.com/stripe/stripe-cli.git",
     "directory": "npm/darwin-arm64"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org",
+    "provenance": true
+  },
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -9,6 +9,11 @@
     "url": "git+https://github.com/stripe/stripe-cli.git",
     "directory": "npm/darwin-x64"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org",
+    "provenance": true
+  },
   "os": [
     "darwin"
   ],

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -9,6 +9,11 @@
     "url": "git+https://github.com/stripe/stripe-cli.git",
     "directory": "npm/linux-arm64"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org",
+    "provenance": true
+  },
   "os": [
     "linux"
   ],

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -9,6 +9,11 @@
     "url": "git+https://github.com/stripe/stripe-cli.git",
     "directory": "npm/linux-x64"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org",
+    "provenance": true
+  },
   "os": [
     "linux"
   ],

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -9,6 +9,11 @@
     "url": "git+https://github.com/stripe/stripe-cli.git",
     "directory": "npm/win32-x64"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org",
+    "provenance": true
+  },
   "os": [
     "win32"
   ],

--- a/npm/wrapper/package.json
+++ b/npm/wrapper/package.json
@@ -12,6 +12,11 @@
   "bin": {
     "stripe": "bin/shim.js"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org",
+    "provenance": true
+  },
   "scripts": {
     "postinstall": "node scripts/postinstall.js"
   },


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Many people are having [issues](https://github.com/npm/cli/issues/9088) with OIDC Trusted Publishing.  Another developer [found](https://github.com/alexanderop/defineworkflow/pull/41) that providing a `registry-url` to `action/setup-node`, as specified in npm's guidance, causes the action to produce an `.npmrc` file with an empty `NODE_AUTH_TOKEN`, breaking OIDC publishing.

Some users also mentioned needing a later LTS version, but our action is installing `node@24.16.0` and that [ships](https://nodejs.org/en/blog/release/v24.16.0#:~:text=%5B3e1036583a%5D%20%2D%20deps%3A%20upgrade%20npm%20to%2011.13.0%20(npm%20team)%20%2362898) with `npm@11.13.0`, which is later than the versions with reported issues. I'm choosing not to upgrade to `npm@latest` in here, as that may cause regressions down the road.

For the sake of the papertrail, here are all the references I've come across while researching to try and resolve this OIDC publishing issue:
- https://github.com/npm/cli/issues/9088
- https://github.com/orgs/community/discussions/176761
- https://github.com/npm/cli/issues/8730

If you look at the last one, the majority of issues referencing this problem are now talking about dropping the `registry-url`, so I'm hopeful that's the root cause.