### PR TITLE
Support experimental UAT login

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -414,6 +414,7 @@ func (c *Config) RemoveAuthFields(profileName string) error {
 				p := &Profile{ProfileName: field}
 				runtimeViper = p.deleteAuthFields(runtimeViper)
 				deleteLivemodeKey(LiveModeAPIKeyName, field)
+				deleteLivemodeKey(UATName, field)
 			}
 		}
 	}
@@ -431,6 +432,7 @@ func (c *Config) RemoveAllAuthFields() error {
 			p := &Profile{ProfileName: field}
 			runtimeViper = p.deleteAuthFields(runtimeViper)
 			deleteLivemodeKey(LiveModeAPIKeyName, field)
+			deleteLivemodeKey(UATName, field)
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -414,9 +414,14 @@ func (c *Config) RemoveAuthFields(profileName string) error {
 				p := &Profile{ProfileName: field}
 				runtimeViper = p.deleteAuthFields(runtimeViper)
 				deleteLivemodeKey(LiveModeAPIKeyName, field)
-				deleteLivemodeKey(UATName, field)
 			}
 		}
+	}
+
+	deleteTopLevelLivemodeKey(UATKeychainItemKey)
+
+	if runtimeViper.IsSet(UserInfoName) {
+		runtimeViper, _ = removeKey(runtimeViper, UserInfoName)
 	}
 
 	return writeConfig(runtimeViper)
@@ -432,8 +437,13 @@ func (c *Config) RemoveAllAuthFields() error {
 			p := &Profile{ProfileName: field}
 			runtimeViper = p.deleteAuthFields(runtimeViper)
 			deleteLivemodeKey(LiveModeAPIKeyName, field)
-			deleteLivemodeKey(UATName, field)
 		}
+	}
+
+	deleteTopLevelLivemodeKey(UATKeychainItemKey)
+
+	if runtimeViper.IsSet(UserInfoName) {
+		runtimeViper, _ = removeKey(runtimeViper, UserInfoName)
 	}
 
 	return writeConfig(runtimeViper)
