### PR TITLE
Require approval before releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,14 @@ permissions:
   id-token: write # Required for OIDC to npm
 
 jobs:
+  approve-release:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - run: echo "Release approved, proceeding."
+
   canary-tests:
+    needs: [approve-release]
     uses: ./.github/workflows/canary-test.yml
     with:
       run_api_tests: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,22 +10,22 @@ permissions:
   id-token: write # Required for OIDC to npm
 
 jobs:
-  approve-release:
-    runs-on: ubuntu-latest
-    environment: release
-    steps:
-      - run: echo "Release approved, proceeding."
-
   canary-tests:
-    needs: [approve-release]
     uses: ./.github/workflows/canary-test.yml
     with:
       run_api_tests: true
     secrets:
       STRIPE_TEST_API_KEY: ${{ secrets.STRIPE_TEST_API_KEY }}
 
-  build-mac:
+  approve-release:
     needs: [canary-tests]
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - run: echo "Release approved, proceeding."
+
+  build-mac:
+    needs: [approve-release]
     runs-on: macos-latest
     steps:
       - name: Code checkout
@@ -47,7 +47,7 @@ jobs:
           GORELEASER_GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
 
   build-linux:
-    needs: [canary-tests]
+    needs: [approve-release]
     runs-on: ubuntu-22.04
     env:
       # https://goreleaser.com/customization/docker_manifest/
@@ -82,7 +82,7 @@ jobs:
           ARTIFACTORY_SECRET: ${{ secrets.ARTIFACTORY_SECRET }}
 
   build-windows:
-    needs: [canary-tests]
+    needs: [approve-release]
     runs-on: windows-latest
     steps:
       - name: Code checkout

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,12 @@ release:
 # Makefile's execute each line in its own subshell so variables don't
 # persist. Instead, grab the version and run the `tag` command in the same
 # subprocess by escaping the newline
-	@read -p "Enter new version (of the format vN.N.N): " version; \
+	@current=$$(git tag --sort=-version:refname | head -1); \
+	read -p "Enter new version (of the format vN.N.N) [current latest: $$current]: " version; \
+	case "$$version" in \
+	  v*) ;; \
+	  *) echo "Error: version must start with 'v'" && exit 1 ;; \
+	esac; \
 	git tag $$version && \
 	git push origin refs/tags/$$version
 .PHONY: release


### PR DESCRIPTION
### Summary

Updates the release workflow to wait for the `release` github environment to be approved.

Before:
```
canary-tests → build-mac / build-linux / build-windows 
```

After:
```
canary-tests → approve-release (pauses for approval) → build-mac / build-linux / build-windows 
```

I set up the `release` github environment so that:
- it requires a member of @stripe/developer-products to approve it
- only semver tags can be deployed to it

For better DX, I also updated the `make release` prompt to show the most recent version and validate the name of the tag.

I think I can only test this by pushing a tag for real, so I will do that once this PR merges.