### PR TITLE
Run package manager test every 10 minutes instead of hourly

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -6,7 +6,7 @@ on:
         type: boolean
         default: true
   schedule:
-    - cron: '0 * * * *' # Every hour
+    - cron: '*/10 * * * *' # Every 10 minutes
 name: Package manager test
 permissions:
   contents: read


### PR DESCRIPTION
This will help us catch issues faster.