@@ -448,6 +458,20 @@ func deleteLivemodeKey(key string, profile string) error {
 	for _, item := range existingKeys {
 		if item == fieldID {
 			KeyRing.Remove(fieldID)
+			return nil
+		}
+	}
+	return nil
+}
+
+func deleteTopLevelLivemodeKey(key string) error {
+	existingKeys, err := KeyRing.Keys()
+	if err != nil {
+		return err
+	}
+	for _, item := range existingKeys {
+		if item == key {
+			KeyRing.Remove(key)
 			return nil
 		}
 	}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -33,6 +33,9 @@ type Profile struct {
 	AccountID              string
 	SandboxClaimURL        string
 	SandboxExpiresAt       string
+	UAT                    string
+	LiveContext            string
+	TestWorkspaceID        string
 }
 
 // config key names
@@ -49,6 +52,9 @@ const (
 	LiveModeKeyExpiresAtName   = "live_mode_key_expires_at"
 	SandboxClaimURLName        = "sandbox_claim_url"
 	SandboxExpiresAtName       = "sandbox_expires_at"
+	UATName                    = "uat"
+	LiveContextName            = "live_context"
+	TestWorkspaceIDName        = "test_workspace_id"
 )
 
 const (
@@ -487,6 +493,18 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 
 	if p.SandboxExpiresAt != "" {
 		runtimeViper.Set(p.GetConfigField(SandboxExpiresAtName), strings.TrimSpace(p.SandboxExpiresAt))
+	}
+
+	if p.UAT != "" {
+		p.saveLivemodeValue(UATName, strings.TrimSpace(p.UAT), "UAT")
+	}
+
+	if p.LiveContext != "" {
+		runtimeViper.Set(p.GetConfigField(LiveContextName), strings.TrimSpace(p.LiveContext))
+	}
+
+	if p.TestWorkspaceID != "" {
+		runtimeViper.Set(p.GetConfigField(TestWorkspaceIDName), strings.TrimSpace(p.TestWorkspaceID))
 	}
 
 	runtimeViper.MergeInConfig()

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -136,6 +136,8 @@ var authFieldNames = []string{
 	LiveModeAPIKeyName,
 	LiveModePubKeyName,
 	LiveModeKeyExpiresAtName,
+	LiveContextName,
+	TestWorkspaceIDName,
 	"profile_name",
 	// sandbox-specific fields from stripe sandbox create
 	SandboxClaimURLName,

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -515,12 +515,16 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 		runtimeViper.Set(p.GetConfigField(SandboxExpiresAtName), strings.TrimSpace(p.SandboxExpiresAt))
 	}
 
-	if p.UAT != "" {
-		_ = KeyRing.Set(keyring.Item{
-			Key:   UATKeychainItemKey,
-			Data:  []byte(strings.TrimSpace(p.UAT)),
-			Label: "Stripe CLI user access token",
-		})
+	if KeyRing != nil {
+		if p.UAT != "" {
+			_ = KeyRing.Set(keyring.Item{
+				Key:   UATKeychainItemKey,
+				Data:  []byte(strings.TrimSpace(p.UAT)),
+				Label: "Stripe CLI user access token",
+			})
+		} else {
+			_ = KeyRing.Remove(UATKeychainItemKey)
+		}
 	}
 
 	if p.UserInfo != nil {

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -21,22 +21,14 @@ import (
 
 // Compartment represents a Stripe compartment from the OIDC userinfo response.
 type Compartment struct {
-	CompartmentID   string   `json:"compartment_id"   mapstructure:"compartment_id"   toml:"compartment_id"`
-	CompartmentType string   `json:"compartment_type" mapstructure:"compartment_type" toml:"compartment_type"`
-	Livemode        bool     `json:"livemode"         mapstructure:"livemode"         toml:"livemode"`
-	Permissions     []string `json:"permissions"      mapstructure:"permissions"      toml:"permissions"`
+	CompartmentID string `json:"compartment_id" mapstructure:"compartment_id" toml:"compartment_id"`
+	Livemode      bool   `json:"livemode"        mapstructure:"livemode"        toml:"livemode"`
 }
 
 // UserInfo mirrors the OIDC userinfo endpoint response and is persisted as a
 // nested table in the profile config.
 type UserInfo struct {
-	Sub                    string        `json:"sub"                                              mapstructure:"sub"                       toml:"sub"`
-	Email                  string        `json:"email"                                            mapstructure:"email"                     toml:"email"`
-	EmailVerified          bool          `json:"email_verified"                                   mapstructure:"email_verified"             toml:"email_verified"`
-	Name                   string        `json:"name"                                             mapstructure:"name"                      toml:"name"`
-	Compartments           []Compartment `json:"https://stripe.com/compartments"                  mapstructure:"compartments"               toml:"compartments"`
-	InheritUserPermissions bool          `json:"https://stripe.com/inherit_user_permissions"      mapstructure:"inherit_user_permissions"   toml:"inherit_user_permissions"`
-	PermissionsUpdatedAt   string        `json:"https://stripe.com/permissions_updated_at"        mapstructure:"permissions_updated_at"     toml:"permissions_updated_at"`
+	Compartments []Compartment `json:"https://stripe.com/compartments" mapstructure:"compartments" toml:"compartments"`
 }
 
 // Profile handles all things related to managing the project specific configurations

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -53,8 +53,8 @@ type Profile struct {
 	AccountID              string
 	SandboxClaimURL        string
 	SandboxExpiresAt       string
-	UAT      string
-	UserInfo *UserInfo
+	UAT                    string
+	UserInfo               *UserInfo
 }
 
 // config key names

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -19,6 +19,26 @@ import (
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
+// Compartment represents a Stripe compartment from the OIDC userinfo response.
+type Compartment struct {
+	CompartmentID   string   `json:"compartment_id"   mapstructure:"compartment_id"   toml:"compartment_id"`
+	CompartmentType string   `json:"compartment_type" mapstructure:"compartment_type" toml:"compartment_type"`
+	Livemode        bool     `json:"livemode"         mapstructure:"livemode"         toml:"livemode"`
+	Permissions     []string `json:"permissions"      mapstructure:"permissions"      toml:"permissions"`
+}
+
+// UserInfo mirrors the OIDC userinfo endpoint response and is persisted as a
+// nested table in the profile config.
+type UserInfo struct {
+	Sub                    string        `json:"sub"                                              mapstructure:"sub"                       toml:"sub"`
+	Email                  string        `json:"email"                                            mapstructure:"email"                     toml:"email"`
+	EmailVerified          bool          `json:"email_verified"                                   mapstructure:"email_verified"             toml:"email_verified"`
+	Name                   string        `json:"name"                                             mapstructure:"name"                      toml:"name"`
+	Compartments           []Compartment `json:"https://stripe.com/compartments"                  mapstructure:"compartments"               toml:"compartments"`
+	InheritUserPermissions bool          `json:"https://stripe.com/inherit_user_permissions"      mapstructure:"inherit_user_permissions"   toml:"inherit_user_permissions"`
+	PermissionsUpdatedAt   string        `json:"https://stripe.com/permissions_updated_at"        mapstructure:"permissions_updated_at"     toml:"permissions_updated_at"`
+}
+
 // Profile handles all things related to managing the project specific configurations
 type Profile struct {
 	DeviceName             string
@@ -33,9 +53,8 @@ type Profile struct {
 	AccountID              string
 	SandboxClaimURL        string
 	SandboxExpiresAt       string
-	UAT                    string
-	LiveContext            string
-	TestWorkspaceID        string
+	UAT      string
+	UserInfo *UserInfo
 }
 
 // config key names
@@ -52,10 +71,10 @@ const (
 	LiveModeKeyExpiresAtName   = "live_mode_key_expires_at"
 	SandboxClaimURLName        = "sandbox_claim_url"
 	SandboxExpiresAtName       = "sandbox_expires_at"
-	UATName                    = "uat"
-	LiveContextName            = "live_context"
-	TestWorkspaceIDName        = "test_workspace_id"
+	UserInfoName               = "user_info"
 )
+
+const UATKeychainItemKey = "uat"
 
 const (
 	// DateStringFormat is the format for expiredAt date
@@ -136,8 +155,6 @@ var authFieldNames = []string{
 	LiveModeAPIKeyName,
 	LiveModePubKeyName,
 	LiveModeKeyExpiresAtName,
-	LiveContextName,
-	TestWorkspaceIDName,
 	"profile_name",
 	// sandbox-specific fields from stripe sandbox create
 	SandboxClaimURLName,
@@ -158,6 +175,15 @@ func (p *Profile) CreateProfile() error {
 
 	// Fail open to avoid blocking login
 	p.deleteLivemodeValue(LiveModeAPIKeyName)
+
+	// user_info is top-level; remove it before re-writing so stale data is never kept
+	if v.IsSet(UserInfoName) {
+		var err error
+		v, err = removeKey(v, UserInfoName)
+		if err != nil {
+			return err
+		}
+	}
 
 	writeErr := p.writeProfile(v)
 	if writeErr != nil {
@@ -498,15 +524,15 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 	}
 
 	if p.UAT != "" {
-		p.saveLivemodeValue(UATName, strings.TrimSpace(p.UAT), "UAT")
+		_ = KeyRing.Set(keyring.Item{
+			Key:   UATKeychainItemKey,
+			Data:  []byte(strings.TrimSpace(p.UAT)),
+			Label: "Stripe CLI user access token",
+		})
 	}
 
-	if p.LiveContext != "" {
-		runtimeViper.Set(p.GetConfigField(LiveContextName), strings.TrimSpace(p.LiveContext))
-	}
-
-	if p.TestWorkspaceID != "" {
-		runtimeViper.Set(p.GetConfigField(TestWorkspaceIDName), strings.TrimSpace(p.TestWorkspaceID))
+	if p.UserInfo != nil {
+		runtimeViper.Set(UserInfoName, p.UserInfo)
 	}
 
 	runtimeViper.MergeInConfig()
@@ -640,6 +666,25 @@ func (p *Profile) deleteLivemodeValue(key string) error {
 		}
 	}
 	return nil
+}
+
+// GetUserInfo reads the stored UserInfo from the profile config.
+// Returns nil, nil when no user_info has been saved yet.
+func (p *Profile) GetUserInfo() (*UserInfo, error) {
+	if err := viper.ReadInConfig(); err != nil {
+		return nil, err
+	}
+
+	if !viper.IsSet(UserInfoName) {
+		return nil, nil
+	}
+
+	var ui UserInfo
+	if err := viper.UnmarshalKey(UserInfoName, &ui); err != nil {
+		return nil, err
+	}
+
+	return &ui, nil
 }
 
 // SessionCredentials are the credentials needed for this session

--- a/pkg/login/keys/configurer.go
+++ b/pkg/login/keys/configurer.go
@@ -46,16 +46,14 @@ func (c *RAKConfigurer) SaveLoginDetails(response *PollAPIKeyResponse) error {
 	var compartments []config.Compartment
 	if response.LiveContext != "" {
 		compartments = append(compartments, config.Compartment{
-			CompartmentID:   response.LiveContext,
-			CompartmentType: "account",
-			Livemode:        true,
+			CompartmentID: response.LiveContext,
+			Livemode:      true,
 		})
 	}
 	if response.TestWorkspaceID != "" {
 		compartments = append(compartments, config.Compartment{
-			CompartmentID:   response.TestWorkspaceID,
-			CompartmentType: "account",
-			Livemode:        false,
+			CompartmentID: response.TestWorkspaceID,
+			Livemode:      false,
 		})
 	}
 	if len(compartments) > 0 {

--- a/pkg/login/keys/configurer.go
+++ b/pkg/login/keys/configurer.go
@@ -60,6 +60,8 @@ func (c *RAKConfigurer) SaveLoginDetails(response *PollAPIKeyResponse) error {
 		c.cfg.Profile.UserInfo = &config.UserInfo{
 			Compartments: compartments,
 		}
+	} else {
+		c.cfg.Profile.UserInfo = nil
 	}
 
 	// TODO: AccountDisplayName appears to be empty for test mode accounts; is there a better default?

--- a/pkg/login/keys/configurer.go
+++ b/pkg/login/keys/configurer.go
@@ -42,8 +42,28 @@ func (c *RAKConfigurer) SaveLoginDetails(response *PollAPIKeyResponse) error {
 	c.cfg.Profile.TestModeAPIKey = response.TestModeAPIKey
 	c.cfg.Profile.TestModePublishableKey = response.TestModePublishableKey
 	c.cfg.Profile.UAT = response.UAT
-	c.cfg.Profile.LiveContext = response.LiveContext
-	c.cfg.Profile.TestWorkspaceID = response.TestWorkspaceID
+
+	var compartments []config.Compartment
+	if response.LiveContext != "" {
+		compartments = append(compartments, config.Compartment{
+			CompartmentID:   response.LiveContext,
+			CompartmentType: "account",
+			Livemode:        true,
+		})
+	}
+	if response.TestWorkspaceID != "" {
+		compartments = append(compartments, config.Compartment{
+			CompartmentID:   response.TestWorkspaceID,
+			CompartmentType: "account",
+			Livemode:        false,
+		})
+	}
+	if len(compartments) > 0 {
+		c.cfg.Profile.UserInfo = &config.UserInfo{
+			Compartments: compartments,
+		}
+	}
+
 	// TODO: AccountDisplayName appears to be empty for test mode accounts; is there a better default?
 	if response.AccountDisplayName != "" {
 		c.cfg.Profile.DisplayName = response.AccountDisplayName

--- a/pkg/login/keys/configurer.go
+++ b/pkg/login/keys/configurer.go
@@ -41,6 +41,9 @@ func (c *RAKConfigurer) SaveLoginDetails(response *PollAPIKeyResponse) error {
 	c.cfg.Profile.LiveModePublishableKey = response.LiveModePublishableKey
 	c.cfg.Profile.TestModeAPIKey = response.TestModeAPIKey
 	c.cfg.Profile.TestModePublishableKey = response.TestModePublishableKey
+	c.cfg.Profile.UAT = response.UAT
+	c.cfg.Profile.LiveContext = response.LiveContext
+	c.cfg.Profile.TestWorkspaceID = response.TestWorkspaceID
 	// TODO: AccountDisplayName appears to be empty for test mode accounts; is there a better default?
 	if response.AccountDisplayName != "" {
 		c.cfg.Profile.DisplayName = response.AccountDisplayName

--- a/pkg/login/keys/configurer_test.go
+++ b/pkg/login/keys/configurer_test.go
@@ -49,3 +49,67 @@ func TestSaveLoginDetails(t *testing.T) {
 	assert.Equal(t, "rk_test_1234567890000", v.GetString("tests.test_mode_api_key"))
 	assert.Equal(t, "pk_test_1234567890000", v.GetString("tests.test_mode_pub_key"))
 }
+
+func TestSaveLoginDetails_UserInfo(t *testing.T) {
+	profilesFile := filepath.Join(t.TempDir(), "stripe", "config.toml")
+	c := &config.Config{
+		LogLevel: "info",
+		Profile: config.Profile{
+			ProfileName: "tests",
+		},
+		ProfilesFile: profilesFile,
+	}
+	c.InitConfig()
+
+	configurer := NewRAKConfigurer(c, afero.NewOsFs())
+	err := configurer.SaveLoginDetails(&PollAPIKeyResponse{
+		Redeemed:        true,
+		AccountID:       "acct_123",
+		TestModeAPIKey:  "rk_test_1234567890000",
+		LiveContext:     "acct_live_456",
+		TestWorkspaceID: "acct_test_789",
+	})
+	require.NoError(t, err)
+
+	ui, err := c.Profile.GetUserInfo()
+	require.NoError(t, err)
+	require.NotNil(t, ui)
+
+	var liveComp, testComp config.Compartment
+	for _, comp := range ui.Compartments {
+		if comp.Livemode {
+			liveComp = comp
+		} else {
+			testComp = comp
+		}
+	}
+	assert.Equal(t, "acct_live_456", liveComp.CompartmentID)
+	assert.Equal(t, "account", liveComp.CompartmentType)
+	assert.Equal(t, "acct_test_789", testComp.CompartmentID)
+	assert.Equal(t, "account", testComp.CompartmentType)
+}
+
+func TestSaveLoginDetails_UserInfoEmpty(t *testing.T) {
+	profilesFile := filepath.Join(t.TempDir(), "stripe", "config.toml")
+	c := &config.Config{
+		LogLevel: "info",
+		Profile: config.Profile{
+			ProfileName: "tests",
+		},
+		ProfilesFile: profilesFile,
+	}
+	c.InitConfig()
+
+	configurer := NewRAKConfigurer(c, afero.NewOsFs())
+	err := configurer.SaveLoginDetails(&PollAPIKeyResponse{
+		Redeemed:       true,
+		AccountID:      "acct_123",
+		TestModeAPIKey: "rk_test_1234567890000",
+		// no LiveContext or TestWorkspaceID
+	})
+	require.NoError(t, err)
+
+	ui, err := c.Profile.GetUserInfo()
+	require.NoError(t, err)
+	assert.Nil(t, ui)
+}

--- a/pkg/login/keys/configurer_test.go
+++ b/pkg/login/keys/configurer_test.go
@@ -84,9 +84,7 @@ func TestSaveLoginDetails_UserInfo(t *testing.T) {
 		}
 	}
 	assert.Equal(t, "acct_live_456", liveComp.CompartmentID)
-	assert.Equal(t, "account", liveComp.CompartmentType)
 	assert.Equal(t, "acct_test_789", testComp.CompartmentID)
-	assert.Equal(t, "account", testComp.CompartmentType)
 }
 
 func TestSaveLoginDetails_UserInfoEmpty(t *testing.T) {

--- a/pkg/login/keys/polling.go
+++ b/pkg/login/keys/polling.go
@@ -26,6 +26,9 @@ type PollAPIKeyResponse struct {
 	LiveModePublishableKey string `json:"livemode_key_publishable"`
 	TestModeAPIKey         string `json:"testmode_key_secret"`
 	TestModePublishableKey string `json:"testmode_key_publishable"`
+	UAT                    string `json:"uat"`
+	LiveContext            string `json:"live_context"`
+	TestWorkspaceID        string `json:"test_workspace_id"`
 }
 
 // PollForKey polls Stripe at the specified interval until either the API key is available or we've reached the max attempts.


### PR DESCRIPTION
### Summary

Supports UAT auth in the config:
- Update `stripe login` to save the UAT into the keyring and user information into the config, if it comes back from the server (requires a flag).
- Update `stripe logout` to delete those fields.

The UAT lives in the user's credential storage under the name "Stripe CLI user access token".

The new config lives under a top-level `user_info` field, not associated with a profile because this information is not associated with the logged in _user_, not any particular _merchant_. Eventually, this data will come from an [OIDC userinfo endpoint](https://connect2id.com/products/server/docs/api/userinfo), but today it just gets returned from the existing login methods.

```toml
[user_info]
[[user_info.compartments]]
compartment_id = 'wksp_6OlwMt74SQtyFiRK3qSeJRw'
livemode = true

[[user_info.compartments]]
compartment_id = 'wksp_test_6TSTeR74SQtyFiReWVpLOIq'
livemode = false
```

I tested the credentials and config get saved and deleted correctly when logging in for the first time, logging in again, and logging out.