### PR TITLE
Improve install-test: dryrun mode, winget support, and bug fixes

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -169,4 +169,3 @@ jobs:
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
           DRYRUN: ${{ inputs.dryrun }}
-          npm_config_optional: "true"

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -165,6 +165,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
+      - run: npm install -g npm@11
       - run: bash scripts/install-test.sh npx
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -165,6 +165,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
+      # npm 10 has a bug where conflicting bin entries across a package and its
+      # optional dependency silently drop the bin link, causing "stripe: not found".
       - run: npm install -g npm@11
       - run: bash scripts/install-test.sh npx
         env:

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,5 +1,10 @@
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: 'Skip PagerDuty alert on failure'
+        type: boolean
+        default: true
   schedule:
     - cron: '0 * * * *' # Every hour
 name: Package manager test
@@ -17,6 +22,7 @@ jobs:
       - run: bash scripts/install-test.sh homebrew
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          DRYRUN: ${{ inputs.dryrun }}
   apt:
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +34,7 @@ jobs:
       - run: bash scripts/install-test.sh apt
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          DRYRUN: ${{ inputs.dryrun }}
   yum:
     runs-on: ubuntu-latest
     container: fedora:latest
@@ -50,6 +57,7 @@ jobs:
       - run: bash scripts/install-test.sh yum
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          DRYRUN: ${{ inputs.dryrun }}
   scoop:
     runs-on: windows-latest
     steps:
@@ -63,6 +71,7 @@ jobs:
       run: bash scripts/install-test.sh scoop
       env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          DRYRUN: ${{ inputs.dryrun }}
   winget:
     runs-on: windows-latest
     steps:
@@ -90,6 +99,12 @@ jobs:
         run: |
           $manifestDir = Get-ChildItem -Path dist/winget/manifests -Recurse -Directory | Where-Object { $_.GetFiles("*.yaml").Count -gt 0 } | Select-Object -First 1
           winget validate --ignore-warnings $manifestDir.FullName
+      - name: Test winget install
+        shell: powershell
+        run: bash scripts/install-test.sh winget
+        env:
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          DRYRUN: ${{ inputs.dryrun }}
   docker:
     runs-on: ubuntu-latest
     container: stripe/stripe-cli:latest
@@ -102,6 +117,7 @@ jobs:
       - run: sh scripts/install-test.sh docker
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          DRYRUN: ${{ inputs.dryrun }}
 
   npm:
     strategy:
@@ -120,6 +136,7 @@ jobs:
       - run: bash scripts/install-test.sh npm
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          DRYRUN: ${{ inputs.dryrun }}
 
   npm-no-optional:
     runs-on: ubuntu-latest
@@ -135,6 +152,7 @@ jobs:
       - run: bash scripts/install-test.sh npm-no-optional
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          DRYRUN: ${{ inputs.dryrun }}
 
   npx:
     runs-on: ubuntu-latest
@@ -150,3 +168,4 @@ jobs:
       - run: bash scripts/install-test.sh npx
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          DRYRUN: ${{ inputs.dryrun }}

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -169,3 +169,4 @@ jobs:
         env:
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
           DRYRUN: ${{ inputs.dryrun }}
+          npm_config_optional: "true"

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -41,6 +41,13 @@ run_install() {
 
     winget)
         winget install --id Stripe.StripeCli --accept-source-agreements --accept-package-agreements
