### PR TITLE
Add macOS code signing and notarization

### DIFF
--- a/.goreleaser/mac.yml
+++ b/.goreleaser/mac.yml
@@ -44,6 +44,21 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      ids:
+        - stripe-darwin
+        - stripe-darwin-arm
+      sign:
+        certificate: "{{.Env.MACOS_SIGN_P12}}"
+        password: "{{.Env.MACOS_SIGN_PASSWORD}}"
+      notarize:
+        issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
+        key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
+        key: "{{.Env.MACOS_NOTARY_KEY}}"
+        wait: true
+        timeout: 20m
 checksum:
   name_template: "{{ .ProjectName }}-mac-checksums.txt"
 release:


### PR DESCRIPTION
## Summary
- Adds notarization config to the macOS GoReleaser build using the cross-platform (quill) pipeline
- Signs both amd64 and arm64 darwin binaries with a Developer ID Application certificate
- Submits signed binaries to Apple's notary service and waits for acceptance before proceeding
- Gated behind `MACOS_SIGN_P12` env var — builds without secrets skip notarization

## Required CI Secrets
The following secrets need to be added to the release workflow environment:
- `MACOS_SIGN_P12` — base64-encoded .p12 signing certificate
- `MACOS_SIGN_PASSWORD` — password for the .p12
- `MACOS_NOTARY_ISSUER_ID` — App Store Connect API issuer ID
- `MACOS_NOTARY_KEY_ID` — App Store Connect API key ID
- `MACOS_NOTARY_KEY` — base64-encoded .p8 API key

## Test plan
- [x] Verified signing + notarization locally with `xcrun notarytool submit`
- [x] Ran `goreleaser release --snapshot --clean --skip=publish` with all secrets set — both architectures signed and submitted successfully
- [x] Confirmed `isEnvSet` guard skips notarization when secrets are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)