### PR TITLE
Fix PagerDuty not working on Windows and minimal Docker containers

### DIFF
--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -77,8 +77,19 @@ run_install() {
     esac
 }
 
-install_pd_cli() {
-    sh -c "$(curl -sL https://raw.githubusercontent.com/martindstone/pagerduty-cli/master/install.sh)"
+send_pagerduty_event() {
+    body="$1"
+    if command -v curl >/dev/null 2>&1; then
+        curl -s -X POST https://events.pagerduty.com/v2/enqueue \
+            -H "Content-Type: application/json" \
+            -d "$body"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q -O- --post-data="$body" --header="Content-Type: application/json" \
+            https://events.pagerduty.com/v2/enqueue
+    else
+        echo "Error: neither curl nor wget available; cannot send PagerDuty notification" >&2
+        return 1
+    fi
 }
 
 trigger_pagerduty_alert() {
@@ -92,15 +103,17 @@ trigger_pagerduty_alert() {
         echo "  severity:  critical"
         return 0
     fi
-    install_pd_cli
-    pd event alert \
-        --action trigger \
-        --routing_key "$PAGERDUTY_INTEGRATION_KEY" \
-        --dedup_key "gh-actions-stripe-cli-install-test" \
-        --summary "Failed to install Stripe CLI on one or more operating systems. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml" \
-        --timestamp "\"$(date)\"" \
-        --source "Stripe CLI GitHub Actions" \
-        --severity critical
+    send_pagerduty_event '{
+        "routing_key": "'"$PAGERDUTY_INTEGRATION_KEY"'",
+        "event_action": "trigger",
+        "dedup_key": "gh-actions-stripe-cli-install-test",
+        "payload": {
+            "summary": "Failed to install Stripe CLI on one or more operating systems. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml",
+            "source": "Stripe CLI GitHub Actions",
+            "severity": "critical",
+            "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+        }
+    }'
 }
 
 resolve_pagerduty_alert() {
@@ -112,13 +125,16 @@ resolve_pagerduty_alert() {
         echo "  source:    Stripe CLI GitHub Actions"
         return 0
     fi
-    install_pd_cli
-    pd event alert \
-        --action resolve \
-        --routing_key "$PAGERDUTY_INTEGRATION_KEY" \
-        --dedup_key "gh-actions-stripe-cli-install-test" \
-        --source "Stripe CLI GitHub Actions" \
-        --summary "Stripe CLI installation is passing again"
+    send_pagerduty_event '{
+        "routing_key": "'"$PAGERDUTY_INTEGRATION_KEY"'",
+        "event_action": "resolve",
+        "dedup_key": "gh-actions-stripe-cli-install-test",
+        "payload": {
+            "summary": "Stripe CLI installation is passing again",
+            "source": "Stripe CLI GitHub Actions",
+            "severity": "info"
+        }
+    }'
 }
 
 if ! run_install


### PR DESCRIPTION
Fixes the package manager test not working on windows and docker because the pagerduty CLI we were using doesn't work there. This likely never worked! This replaces it with direct curl (and wget for the docker test) to the pagerduty API.

Here is an example of the failures: https://github.com/stripe/stripe-cli/actions/runs/27307309347
Here it is all passing for real with this change: https://github.com/stripe/stripe-cli/actions/runs/27309326302