+        # winget modifies the user PATH but the current shell doesn't inherit the change;
+        # refresh it by reading the updated value from the Windows environment.
+        WINGET_PATH=$(powershell.exe -NoProfile -Command '[Environment]::GetEnvironmentVariable("PATH","User")' 2>/dev/null | tr -d '\r')
+        if [ -n "$WINGET_PATH" ]; then
+            PATH="$PATH:$(echo "$WINGET_PATH" | tr ';' ':')"
+            export PATH
+        fi
         stripe --version
     ;;
 

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -64,6 +64,13 @@ run_install() {
         echo "node: $(node --version)"
         echo "npm: $(npm --version)"
         echo "platform: $(uname -s) $(uname -m)"
+        _tmpdir=$(mktemp -d)
+        npm install --prefix "$_tmpdir" @stripe/cli 2>&1
+        echo "=== installed @stripe/* packages ==="
+        npm ls --prefix "$_tmpdir" --depth=1 2>/dev/null
+        echo "=== platform binary ==="
+        find "$_tmpdir/node_modules/@stripe" \( -name "stripe" -o -name "stripe.exe" \) -exec ls -la {} + 2>/dev/null || echo "no binary found"
+        rm -rf "$_tmpdir"
         npx --yes @stripe/cli --version
     ;;
 

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -62,7 +62,6 @@ run_install() {
 
     npx)
         npx --yes @stripe/cli --version
-        return $?
     ;;
 
     *)

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -7,10 +7,17 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
+if [ "${DRYRUN:-false}" = "true" ]; then
+    echo "Dry run mode: PagerDuty alerts will be suppressed"
+else
+    echo "Live mode: PagerDuty alerts are enabled"
+fi
+
 run_install() {
     case $PACKAGE_MANAGER in
     homebrew)
         brew install stripe/stripe-cli/stripe
+        stripe --version
     ;;
 
     apt)
@@ -18,31 +25,43 @@ run_install() {
         echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee -a /etc/apt/sources.list.d/stripe.list
         sudo apt update
         sudo apt install stripe
+        stripe --version
     ;;
 
     yum)
         yum -y install stripe
+        stripe --version
     ;;
 
     scoop)
         scoop bucket add stripe https://github.com/stripe/scoop-stripe-cli.git
         scoop install stripe
+        stripe --version
+    ;;
+
+    winget)
+        winget install --id Stripe.StripeCli --accept-source-agreements --accept-package-agreements
+        stripe --version
     ;;
 
     docker)
+        docker pull stripe/stripe-cli:latest
+        docker run --rm stripe/stripe-cli:latest --version
     ;;
 
     npm)
         npm install -g @stripe/cli
+        stripe --version
     ;;
 
     npm-no-optional)
         npm install -g @stripe/cli --no-optional
+        stripe --version
     ;;
 
     npx)
         npx --yes @stripe/cli --version
-        exit $?
+        return $?
     ;;
 
     *)
