### PR TITLE
Add co-op domain model and blueprints

### DIFF
--- a/pkg/coop/blueprint.go
+++ b/pkg/coop/blueprint.go
@@ -1,0 +1,195 @@
+package coop
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+//go:embed blueprints/*.json
+var blueprintFS embed.FS
+
+// BlueprintNode is a node definition within a blueprint chapter.
+type BlueprintNode struct {
+	Type          NodeType    `json:"type"`
+	Key           string      `json:"key"`
+	Title         string      `json:"title"`
+	Description   string      `json:"description,omitempty"`
+	ReviewPrompt  string      `json:"review_prompt,omitempty"`
+	ReviewCommand string      `json:"review_command,omitempty"`
+	AutoConfirm   bool        `json:"auto_confirm,omitempty"`
+	Request       *APIRequest `json:"request,omitempty"`
+	Events        []string    `json:"events,omitempty"`
+}
+
+// BlueprintChapter is a chapter definition within a blueprint.
+type BlueprintChapter struct {
+	Key               string            `json:"key"`
+	Title             string            `json:"title"`
+	Description       string            `json:"description,omitempty"`
+	ReviewGranularity ReviewGranularity `json:"review_granularity,omitempty"`
+	Required          bool              `json:"required,omitempty"`
+	Nodes             []BlueprintNode   `json:"nodes"`
+}
+
+// Blueprint is the CLI-friendly representation of a Workbench Blueprint.
+type Blueprint struct {
+	ID          string             `json:"id"`
+	Title       string             `json:"title"`
+	Description string             `json:"description,omitempty"`
+	Prompt      string             `json:"prompt,omitempty"`
+	Type        string             `json:"type"`
+	Products    []string           `json:"products,omitempty"`
+	Settings    []BlueprintSetting `json:"settings,omitempty"`
+	Chapters    []BlueprintChapter `json:"chapters"`
+}
+
+// BlueprintSetting defines a configurable setting for a blueprint.
+type BlueprintSetting struct {
+	Key         string   `json:"key"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Type        string   `json:"type"`
+	Default     string   `json:"default,omitempty"`
+	Options     []string `json:"options,omitempty"`
+}
+
+// LoadBlueprint loads a blueprint by ID from the embedded filesystem.
+// If no exact match is found, it tries prefix matching (e.g. "deploy" → "deploy-stripe-projects").
+func LoadBlueprint(id string) (*Blueprint, error) {
+	filename := fmt.Sprintf("blueprints/%s.json", id)
+	data, err := blueprintFS.ReadFile(filename)
+	if err != nil {
+		// Try prefix match
+		match, matchErr := prefixMatchBlueprint(id)
+		if matchErr != nil {
+			return nil, matchErr
+		}
+		data, err = blueprintFS.ReadFile(fmt.Sprintf("blueprints/%s.json", match))
+		if err != nil {
+			return nil, fmt.Errorf("blueprint %q not found", id)
+		}
+	}
+
+	var bp Blueprint
+	if err := json.Unmarshal(data, &bp); err != nil {
+		return nil, fmt.Errorf("parsing blueprint %q: %w", id, err)
+	}
+
+	return &bp, nil
+}
+
+func prefixMatchBlueprint(prefix string) (string, error) {
+	ids, err := ListBlueprints()
+	if err != nil {
+		return "", fmt.Errorf("blueprint %q not found", prefix)
+	}
+
+	var matches []string
+	for _, id := range ids {
+		if strings.HasPrefix(id, prefix) {
+			matches = append(matches, id)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("blueprint %q not found", prefix)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("ambiguous blueprint prefix %q matches: %s", prefix, strings.Join(matches, ", "))
+	}
+}
+
+// ListBlueprints returns all available blueprint IDs.
+func ListBlueprints() ([]string, error) {
+	entries, err := blueprintFS.ReadDir("blueprints")
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		ids = append(ids, strings.TrimSuffix(e.Name(), ".json"))
+	}
+	return ids, nil
+}
+
+// ListBlueprintsWithMetadata returns all blueprints with their metadata.
+func ListBlueprintsWithMetadata() ([]Blueprint, error) {
+	ids, err := ListBlueprints()
+	if err != nil {
+		return nil, err
+	}
+
+	var blueprints []Blueprint
+	for _, id := range ids {
+		bp, err := LoadBlueprint(id)
+		if err != nil {
+			continue
+		}
+		blueprints = append(blueprints, *bp)
+	}
+	return blueprints, nil
+}
+
+// NewSessionFromBlueprint creates a new Session from a Blueprint definition.
+// A context-gathering step is prepended so the agent scans the project first.
+func NewSessionFromBlueprint(bp *Blueprint, sessionID string, settings map[string]string) *Session {
+	// Prepend a context-gathering chapter (auto-confirmed, no human sign-off needed)
+	contextChapter := SessionChapter{
+		Key:   "context-chapter",
+		Title: "Project context",
+		Nodes: []SessionNode{
+			{
+				Key:         "scan-project",
+				Type:        NodeTestHelper,
+				Title:       "Understand the project",
+				Description: "Scan the codebase to identify language, framework, dependencies, and existing Stripe code. Report what you find.",
+				AutoConfirm: true,
+				State:       StepPending,
+			},
+		},
+	}
+
+	chapters := make([]SessionChapter, 0, len(bp.Chapters)+1)
+	chapters = append(chapters, contextChapter)
+
+	for _, ch := range bp.Chapters {
+		nodes := make([]SessionNode, len(ch.Nodes))
+		for j, n := range ch.Nodes {
+			nodes[j] = SessionNode{
+				Key:           n.Key,
+				Type:          n.Type,
+				Title:         n.Title,
+				Description:   n.Description,
+				ReviewPrompt:  n.ReviewPrompt,
+				ReviewCommand: n.ReviewCommand,
+				AutoConfirm:   n.AutoConfirm,
+				State:         StepPending,
+				Request:       n.Request,
+				Events:        n.Events,
+			}
+		}
+		chapters = append(chapters, SessionChapter{
+			Key:               ch.Key,
+			Title:             ch.Title,
+			ReviewGranularity: ch.ReviewGranularity,
+			Nodes:             nodes,
+		})
+	}
+
+	return &Session{
+		SchemaVersion: CurrentSessionSchemaVersion,
+		ID:            sessionID,
+		Blueprint:     bp.ID,
+		Status:        SessionActive,
+		Settings:      settings,
+		Chapters:      chapters,
+	}
+}

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -1,0 +1,326 @@
+package coop
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadBlueprint(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+	assert.Equal(t, "one-time-payment", bp.ID)
+	assert.Equal(t, "Accept a one-time payment", bp.Title)
+	assert.Contains(t, bp.Products, "Payments")
+	assert.Len(t, bp.Chapters, 4)
+	assert.Equal(t, "setup-chapter", bp.Chapters[0].Key)
+	assert.Equal(t, NodeAPIRequest, bp.Chapters[0].Nodes[0].Type)
+}
+
+func TestAllEmbeddedBlueprintsHaveQualityMetadata(t *testing.T) {
+	ids, err := ListBlueprints()
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+
+	weakPhrases := []string{
+		"do the thing",
+		"verify it works",
+		"todo",
+		"tbd",
+		"placeholder",
+		"lorem ipsum",
+	}
+
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			bp, err := LoadBlueprint(id)
+			require.NoError(t, err)
+
+			assertQualityText(t, "blueprint title", bp.Title, 4, weakPhrases)
+			if bp.Description != "" {
+				assertQualityText(t, "blueprint description", bp.Description, 20, weakPhrases)
+			}
+			assert.True(t, bp.Description != "" || len(bp.Products) > 0, "blueprint should include description or product metadata")
+
+			for _, ch := range bp.Chapters {
+				assertQualityText(t, "chapter title "+ch.Key, ch.Title, 4, weakPhrases)
+				for _, n := range ch.Nodes {
+					assertQualityText(t, "node title "+n.Key, n.Title, 4, weakPhrases)
+					assert.NotEqual(t, "api request", strings.ToLower(strings.TrimSpace(n.Title)), "node %q should have a product-specific title", n.Key)
+					if n.Description != "" {
+						assertQualityText(t, "node description "+n.Key, n.Description, 20, weakPhrases)
+					}
+					if !n.AutoConfirm {
+						assertQualityText(t, "node review prompt "+n.Key, n.ReviewPrompt, 20, weakPhrases)
+						assertObservableGuidance(t, n.Key, n.ReviewPrompt)
+					}
+
+					switch n.Type {
+					case NodeAPIRequest:
+						require.NotNil(t, n.Request, "apiRequest node %q should have request metadata", n.Key)
+					case NodeAsyncHandler:
+						assert.NotEmpty(t, n.Events, "asyncHandler node %q should name webhook events to verify", n.Key)
+					case NodeCLICommand, NodeTestHelper, NodeSetUpWebhooks:
+						if n.Description != "" {
+							assertObservableGuidance(t, n.Key, n.Description)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func assertQualityText(t *testing.T, label, value string, minLen int, weakPhrases []string) {
+	t.Helper()
+	trimmed := strings.TrimSpace(value)
+	require.NotEmpty(t, trimmed, "%s should not be empty", label)
+	assert.GreaterOrEqual(t, len(trimmed), minLen, "%s should be specific enough", label)
+
+	lower := strings.ToLower(trimmed)
+	for _, phrase := range weakPhrases {
+		assert.NotContains(t, lower, phrase, "%s contains weak placeholder text", label)
+	}
+}
+
+func assertObservableGuidance(t *testing.T, key, description string) {
+	t.Helper()
+	lower := strings.ToLower(description)
+	observableTerms := []string{"verify", "confirm", "report", "check", "run", "summarize", "ask", "open"}
+	for _, term := range observableTerms {
+		if strings.Contains(lower, term) {
+			return
+		}
+	}
+	assert.Failf(t, "weak verification guidance", "node %q should name an observable check or reported outcome", key)
+}
+
+func TestLoadBlueprintNotFound(t *testing.T) {
+	_, err := LoadBlueprint("nonexistent-blueprint")
+	assert.Error(t, err)
+}
+
+func TestLoadBlueprintPrefixMatchUnique(t *testing.T) {
+	bp, err := LoadBlueprint("one-time")
+	require.NoError(t, err)
+	assert.Equal(t, "one-time-payment", bp.ID)
+}
+
+func TestLoadBlueprintPrefixMatchAmbiguous(t *testing.T) {
+	// "flat" matches both "flat-fee-and-overages" and "flat-subscription-with-entitlements"
+	_, err := LoadBlueprint("flat")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+}
+
+func TestListBlueprints(t *testing.T) {
+	ids, err := ListBlueprints()
+	require.NoError(t, err)
+	assert.Contains(t, ids, "one-time-payment")
+	assert.Contains(t, ids, "setup-future-payments")
+}
+
+func TestNewSessionFromBlueprint(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	session := NewSessionFromBlueprint(bp, "coop_test123", map[string]string{"language": "node"})
+
+	assert.Equal(t, "coop_test123", session.ID)
+	assert.Equal(t, "one-time-payment", session.Blueprint)
+	assert.Equal(t, SessionActive, session.Status)
+	assert.Equal(t, "node", session.Settings["language"])
+	// 4 blueprint chapters + 1 prepended context chapter
+	assert.Len(t, session.Chapters, 5)
+
+	// First chapter is always the context-gathering step
+	assert.Equal(t, "context-chapter", session.Chapters[0].Key)
+	assert.Equal(t, "Understand the project", session.Chapters[0].Nodes[0].Title)
+
+	// All nodes should be pending
+	for _, ch := range session.Chapters {
+		for _, n := range ch.Nodes {
+			assert.Equal(t, StepPending, n.State)
+		}
+	}
+
+	// Total steps = blueprint steps (6) + context step (1)
+	assert.Equal(t, 7, session.TotalSteps())
+
+	assert.Empty(t, session.Chapters[2].ReviewGranularity)
+	assert.NotEmpty(t, session.Chapters[1].Nodes[0].ReviewPrompt)
+	assert.Equal(t, "stripe trigger checkout.session.completed", session.Chapters[3].Nodes[0].ReviewCommand)
+}
+
+func TestListBlueprintsWithMetadata(t *testing.T) {
+	bps, err := ListBlueprintsWithMetadata()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(bps), 2)
+
+	found := false
+	for _, bp := range bps {
+		if bp.ID == "setup-future-payments" {
+			found = true
+			assert.Equal(t, "Save a card for future payments", bp.Title)
+		}
+	}
+	assert.True(t, found, "expected to find setup-future-payments")
+}
+
+func TestLoadBlueprintChapterStructure(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	// Verify chapter keys are unique
+	keys := make(map[string]bool)
+	for _, ch := range bp.Chapters {
+		assert.False(t, keys[ch.Key], "duplicate chapter key: %s", ch.Key)
+		keys[ch.Key] = true
+		assert.NotEmpty(t, ch.Title)
+		assert.NotEmpty(t, ch.Nodes)
+
+		// Verify node keys are unique within chapter
+		nodeKeys := make(map[string]bool)
+		for _, n := range ch.Nodes {
+			assert.False(t, nodeKeys[n.Key], "duplicate node key: %s", n.Key)
+			nodeKeys[n.Key] = true
+			assert.NotEmpty(t, n.Title)
+			assert.NotEmpty(t, n.Type)
+		}
+	}
+}
+
+func TestLoadBlueprintNodeTypes(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	typesSeen := make(map[NodeType]bool)
+	for _, ch := range bp.Chapters {
+		for _, n := range ch.Nodes {
+			typesSeen[n.Type] = true
+		}
+	}
+
+	assert.True(t, typesSeen[NodeAPIRequest], "expected apiRequest nodes")
+	assert.True(t, typesSeen[NodeUIComponent], "expected uiComponent nodes")
+	assert.True(t, typesSeen[NodeAsyncHandler], "expected asyncHandler nodes")
+}
+
+func TestLoadBlueprintAPIRequestHasRequest(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	for _, ch := range bp.Chapters {
+		for _, n := range ch.Nodes {
+			if n.Type == NodeAPIRequest {
+				assert.NotNil(t, n.Request, "apiRequest node %q should have request field", n.Key)
+				assert.NotEmpty(t, n.Request.Path)
+				assert.NotEmpty(t, n.Request.Method)
+			}
+		}
+	}
+}
+
+func TestLoadBlueprintAsyncHandlerHasEvents(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	for _, ch := range bp.Chapters {
+		for _, n := range ch.Nodes {
+			if n.Type == NodeAsyncHandler {
+				assert.NotEmpty(t, n.Events, "asyncHandler node %q should have events", n.Key)
+			}
+		}
+	}
+}
+
+func TestNewSessionFromBlueprintPreservesRequest(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	session := NewSessionFromBlueprint(bp, "test_123", nil)
+
+	// First blueprint node (after context chapter) is apiRequest — should preserve the request
+	firstBlueprintNode := session.Chapters[1].Nodes[0]
+	assert.Equal(t, NodeAPIRequest, firstBlueprintNode.Type)
+	assert.NotNil(t, firstBlueprintNode.Request)
+	assert.Equal(t, "/v1/products", firstBlueprintNode.Request.Path)
+	assert.Equal(t, "post", firstBlueprintNode.Request.Method)
+}
+
+func TestNewSessionFromBlueprintPreservesEvents(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	session := NewSessionFromBlueprint(bp, "test_123", nil)
+
+	// Find the asyncHandler node
+	for _, ch := range session.Chapters {
+		for _, n := range ch.Nodes {
+			if n.Type == NodeAsyncHandler {
+				assert.Contains(t, n.Events, "checkout.session.completed")
+				return
+			}
+		}
+	}
+	t.Fatal("expected to find asyncHandler node")
+}
+
+func TestAllEmbeddedBlueprintsAreStructurallyValid(t *testing.T) {
+	ids, err := ListBlueprints()
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+
+	allowedTypes := map[NodeType]bool{
+		NodeAPIRequest:    true,
+		NodeAsyncHandler:  true,
+		NodeUIComponent:   true,
+		NodeTestHelper:    true,
+		NodeCLICommand:    true,
+		NodeDashboard:     true,
+		NodeSetUpWebhooks: true,
+	}
+
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			bp, err := LoadBlueprint(id)
+			require.NoError(t, err)
+			assert.Equal(t, id, bp.ID)
+			assert.NotEmpty(t, bp.Title)
+			require.NotEmpty(t, bp.Chapters)
+
+			chapterKeys := make(map[string]bool)
+			for _, ch := range bp.Chapters {
+				assert.NotEmpty(t, ch.Key)
+				assert.False(t, chapterKeys[ch.Key], "duplicate chapter key: %s", ch.Key)
+				chapterKeys[ch.Key] = true
+				assert.NotEmpty(t, ch.Title)
+				require.NotEmpty(t, ch.Nodes)
+
+				nodeKeys := make(map[string]bool)
+				for _, n := range ch.Nodes {
+					assert.NotEmpty(t, n.Key)
+					assert.False(t, nodeKeys[n.Key], "duplicate node key: %s", n.Key)
+					nodeKeys[n.Key] = true
+					assert.NotEmpty(t, n.Title)
+					assert.True(t, allowedTypes[n.Type], "unsupported node type: %s", n.Type)
+
+					if n.Type == NodeAPIRequest {
+						require.NotNil(t, n.Request, "apiRequest node %q should have request field", n.Key)
+						assert.NotEmpty(t, n.Request.Path)
+						assert.NotEmpty(t, n.Request.Method)
+					}
+				}
+			}
+
+			session := NewSessionFromBlueprint(bp, "test_"+id, map[string]string{"language": "node"})
+			assert.Equal(t, id, session.Blueprint)
+			require.NotEmpty(t, session.Chapters)
+			require.NotEmpty(t, session.Chapters[0].Nodes)
+			assert.Equal(t, "Understand the project", session.Chapters[0].Nodes[0].Title)
+			assert.Equal(t, len(bp.Chapters)+1, len(session.Chapters))
+		})
+	}
+}

--- a/pkg/coop/blueprints/billing-portal.json
+++ b/pkg/coop/blueprints/billing-portal.json
@@ -1,0 +1,22 @@
+{
+  "id": "billing-portal",
+  "title": "Give customers access to billing portal",
+  "description": "Create a billing portal session to allow customers to manage their billing and subscription information.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Give customers access to billing portal",
+      "nodes": [
+        {
+          "type": "uiComponent",
+          "key": "redirect-to-portal",
+          "title": "Open billing portal",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/checkout-studio.json
+++ b/pkg/coop/blueprints/checkout-studio.json
@@ -1,0 +1,35 @@
+{
+  "id": "checkout-studio",
+  "title": "Build your Integration",
+  "description": "Create a Checkout Session and add the frontend entry point for a hosted Checkout payment flow.",
+  "type": "learning",
+  "products": [
+    "Checkout",
+    "Payments"
+  ],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Build your Integration",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "create-checkout-session",
+          "title": "Create a checkout session",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "setup-stripe-elements-html-snippet",
+          "title": "Set up your frontend",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/credit-burndown.json
+++ b/pkg/coop/blueprints/credit-burndown.json
@@ -1,0 +1,191 @@
+{
+  "id": "credit-burndown",
+  "title": "Set up credit burndown pricing",
+  "description": "Charge customers for pre-purchased credits that burn down in real time as they consume usage.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Set up credit burndown pricing",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "createCustomer",
+          "title": "Create a customer",
+          "request": {
+            "path": "/v1/customers",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createEmptyPricingPlan",
+          "title": "Create a Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createMeter",
+          "title": "Create a meter",
+          "request": {
+            "path": "/v1/billing/meters",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createRateCard",
+          "title": "Create a rate card",
+          "request": {
+            "path": "/v2/billing/rate_cards",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createMeteredItem",
+          "title": "Create a metered item",
+          "request": {
+            "path": "/v2/billing/metered_items",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "addRateToRateCard",
+          "title": "Add rate to rate card",
+          "request": {
+            "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attachRateCardToPricingPlan",
+          "title": "Attach rate card to Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "setLiveVersion",
+          "title": "Set live version to latest",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createCheckoutSession",
+          "title": "Create checkout session",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "completeCheckout",
+          "title": "Complete the checkout",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "waitForServicingActivated",
+          "title": "Wait for servicing activated event",
+          "events": [
+            "v2.billing.pricing_plan_subscription.servicing_activated"
+          ],
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createPaymentMethod",
+          "title": "Create a payment method",
+          "request": {
+            "path": "/v1/payment_methods",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attachPaymentMethod",
+          "title": "Attach payment method to customer",
+          "request": {
+            "path": "/v1/payment_methods/${node.grant-credits-chapter.createPaymentMethod.createPaymentMethodRequest:id}/attach",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createCreditInvoice",
+          "title": "Create an invoice for credits",
+          "request": {
+            "path": "/v1/invoices",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "addCreditInvoiceItem",
+          "title": "Add credit line item to invoice",
+          "request": {
+            "path": "/v1/invoiceitems",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "payInvoice",
+          "title": "Finalize and pay the invoice",
+          "request": {
+            "path": "/v1/invoices/${node.grant-credits-chapter.createCreditInvoice.createCreditInvoiceRequest:id}/pay",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "grantCredits",
+          "title": "Grant credits",
+          "request": {
+            "path": "/v1/billing/credit_grants",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createCreditBalanceAlert",
+          "title": "Create credit balance alert",
+          "request": {
+            "path": "/v1/billing/alerts",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/destination-charge.json
+++ b/pkg/coop/blueprints/destination-charge.json
@@ -1,0 +1,29 @@
+{
+  "id": "destination-charge",
+  "title": "Create a destination charge",
+  "description": "Create a Connect destination charge by collecting payment on the platform and transferring funds to a connected account.",
+  "type": "learning",
+  "products": [
+    "Connect",
+    "Payments"
+  ],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Create a destination charge",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "createCharge",
+          "title": "Create a PaymentIntent",
+          "request": {
+            "path": "/v1/payment_intents",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/direct-charge.json
+++ b/pkg/coop/blueprints/direct-charge.json
@@ -1,0 +1,26 @@
+{
+  "id": "direct-charge",
+  "title": "Create a direct charge",
+  "description": "Creates a charge directly on a connected account and transfers a collected fee to the platform.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Create a direct charge",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "createCharge",
+          "title": "Create a payment intent",
+          "request": {
+            "path": "/v1/payment_intents",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/flat-fee-and-overages.json
+++ b/pkg/coop/blueprints/flat-fee-and-overages.json
@@ -1,0 +1,151 @@
+{
+  "id": "flat-fee-and-overages",
+  "title": "Set up flat fee and overages pricing",
+  "description": "Charge customers a flat recurring fee with overage charges for usage beyond included limits.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Set up flat fee and overages pricing",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "createCustomer",
+          "title": "Create a customer",
+          "request": {
+            "path": "/v1/customers",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createEmptyPricingPlan",
+          "title": "Create a Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createMeter",
+          "title": "Create a meter",
+          "request": {
+            "path": "/v1/billing/meters",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createRateCard",
+          "title": "Create a rate card",
+          "request": {
+            "path": "/v2/billing/rate_cards",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createMeteredItem",
+          "title": "Create a metered item",
+          "request": {
+            "path": "/v2/billing/metered_items",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "addGraduatedRateToRateCard",
+          "title": "Add graduated rate to rate card",
+          "request": {
+            "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attachRateCardToPricingPlan",
+          "title": "Attach rate card to Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createLicensedItem",
+          "title": "Create a licensed item",
+          "request": {
+            "path": "/v2/billing/licensed_items",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createLicenseFee",
+          "title": "Create a license fee",
+          "request": {
+            "path": "/v2/billing/license_fees",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attachLicenseFeeToPricingPlan",
+          "title": "Attach license fee to Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "setLiveVersion",
+          "title": "Set live version to latest",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createCheckoutSession",
+          "title": "Create checkout session",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "completeCheckout",
+          "title": "Complete the checkout",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "waitForServicingActivated",
+          "title": "Wait for servicing activated event",
+          "events": [
+            "v2.billing.pricing_plan_subscription.servicing_activated"
+          ],
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/flat-subscription-with-entitlements.json
+++ b/pkg/coop/blueprints/flat-subscription-with-entitlements.json
@@ -1,0 +1,132 @@
+{
+  "id": "flat-subscription-with-entitlements",
+  "title": "Flat rate subscription with entitlements",
+  "description": "Learn how to create a flat rate subscription with entitlements to manage customer feature access.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Flat rate subscription with entitlements",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "create-basic-product",
+          "title": "Create a Basic product tier",
+          "request": {
+            "path": "/v1/products",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-basic-feature",
+          "title": "Create a feature for the Basic tier",
+          "request": {
+            "path": "/v1/entitlements/features",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attach-feature-to-product",
+          "title": "Attach the feature to the product",
+          "request": {
+            "path": "/v1/products/${node.create-products-chapter.create-basic-product.create-basic-product-request:id}/features",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "testHelper",
+          "key": "create-test-clock",
+          "title": "Create a test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        },
+        {
+          "type": "testHelper",
+          "key": "create-customer",
+          "title": "Create a customer",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-checkout-session",
+          "title": "Create a checkout session",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "complete-checkout",
+          "title": "Complete the checkout process",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "track-subscription-creation",
+          "title": "Track subscription creation",
+          "events": [
+            "customer.subscription.created"
+          ],
+          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "check-entitlements",
+          "title": "Check customer entitlements",
+          "events": [
+            "entitlements.active_entitlement_summary.updated"
+          ],
+          "review_prompt": "Run stripe trigger entitlements.active_entitlement_summary.updated and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "testHelper",
+          "key": "advance-time",
+          "title": "Advance time to billing date",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "wait-for-invoice-created",
+          "title": "View the invoice created",
+          "events": [
+            "invoice.created"
+          ],
+          "review_prompt": "Run stripe trigger invoice.created and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "apiRequest",
+          "key": "view-invoice",
+          "title": "View the invoice created",
+          "request": {
+            "path": "/v1/invoices/${node.next-billing-cycle-chapter.wait-for-invoice-created.0:id}",
+            "method": "get"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "test-clock-advanced",
+          "title": "Wait for test clock to be ready.",
+          "events": [
+            "test_helpers.test_clock.ready"
+          ],
+          "review_prompt": "Run stripe trigger test_helpers.test_clock.ready and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "testHelper",
+          "key": "delete-test-clock",
+          "title": "Delete the test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/invoice-payments.json
+++ b/pkg/coop/blueprints/invoice-payments.json
@@ -1,0 +1,87 @@
+{
+  "id": "invoice-payments",
+  "title": "Invoice payment with hosted page",
+  "description": "Learn how to create and collect payment on an invoice using a hosted payment page.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Invoice payment with hosted page",
+      "nodes": [
+        {
+          "type": "testHelper",
+          "key": "create-test-clock",
+          "title": "Create a test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-product",
+          "title": "Create a product with a price",
+          "request": {
+            "path": "/v1/products",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-customer",
+          "title": "Create a customer",
+          "request": {
+            "path": "/v1/customers",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-invoice",
+          "title": "Create an invoice",
+          "request": {
+            "path": "/v1/invoices",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "add-invoice-item",
+          "title": "Add an invoice item",
+          "request": {
+            "path": "/v1/invoiceitems",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "send-invoice",
+          "title": "Send the invoice",
+          "request": {
+            "path": "/v1/invoices/${node.create-invoice-chapter.create-invoice.create-invoice-request:id}/send",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "view-invoice",
+          "title": "View and pay the invoice",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "wait-for-invoice-paid",
+          "title": "Handle invoice payment events",
+          "events": [
+            "invoice.paid"
+          ],
+          "review_prompt": "Run stripe trigger invoice.paid and confirm the handler processes the signed event correctly."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/managed-payments.json
+++ b/pkg/coop/blueprints/managed-payments.json
@@ -1,0 +1,64 @@
+{
+  "id": "managed-payments",
+  "title": "Set up Managed Payments",
+  "description": "Set up Checkout for managed payments with subscription and one-time product options, then listen for completed checkout events.",
+  "type": "learning",
+  "products": [
+    "Checkout",
+    "Payments"
+  ],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Set up Managed Payments",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "create-subscription-product",
+          "title": "Create subscription product",
+          "request": {
+            "path": "/v1/products",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-one-time-product",
+          "title": "Create one-time product",
+          "request": {
+            "path": "/v1/products",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-checkout-session",
+          "title": "Create managed Checkout Session",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "complete-checkout",
+          "title": "Complete a test payment",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "wait-for-checkout-completed",
+          "title": "Listen for checkout.session.completed",
+          "events": [
+            "checkout.session.completed"
+          ],
+          "review_prompt": "Run stripe trigger checkout.session.completed and confirm the handler processes the signed event correctly."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/metered-subscription.json
+++ b/pkg/coop/blueprints/metered-subscription.json
@@ -1,0 +1,162 @@
+{
+  "id": "metered-subscription",
+  "title": "Metered subscription with entitlements",
+  "description": "Learn how to create a usage-based subscription with metering and entitlements to manage customer feature access.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Metered subscription with entitlements",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "create-meter",
+          "title": "Create a meter",
+          "request": {
+            "path": "/v1/billing/meters",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-usage-product",
+          "title": "Create a usage-based product",
+          "request": {
+            "path": "/v1/products",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-usage-price",
+          "title": "Create a metered price",
+          "request": {
+            "path": "/v1/prices",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-usage-feature",
+          "title": "Create a feature for the usage plan",
+          "request": {
+            "path": "/v1/entitlements/features",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attach-feature-to-product",
+          "title": "Attach the feature to the product",
+          "request": {
+            "path": "/v1/products/${node.metering-setup-chapter.create-usage-product.create-usage-product-request:id}/features",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "testHelper",
+          "key": "create-test-clock",
+          "title": "Create a test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        },
+        {
+          "type": "testHelper",
+          "key": "create-customer",
+          "title": "Create a customer",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-checkout-session",
+          "title": "Create a checkout session",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "complete-checkout",
+          "title": "Complete the checkout process",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "check-entitlements",
+          "title": "Check customer entitlements",
+          "events": [
+            "entitlements.active_entitlement_summary.updated"
+          ],
+          "review_prompt": "Run stripe trigger entitlements.active_entitlement_summary.updated and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "track-subscription-creation",
+          "title": "Track subscription creation",
+          "events": [
+            "customer.subscription.created"
+          ],
+          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "apiRequest",
+          "key": "report-usage",
+          "title": "Report customer usage",
+          "request": {
+            "path": "/v1/billing/meter_events",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "testHelper",
+          "key": "advance-time",
+          "title": "Advance time to billing date",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "wait-for-invoice-created",
+          "title": "Wait for the invoice to be created",
+          "events": [
+            "invoice.created"
+          ],
+          "review_prompt": "Run stripe trigger invoice.created and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "apiRequest",
+          "key": "view-invoice",
+          "title": "View the invoice created",
+          "request": {
+            "path": "/v1/invoices/${node.usage-chapter.wait-for-invoice-created.0:id}",
+            "method": "get"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "test-clock-advanced",
+          "title": "Wait for test clock to be ready.",
+          "events": [
+            "test_helpers.test_clock.ready"
+          ],
+          "review_prompt": "Run stripe trigger test_helpers.test_clock.ready and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "testHelper",
+          "key": "delete-test-clock",
+          "title": "Delete the test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/one-time-payment.json
+++ b/pkg/coop/blueprints/one-time-payment.json
@@ -1,0 +1,116 @@
+{
+  "chapters": [
+    {
+      "description": "Create a product and price in your Stripe account.",
+      "key": "setup-chapter",
+      "nodes": [
+        {
+          "description": "Create a Stripe Product with inline default_price_data, then save the returned default_price ID for the Checkout Session. Do not put generated IDs in .env files.",
+          "key": "create-product",
+          "request": {
+            "key": "create-product-request",
+            "method": "post",
+            "params": {
+              "default_price_data": {
+                "currency": "usd",
+                "unit_amount": 2000
+              },
+              "name": "T-shirt"
+            },
+            "path": "/v1/products"
+          },
+          "title": "Create a product",
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        }
+      ],
+      "required": true,
+      "title": "Set up your product catalog"
+    },
+    {
+      "description": "Build a server endpoint that creates a Checkout Session and redirects the customer.",
+      "key": "checkout-chapter",
+      "nodes": [
+        {
+          "description": "Create a Checkout Session with the price from the previous step.",
+          "key": "create-checkout-session",
+          "request": {
+            "key": "create-checkout-session-request",
+            "method": "post",
+            "params": {
+              "cancel_url": "https://example.com/cancel",
+              "line_items": [
+                {
+                  "price": "${node.setup-chapter.create-product.create-product-request:default_price}",
+                  "quantity": 1
+                }
+              ],
+              "mode": "payment",
+              "success_url": "https://example.com/success"
+            },
+            "path": "/v1/checkout/sessions"
+          },
+          "title": "Create a Checkout Session",
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "description": "Add a button or link that redirects the customer to the Checkout page.",
+          "key": "redirect-to-checkout",
+          "title": "Redirect to Checkout",
+          "type": "uiComponent",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "description": "Create a page to show after the customer completes payment.",
+          "key": "add-success-page",
+          "title": "Add a success page",
+          "type": "uiComponent",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        }
+      ],
+      "title": "Create a Checkout Session"
+    },
+    {
+      "description": "Listen for webhook events to handle fulfillment.",
+      "key": "webhook-chapter",
+      "nodes": [
+        {
+          "description": "Set up a webhook endpoint to receive the checkout.session.completed event and fulfill the order.",
+          "events": [
+            "checkout.session.completed"
+          ],
+          "key": "handle-checkout-completed",
+          "title": "Handle checkout.session.completed",
+          "type": "asyncHandler",
+          "review_prompt": "Run `stripe trigger checkout.session.completed` and confirm fulfillment happens only after verifying the Stripe signature.",
+          "review_command": "stripe trigger checkout.session.completed"
+        }
+      ],
+      "title": "Handle post-payment events"
+    },
+    {
+      "description": "Verify the complete flow works end to end.",
+      "key": "test-chapter",
+      "nodes": [
+        {
+          "description": "Run through the complete payment flow using a test card number.",
+          "key": "test-payment-flow",
+          "title": "Make a test payment",
+          "type": "testHelper",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        }
+      ],
+      "title": "Test the integration"
+    }
+  ],
+  "description": "Set up Checkout to accept a one-time payment with a prebuilt, hosted payment page.",
+  "id": "one-time-payment",
+  "products": [
+    "Payments",
+    "Checkout"
+  ],
+  "settings": [],
+  "title": "Accept a one-time payment",
+  "type": "learning"
+}

--- a/pkg/coop/blueprints/pay-as-you-go.json
+++ b/pkg/coop/blueprints/pay-as-you-go.json
@@ -1,0 +1,121 @@
+{
+  "id": "pay-as-you-go",
+  "title": "Set up pay-as-you-go pricing",
+  "description": "Charge customers based on their actual usage with per-unit pricing.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Set up pay-as-you-go pricing",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "createCustomer",
+          "title": "Create a customer",
+          "request": {
+            "path": "/v1/customers",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createEmptyPricingPlan",
+          "title": "Create a Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createMeter",
+          "title": "Create a meter",
+          "request": {
+            "path": "/v1/billing/meters",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createRateCard",
+          "title": "Create a rate card",
+          "request": {
+            "path": "/v2/billing/rate_cards",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createMeteredItem",
+          "title": "Create a metered item",
+          "request": {
+            "path": "/v2/billing/metered_items",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "addRateToRateCard",
+          "title": "Add rate to rate card",
+          "request": {
+            "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attachRateCardToPricingPlan",
+          "title": "Attach rate card to Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "setLiveVersion",
+          "title": "Set live version to latest",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createCheckoutSession",
+          "title": "Create checkout session",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "completeCheckout",
+          "title": "Complete the checkout",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "waitForServicingActivated",
+          "title": "Wait for servicing activated event",
+          "events": [
+            "v2.billing.pricing_plan_subscription.servicing_activated"
+          ],
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/setup-future-payments.json
+++ b/pkg/coop/blueprints/setup-future-payments.json
@@ -1,0 +1,109 @@
+{
+  "chapters": [
+    {
+      "description": "Create a Checkout Session in setup mode to collect payment details.",
+      "key": "setup-chapter",
+      "nodes": [
+        {
+          "description": "Create a customer to attach the saved payment method to.",
+          "key": "create-customer",
+          "request": {
+            "key": "create-customer-request",
+            "method": "post",
+            "params": {
+              "email": "jenny@example.com",
+              "name": "Jenny Rosen"
+            },
+            "path": "/v1/customers"
+          },
+          "title": "Create a customer",
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "description": "Create a Checkout Session with mode=setup to save a payment method.",
+          "key": "create-setup-session",
+          "request": {
+            "key": "create-setup-session-request",
+            "method": "post",
+            "params": {
+              "cancel_url": "https://example.com/cancel",
+              "customer": "${node.setup-chapter.create-customer.create-customer-request:id}",
+              "mode": "setup",
+              "payment_method_types": [
+                "card"
+              ],
+              "success_url": "https://example.com/success"
+            },
+            "path": "/v1/checkout/sessions"
+          },
+          "title": "Create a Checkout Session (setup mode)",
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        }
+      ],
+      "required": true,
+      "title": "Create a Setup Session"
+    },
+    {
+      "description": "Redirect the customer and handle the result.",
+      "key": "complete-chapter",
+      "nodes": [
+        {
+          "description": "Redirect the customer to the Checkout Session URL.",
+          "key": "redirect-to-setup",
+          "title": "Redirect to setup page",
+          "type": "uiComponent",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "description": "Listen for the setup_intent.succeeded event to confirm the payment method was saved.",
+          "events": [
+            "setup_intent.succeeded"
+          ],
+          "key": "handle-setup-completed",
+          "title": "Handle setup_intent.succeeded",
+          "type": "asyncHandler",
+          "review_prompt": "Run stripe trigger setup_intent.succeeded and confirm the handler processes the signed event correctly."
+        }
+      ],
+      "title": "Complete the setup"
+    },
+    {
+      "description": "Create a PaymentIntent using the saved payment method.",
+      "key": "charge-chapter",
+      "nodes": [
+        {
+          "description": "Charge the customer using their saved payment method.",
+          "key": "create-payment-intent",
+          "request": {
+            "key": "create-payment-intent-request",
+            "method": "post",
+            "params": {
+              "amount": 1099,
+              "confirm": true,
+              "currency": "usd",
+              "customer": "${node.setup-chapter.create-customer.create-customer-request:id}",
+              "off_session": true,
+              "payment_method": "${node.complete-chapter.handle-setup-completed:payment_method}"
+            },
+            "path": "/v1/payment_intents"
+          },
+          "title": "Create a PaymentIntent off-session",
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        }
+      ],
+      "title": "Charge the saved card"
+    }
+  ],
+  "description": "Use Checkout in setup mode to collect payment details and charge customers later.",
+  "id": "setup-future-payments",
+  "products": [
+    "Payments",
+    "Checkout"
+  ],
+  "settings": [],
+  "title": "Save a card for future payments",
+  "type": "learning"
+}

--- a/pkg/coop/blueprints/subscription-with-trial.json
+++ b/pkg/coop/blueprints/subscription-with-trial.json
@@ -1,0 +1,50 @@
+{
+  "id": "subscription-with-trial",
+  "title": "Create subscription with trial period",
+  "description": "Learn how to create a subscription with a trial period using Stripe Checkout.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Create subscription with trial period",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "create-checkout-session",
+          "title": "Create Checkout Session",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "complete-checkout",
+          "title": "Complete checkout",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "handle-checkout-completed",
+          "title": "Wait for checkout.session.completed event",
+          "events": [
+            "checkout.session.completed"
+          ],
+          "review_prompt": "Run stripe trigger checkout.session.completed and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "handle-subscription-created",
+          "title": "Wait for customer.subscription.created event",
+          "events": [
+            "customer.subscription.created"
+          ],
+          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/usage-based-billing.json
+++ b/pkg/coop/blueprints/usage-based-billing.json
@@ -1,0 +1,180 @@
+{
+  "id": "usage-based-billing",
+  "title": "Model hybrid pricing with pricing plans",
+  "description": "Charge your customers based on usage, recurring, or one-time fees.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Model hybrid pricing with pricing plans",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "createCustomer",
+          "title": "Create a customer",
+          "request": {
+            "path": "/v1/customers",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createEmptyPricingPlan",
+          "title": "Create an empty Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createMeter",
+          "title": "Create a meter",
+          "request": {
+            "path": "/v1/billing/meters",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createRateCard",
+          "title": "Create a rate card",
+          "request": {
+            "path": "/v2/billing/rate_cards",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createMeteredItem",
+          "title": "Create a metered item",
+          "request": {
+            "path": "/v2/billing/metered_items",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "addRateToRateCard",
+          "title": "Add rate to rate card",
+          "request": {
+            "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard.createRateCardRequest:id}/rates",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attachRateCardToPricingPlan",
+          "title": "Attach rate card to Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createLicensedItem",
+          "title": "Create a licensed item",
+          "request": {
+            "path": "/v2/billing/licensed_items",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createLicenseFee",
+          "title": "Create a license fee",
+          "request": {
+            "path": "/v2/billing/license_fees",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attachLicenseFeeToPricingPlan",
+          "title": "Attach license fee to Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createServiceAction",
+          "title": "Create recurring credit grant service action",
+          "request": {
+            "path": "/v2/billing/service_actions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attachServiceActionToPricingPlan",
+          "title": "Attach service action to Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "setLiveVersion",
+          "title": "Set live version to latest",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createCheckoutSession",
+          "title": "Create checkout session",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "completeCheckout",
+          "title": "Complete the checkout",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "waitForServicingActivated",
+          "title": "Wait for servicing activated event",
+          "events": [
+            "v2.billing.pricing_plan_subscription.servicing_activated"
+          ],
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "waitForCreditGrantCreated",
+          "title": "Wait for credit grant created event",
+          "events": [
+            "v2.billing.credit_grant.created"
+          ],
+          "review_prompt": "Run stripe trigger v2.billing.credit_grant.created and confirm the handler processes the signed event correctly."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/usage-recording.json
+++ b/pkg/coop/blueprints/usage-recording.json
@@ -1,0 +1,36 @@
+{
+  "id": "usage-recording",
+  "title": "Record usage events for billing",
+  "description": "Record usage events to track customer consumption for usage-based billing.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "main",
+      "title": "Record usage events for billing",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "create-meter",
+          "title": "Create a meter",
+          "request": {
+            "path": "/v1/billing/meters",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "record-usage",
+          "title": "Record usage event",
+          "request": {
+            "path": "/v1/billing/meter_events",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/session.go
+++ b/pkg/coop/session.go
@@ -1,0 +1,226 @@
+package coop
+
+import (
+	"fmt"
+	"time"
+)
+
+// validTransitions defines allowed state transitions.
+var validTransitions = map[StepState][]StepState{
+	StepPending: {StepActive, StepSkipped},
+	StepActive:  {StepReview, StepDone, StepSkipped},
+	StepReview:  {StepDone, StepActive, StepSkipped}, // active = rejected, redo
+}
+
+// TotalSteps returns the total number of nodes across all chapters.
+func (s *Session) TotalSteps() int {
+	count := 0
+	for _, ch := range s.Chapters {
+		count += len(ch.Nodes)
+	}
+	return count
+}
+
+// NodeByNumber returns a pointer to the node at the given 1-based index,
+// counting sequentially across chapters. Returns an error if out of range.
+func (s *Session) NodeByNumber(n int) (*SessionNode, error) {
+	if n < 1 {
+		return nil, fmt.Errorf("step number must be >= 1, got %d", n)
+	}
+	idx := 0
+	for i := range s.Chapters {
+		for j := range s.Chapters[i].Nodes {
+			idx++
+			if idx == n {
+				return &s.Chapters[i].Nodes[j], nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("step %d out of range (session has %d steps)", n, s.TotalSteps())
+}
+
+// ChapterByStepNumber returns the chapter containing a 1-based step number.
+func (s *Session) ChapterByStepNumber(n int) (*SessionChapter, int, int, error) {
+	if n < 1 {
+		return nil, -1, -1, fmt.Errorf("step number must be >= 1, got %d", n)
+	}
+	idx := 0
+	for i := range s.Chapters {
+		for j := range s.Chapters[i].Nodes {
+			idx++
+			if idx == n {
+				return &s.Chapters[i], i, j, nil
+			}
+		}
+	}
+	return nil, -1, -1, fmt.Errorf("step %d out of range (session has %d steps)", n, s.TotalSteps())
+}
+
+// ReviewGranularityForStep returns the effective review granularity for a step.
+func (s *Session) ReviewGranularityForStep(n int) ReviewGranularity {
+	ch, _, _, err := s.ChapterByStepNumber(n)
+	if err != nil || ch.ReviewGranularity == "" {
+		return ReviewGranularityStep
+	}
+	return ch.ReviewGranularity
+}
+
+// ChapterReadyForReview returns true when every reviewable node in a chapter is
+// no longer pending or active.
+func (s *Session) ChapterReadyForReview(chapterIndex int) bool {
+	if chapterIndex < 0 || chapterIndex >= len(s.Chapters) {
+		return false
+	}
+	hasReviewable := false
+	for _, n := range s.Chapters[chapterIndex].Nodes {
+		if n.AutoConfirm {
+			continue
+		}
+		hasReviewable = true
+		switch n.State {
+		case StepReview, StepDone, StepSkipped:
+		default:
+			return false
+		}
+	}
+	return hasReviewable
+}
+
+// ChapterHasReview returns true if any node in the chapter is waiting for human review.
+func (s *Session) ChapterHasReview(chapterIndex int) bool {
+	if chapterIndex < 0 || chapterIndex >= len(s.Chapters) {
+		return false
+	}
+	for _, n := range s.Chapters[chapterIndex].Nodes {
+		if n.State == StepReview {
+			return true
+		}
+	}
+	return false
+}
+
+// FirstReviewStepInChapter returns the 1-based step number of the first review node.
+func (s *Session) FirstReviewStepInChapter(chapterIndex int) int {
+	if chapterIndex < 0 || chapterIndex >= len(s.Chapters) {
+		return 0
+	}
+	step := 0
+	for i := range s.Chapters {
+		for j := range s.Chapters[i].Nodes {
+			step++
+			if i == chapterIndex && s.Chapters[i].Nodes[j].State == StepReview {
+				return step
+			}
+		}
+	}
+	return 0
+}
+
+// FirstActiveStepInChapter returns the 1-based step number of the first active node.
+func (s *Session) FirstActiveStepInChapter(chapterIndex int) int {
+	if chapterIndex < 0 || chapterIndex >= len(s.Chapters) {
+		return 0
+	}
+	step := 0
+	for i := range s.Chapters {
+		for j := range s.Chapters[i].Nodes {
+			step++
+			if i == chapterIndex && s.Chapters[i].Nodes[j].State == StepActive {
+				return step
+			}
+		}
+	}
+	return 0
+}
+
+// ActiveNode returns the first node in active state, or nil.
+func (s *Session) ActiveNode() (*SessionNode, int) {
+	idx := 0
+	for i := range s.Chapters {
+		for j := range s.Chapters[i].Nodes {
+			idx++
+			if s.Chapters[i].Nodes[j].State == StepActive {
+				return &s.Chapters[i].Nodes[j], idx
+			}
+		}
+	}
+	return nil, 0
+}
+
+// TransitionStep validates and applies a state transition on step n.
+func (s *Session) TransitionStep(n int, to StepState) error {
+	node, err := s.NodeByNumber(n)
+	if err != nil {
+		return err
+	}
+
+	allowed, ok := validTransitions[node.State]
+	if !ok {
+		return fmt.Errorf("step %d is in terminal state %q, cannot transition", n, node.State)
+	}
+
+	valid := false
+	for _, target := range allowed {
+		if target == to {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		return fmt.Errorf("invalid transition: step %d is %q, cannot move to %q", n, node.State, to)
+	}
+
+	node.State = to
+	now := time.Now().UTC()
+
+	switch to {
+	case StepActive:
+		node.StartedAt = &now
+		node.CompletedAt = nil
+	case StepDone:
+		node.CompletedAt = &now
+		node.RejectionNote = ""
+	case StepReview:
+		node.CompletedAt = &now
+	}
+
+	return nil
+}
+
+// NextPendingStep returns the number of the next pending step after n, or 0.
+func (s *Session) NextPendingStep(after int) int {
+	idx := 0
+	for i := range s.Chapters {
+		for j := range s.Chapters[i].Nodes {
+			idx++
+			if idx > after && s.Chapters[i].Nodes[j].State == StepPending {
+				return idx
+			}
+		}
+	}
+	return 0
+}
+
+// IsComplete returns true when all nodes are done or skipped.
+func (s *Session) IsComplete() bool {
+	for i := range s.Chapters {
+		for j := range s.Chapters[i].Nodes {
+			state := s.Chapters[i].Nodes[j].State
+			if state != StepDone && state != StepSkipped {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// StepSummary returns counts of each state.
+func (s *Session) StepSummary() map[StepState]int {
+	summary := make(map[StepState]int)
+	for i := range s.Chapters {
+		for j := range s.Chapters[i].Nodes {
+			summary[s.Chapters[i].Nodes[j].State]++
+		}
+	}
+	return summary
+}

--- a/pkg/coop/session_test.go
+++ b/pkg/coop/session_test.go
@@ -1,0 +1,389 @@
+package coop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSession() *Session {
+	return &Session{
+		ID:        "test_abc123",
+		Blueprint: "one-time-payment",
+		Status:    SessionActive,
+		Chapters: []SessionChapter{
+			{
+				Key:   "chapter-1",
+				Title: "Chapter 1",
+				Nodes: []SessionNode{
+					{Key: "node-1", Title: "Step 1", State: StepPending},
+					{Key: "node-2", Title: "Step 2", State: StepPending},
+				},
+			},
+			{
+				Key:   "chapter-2",
+				Title: "Chapter 2",
+				Nodes: []SessionNode{
+					{Key: "node-3", Title: "Step 3", State: StepPending},
+				},
+			},
+		},
+	}
+}
+
+func TestTotalSteps(t *testing.T) {
+	s := newTestSession()
+	assert.Equal(t, 3, s.TotalSteps())
+}
+
+func TestNodeByNumber(t *testing.T) {
+	s := newTestSession()
+
+	node, err := s.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, "node-1", node.Key)
+
+	node, err = s.NodeByNumber(3)
+	require.NoError(t, err)
+	assert.Equal(t, "node-3", node.Key)
+
+	_, err = s.NodeByNumber(0)
+	assert.Error(t, err)
+
+	_, err = s.NodeByNumber(4)
+	assert.Error(t, err)
+}
+
+func TestTransitionStep(t *testing.T) {
+	s := newTestSession()
+
+	// pending -> active
+	err := s.TransitionStep(1, StepActive)
+	require.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, StepActive, node.State)
+	assert.NotNil(t, node.StartedAt)
+
+	// active -> review
+	err = s.TransitionStep(1, StepReview)
+	require.NoError(t, err)
+	node, _ = s.NodeByNumber(1)
+	assert.Equal(t, StepReview, node.State)
+
+	// review -> done
+	err = s.TransitionStep(1, StepDone)
+	require.NoError(t, err)
+	node, _ = s.NodeByNumber(1)
+	assert.Equal(t, StepDone, node.State)
+
+	// done -> active (invalid)
+	err = s.TransitionStep(1, StepActive)
+	assert.Error(t, err)
+}
+
+func TestTransitionStepSkip(t *testing.T) {
+	s := newTestSession()
+
+	// pending -> skipped
+	err := s.TransitionStep(1, StepSkipped)
+	require.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, StepSkipped, node.State)
+}
+
+func TestActiveNode(t *testing.T) {
+	s := newTestSession()
+
+	node, num := s.ActiveNode()
+	assert.Nil(t, node)
+	assert.Equal(t, 0, num)
+
+	s.TransitionStep(2, StepActive)
+	node, num = s.ActiveNode()
+	assert.Equal(t, "node-2", node.Key)
+	assert.Equal(t, 2, num)
+}
+
+func TestNextPendingStep(t *testing.T) {
+	s := newTestSession()
+
+	assert.Equal(t, 1, s.NextPendingStep(0))
+	assert.Equal(t, 2, s.NextPendingStep(1))
+	assert.Equal(t, 3, s.NextPendingStep(2))
+	assert.Equal(t, 0, s.NextPendingStep(3))
+}
+
+func TestIsComplete(t *testing.T) {
+	s := newTestSession()
+	assert.False(t, s.IsComplete())
+
+	for i := 1; i <= 3; i++ {
+		s.TransitionStep(i, StepActive)
+		s.TransitionStep(i, StepDone)
+	}
+	assert.True(t, s.IsComplete())
+}
+
+func TestStepSummary(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepActive)
+	s.TransitionStep(1, StepDone)
+
+	summary := s.StepSummary()
+	assert.Equal(t, 1, summary[StepDone])
+	assert.Equal(t, 2, summary[StepPending])
+}
+
+func TestTransitionStepInvalidFromDone(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepActive)
+	s.TransitionStep(1, StepDone)
+
+	// Can't go anywhere from done
+	assert.Error(t, s.TransitionStep(1, StepActive))
+	assert.Error(t, s.TransitionStep(1, StepPending))
+	assert.Error(t, s.TransitionStep(1, StepReview))
+}
+
+func TestTransitionStepInvalidFromSkipped(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepSkipped)
+
+	// Can't go anywhere from skipped
+	assert.Error(t, s.TransitionStep(1, StepActive))
+	assert.Error(t, s.TransitionStep(1, StepDone))
+}
+
+func TestTransitionStepInvalidPendingToDone(t *testing.T) {
+	s := newTestSession()
+	// Can't go directly from pending to done
+	assert.Error(t, s.TransitionStep(1, StepDone))
+}
+
+func TestTransitionStepInvalidPendingToReview(t *testing.T) {
+	s := newTestSession()
+	// Can't go directly from pending to review
+	assert.Error(t, s.TransitionStep(1, StepReview))
+}
+
+func TestTransitionStepActiveToDone(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepActive)
+	// Can go directly from active to done (--auto-confirm)
+	err := s.TransitionStep(1, StepDone)
+	assert.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, StepDone, node.State)
+	assert.NotNil(t, node.CompletedAt)
+}
+
+func TestTransitionStepSetsTimestamps(t *testing.T) {
+	s := newTestSession()
+
+	s.TransitionStep(1, StepActive)
+	node, _ := s.NodeByNumber(1)
+	assert.NotNil(t, node.StartedAt)
+	assert.Nil(t, node.CompletedAt)
+
+	s.TransitionStep(1, StepReview)
+	node, _ = s.NodeByNumber(1)
+	assert.NotNil(t, node.CompletedAt)
+}
+
+func TestNextPendingStepSkipsNonPending(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepActive)
+	s.TransitionStep(2, StepSkipped)
+
+	// After step 1 (active), next pending should be step 3 (skipping 2 which is skipped)
+	assert.Equal(t, 3, s.NextPendingStep(1))
+}
+
+func TestIsCompleteWithSkipped(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepActive)
+	s.TransitionStep(1, StepDone)
+	s.TransitionStep(2, StepSkipped)
+	s.TransitionStep(3, StepActive)
+	s.TransitionStep(3, StepDone)
+
+	assert.True(t, s.IsComplete())
+}
+
+func TestNodeByNumberAcrossChapters(t *testing.T) {
+	s := &Session{
+		Chapters: []SessionChapter{
+			{Key: "ch1", Nodes: []SessionNode{{Key: "a"}, {Key: "b"}}},
+			{Key: "ch2", Nodes: []SessionNode{{Key: "c"}}},
+			{Key: "ch3", Nodes: []SessionNode{{Key: "d"}, {Key: "e"}, {Key: "f"}}},
+		},
+	}
+
+	node, _ := s.NodeByNumber(3)
+	assert.Equal(t, "c", node.Key)
+
+	node, _ = s.NodeByNumber(6)
+	assert.Equal(t, "f", node.Key)
+
+	assert.Equal(t, 6, s.TotalSteps())
+}
+
+func TestChapterByStepNumber(t *testing.T) {
+	s := newTestSession()
+
+	ch, chapterIndex, nodeIndex, err := s.ChapterByStepNumber(3)
+	require.NoError(t, err)
+	assert.Equal(t, "chapter-2", ch.Key)
+	assert.Equal(t, 1, chapterIndex)
+	assert.Equal(t, 0, nodeIndex)
+
+	ch, chapterIndex, nodeIndex, err = s.ChapterByStepNumber(0)
+	assert.Nil(t, ch)
+	assert.Equal(t, -1, chapterIndex)
+	assert.Equal(t, -1, nodeIndex)
+	assert.Error(t, err)
+
+	ch, chapterIndex, nodeIndex, err = s.ChapterByStepNumber(4)
+	assert.Nil(t, ch)
+	assert.Equal(t, -1, chapterIndex)
+	assert.Equal(t, -1, nodeIndex)
+	assert.Error(t, err)
+}
+
+func TestReviewGranularityForStep(t *testing.T) {
+	s := newTestSession()
+	s.Chapters[0].ReviewGranularity = ReviewGranularityChapter
+	s.Chapters[1].ReviewGranularity = ReviewGranularityAuto
+
+	assert.Equal(t, ReviewGranularityChapter, s.ReviewGranularityForStep(1))
+	assert.Equal(t, ReviewGranularityChapter, s.ReviewGranularityForStep(2))
+	assert.Equal(t, ReviewGranularityAuto, s.ReviewGranularityForStep(3))
+	assert.Equal(t, ReviewGranularityStep, s.ReviewGranularityForStep(4))
+}
+
+func TestChapterReadyForReview(t *testing.T) {
+	s := newTestSession()
+	assert.False(t, s.ChapterReadyForReview(-1))
+	assert.False(t, s.ChapterReadyForReview(99))
+
+	s.Chapters[0].Nodes[0].State = StepReview
+	s.Chapters[0].Nodes[1].State = StepPending
+	assert.False(t, s.ChapterReadyForReview(0))
+
+	s.Chapters[0].Nodes[1].State = StepSkipped
+	assert.True(t, s.ChapterReadyForReview(0))
+
+	s.Chapters[0].Nodes[0].State = StepActive
+	assert.False(t, s.ChapterReadyForReview(0))
+}
+
+func TestChapterReadyForReviewIgnoresAutoConfirmNodes(t *testing.T) {
+	s := &Session{
+		Chapters: []SessionChapter{
+			{Nodes: []SessionNode{
+				{Key: "a", State: StepReview},
+				{Key: "auto", State: StepPending, AutoConfirm: true},
+			}},
+			{Nodes: []SessionNode{
+				{Key: "only-auto", State: StepPending, AutoConfirm: true},
+			}},
+		},
+	}
+
+	assert.True(t, s.ChapterReadyForReview(0))
+	assert.False(t, s.ChapterReadyForReview(1))
+}
+
+func TestChapterReviewStateHelpers(t *testing.T) {
+	s := newTestSession()
+	s.Chapters[0].Nodes[0].State = StepDone
+	s.Chapters[0].Nodes[1].State = StepReview
+	s.Chapters[1].Nodes[0].State = StepActive
+
+	assert.True(t, s.ChapterHasReview(0))
+	assert.False(t, s.ChapterHasReview(1))
+	assert.False(t, s.ChapterHasReview(-1))
+
+	assert.Equal(t, 2, s.FirstReviewStepInChapter(0))
+	assert.Equal(t, 0, s.FirstReviewStepInChapter(1))
+	assert.Equal(t, 0, s.FirstReviewStepInChapter(99))
+
+	assert.Equal(t, 0, s.FirstActiveStepInChapter(0))
+	assert.Equal(t, 3, s.FirstActiveStepInChapter(1))
+	assert.Equal(t, 0, s.FirstActiveStepInChapter(-1))
+}
+
+func TestActiveNodeReturnsFirst(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepActive)
+	s.Chapters[1].Nodes[0].State = StepActive // manually set step 3 active too
+
+	node, num := s.ActiveNode()
+	// Should return the FIRST active node
+	assert.Equal(t, "node-1", node.Key)
+	assert.Equal(t, 1, num)
+}
+
+func TestTransitionStepReviewToActive(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepActive)
+	s.TransitionStep(1, StepReview)
+
+	// Rejection: review -> active
+	err := s.TransitionStep(1, StepActive)
+	assert.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, StepActive, node.State)
+}
+
+func TestTransitionStepActiveToSkipped(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepActive)
+
+	err := s.TransitionStep(1, StepSkipped)
+	assert.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, StepSkipped, node.State)
+}
+
+func TestIsCompleteAllSkipped(t *testing.T) {
+	s := newTestSession()
+	for i := 1; i <= s.TotalSteps(); i++ {
+		s.TransitionStep(i, StepSkipped)
+	}
+	assert.True(t, s.IsComplete())
+}
+
+func TestIsCompletePartialDone(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepActive)
+	s.TransitionStep(1, StepDone)
+	// Steps 2 and 3 still pending
+	assert.False(t, s.IsComplete())
+}
+
+func TestNodeByNumberNegative(t *testing.T) {
+	s := newTestSession()
+	_, err := s.NodeByNumber(-1)
+	assert.Error(t, err)
+}
+
+func TestTransitionStepActiveToActive(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepActive)
+	// Can't transition active -> active (not in valid transitions)
+	err := s.TransitionStep(1, StepActive)
+	assert.Error(t, err)
+}
+
+func TestTransitionStepReviewToSkipped(t *testing.T) {
+	s := newTestSession()
+	s.TransitionStep(1, StepActive)
+	s.TransitionStep(1, StepReview)
+
+	err := s.TransitionStep(1, StepSkipped)
+	assert.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, StepSkipped, node.State)
+}

--- a/pkg/coop/snippet.go
+++ b/pkg/coop/snippet.go
@@ -1,0 +1,61 @@
+package coop
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+var snippetEndpoint = "https://docs.stripe.com/_endpoint/generate-example-snippet"
+
+var httpClient = &http.Client{Timeout: 5 * time.Second}
+
+// FetchSDKSnippet fetches a generated SDK code snippet from the docs endpoint.
+// path is the API path (e.g. "/v1/customers"), method is "post"/"get"/etc,
+// params is the JSON-encoded request params, and language is "node"/"python"/etc.
+func FetchSDKSnippet(path, method string, params interface{}, language string) (string, error) {
+	argsJSON := "{}"
+	if params != nil {
+		data, err := json.Marshal(params)
+		if err == nil {
+			argsJSON = string(data)
+		}
+	}
+
+	u, _ := url.Parse(snippetEndpoint)
+	q := u.Query()
+	q.Set("path", path)
+	q.Set("verb", method)
+	q.Set("args", argsJSON)
+	u.RawQuery = q.Encode()
+
+	resp, err := httpClient.Get(u.String())
+	if err != nil {
+		return "", fmt.Errorf("fetching snippet: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("snippet API returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading snippet response: %w", err)
+	}
+
+	var snippets map[string]string
+	if err := json.Unmarshal(body, &snippets); err != nil {
+		return "", fmt.Errorf("parsing snippet response: %w", err)
+	}
+
+	snippet, ok := snippets[language]
+	if !ok {
+		return "", fmt.Errorf("language %q not available (have: curl, node, python, ruby, php, java, go, dotnet)", language)
+	}
+
+	return snippet, nil
+}

--- a/pkg/coop/snippet_test.go
+++ b/pkg/coop/snippet_test.go
@@ -1,0 +1,72 @@
+package coop
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchSDKSnippet(t *testing.T) {
+	snippets := map[string]string{
+		"node":   "const stripe = require('stripe')('sk_test');\nawait stripe.customers.create({name: 'Test'});",
+		"python": "import stripe\nstripe.Customer.create(name='Test')",
+		"ruby":   "Stripe::Customer.create(name: 'Test')",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/customers", r.URL.Query().Get("path"))
+		assert.Equal(t, "post", r.URL.Query().Get("verb"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(snippets)
+	}))
+	defer server.Close()
+
+	// Override the endpoint for testing
+	origEndpoint := snippetEndpoint
+	snippetEndpoint = server.URL
+	defer func() { snippetEndpoint = origEndpoint }()
+
+	snippet, err := FetchSDKSnippet("/v1/customers", "post", map[string]string{"name": "Test"}, "node")
+	require.NoError(t, err)
+	assert.Contains(t, snippet, "stripe.customers.create")
+
+	snippet, err = FetchSDKSnippet("/v1/customers", "post", nil, "python")
+	require.NoError(t, err)
+	assert.Contains(t, snippet, "stripe.Customer.create")
+}
+
+func TestFetchSDKSnippetInvalidLanguage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"node": "code"})
+	}))
+	defer server.Close()
+
+	origEndpoint := snippetEndpoint
+	snippetEndpoint = server.URL
+	defer func() { snippetEndpoint = origEndpoint }()
+
+	_, err := FetchSDKSnippet("/v1/customers", "post", nil, "cobol")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cobol")
+}
+
+func TestFetchSDKSnippetServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer server.Close()
+
+	origEndpoint := snippetEndpoint
+	snippetEndpoint = server.URL
+	defer func() { snippetEndpoint = origEndpoint }()
+
+	_, err := FetchSDKSnippet("/v1/customers", "post", nil, "node")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}

--- a/pkg/coop/store.go
+++ b/pkg/coop/store.go
@@ -106,10 +106,28 @@ func (s *Store) writePath(path string, session *Session) error {
 		return fmt.Errorf("closing temp file: %w", err)
 	}
 
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := replaceSessionFile(tmpPath, path); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func replaceSessionFile(tmpPath, path string) error {
+	if err := os.Rename(tmpPath, path); err == nil {
+		return nil
+	} else if runtime.GOOS != "windows" {
 		return fmt.Errorf("renaming temp file: %w", err)
 	}
 
+	// Windows does not replace an existing destination with os.Rename.
+	// Writers are already serialized by the session lock, so remove first.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing existing session file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
 	return nil
 }
 
@@ -168,15 +186,15 @@ func readSessionFile(path string) ([]byte, error) {
 	deadline := time.Now().Add(250 * time.Millisecond)
 	for {
 		data, err := os.ReadFile(path)
-		if err == nil || !isWindowsSharingViolation(err) || time.Now().After(deadline) {
+		if err == nil || !isWindowsTransientReadError(err) || time.Now().After(deadline) {
 			return data, err
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 }
 
-func isWindowsSharingViolation(err error) bool {
-	return runtime.GOOS == "windows" && strings.Contains(err.Error(), "being used by another process")
+func isWindowsTransientReadError(err error) bool {
+	return runtime.GOOS == "windows" && (os.IsNotExist(err) || strings.Contains(err.Error(), "being used by another process"))
 }
 
 // Update loads, mutates, and atomically writes a session with optimistic locking.
@@ -242,8 +260,8 @@ func (s *Store) writeUnlocked(path string, session *Session) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("closing temp file: %w", err)
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("renaming temp file: %w", err)
+	if err := replaceSessionFile(tmpPath, path); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/coop/store.go
+++ b/pkg/coop/store.go
@@ -1,0 +1,396 @@
+package coop
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Store manages session persistence with atomic writes.
+type Store struct {
+	baseDir string
+}
+
+var (
+	ErrInvalidSessionID = errors.New("invalid session id")
+	ErrSessionNotFound  = errors.New("session not found")
+	ErrVersionConflict  = errors.New("version conflict")
+	ErrLockTimeout      = errors.New("timed out waiting for session lock")
+	ErrCorruptSession   = errors.New("corrupt session")
+)
+
+// NewStore creates a Store, ensuring the coop directory exists.
+func NewStore(configFolder string) (*Store, error) {
+	dir := filepath.Join(configFolder, "coop")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("creating coop directory: %w", err)
+	}
+	return &Store{baseDir: dir}, nil
+}
+
+// NewStoreAt creates a Store at a specific path (for testing).
+func NewStoreAt(dir string) (*Store, error) {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("creating coop directory: %w", err)
+	}
+	return &Store{baseDir: dir}, nil
+}
+
+func (s *Store) sessionPath(id string) (string, error) {
+	// Validate ID to prevent path traversal
+	base := filepath.Base(id)
+	if base != id || id == "" || id == "." || id == ".." {
+		return "", fmt.Errorf("%w: %q", ErrInvalidSessionID, id)
+	}
+	return filepath.Join(s.baseDir, id+".json"), nil
+}
+
+// Write atomically persists a session (write to .tmp then rename).
+// Uses optimistic locking: checks that the file's current version matches
+// the session's version before writing. Returns an error on conflict.
+func (s *Store) Write(session *Session) error {
+	path, err := s.sessionPath(session.ID)
+	if err != nil {
+		return err
+	}
+	return s.writePath(path, session)
+}
+
+func (s *Store) writePath(path string, session *Session) error {
+	unlock, err := s.acquireSessionLock(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	// Optimistic lock: if file exists, verify version hasn't changed
+	if existing, err := os.ReadFile(path); err == nil {
+		var current Session
+		if json.Unmarshal(existing, &current) == nil {
+			if current.Version != session.Version {
+				// Re-read to get latest state
+				return fmt.Errorf("%w: expected %d, file has %d", ErrVersionConflict, session.Version, current.Version)
+			}
+		}
+	}
+
+	if session.SchemaVersion == 0 {
+		session.SchemaVersion = CurrentSessionSchemaVersion
+	}
+	session.UpdatedAt = time.Now().UTC()
+	session.Version++
+
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling session: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(s.baseDir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Store) acquireSessionLock(path string) (func(), error) {
+	lockPath := path + ".lock"
+	deadline := time.Now().Add(5 * time.Second)
+
+	for {
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+		if err == nil {
+			f.Close()
+			return func() { os.Remove(lockPath) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, fmt.Errorf("creating lock file: %w", err)
+		}
+
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > 30*time.Second {
+			os.Remove(lockPath)
+			continue
+		}
+
+		if time.Now().After(deadline) {
+			return nil, ErrLockTimeout
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+// Read loads a session from disk.
+func (s *Store) Read(id string) (*Session, error) {
+	path, err := s.sessionPath(id)
+	if err != nil {
+		return nil, err
+	}
+	data, err := readSessionFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: %q", ErrSessionNotFound, id)
+		}
+		return nil, fmt.Errorf("reading session %q: %w", id, err)
+	}
+
+	var session Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("%w: parsing session %q: %v", ErrCorruptSession, id, err)
+	}
+	if session.SchemaVersion == 0 {
+		session.SchemaVersion = 1
+	}
+
+	return &session, nil
+}
+
+func readSessionFile(path string) ([]byte, error) {
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil || !isWindowsSharingViolation(err) || time.Now().After(deadline) {
+			return data, err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func isWindowsSharingViolation(err error) bool {
+	return runtime.GOOS == "windows" && strings.Contains(err.Error(), "being used by another process")
+}
+
+// Update loads, mutates, and atomically writes a session with optimistic locking.
+func (s *Store) Update(id string, fn func(*Session) error) (*Session, error) {
+	path, err := s.sessionPath(id)
+	if err != nil {
+		return nil, err
+	}
+
+	unlock, err := s.acquireSessionLock(path)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: %q", ErrSessionNotFound, id)
+		}
+		return nil, fmt.Errorf("reading session %q: %w", id, err)
+	}
+
+	var session Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("%w: parsing session %q: %v", ErrCorruptSession, id, err)
+	}
+	if session.SchemaVersion == 0 {
+		session.SchemaVersion = 1
+	}
+	if err := fn(&session); err != nil {
+		return nil, err
+	}
+	if session.SchemaVersion == 0 || session.SchemaVersion == 1 {
+		session.SchemaVersion = CurrentSessionSchemaVersion
+	}
+	session.UpdatedAt = time.Now().UTC()
+	session.Version++
+
+	if err := s.writeUnlocked(path, &session); err != nil {
+		return nil, err
+	}
+	return &session, nil
+}
+
+func (s *Store) writeUnlocked(path string, session *Session) error {
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling session: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(s.baseDir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+	return nil
+}
+
+// ModTime returns the file modification time (for polling).
+func (s *Store) ModTime(id string) (time.Time, error) {
+	path, err := s.sessionPath(id)
+	if err != nil {
+		return time.Time{}, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return info.ModTime(), nil
+}
+
+// List returns all session IDs found on disk.
+func (s *Store) List() ([]string, error) {
+	entries, err := os.ReadDir(s.baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var ids []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			continue
+		}
+		ids = append(ids, strings.TrimSuffix(e.Name(), ".json"))
+	}
+	return ids, nil
+}
+
+// LatestSession returns the most recently updated session.
+func (s *Store) LatestSession() (*Session, error) {
+	ids, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("no coop sessions found")
+	}
+
+	type entry struct {
+		id      string
+		modTime time.Time
+	}
+	var entries []entry
+	for _, id := range ids {
+		mt, err := s.ModTime(id)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, entry{id: id, modTime: mt})
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no readable coop sessions found")
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].modTime.After(entries[j].modTime)
+	})
+
+	return s.Read(entries[0].id)
+}
+
+// LatestActiveSession returns the most recently updated session with status "active".
+func (s *Store) LatestActiveSession() (*Session, error) {
+	ids, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("no coop sessions found")
+	}
+
+	type entry struct {
+		id      string
+		modTime time.Time
+	}
+	var entries []entry
+	for _, id := range ids {
+		mt, err := s.ModTime(id)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, entry{id: id, modTime: mt})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].modTime.After(entries[j].modTime)
+	})
+
+	for _, e := range entries {
+		session, err := s.Read(e.id)
+		if err != nil {
+			continue
+		}
+		if session.Status == SessionActive {
+			return session, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no active coop sessions found")
+}
+
+// Delete removes a session file.
+func (s *Store) Delete(id string) error {
+	path, err := s.sessionPath(id)
+	if err != nil {
+		return err
+	}
+	return os.Remove(path)
+}
+
+func (s *Store) heartbeatPath(id string) string {
+	path, err := s.sessionPath(id)
+	if err != nil {
+		return filepath.Join(s.baseDir, "invalid.heartbeat")
+	}
+	return path + ".heartbeat"
+}
+
+// WriteHeartbeat updates the heartbeat file for a session (signals agent is polling).
+func (s *Store) WriteHeartbeat(id string) {
+	os.WriteFile(s.heartbeatPath(id), []byte(time.Now().UTC().Format(time.RFC3339)), 0600)
+}
+
+// HeartbeatAge returns how long ago the heartbeat was updated.
+// Returns -1 if no heartbeat file exists.
+func (s *Store) HeartbeatAge(id string) time.Duration {
+	info, err := os.Stat(s.heartbeatPath(id))
+	if err != nil {
+		return -1
+	}
+	return time.Since(info.ModTime())
+}
+
+// RemoveHeartbeat cleans up the heartbeat file.
+func (s *Store) RemoveHeartbeat(id string) {
+	os.Remove(s.heartbeatPath(id))
+}

--- a/pkg/coop/store_test.go
+++ b/pkg/coop/store_test.go
@@ -1,0 +1,248 @@
+package coop
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreWriteRead(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	session := &Session{
+		ID:        "test_001",
+		Blueprint: "one-time-payment",
+		Status:    SessionActive,
+		Chapters: []SessionChapter{
+			{
+				Key:   "ch-1",
+				Title: "Chapter 1",
+				Nodes: []SessionNode{
+					{Key: "n-1", Title: "Step 1", State: StepPending},
+				},
+			},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = store.Write(session)
+	require.NoError(t, err)
+	assert.Equal(t, 1, session.Version)
+
+	loaded, err := store.Read("test_001")
+	require.NoError(t, err)
+	assert.Equal(t, "test_001", loaded.ID)
+	assert.Equal(t, "one-time-payment", loaded.Blueprint)
+	assert.Equal(t, CurrentSessionSchemaVersion, loaded.SchemaVersion)
+	assert.Equal(t, 1, loaded.Version)
+	assert.Equal(t, StepPending, loaded.Chapters[0].Nodes[0].State)
+}
+
+func TestStoreWriteIncrementsVersion(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	session := &Session{ID: "test_002", Status: SessionActive}
+	store.Write(session)
+	assert.Equal(t, 1, session.Version)
+
+	store.Write(session)
+	assert.Equal(t, 2, session.Version)
+}
+
+func TestStoreUpdateMutatesAndVersionsSession(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	session := &Session{
+		ID:       "update_test",
+		Status:   SessionActive,
+		Chapters: []SessionChapter{{Key: "chapter", Nodes: []SessionNode{{Key: "step", Title: "Step", State: StepPending}}}},
+	}
+	require.NoError(t, store.Write(session))
+
+	updated, err := store.Update("update_test", func(session *Session) error {
+		node, err := session.NodeByNumber(1)
+		require.NoError(t, err)
+		node.Activity = "working"
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, updated.Version)
+	assert.Equal(t, CurrentSessionSchemaVersion, updated.SchemaVersion)
+	assert.Equal(t, "working", updated.Chapters[0].Nodes[0].Activity)
+
+	loaded, err := store.Read("update_test")
+	require.NoError(t, err)
+	assert.Equal(t, "working", loaded.Chapters[0].Nodes[0].Activity)
+}
+
+func TestStoreUpdateInvalidSessionID(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	_, err = store.Update("../bad", func(session *Session) error { return nil })
+	require.ErrorIs(t, err, ErrInvalidSessionID)
+}
+
+func TestStoreList(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "sess_a", Status: SessionActive})
+	store.Write(&Session{ID: "sess_b", Status: SessionActive})
+
+	ids, err := store.List()
+	require.NoError(t, err)
+	assert.Len(t, ids, 2)
+	assert.Contains(t, ids, "sess_a")
+	assert.Contains(t, ids, "sess_b")
+}
+
+func TestStoreLatestSession(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "old", Status: SessionActive})
+	time.Sleep(10 * time.Millisecond)
+	store.Write(&Session{ID: "new", Status: SessionActive})
+
+	latest, err := store.LatestSession()
+	require.NoError(t, err)
+	assert.Equal(t, "new", latest.ID)
+}
+
+func TestStoreModTime(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "timed", Status: SessionActive})
+
+	mt, err := store.ModTime("timed")
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now(), mt, 2*time.Second)
+}
+
+func TestStoreDelete(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "doomed", Status: SessionActive})
+	err = store.Delete("doomed")
+	require.NoError(t, err)
+
+	_, err = store.Read("doomed")
+	assert.Error(t, err)
+}
+
+func TestStoreReadNotFound(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	_, err = store.Read("nonexistent")
+	assert.Error(t, err)
+}
+
+func TestStoreLatestActiveSession(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	// Write a completed session
+	store.Write(&Session{ID: "completed_one", Status: SessionCompleted})
+	time.Sleep(10 * time.Millisecond)
+
+	// Write an active session
+	store.Write(&Session{ID: "active_one", Status: SessionActive})
+	time.Sleep(10 * time.Millisecond)
+
+	// Write an aborted session (most recent, but not active)
+	store.Write(&Session{ID: "aborted_one", Status: SessionAborted})
+
+	// Should find the active one
+	session, err := store.LatestActiveSession()
+	require.NoError(t, err)
+	assert.Equal(t, "active_one", session.ID)
+}
+
+func TestStoreLatestActiveSessionNoneActive(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "done", Status: SessionCompleted})
+	store.Write(&Session{ID: "aborted", Status: SessionAborted})
+
+	_, err = store.LatestActiveSession()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no active")
+}
+
+func TestStoreLatestActiveSessionEmpty(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	_, err = store.LatestActiveSession()
+	assert.Error(t, err)
+}
+
+func TestStoreAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	session := &Session{ID: "atomic_test", Status: SessionActive}
+	err = store.Write(session)
+	require.NoError(t, err)
+
+	// Verify no .tmp file left behind
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		assert.False(t, strings.HasSuffix(e.Name(), ".tmp"), "temp file should be cleaned up")
+	}
+}
+
+func TestStoreWriteCleansLockAndTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	session := &Session{ID: "clean_test", Status: SessionActive}
+	require.NoError(t, store.Write(session))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasSuffix(e.Name(), ".tmp"), "temp file should be cleaned up")
+		assert.False(t, strings.HasSuffix(e.Name(), ".lock"), "lock file should be cleaned up")
+	}
+}
+
+func TestStoreListIgnoresTmpFiles(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "real", Status: SessionActive})
+	// Simulate a leftover tmp file
+	os.WriteFile(dir+"/orphan.json.tmp", []byte("{}"), 0600)
+
+	ids, err := store.List()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"real"}, ids)
+}

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -1,0 +1,148 @@
+// Package coop implements the co-op mode feature for collaborative
+// AI agent + human developer Stripe integration building.
+package coop
+
+import "time"
+
+// StepState represents the lifecycle state of a single step/node.
+type StepState string
+
+const (
+	CurrentSessionSchemaVersion = 2
+)
+
+const (
+	StepPending StepState = "pending"
+	StepActive  StepState = "active"
+	StepReview  StepState = "review"
+	StepDone    StepState = "done"
+	StepSkipped StepState = "skipped"
+)
+
+// NodeType represents the type of a blueprint node.
+type NodeType string
+
+const (
+	NodeAPIRequest    NodeType = "apiRequest"
+	NodeAsyncHandler  NodeType = "asyncHandler"
+	NodeUIComponent   NodeType = "uiComponent"
+	NodeTestHelper    NodeType = "testHelper"
+	NodeCLICommand    NodeType = "cliCommand"
+	NodeDashboard     NodeType = "dashboard"
+	NodeSetUpWebhooks NodeType = "setUpWebhooks"
+)
+
+// ReviewGranularity controls where human approval happens.
+type ReviewGranularity string
+
+const (
+	ReviewGranularityStep    ReviewGranularity = "step"
+	ReviewGranularityChapter ReviewGranularity = "chapter"
+	ReviewGranularityAuto    ReviewGranularity = "auto"
+)
+
+// SessionStatus represents the overall session lifecycle.
+type SessionStatus string
+
+const (
+	SessionActive    SessionStatus = "active"
+	SessionCompleted SessionStatus = "completed"
+	SessionAborted   SessionStatus = "aborted"
+)
+
+// Implementation captures what the agent did for a step.
+type Implementation struct {
+	File    string `json:"file,omitempty"`
+	Lines   string `json:"lines,omitempty"`
+	Snippet string `json:"snippet,omitempty"`
+	Note    string `json:"note,omitempty"`
+}
+
+// Verification is a single check the agent ran.
+type Verification struct {
+	Check  string `json:"check"`
+	Passed bool   `json:"passed"`
+}
+
+// APIRequest describes the expected API call for a node.
+type APIRequest struct {
+	Key    string      `json:"key,omitempty"`
+	Path   string      `json:"path"`
+	Method string      `json:"method"`
+	Params interface{} `json:"params,omitempty"`
+}
+
+// SessionNode is a single step within a session chapter.
+type SessionNode struct {
+	Key            string          `json:"key"`
+	Type           NodeType        `json:"type"`
+	Title          string          `json:"title"`
+	Description    string          `json:"description,omitempty"`
+	ReviewPrompt   string          `json:"review_prompt,omitempty"`
+	ReviewCommand  string          `json:"review_command,omitempty"`
+	AutoConfirm    bool            `json:"auto_confirm,omitempty"`
+	State          StepState       `json:"state"`
+	Activity       string          `json:"activity,omitempty"`
+	Implementation *Implementation `json:"implementation,omitempty"`
+	Verifications  []Verification  `json:"verifications,omitempty"`
+	Request        *APIRequest     `json:"request,omitempty"`
+	Events         []string        `json:"events,omitempty"`
+	RejectionNote  string          `json:"rejection_note,omitempty"`
+	StartedAt      *time.Time      `json:"started_at,omitempty"`
+	CompletedAt    *time.Time      `json:"completed_at,omitempty"`
+}
+
+// SessionChapter groups nodes under a titled section.
+type SessionChapter struct {
+	Key               string            `json:"key"`
+	Title             string            `json:"title"`
+	ReviewGranularity ReviewGranularity `json:"review_granularity,omitempty"`
+	Nodes             []SessionNode     `json:"nodes"`
+}
+
+// Session is the shared state file between agent and TUI.
+type Session struct {
+	SchemaVersion   int               `json:"schema_version"`
+	ID              string            `json:"id"`
+	Blueprint       string            `json:"blueprint"`
+	Status          SessionStatus     `json:"status"`
+	Settings        map[string]string `json:"settings,omitempty"`
+	Chapters        []SessionChapter  `json:"chapters"`
+	ClaimURL        string            `json:"claim_url,omitempty"`
+	NextSteps       *NextStepsState   `json:"next_steps,omitempty"`
+	ParentSessionID string            `json:"parent_session_id,omitempty"`
+	ParentStepID    string            `json:"parent_step_id,omitempty"` // which next-step this session fulfills
+	CreatedAt       time.Time         `json:"created_at"`
+	UpdatedAt       time.Time         `json:"updated_at"`
+	Version         int               `json:"version"`
+}
+
+// NextStepsState tracks post-completion suggestions and selection.
+type NextStepsState struct {
+	Suggestions []NextStepSuggestion `json:"suggestions"`
+	Selected    string               `json:"selected,omitempty"`
+	Completed   []string             `json:"completed,omitempty"`
+}
+
+// NextStepSuggestion is a post-completion recommendation.
+type NextStepSuggestion struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+// CommandResponse is the JSON output format for agent-facing commands.
+type CommandResponse struct {
+	OK          bool        `json:"ok"`
+	SessionID   string      `json:"session_id,omitempty"`
+	Step        int         `json:"step,omitempty"`
+	State       string      `json:"state,omitempty"`
+	Message     string      `json:"message,omitempty"`
+	Next        string      `json:"next,omitempty"`
+	AgentPrompt string      `json:"agent_prompt,omitempty"`
+	APIRequest  *APIRequest `json:"api_request,omitempty"`
+	SDKExample  string      `json:"sdk_example,omitempty"`
+	Error       string      `json:"error,omitempty"`
+	Hint        string      `json:"hint,omitempty"`
+}


### PR DESCRIPTION
## What this adds

This is the foundation PR for co-op mode. It adds the domain layer only: no Cobra command registration, no TUI, no launcher, and no deploy follow-up behavior.

- Adds the co-op session schema and step/chapter state machine
- Adds file-backed session persistence with locking, versioning, latest-session lookup, and heartbeat helpers
- Adds embedded blueprint loading, prefix matching, metadata listing, and validation tests
- Adds SDK snippet fetching support for API request steps
- Adds the initial non-deploy blueprint catalog

## Base branch strategy

This PR targets `tomer/coop-stack-base`, an empty branch created from latest `master`. The stack should be reviewed and merged into that branch first, not directly into `master`.

After all stack PRs have been reviewed and merged into `tomer/coop-stack-base`, we can open the final integration PR from `tomer/coop-stack-base` into `master` and merge the complete co-op feature in one step. GitHub does not allow opening that final integration PR while the base branch is still identical to `master`, so it will be created after the stack starts landing.

## Why this is split out

Reviewers can evaluate the data model and persistence behavior without needing to understand the agent protocol, tmux launcher, or Bubble Tea UI. Later PRs build on these types and store APIs.

## Review focus

- Session and step state transitions
- Store behavior and file locking semantics
- Blueprint JSON shape and loader behavior
- Whether the domain model gives the later workflow/TUI enough structure without coupling to UI concerns

## Stack

Base branch: `tomer/coop-stack-base`

1. This PR: domain model and blueprints
2. #1665: agent workflow protocol
3. #1666: terminal UI
4. #1667: launcher and debug harness
5. #1668: deploy follow-up support
6. #1669: root registration and docs

## Validation

- `go test ./pkg/coop -count=1`