### PR TITLE
Fix Winget release: split Windows publish into two steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,12 +86,29 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 1.26.0
-      - name: Run GoReleaser
+      - name: Publish Windows release assets
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release -f .goreleaser/windows.yml --clean
+          args: release -f .goreleaser/windows.yml --clean --skip=scoop,winget
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+      - name: Wait for public Windows release assets
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          bash scripts/wait-for-github-release-assets.sh stripe/stripe-cli "$GITHUB_REF_NAME" \
+            "stripe_${version}_windows_i386.zip" \
+            "stripe_${version}_windows_x86_64.zip"
+      - name: Publish Scoop and Winget manifests
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release -f .goreleaser/windows.yml --clean --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}

--- a/scripts/wait-for-github-release-assets.sh
+++ b/scripts/wait-for-github-release-assets.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 <repo> <tag> <asset> [<asset> ...]"
+  exit 1
+fi
+
+repo="$1"
+tag="$2"
+shift 2
+
+attempts="${RELEASE_ASSET_CHECK_ATTEMPTS:-20}"
+sleep_seconds="${RELEASE_ASSET_CHECK_INTERVAL_SECONDS:-15}"
+
+for asset in "$@"; do
+  url="https://github.com/${repo}/releases/download/${tag}/${asset}"
+  echo "Waiting for public release asset: ${url}"
+
+  available=false
+  attempt=1
+  while [ "$attempt" -le "$attempts" ]; do
+    status_code="$(curl -sSI -o /dev/null -w "%{http_code}" "$url" || true)"
+    if [ "$status_code" = "200" ] || [ "$status_code" = "302" ]; then
+      echo "Asset is reachable: ${asset}"
+      available=true
+      break
+    fi
+
+    echo "Attempt ${attempt}/${attempts} returned HTTP ${status_code:-unknown} for ${asset}"
+    if [ "$attempt" -lt "$attempts" ]; then
+      sleep "$sleep_seconds"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  if [ "$available" != "true" ]; then
+    echo "Timed out waiting for public release asset: ${asset}"
+    exit 1
+  fi
+done


### PR DESCRIPTION
Winget and Scoop manifest publishing requires the release assets to be publicly available on GitHub before the manifest PRs are opened. This splits the Windows GoReleaser invocation into two steps—first publishing the binaries (skipping scoop/winget), then waiting for the assets to become reachable, and finally running the manifest publishers (skipping the binary publish). A helper script polls for public asset availability between the two steps.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