@@ -52,11 +71,17 @@ run_install() {
         exit 1
         ;;
     esac
-
-    stripe --version
 }
 
 trigger_pagerduty_alert() {
+    if [ "${DRYRUN:-false}" = "true" ]; then
+        echo "Dry run: PagerDuty alert would have fired with:"
+        echo "  summary:  Failed to install Stripe CLI on one or more operating systems. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml"
+        echo "  timestamp: $(date)"
+        echo "  source:   Stripe CLI GitHub Actions"
+        echo "  severity: critical"
+        return 0
+    fi
     sh -c "$(curl -sL https://raw.githubusercontent.com/martindstone/pagerduty-cli/master/install.sh)"
     pd event alert --routing_key "$PAGERDUTY_INTEGRATION_KEY" \
     --summary "Failed to install Stripe CLI on one or more operating systems. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml" \

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -70,6 +70,10 @@ run_install() {
         npm ls --prefix "$_tmpdir" --depth=1 2>/dev/null
         echo "=== platform binary ==="
         find "$_tmpdir/node_modules/@stripe" \( -name "stripe" -o -name "stripe.exe" \) -exec ls -la {} + 2>/dev/null || echo "no binary found"
+        echo "=== node_modules/.bin/stripe ==="
+        ls -la "$_tmpdir/node_modules/.bin/stripe" 2>/dev/null || echo "bin link not found"
+        file "$_tmpdir/node_modules/.bin/stripe" 2>/dev/null || true
+        cat "$_tmpdir/node_modules/.bin/stripe" 2>/dev/null || echo "(not a text file)"
         rm -rf "$_tmpdir"
         npx --yes @stripe/cli --version
     ;;

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -61,20 +61,6 @@ run_install() {
     ;;
 
     npx)
-        echo "node: $(node --version)"
-        echo "npm: $(npm --version)"
-        echo "platform: $(uname -s) $(uname -m)"
-        _tmpdir=$(mktemp -d)
-        npm install --prefix "$_tmpdir" @stripe/cli 2>&1
-        echo "=== installed @stripe/* packages ==="
-        npm ls --prefix "$_tmpdir" --depth=1 2>/dev/null
-        echo "=== platform binary ==="
-        find "$_tmpdir/node_modules/@stripe" \( -name "stripe" -o -name "stripe.exe" \) -exec ls -la {} + 2>/dev/null || echo "no binary found"
-        echo "=== node_modules/.bin/stripe ==="
-        ls -la "$_tmpdir/node_modules/.bin/stripe" 2>/dev/null || echo "bin link not found"
-        file "$_tmpdir/node_modules/.bin/stripe" 2>/dev/null || true
-        cat "$_tmpdir/node_modules/.bin/stripe" 2>/dev/null || echo "(not a text file)"
-        rm -rf "$_tmpdir"
         npx --yes @stripe/cli --version
     ;;
 

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -41,13 +41,10 @@ run_install() {
 
     winget)
         winget install --id Stripe.StripeCli --accept-source-agreements --accept-package-agreements
-        # winget modifies the user PATH but the current shell doesn't inherit the change;
-        # refresh it by reading the updated value from the Windows environment.
-        WINGET_PATH=$(powershell.exe -NoProfile -Command '[Environment]::GetEnvironmentVariable("PATH","User")' 2>/dev/null | tr -d '\r')
-        if [ -n "$WINGET_PATH" ]; then
-            PATH="$PATH:$(echo "$WINGET_PATH" | tr ';' ':')"
-            export PATH
-        fi
+        # winget modifies PATH but the current shell process doesn't inherit the change;
+        # explicitly add the WinGet Links directory where the stripe alias was created.
+        PATH="$PATH:$(cygpath -u "$LOCALAPPDATA/Microsoft/WinGet/Links")"
+        export PATH
         stripe --version
     ;;
 

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -61,7 +61,7 @@ run_install() {
     ;;
 
     npx)
-        npx --include=optional --yes @stripe/cli --version
+        npx --yes @stripe/cli --version
         return $?
     ;;
 

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -61,6 +61,9 @@ run_install() {
     ;;
 
     npx)
+        echo "node: $(node --version)"
+        echo "npm: $(npm --version)"
+        echo "platform: $(uname -s) $(uname -m)"
         npx --yes @stripe/cli --version
     ;;
 

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -45,8 +45,9 @@ run_install() {
     ;;
 
     docker)
-        docker pull stripe/stripe-cli:latest
-        docker run --rm stripe/stripe-cli:latest --version
+        # The workflow runs this script inside the stripe/stripe-cli:latest container,
+        # so the stripe binary is already present. No install step needed.
+        stripe --version
     ;;
 
     npm)
@@ -60,7 +61,7 @@ run_install() {
     ;;
 
     npx)
-        npx --yes @stripe/cli --version
+        npx --include=optional --yes @stripe/cli --version
         return $?
     ;;
 


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Updates the package manager test:
- Fix the npx and winget tests. Today these tests are not actually covering these flows end to end.
- Add a dryrun mode so you can test changes to this workflow manually before merging to master. Go to https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml, select your branch, and click Run workflow:
<img width="345" height="283" alt="Screenshot 2026-06-09 at 4 49 17 PM" src="https://github.com/user-attachments/assets/24984ef1-e6e5-4da7-995c-f4818306f723" />

Example of what the dryrun output looks like:
```
Dry run: PagerDuty alert would have fired with:
  summary:  Failed to install Stripe CLI on one or more operating systems. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml
  timestamp: Tue Jun  9 23:01:36 CUT 2026
  source:   Stripe CLI GitHub Actions
  severity: critical
```

Example of everything passing: https://github.com/stripe/stripe-cli/actions/runs/27293760201
