### PR TITLE
Add co-op agent workflow protocol

### DIFF
--- a/pkg/cmd/coop/coop.go
+++ b/pkg/cmd/coop/coop.go
@@ -83,9 +83,3 @@ func mustMarkFlagRequired(cmd *cobra.Command, name string) {
 		panic("marking required flag " + name + ": " + err.Error())
 	}
 }
-
-func mustMarkFlagHidden(cmd *cobra.Command, name string) {
-	if err := cmd.Flags().MarkHidden(name); err != nil {
-		panic("hiding flag " + name + ": " + err.Error())
-	}
-}

--- a/pkg/cmd/coop/coop.go
+++ b/pkg/cmd/coop/coop.go
@@ -1,0 +1,91 @@
+// Package coopcmd wires the co-op mode Cobra commands into the Stripe CLI.
+package coopcmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+type Options struct {
+	ConfigFolder             func() string
+	ClaimURL                 func() string
+	AIAgentHelpAnnotationKey string
+}
+
+const defaultAIAgentHelpAnnotationKey = "ai_agent_help"
+
+var options Options
+
+func New(opts Options) *cobra.Command {
+	options = opts
+	return newCoopCmd().cmd
+}
+
+type coopCmd struct {
+	cmd *cobra.Command
+}
+
+func newCoopCmd() *coopCmd {
+	cc := &coopCmd{}
+	annotationKey := options.AIAgentHelpAnnotationKey
+	if annotationKey == "" {
+		annotationKey = defaultAIAgentHelpAnnotationKey
+	}
+	cc.cmd = &cobra.Command{
+		Use:   "coop",
+		Short: "Collaborative integration mode (AI agent + human developer)",
+		Long: `Co-op mode enables AI agents and human developers to collaborate on Stripe
+integrations in real time. The agent writes code and reports progress via CLI
+commands; the developer watches live in a terminal UI.
+
+Start a session with a blueprint, then let the agent work through it step by step.
+The developer confirms each step before the agent moves on.`,
+		Annotations: map[string]string{
+			annotationKey: `  Workflow: start a session, then use typed agent commands to progress through it.
+  1. stripe coop run <blueprint-id> — begin a session
+  2. stripe coop agent start-work --session=<id> --step=<n> --note="..." — mark work active
+  3. stripe coop agent report-check --session=<id> --step=<n> --check="..." --passed — add verification
+  4. stripe coop agent report-work --session=<id> --step=<n> --file=... --note="..." — report work complete
+  All commands output JSON with a "next" field suggesting the next command.
+  Run "stripe coop recommend --query=..." to discover available blueprints.`,
+		},
+	}
+
+	cc.cmd.AddCommand(newCoopStartCmd().cmd)
+	cc.cmd.AddCommand(newCoopAgentCmd().cmd)
+	cc.cmd.AddCommand(newCoopStatusCmd().cmd)
+	cc.cmd.AddCommand(newCoopStopCmd().cmd)
+	cc.cmd.AddCommand(newCoopRecommendCmd().cmd)
+
+	return cc
+}
+
+func coopConfigFolder() string {
+	if options.ConfigFolder == nil {
+		var cfg config.Config
+		return cfg.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	}
+	return options.ConfigFolder()
+}
+
+func coopClaimURL() string {
+	if options.ClaimURL == nil {
+		return ""
+	}
+	return options.ClaimURL()
+}
+
+func mustMarkFlagRequired(cmd *cobra.Command, name string) {
+	if err := cmd.MarkFlagRequired(name); err != nil {
+		panic("marking required flag " + name + ": " + err.Error())
+	}
+}
+
+func mustMarkFlagHidden(cmd *cobra.Command, name string) {
+	if err := cmd.Flags().MarkHidden(name); err != nil {
+		panic("hiding flag " + name + ": " + err.Error())
+	}
+}

--- a/pkg/cmd/coop/coop_agent.go
+++ b/pkg/cmd/coop/coop_agent.go
@@ -1,0 +1,208 @@
+package coopcmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/helpers"
+	"github.com/stripe/stripe-cli/pkg/coop/workflow"
+)
+
+type coopAgentCmd struct {
+	cmd *cobra.Command
+}
+
+type coopAgentActionCmd struct {
+	cmd     *cobra.Command
+	session string
+	step    int
+	note    string
+
+	file    string
+	lines   string
+	snippet string
+	check   string
+	passed  bool
+
+	completed string
+}
+
+func newCoopAgentCmd() *coopAgentCmd {
+	ac := &coopAgentCmd{}
+	ac.cmd = &cobra.Command{
+		Use:   "agent",
+		Short: "Agent-facing co-op lifecycle commands",
+		Long:  "Typed commands used by agents to report co-op progress and wait for human review.",
+	}
+	ac.cmd.AddCommand(newCoopAgentStartWorkCmd().cmd)
+	ac.cmd.AddCommand(newCoopAgentReportWorkCmd().cmd)
+	ac.cmd.AddCommand(newCoopAgentReportCheckCmd().cmd)
+	ac.cmd.AddCommand(newCoopAgentSkipCmd().cmd)
+	ac.cmd.AddCommand(newCoopAgentAwaitReviewCmd().cmd)
+	ac.cmd.AddCommand(newCoopAgentNextActionCmd().cmd)
+	return ac
+}
+
+func newCoopAgentStartWorkCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "start-work",
+		Short: "Mark a step as active",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newWorkflowService()
+			if err != nil {
+				return err
+			}
+			resp, err := service.StartWork(c.session, c.step, c.note)
+			return outputAgentResponse(resp, err)
+		},
+	}
+	c.addSessionStepFlags()
+	c.cmd.Flags().StringVar(&c.note, "note", "", "Activity note")
+	return c
+}
+
+func newCoopAgentReportWorkCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "report-work",
+		Short: "Report completed implementation work",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newWorkflowService()
+			if err != nil {
+				return err
+			}
+			resp, err := service.ReportWork(c.session, c.step, workflow.ReportWorkInput{
+				File:    c.file,
+				Lines:   c.lines,
+				Snippet: c.snippet,
+				Note:    c.note,
+			}, false)
+			return outputAgentResponse(resp, err)
+		},
+	}
+	c.addSessionStepFlags()
+	c.cmd.Flags().StringVar(&c.file, "file", "", "File path for implementation")
+	c.cmd.Flags().StringVar(&c.lines, "lines", "", "Line range, e.g. 1-15")
+	c.cmd.Flags().StringVar(&c.snippet, "snippet", "", "Code snippet")
+	c.cmd.Flags().StringVar(&c.note, "note", "", "Implementation summary")
+	return c
+}
+
+func newCoopAgentReportCheckCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "report-check",
+		Short: "Report a verification check",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newWorkflowService()
+			if err != nil {
+				return err
+			}
+			resp, err := service.ReportCheck(c.session, c.step, c.check, c.passed)
+			return outputAgentResponse(resp, err)
+		},
+	}
+	c.addSessionStepFlags()
+	c.cmd.Flags().StringVar(&c.check, "check", "", "Verification check label")
+	c.cmd.Flags().BoolVar(&c.passed, "passed", false, "Whether the verification passed")
+	return c
+}
+
+func newCoopAgentSkipCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "skip",
+		Short: "Skip a step",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newWorkflowService()
+			if err != nil {
+				return err
+			}
+			resp, err := service.Skip(c.session, c.step, c.note)
+			return outputAgentResponse(resp, err)
+		},
+	}
+	c.addSessionStepFlags()
+	c.cmd.Flags().StringVar(&c.note, "note", "", "Skip reason")
+	return c
+}
+
+func newCoopAgentAwaitReviewCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "await-review",
+		Short: "Block until the developer confirms or requests changes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newWorkflowService()
+			if err != nil {
+				return err
+			}
+			resp, err := service.AwaitReview(c.session, c.step)
+			return outputAgentResponse(resp, err)
+		},
+	}
+	c.addSessionStepFlags()
+	return c
+}
+
+func newCoopAgentNextActionCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "next-action",
+		Short: "Wait for or record the developer's next action",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCoopNextAction(c.session, c.completed)
+		},
+	}
+	c.cmd.Flags().StringVar(&c.session, "session", "", "Session ID")
+	c.cmd.Flags().StringVar(&c.completed, "completed", "", "Mark a next action as completed")
+	mustMarkFlagRequired(c.cmd, "session")
+	return c
+}
+
+func (c *coopAgentActionCmd) addSessionStepFlags() {
+	c.cmd.Flags().StringVar(&c.session, "session", "", "Session ID")
+	c.cmd.Flags().IntVar(&c.step, "step", 0, "1-based step number")
+	mustMarkFlagRequired(c.cmd, "session")
+	mustMarkFlagRequired(c.cmd, "step")
+}
+
+func newWorkflowService() (*workflow.Service, error) {
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return nil, fmt.Errorf("creating store: %w", err)
+	}
+	return workflow.NewService(store), nil
+}
+
+func runCoopNextAction(sessionID, completed string) error {
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+	resp, err := helpers.Run(store, helpers.Input{SessionID: sessionID, Completed: completed})
+	if errors.Is(err, helpers.ErrNoSession) {
+		return outputCoopError("No session found.", "stripe coop run <blueprint>")
+	}
+	if err != nil {
+		return err
+	}
+	return outputJSON(resp)
+}
+
+func outputAgentResponse(resp coop.CommandResponse, err error) error {
+	if err != nil {
+		return err
+	}
+	if outErr := outputJSON(resp); outErr != nil {
+		return outErr
+	}
+	if !resp.OK {
+		return RenderedError{}
+	}
+	return nil
+}

--- a/pkg/cmd/coop/coop_agent_test.go
+++ b/pkg/cmd/coop/coop_agent_test.go
@@ -1,0 +1,83 @@
+package coopcmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func setupAgentCommandTest(t *testing.T) (*coop.Store, *coop.Session) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	store, err := coop.NewStore(coopConfigFolder())
+	require.NoError(t, err)
+	session := &coop.Session{
+		SchemaVersion: coop.CurrentSessionSchemaVersion,
+		ID:            "agent_test_session",
+		Status:        coop.SessionActive,
+		Settings:      map[string]string{"language": "node"},
+		Chapters: []coop.SessionChapter{
+			{
+				Key:   "ch1",
+				Title: "Section 1",
+				Nodes: []coop.SessionNode{
+					{Key: "n1", Title: "Step 1", State: coop.StepPending, Type: coop.NodeTestHelper},
+				},
+			},
+		},
+	}
+	require.NoError(t, store.Write(session))
+	return store, session
+}
+
+func TestCoopAgentStartWorkCommand(t *testing.T) {
+	store, session := setupAgentCommandTest(t)
+	cmd := newCoopAgentStartWorkCmd().cmd
+	cmd.SetArgs([]string{"--session", session.ID, "--step", "1", "--note", "Starting"})
+
+	output := captureStdout(t, func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &resp))
+	require.True(t, resp.OK)
+	assert.Contains(t, resp.Next, "stripe coop agent report-work")
+
+	loaded, err := store.Read(session.ID)
+	require.NoError(t, err)
+	node, err := loaded.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.StepActive, node.State)
+}
+
+func TestCoopAgentReportCheckCommand(t *testing.T) {
+	store, session := setupAgentCommandTest(t)
+	_, err := store.Update(session.ID, func(session *coop.Session) error {
+		return session.TransitionStep(1, coop.StepActive)
+	})
+	require.NoError(t, err)
+
+	cmd := newCoopAgentReportCheckCmd().cmd
+	cmd.SetArgs([]string{"--session", session.ID, "--step", "1", "--check", "Manual checkout passed", "--passed"})
+
+	output := captureStdout(t, func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &resp))
+	require.True(t, resp.OK)
+
+	loaded, err := store.Read(session.ID)
+	require.NoError(t, err)
+	node, err := loaded.NodeByNumber(1)
+	require.NoError(t, err)
+	require.Len(t, node.Verifications, 1)
+	assert.Equal(t, "Manual checkout passed", node.Verifications[0].Check)
+	assert.True(t, node.Verifications[0].Passed)
+}

--- a/pkg/cmd/coop/coop_recommend.go
+++ b/pkg/cmd/coop/coop_recommend.go
@@ -1,0 +1,129 @@
+package coopcmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type coopRecommendCmd struct {
+	cmd   *cobra.Command
+	query string
+}
+
+func newCoopRecommendCmd() *coopRecommendCmd {
+	rc := &coopRecommendCmd{}
+	rc.cmd = &cobra.Command{
+		Use:   "recommend",
+		Short: "Find blueprints matching your integration needs",
+		Long: `Search available blueprints by keyword. Useful for discovering which
+blueprint to use for a given integration scenario.`,
+		Example: `  stripe coop recommend --query="accept payments"
+  stripe coop recommend --query="subscriptions"
+  stripe coop recommend --query="save card future"`,
+		RunE: rc.runRecommendCmd,
+	}
+
+	rc.cmd.Flags().StringVar(&rc.query, "query", "", "Search query to match against blueprints")
+
+	return rc
+}
+
+func (rc *coopRecommendCmd) runRecommendCmd(cmd *cobra.Command, args []string) error {
+	blueprints, err := coop.ListBlueprintsWithMetadata()
+	if err != nil {
+		return fmt.Errorf("loading blueprints: %w", err)
+	}
+
+	type bpEntry struct {
+		ID          string   `json:"id"`
+		Title       string   `json:"title"`
+		Description string   `json:"description"`
+		Products    []string `json:"products,omitempty"`
+		StepCount   int      `json:"step_count"`
+		Command     string   `json:"command"`
+		Score       int      `json:"score,omitempty"`
+	}
+
+	var catalog []bpEntry
+	for _, bp := range blueprints {
+		steps := 0
+		for _, ch := range bp.Chapters {
+			steps += len(ch.Nodes)
+		}
+		entry := bpEntry{
+			ID:          bp.ID,
+			Title:       bp.Title,
+			Description: bp.Description,
+			Products:    bp.Products,
+			StepCount:   steps,
+			Command:     fmt.Sprintf("stripe coop run %s", bp.ID),
+		}
+		if rc.query != "" {
+			entry.Score = blueprintMatchScore(bp, rc.query)
+			if entry.Score == 0 {
+				continue
+			}
+		}
+		catalog = append(catalog, entry)
+	}
+
+	if rc.query != "" {
+		sort.SliceStable(catalog, func(i, j int) bool {
+			return catalog[i].Score > catalog[j].Score
+		})
+	}
+
+	response := map[string]interface{}{
+		"blueprints": catalog,
+		"agent_instructions": `Pick the blueprint that best matches what the developer described.
+Consider: what they're building, whether it's one-time or recurring, if it involves platforms/marketplaces.
+If multiple could fit, ask the developer to clarify between the top 2-3 options.
+Once decided, run the "command" field for that blueprint.`,
+	}
+
+	if rc.query != "" {
+		response["query"] = rc.query
+	}
+
+	return outputJSON(response)
+}
+
+func blueprintMatchScore(bp coop.Blueprint, query string) int {
+	query = strings.ToLower(query)
+	terms := strings.FieldsFunc(query, func(r rune) bool {
+		return r == ' ' || r == '-' || r == '_' || r == ',' || r == '.' || r == '/'
+	})
+	if len(terms) == 0 {
+		return 0
+	}
+
+	id := strings.ToLower(bp.ID)
+	title := strings.ToLower(bp.Title)
+	description := strings.ToLower(bp.Description)
+	products := strings.ToLower(strings.Join(bp.Products, " "))
+
+	score := 0
+	for _, term := range terms {
+		switch {
+		case term == "":
+			continue
+		case strings.Contains(id, term):
+			score += 5
+		case strings.Contains(title, term):
+			score += 4
+		case strings.Contains(products, term):
+			score += 3
+		case strings.Contains(description, term):
+			score += 2
+		}
+	}
+	if strings.Contains(title, query) || strings.Contains(description, query) || strings.Contains(id, strings.ReplaceAll(query, " ", "-")) {
+		score += 5
+	}
+	return score
+}

--- a/pkg/cmd/coop/coop_run.go
+++ b/pkg/cmd/coop/coop_run.go
@@ -1,0 +1,225 @@
+package coopcmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type coopStartCmd struct {
+	cmd           *cobra.Command
+	language      string
+	settings      []string
+	parentSession string
+	parentStep    string
+}
+
+func newCoopStartCmd() *coopStartCmd {
+	sc := &coopStartCmd{}
+	sc.cmd = &cobra.Command{
+		Use:   "run <blueprint-id>",
+		Short: "Create a co-op session from a blueprint (agent-facing)",
+		Long: `Creates a new co-op session using the specified blueprint. The session file
+is written to disk and the agent can immediately begin working through steps.
+
+This is the agent-facing command. Developers should use "stripe coop start" instead.`,
+		Example: `  stripe coop run one-time-payment
+  stripe coop run one-time-payment --language=node
+  stripe coop run setup-future-payments --setting=framework=express`,
+		Args: cobra.ExactArgs(1),
+		RunE: sc.runStartCmd,
+	}
+
+	sc.cmd.Flags().StringVar(&sc.language, "language", "", "Programming language for the integration")
+	sc.cmd.Flags().StringArrayVar(&sc.settings, "setting", nil, "Blueprint settings as key=value pairs")
+	sc.cmd.Flags().StringVar(&sc.parentSession, "parent-session", "", "Parent co-op session ID for follow-up work")
+	sc.cmd.Flags().StringVar(&sc.parentStep, "parent-step", "", "Parent next-step ID this session fulfills")
+
+	return sc
+}
+
+func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
+	blueprintID := args[0]
+
+	bp, err := coop.LoadBlueprint(blueprintID)
+	if err != nil {
+		return outputCoopError(fmt.Sprintf("Blueprint %q not found. Run 'stripe coop recommend' to see available blueprints.", blueprintID), "stripe coop recommend")
+	}
+
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+
+	sessionID := "coop_" + uuid.New().String()[:8]
+
+	session := newCoopSession(bp, sessionID, sc.language, sc.settings, sc.parentSession, sc.parentStep)
+
+	if err := store.Write(session); err != nil {
+		return fmt.Errorf("writing session: %w", err)
+	}
+
+	// Build step overview for the agent
+	var steps []stepBrief
+	stepNum := 0
+	for _, ch := range session.Chapters {
+		for _, n := range ch.Nodes {
+			stepNum++
+			steps = append(steps, stepBrief{
+				Number:            stepNum,
+				Title:             n.Title,
+				Type:              string(n.Type),
+				Description:       n.Description,
+				ReviewPrompt:      n.ReviewPrompt,
+				ReviewCommand:     n.ReviewCommand,
+				ReviewGranularity: string(ch.ReviewGranularity),
+				AutoConfirm:       n.AutoConfirm,
+			})
+		}
+	}
+
+	resp := coopStartResponse{
+		CommandResponse: coop.CommandResponse{
+			OK:        true,
+			SessionID: sessionID,
+			Step:      1,
+			State:     "created",
+			Message:   fmt.Sprintf("Session started: %s (%d steps)", bp.Title, session.TotalSteps()),
+			Next:      fmt.Sprintf("stripe coop agent start-work --session=%s --step=1 --note=%s", sessionID, quoteArg("Beginning: "+session.Chapters[0].Nodes[0].Title)),
+		},
+		AgentInstructions: agentInstructions(bp, session),
+		Steps:             steps,
+	}
+
+	return outputJSON(resp)
+}
+
+func newCoopSession(bp *coop.Blueprint, sessionID, language string, rawSettings []string, parentSession, parentStep string) *coop.Session {
+	settings := make(map[string]string)
+	if language != "" {
+		settings["language"] = language
+	}
+	for _, s := range rawSettings {
+		for i := range s {
+			if s[i] == '=' {
+				settings[s[:i]] = s[i+1:]
+				break
+			}
+		}
+	}
+
+	session := coop.NewSessionFromBlueprint(bp, sessionID, settings)
+	session.CreatedAt = time.Now().UTC()
+	session.ParentSessionID = parentSession
+	session.ParentStepID = parentStep
+	if claimURL := coopClaimURL(); claimURL != "" {
+		session.ClaimURL = claimURL
+	}
+	return session
+}
+
+type coopStartResponse struct {
+	coop.CommandResponse
+	AgentInstructions string      `json:"agent_instructions"`
+	Steps             []stepBrief `json:"steps"`
+}
+
+type stepBrief struct {
+	Number            int    `json:"number"`
+	Title             string `json:"title"`
+	Type              string `json:"type"`
+	Description       string `json:"description,omitempty"`
+	ReviewPrompt      string `json:"review_prompt,omitempty"`
+	ReviewCommand     string `json:"review_command,omitempty"`
+	ReviewGranularity string `json:"review_granularity,omitempty"`
+	AutoConfirm       bool   `json:"auto_confirm,omitempty"`
+}
+
+func agentInstructions(bp *coop.Blueprint, session *coop.Session) string {
+	preamble := fmt.Sprintf("You are building a working Stripe integration: %q", bp.Title)
+	if bp.Prompt != "" {
+		preamble = bp.Prompt
+	}
+
+	return fmt.Sprintf(`%s
+
+BEFORE YOU START — ensure you have API access:
+1. Run "stripe whoami" to check if you're authenticated.
+2. If not authenticated OR if the output shows "Test mode key: not available",
+   run "stripe sandbox create --from-git" to provision a sandbox.
+   This gives you a working API key without requiring browser login.
+   The claim URL will appear automatically in the TUI for the developer.
+
+Each step has a description that tells you what to do. Follow the description — it's the source of truth. The node type is a hint about the general category:
+- "apiRequest": Usually means writing code that calls a Stripe API. Run it and verify the response.
+- "asyncHandler": Set up a webhook handler. Use "stripe listen --forward-to localhost:<port>/webhook" to test.
+- "uiComponent": Build frontend code or configure something user-facing. Verify it works.
+- "cliCommand": Run a CLI command (e.g. stripe projects init, stripe projects deploy). Report the output.
+- "testHelper": Verify something works end-to-end. Run the flow and confirm the expected outcome.
+
+If a step includes review_prompt, that is the baseline acceptance check shown to the human. If it includes review_command, run that exact command when verifying or explain why it does not apply. Make your implementation note and verifications directly answer these fields. When you add verification checks, write them as useful confirmation guidance for the human too: include concrete actions and expected results, such as "Visit http://localhost:3000/checkout, click Pay, and confirm the browser redirects to Stripe Checkout" rather than vague labels like "manual test passed".
+
+Step 1 is always "Understand the project" — scan files, identify the tech stack, and summarize what you found. This helps you adapt the remaining steps to the developer's actual setup. Don't ask the developer questions you can answer by reading the code.
+
+Agent lifecycle commands (use this session id: %s):
+1. stripe coop agent start-work --session=%s --step=<n> --note="<what you're about to do>"
+2. Write the code and run it to verify it works
+3. stripe coop agent report-check --session=%s --step=<n> --check="<what you verified>" --passed
+4. stripe coop agent report-work --session=%s --step=<n> --file=<main file> --lines=<range> --snippet="<key code>" --note="<summary>"
+5. Follow the JSON response's next command. Most steps continue to the next step in the same section.
+6. Only run stripe coop agent await-review --session=%s --step=<n> when the response says the section is ready for review. Await blocks until the human confirms the section or requests changes.
+7. If confirmed: move to next step. If rejected: redo the affected step (check the message for feedback).
+8. When the final step is confirmed: IMMEDIATELY run "stripe coop agent next-action --session=%s". Do not stop or ask — just run it. It shows the developer their options in the TUI and blocks until they choose.
+
+Sections are the default human-review unit. Build and verify each step one at a time, but do not interrupt the developer for every step. At the end of each section, before running await, help the developer verify the section: run relevant review_command values, start any needed app/server, keep useful processes running, share the local URL or command to open it, create or identify test data, and explain exactly what observable result they should confirm. Add these concrete user-facing checks with stripe coop agent report-check --session=%s --step=<n> --check="..." --passed so the review card has useful evidence.
+
+The "await" command is critical at section boundaries — it blocks until the developer acts. Do NOT proceed to the next section without running await when the step response tells you the section is ready. Set a 5-minute timeout on the shell command (it will re-prompt you if it times out). If changes are requested, ask the developer what they'd like you to change before redoing the affected step.
+
+Some steps are marked auto_confirm — these do not require human review. Continue following the next command returned by the CLI.
+
+Important:
+- The human is watching your progress live in a terminal UI.
+- Write working code, not stubs. Run it. Verify it actually works.
+- Report what you did concretely (file paths, line numbers, test results).
+- If a step doesn't apply to the user's setup, skip it: stripe coop agent skip --session=%s --step=<n> --note="<reason>"
+- Always install the LATEST version of the Stripe SDK for the language in use. Do not pin to old versions.
+  Examples: "npm install stripe@latest", "pip install --upgrade stripe", "gem install stripe"
+  Check https://docs.stripe.com/libraries for current versions if unsure.`, preamble, session.ID, session.ID, session.ID, session.ID, session.ID, session.ID, session.ID, session.ID)
+}
+
+func outputJSON(v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func quoteArg(value string) string {
+	return strconv.Quote(value)
+}
+
+func outputCoopError(msg, hint string) error {
+	resp := coop.CommandResponse{
+		OK:    false,
+		Error: msg,
+		Hint:  hint,
+	}
+	data, _ := json.MarshalIndent(resp, "", "  ")
+	fmt.Fprintln(os.Stderr, string(data))
+	return RenderedError{}
+}
+
+type RenderedError struct{}
+
+func (RenderedError) Error() string {
+	return "coop command failed"
+}

--- a/pkg/cmd/coop/coop_run_test.go
+++ b/pkg/cmd/coop/coop_run_test.go
@@ -1,0 +1,34 @@
+package coopcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestNewCoopSessionAppliesSharedMetadata(t *testing.T) {
+	previousOptions := options
+	options = Options{ClaimURL: func() string { return "https://dashboard.stripe.com/sandbox/claim_test" }}
+	t.Cleanup(func() { options = previousOptions })
+
+	session := newCoopSession(
+		&coop.Blueprint{ID: "one-time-payment"},
+		"coop_123",
+		"go",
+		[]string{"framework=gin", "ignored"},
+		"parent_123",
+		"deploy",
+	)
+
+	require.Equal(t, "coop_123", session.ID)
+	assert.Equal(t, "go", session.Settings["language"])
+	assert.Equal(t, "gin", session.Settings["framework"])
+	assert.NotContains(t, session.Settings, "ignored")
+	assert.Equal(t, "parent_123", session.ParentSessionID)
+	assert.Equal(t, "deploy", session.ParentStepID)
+	assert.Equal(t, "https://dashboard.stripe.com/sandbox/claim_test", session.ClaimURL)
+	assert.False(t, session.CreatedAt.IsZero())
+}

--- a/pkg/cmd/coop/coop_status.go
+++ b/pkg/cmd/coop/coop_status.go
@@ -1,0 +1,78 @@
+package coopcmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type coopStatusCmd struct {
+	cmd     *cobra.Command
+	session string
+	asJSON  bool
+}
+
+func newCoopStatusCmd() *coopStatusCmd {
+	sc := &coopStatusCmd{}
+	sc.cmd = &cobra.Command{
+		Use:   "status",
+		Short: "Show the current co-op session status",
+		Long:  `Displays a summary of the current co-op session including step progress.`,
+		RunE:  sc.runStatusCmd,
+	}
+
+	sc.cmd.Flags().StringVar(&sc.session, "session", "", "Session ID (defaults to latest)")
+	sc.cmd.Flags().BoolVar(&sc.asJSON, "json", false, "Output in JSON format")
+
+	return sc
+}
+
+func (sc *coopStatusCmd) runStatusCmd(cmd *cobra.Command, args []string) error {
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+
+	var session *coop.Session
+	if sc.session != "" {
+		session, err = store.Read(sc.session)
+	} else {
+		session, err = store.LatestSession()
+	}
+	if err != nil {
+		return outputCoopError("No active session found. Start one with 'stripe coop start <blueprint>'.", "stripe coop start one-time-payment")
+	}
+
+	if sc.asJSON {
+		return outputJSON(session)
+	}
+
+	summary := session.StepSummary()
+	total := session.TotalSteps()
+
+	fmt.Printf("Session: %s\n", session.ID)
+	fmt.Printf("Blueprint: %s\n", session.Blueprint)
+	fmt.Printf("Status: %s\n", session.Status)
+	fmt.Printf("Progress: %d/%d steps complete\n", summary[coop.StepDone], total)
+	fmt.Println()
+
+	if summary[coop.StepActive] > 0 {
+		fmt.Printf("  Active: %d\n", summary[coop.StepActive])
+	}
+	if summary[coop.StepReview] > 0 {
+		fmt.Printf("  Awaiting review: %d\n", summary[coop.StepReview])
+	}
+	if summary[coop.StepPending] > 0 {
+		fmt.Printf("  Pending: %d\n", summary[coop.StepPending])
+	}
+	if summary[coop.StepSkipped] > 0 {
+		fmt.Printf("  Skipped: %d\n", summary[coop.StepSkipped])
+	}
+
+	fmt.Println()
+	fmt.Printf("Join the live view: stripe coop join %s\n", session.ID)
+
+	return nil
+}

--- a/pkg/cmd/coop/coop_stop.go
+++ b/pkg/cmd/coop/coop_stop.go
@@ -1,0 +1,69 @@
+package coopcmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type coopStopCmd struct {
+	cmd     *cobra.Command
+	session string
+	abort   bool
+}
+
+func newCoopStopCmd() *coopStopCmd {
+	sc := &coopStopCmd{}
+	sc.cmd = &cobra.Command{
+		Use:   "stop",
+		Short: "End the current co-op session",
+		Long: `Ends the current co-op session. By default marks it as "completed"
+(integration finished successfully). Use --abort to mark it as "aborted"
+(stopped early, integration incomplete).
+
+Ended sessions won't be picked up by co-op join or agent lifecycle commands.`,
+		RunE: sc.runStopCmd,
+	}
+
+	sc.cmd.Flags().StringVar(&sc.session, "session", "", "Session ID (defaults to latest active)")
+	sc.cmd.Flags().BoolVar(&sc.abort, "abort", false, "Mark session as aborted (incomplete, not finishing) instead of completed (done successfully)")
+
+	return sc
+}
+
+func (sc *coopStopCmd) runStopCmd(cmd *cobra.Command, args []string) error {
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+
+	var session *coop.Session
+	if sc.session != "" {
+		session, err = store.Read(sc.session)
+	} else {
+		session, err = store.LatestActiveSession()
+	}
+	if err != nil {
+		return outputCoopError("No active session found.", "stripe coop start <blueprint>")
+	}
+
+	if sc.abort {
+		session.Status = coop.SessionAborted
+	} else {
+		session.Status = coop.SessionCompleted
+	}
+
+	if err := store.Write(session); err != nil {
+		return fmt.Errorf("writing session: %w", err)
+	}
+
+	status := string(session.Status)
+	return outputJSON(coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		State:     status,
+		Message:   fmt.Sprintf("Session %s: %s", status, session.ID),
+	})
+}

--- a/pkg/cmd/coop/coop_test.go
+++ b/pkg/cmd/coop/coop_test.go
@@ -1,0 +1,17 @@
+package coopcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoopCommandDoesNotRegisterLegacyAgentCommands(t *testing.T) {
+	cmd := newCoopCmd().cmd
+
+	_, _, err := cmd.Find([]string{"step"})
+	require.Error(t, err)
+
+	_, _, err = cmd.Find([]string{"next-steps"})
+	require.Error(t, err)
+}

--- a/pkg/cmd/coop/coop_test_helpers_test.go
+++ b/pkg/cmd/coop/coop_test_helpers_test.go
@@ -1,0 +1,30 @@
+package coopcmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	fn()
+
+	require.NoError(t, w.Close())
+	os.Stdout = orig
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	return strings.TrimSpace(buf.String())
+}

--- a/pkg/coop/helpers/nextaction.go
+++ b/pkg/coop/helpers/nextaction.go
@@ -1,0 +1,214 @@
+// Package helpers contains shared support logic for co-op commands and workflows.
+package helpers
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+var ErrNoSession = errors.New("no session found")
+
+type Input struct {
+	SessionID string
+	Completed string
+}
+
+type Store interface {
+	Read(id string) (*coop.Session, error)
+	LatestSession() (*coop.Session, error)
+	Write(session *coop.Session) error
+}
+
+type Suggestion struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Available   bool   `json:"available"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+type Response struct {
+	OK          bool         `json:"ok"`
+	SessionID   string       `json:"session_id"`
+	Completed   string       `json:"completed"`
+	Suggestions []Suggestion `json:"suggestions"`
+	AgentPrompt string       `json:"agent_prompt"`
+	Next        string       `json:"next"`
+}
+
+type Environment struct {
+}
+
+func Run(store Store, input Input) (Response, error) {
+	var session *coop.Session
+	var err error
+	if input.SessionID != "" {
+		session, err = store.Read(input.SessionID)
+	} else {
+		session, err = store.LatestSession()
+	}
+	if err != nil {
+		return Response{}, ErrNoSession
+	}
+
+	suggestions := BuildSuggestions(session, DetectProjectEnvironment())
+	if err := ShowSuggestions(store, session, suggestions, input.Completed); err != nil {
+		return Response{}, err
+	}
+
+	selected, err := WaitForSelection(store, session.ID)
+	if err != nil {
+		return Response{}, err
+	}
+	return BuildResponse(session, suggestions, selected), nil
+}
+
+func ShowSuggestions(store Store, session *coop.Session, suggestions []Suggestion, completed string) error {
+	var tuiSuggestions []coop.NextStepSuggestion
+	for _, s := range suggestions {
+		tuiSuggestions = append(tuiSuggestions, coop.NextStepSuggestion{
+			ID:          s.ID,
+			Title:       s.Title,
+			Description: s.Description,
+			Reason:      s.Reason,
+		})
+	}
+
+	if session.NextSteps == nil {
+		session.NextSteps = &coop.NextStepsState{}
+	}
+	session.NextSteps.Suggestions = tuiSuggestions
+	session.NextSteps.Selected = ""
+	session.Status = coop.SessionCompleted
+	if err := store.Write(session); err != nil {
+		return fmt.Errorf("writing next-action suggestions: %w", err)
+	}
+
+	if completed != "" {
+		session.NextSteps.Completed = append(session.NextSteps.Completed, completed)
+		if err := store.Write(session); err != nil {
+			return fmt.Errorf("marking next-action completed: %w", err)
+		}
+	}
+	return nil
+}
+
+func WaitForSelection(store Store, sessionID string) (string, error) {
+	for {
+		time.Sleep(500 * time.Millisecond)
+		session, err := store.Read(sessionID)
+		if err != nil {
+			continue
+		}
+		if session.NextSteps == nil || session.NextSteps.Selected == "" {
+			continue
+		}
+
+		selected := session.NextSteps.Selected
+		session.NextSteps.Selected = ""
+		if err := store.Write(session); err != nil {
+			return "", fmt.Errorf("clearing next-action selection: %w", err)
+		}
+		return selected, nil
+	}
+}
+
+func BuildSuggestions(session *coop.Session, env Environment) []Suggestion {
+	var suggestions []Suggestion
+
+	suggestions = append(suggestions, Suggestion{
+		ID:          "summarize",
+		Title:       "Write a STRIPE.md summary",
+		Description: "Generate a STRIPE.md with what was built, API resources created, environment setup, and how to run",
+		Available:   true,
+	})
+
+	suggestions = append(suggestions, Suggestion{
+		ID:          "add-integration",
+		Title:       "Add another Stripe feature",
+		Description: "Subscriptions, Connect, billing portal, and more",
+		Available:   true,
+	})
+
+	suggestions = append(suggestions, Suggestion{
+		ID:          "done",
+		Title:       "Finish",
+		Description: "Close this session",
+		Available:   true,
+	})
+
+	return suggestions
+}
+
+func BuildResponse(session *coop.Session, suggestions []Suggestion, selected string) Response {
+	switch selected {
+	case "summarize":
+		return Response{
+			OK:          true,
+			SessionID:   session.ID,
+			Completed:   session.Blueprint,
+			Suggestions: suggestions,
+			AgentPrompt: BuildSummarizePrompt(session),
+			Next:        fmt.Sprintf("Write STRIPE.md, then run: stripe coop agent next-action --session=%s --completed=summarize", session.ID),
+		}
+	case "add-integration":
+		return Response{
+			OK:          true,
+			SessionID:   session.ID,
+			Completed:   session.Blueprint,
+			Suggestions: suggestions,
+			AgentPrompt: fmt.Sprintf("The developer wants to add another Stripe feature. Run 'stripe coop recommend' and ask what they need, then start a new session with --parent-session=%s --parent-step=add-integration.", session.ID),
+			Next:        "stripe coop recommend",
+		}
+	case "done":
+		return Response{
+			OK:          true,
+			SessionID:   session.ID,
+			Completed:   session.Blueprint,
+			AgentPrompt: "The developer is done. End the session.",
+			Next:        fmt.Sprintf("stripe coop stop --session=%s", session.ID),
+		}
+	default:
+		return Response{
+			OK:          true,
+			SessionID:   session.ID,
+			Completed:   session.Blueprint,
+			AgentPrompt: fmt.Sprintf("The developer selected: %s", selected),
+			Next:        "stripe coop stop",
+		}
+	}
+}
+
+func BuildSummarizePrompt(session *coop.Session) string {
+	return fmt.Sprintf(`The developer wants a STRIPE.md summary. Create a STRIPE.md file in the project root with:
+
+## What was built
+- Integration: %s
+- Blueprint steps completed
+
+## Stripe resources created
+- List any product IDs, price IDs, customer IDs created during the session
+
+## Environment variables
+- STRIPE_SECRET_KEY — your Stripe test secret key
+- STRIPE_WEBHOOK_SECRET — webhook signing secret (from stripe listen)
+
+## How to run
+- Commands to install deps and start the server
+
+## Webhook events handled
+- List the events this integration listens for
+
+## Useful links
+- Stripe Dashboard: https://dashboard.stripe.com/test
+- API docs: https://docs.stripe.com/api
+
+After writing the file, run "stripe coop agent next-action --session=%s --completed=summarize" again to offer more options.`, session.Blueprint, session.ID)
+}
+
+func DetectProjectEnvironment() Environment {
+	return Environment{}
+}

--- a/pkg/coop/helpers/nextaction_test.go
+++ b/pkg/coop/helpers/nextaction_test.go
@@ -1,0 +1,19 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestBuildSuggestionsIncludesCoreNextActions(t *testing.T) {
+	session := &coop.Session{ID: "sess_123", Blueprint: "one-time-payment"}
+
+	suggestions := BuildSuggestions(session, Environment{})
+
+	assert.Equal(t, "summarize", suggestions[0].ID)
+	assert.Equal(t, "add-integration", suggestions[1].ID)
+	assert.Equal(t, "done", suggestions[2].ID)
+}

--- a/pkg/coop/helpers/review.go
+++ b/pkg/coop/helpers/review.go
@@ -1,0 +1,29 @@
+package helpers
+
+import "github.com/stripe/stripe-cli/pkg/coop"
+
+func NextPendingStepInChapter(session *coop.Session, chapterIndex, afterStep int) int {
+	step := 0
+	for i := range session.Chapters {
+		for j := range session.Chapters[i].Nodes {
+			step++
+			if i == chapterIndex && step > afterStep && session.Chapters[i].Nodes[j].State == coop.StepPending {
+				return step
+			}
+		}
+	}
+	return 0
+}
+
+func ChapterReviewApplies(session *coop.Session, step int) bool {
+	chapter, _, _, err := session.ChapterByStepNumber(step)
+	if err != nil {
+		return false
+	}
+	switch chapter.ReviewGranularity {
+	case coop.ReviewGranularityAuto, coop.ReviewGranularityStep:
+		return false
+	default:
+		return true
+	}
+}

--- a/pkg/coop/helpers/review_test.go
+++ b/pkg/coop/helpers/review_test.go
@@ -1,0 +1,50 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestNextPendingStepInChapter(t *testing.T) {
+	session := &coop.Session{
+		Chapters: []coop.SessionChapter{
+			{
+				Nodes: []coop.SessionNode{
+					{State: coop.StepDone},
+					{State: coop.StepPending},
+				},
+			},
+			{
+				Nodes: []coop.SessionNode{
+					{State: coop.StepPending},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, 2, NextPendingStepInChapter(session, 0, 1))
+	assert.Equal(t, 0, NextPendingStepInChapter(session, 0, 2))
+	assert.Equal(t, 3, NextPendingStepInChapter(session, 1, 0))
+}
+
+func TestChapterReviewApplies(t *testing.T) {
+	session := &coop.Session{
+		Chapters: []coop.SessionChapter{
+			{
+				ReviewGranularity: coop.ReviewGranularityChapter,
+				Nodes:             []coop.SessionNode{{State: coop.StepReview}},
+			},
+			{
+				ReviewGranularity: coop.ReviewGranularityStep,
+				Nodes:             []coop.SessionNode{{State: coop.StepReview}},
+			},
+		},
+	}
+
+	assert.True(t, ChapterReviewApplies(session, 1))
+	assert.False(t, ChapterReviewApplies(session, 2))
+	assert.False(t, ChapterReviewApplies(session, 99))
+}

--- a/pkg/coop/workflow/service.go
+++ b/pkg/coop/workflow/service.go
@@ -1,0 +1,528 @@
+// Package workflow applies co-op agent lifecycle transitions to sessions.
+package workflow
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/helpers"
+)
+
+const AwaitTimeout = 10 * time.Minute
+
+type Store interface {
+	Read(id string) (*coop.Session, error)
+	Update(id string, fn func(*coop.Session) error) (*coop.Session, error)
+	WriteHeartbeat(id string)
+	RemoveHeartbeat(id string)
+}
+
+type Service struct {
+	store        Store
+	fetchSnippet func(path, method string, params interface{}, language string) (string, error)
+	now          func() time.Time
+	sleep        func(time.Duration)
+	awaitTimeout time.Duration
+}
+
+type Option func(*Service)
+
+func WithSnippetFetcher(fetch func(path, method string, params interface{}, language string) (string, error)) Option {
+	return func(s *Service) {
+		s.fetchSnippet = fetch
+	}
+}
+
+func WithClock(now func() time.Time, sleep func(time.Duration)) Option {
+	return func(s *Service) {
+		if now != nil {
+			s.now = now
+		}
+		if sleep != nil {
+			s.sleep = sleep
+		}
+	}
+}
+
+func WithAwaitTimeout(timeout time.Duration) Option {
+	return func(s *Service) {
+		s.awaitTimeout = timeout
+	}
+}
+
+func NewService(store Store, opts ...Option) *Service {
+	s := &Service{
+		store:        store,
+		fetchSnippet: coop.FetchSDKSnippet,
+		now:          time.Now,
+		sleep:        time.Sleep,
+		awaitTimeout: AwaitTimeout,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+type ReportWorkInput struct {
+	File    string
+	Lines   string
+	Snippet string
+	Note    string
+}
+
+func (s *Service) StartWork(sessionID string, step int, note string) (coop.CommandResponse, error) {
+	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		if err := session.TransitionStep(step, coop.StepActive); err != nil {
+			return err
+		}
+		node, _ := session.NodeByNumber(step)
+		node.Activity = note
+		return nil
+	})
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+
+	node, _ := session.NodeByNumber(step)
+	resp := coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Step:      step,
+		State:     string(coop.StepActive),
+		Message:   fmt.Sprintf("Started: %s", node.Title),
+		Next:      fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --file=<path> --note=\"<what you did>\"", session.ID, step),
+	}
+	if node.Type == coop.NodeAPIRequest && node.Request != nil {
+		resp.APIRequest = node.Request
+		if snippet, err := s.fetchSnippet(node.Request.Path, node.Request.Method, node.Request.Params, language(session)); err == nil {
+			resp.SDKExample = snippet
+		}
+	}
+	return resp, nil
+}
+
+func (s *Service) ReportWork(sessionID string, step int, input ReportWorkInput, autoConfirm bool) (coop.CommandResponse, error) {
+	var targetState coop.StepState
+	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		node, err := session.NodeByNumber(step)
+		if err != nil {
+			return err
+		}
+		targetState = coop.StepReview
+		if autoConfirm || node.AutoConfirm || session.ReviewGranularityForStep(step) == coop.ReviewGranularityAuto {
+			targetState = coop.StepDone
+		}
+		if err := session.TransitionStep(step, targetState); err != nil {
+			return err
+		}
+		node, _ = session.NodeByNumber(step)
+		if input.File != "" || input.Snippet != "" || input.Note != "" {
+			node.Implementation = &coop.Implementation{
+				File:    input.File,
+				Lines:   input.Lines,
+				Snippet: input.Snippet,
+				Note:    input.Note,
+			}
+		}
+		node.Activity = ""
+		if session.IsComplete() {
+			session.Status = coop.SessionCompleted
+		}
+		return nil
+	})
+	if err != nil {
+		return errorResponse(err, fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d", sessionID, step)), nil
+	}
+	node, _ := session.NodeByNumber(step)
+	return s.reportWorkResponse(session, node, step, targetState), nil
+}
+
+func (s *Service) ReportCheck(sessionID string, step int, check string, passed bool) (coop.CommandResponse, error) {
+	if strings.TrimSpace(check) == "" {
+		return errorResponse(fmt.Errorf("--check flag is required"), fmt.Sprintf("stripe coop agent report-check --session=%s --step=%d --check=\"<label>\" --passed", sessionID, step)), nil
+	}
+	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		node, err := session.NodeByNumber(step)
+		if err != nil {
+			return err
+		}
+		node.Verifications = append(node.Verifications, coop.Verification{Check: check, Passed: passed})
+		return nil
+	})
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+	node, _ := session.NodeByNumber(step)
+	status := "failed"
+	if passed {
+		status = "passed"
+	}
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Step:      step,
+		State:     string(node.State),
+		Message:   fmt.Sprintf("Verification %s: %s", status, check),
+		Next:      fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --file=<path> --note=\"<what you did>\"", session.ID, step),
+	}, nil
+}
+
+func (s *Service) Skip(sessionID string, step int, note string) (coop.CommandResponse, error) {
+	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		if err := session.TransitionStep(step, coop.StepSkipped); err != nil {
+			return err
+		}
+		node, _ := session.NodeByNumber(step)
+		node.Activity = note
+		if session.IsComplete() {
+			session.Status = coop.SessionCompleted
+		}
+		return nil
+	})
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+	node, _ := session.NodeByNumber(step)
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Step:      step,
+		State:     string(coop.StepSkipped),
+		Message:   fmt.Sprintf("Skipped: %s", node.Title),
+		Next:      nextAfterStep(session, step),
+	}, nil
+}
+
+func (s *Service) ConfirmReview(sessionID string, steps []int) (*coop.Session, error) {
+	return s.store.Update(sessionID, func(session *coop.Session) error {
+		for _, step := range steps {
+			node, err := session.NodeByNumber(step)
+			if err != nil {
+				return err
+			}
+			if node.State == coop.StepDone {
+				continue
+			}
+			if err := session.TransitionStep(step, coop.StepDone); err != nil {
+				return err
+			}
+		}
+		if session.IsComplete() {
+			session.Status = coop.SessionCompleted
+		}
+		return nil
+	})
+}
+
+func (s *Service) RequestChanges(sessionID string, steps []int, note string) (*coop.Session, error) {
+	if strings.TrimSpace(note) == "" {
+		return nil, fmt.Errorf("request changes note is required")
+	}
+	return s.store.Update(sessionID, func(session *coop.Session) error {
+		for _, step := range steps {
+			node, err := session.NodeByNumber(step)
+			if err != nil {
+				return err
+			}
+			if node.State != coop.StepActive {
+				if err := session.TransitionStep(step, coop.StepActive); err != nil {
+					return err
+				}
+				node, _ = session.NodeByNumber(step)
+			}
+			node.RejectionNote = note
+			node.Implementation = nil
+			node.Verifications = nil
+		}
+		return nil
+	})
+}
+
+func (s *Service) AwaitReview(sessionID string, step int) (coop.CommandResponse, error) {
+	session, err := s.store.Read(sessionID)
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+	node, err := session.NodeByNumber(step)
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+
+	if node.AutoConfirm && node.State == coop.StepReview {
+		return s.autoConfirm(sessionID, step)
+	}
+	if helpers.ChapterReviewApplies(session, step) && node.State == coop.StepReview {
+		chapter, chapterIndex, _, err := session.ChapterByStepNumber(step)
+		if err != nil {
+			return errorResponse(err, "stripe coop status"), nil
+		}
+		if !session.ChapterReadyForReview(chapterIndex) {
+			return coop.CommandResponse{
+				OK:        true,
+				SessionID: session.ID,
+				Step:      step,
+				State:     string(coop.StepReview),
+				Message:   fmt.Sprintf("Step %d is ready. Continue the section before asking for human review.", step),
+				Next:      nextInChapterOrStatus(session, chapterIndex, step),
+			}, nil
+		}
+		return s.awaitChapterReview(session.ID, chapter.Title, chapterIndex, step)
+	}
+	if node.State != coop.StepReview {
+		return alreadyMovedResponse(session, step, node.State), nil
+	}
+	return s.awaitStepReview(session.ID, step)
+}
+
+func (s *Service) SelectNextAction(sessionID, selected, completed string, suggestions []coop.NextStepSuggestion) (*coop.Session, error) {
+	return s.store.Update(sessionID, func(session *coop.Session) error {
+		if session.NextSteps == nil {
+			session.NextSteps = &coop.NextStepsState{}
+		}
+		if len(suggestions) > 0 {
+			session.NextSteps.Suggestions = suggestions
+		}
+		if completed != "" && !contains(session.NextSteps.Completed, completed) {
+			session.NextSteps.Completed = append(session.NextSteps.Completed, completed)
+		}
+		session.NextSteps.Selected = selected
+		session.Status = coop.SessionCompleted
+		return nil
+	})
+}
+
+func (s *Service) autoConfirm(sessionID string, step int) (coop.CommandResponse, error) {
+	session, err := s.ConfirmReview(sessionID, []int{step})
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Step:      step,
+		State:     "confirmed",
+		Message:   fmt.Sprintf("Step %d auto-confirmed. Proceed to next step.", step),
+		Next:      nextAfterStep(session, step),
+	}, nil
+}
+
+func (s *Service) awaitStepReview(sessionID string, step int) (coop.CommandResponse, error) {
+	s.store.WriteHeartbeat(sessionID)
+	defer s.store.RemoveHeartbeat(sessionID)
+
+	deadline := s.now().Add(s.awaitTimeout)
+	for {
+		if s.now().After(deadline) {
+			return timeoutResponse(sessionID, step), nil
+		}
+		s.sleep(500 * time.Millisecond)
+		s.store.WriteHeartbeat(sessionID)
+
+		session, err := s.store.Read(sessionID)
+		if err != nil {
+			return coop.CommandResponse{}, err
+		}
+		node, err := session.NodeByNumber(step)
+		if err != nil {
+			return coop.CommandResponse{}, err
+		}
+		if node.State == coop.StepReview {
+			continue
+		}
+		if node.State == coop.StepDone {
+			return confirmedResponse(session, step), nil
+		}
+		if node.State == coop.StepActive {
+			return rejectedResponse(session, step, node), nil
+		}
+		return alreadyMovedResponse(session, step, node.State), nil
+	}
+}
+
+func (s *Service) awaitChapterReview(sessionID, chapterTitle string, chapterIndex, step int) (coop.CommandResponse, error) {
+	s.store.WriteHeartbeat(sessionID)
+	defer s.store.RemoveHeartbeat(sessionID)
+
+	deadline := s.now().Add(s.awaitTimeout)
+	for {
+		if s.now().After(deadline) {
+			return timeoutResponse(sessionID, step), nil
+		}
+		s.sleep(500 * time.Millisecond)
+		s.store.WriteHeartbeat(sessionID)
+
+		session, err := s.store.Read(sessionID)
+		if err != nil {
+			return coop.CommandResponse{}, err
+		}
+		if activeStep := session.FirstActiveStepInChapter(chapterIndex); activeStep > 0 {
+			activeNode, _ := session.NodeByNumber(activeStep)
+			msg := fmt.Sprintf("Section %q requested changes.", chapterTitle)
+			if activeNode != nil && activeNode.RejectionNote != "" {
+				msg += fmt.Sprintf("\nFeedback: %s", activeNode.RejectionNote)
+			}
+			msg += "\nRedo the section from the first affected step."
+			return coop.CommandResponse{
+				OK:        true,
+				SessionID: session.ID,
+				Step:      activeStep,
+				State:     "rejected",
+				Message:   msg,
+				Next:      fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d --note=%s", session.ID, activeStep, quoteArg("Redoing: "+activeNode.Title)),
+			}, nil
+		}
+		if session.ChapterHasReview(chapterIndex) {
+			continue
+		}
+		return confirmedResponse(session, step), nil
+	}
+}
+
+func (s *Service) reportWorkResponse(session *coop.Session, node *coop.SessionNode, step int, targetState coop.StepState) coop.CommandResponse {
+	if targetState == coop.StepReview {
+		if helpers.ChapterReviewApplies(session, step) {
+			chapter, chapterIndex, _, err := session.ChapterByStepNumber(step)
+			if err == nil && !session.ChapterReadyForReview(chapterIndex) {
+				return coop.CommandResponse{
+					OK:        true,
+					SessionID: session.ID,
+					Step:      step,
+					State:     string(coop.StepReview),
+					Message:   fmt.Sprintf("Ready: %s. Continue the section before asking for human review.", node.Title),
+					Next:      nextInChapterOrStatus(session, chapterIndex, step),
+				}
+			}
+			if err == nil {
+				return coop.CommandResponse{
+					OK:        true,
+					SessionID: session.ID,
+					Step:      step,
+					State:     string(coop.StepReview),
+					Message:   fmt.Sprintf("Section ready for review: %s. Run relevant checks, keep useful servers running, share local URLs or test data, then await review.", chapter.Title),
+					Next:      fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", session.ID, step),
+				}
+			}
+		}
+		return coop.CommandResponse{
+			OK:        true,
+			SessionID: session.ID,
+			Step:      step,
+			State:     string(coop.StepReview),
+			Message:   fmt.Sprintf("Ready for review: %s", node.Title),
+			Next:      fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", session.ID, step),
+		}
+	}
+
+	msg := fmt.Sprintf("Completed: %s", node.Title)
+	next := nextAfterStep(session, step)
+	if session.IsComplete() {
+		msg += " All steps complete. Run next-action so the developer can choose what happens next."
+	}
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Step:      step,
+		State:     string(targetState),
+		Message:   msg,
+		Next:      next,
+	}
+}
+
+func nextAfterStep(session *coop.Session, step int) string {
+	if nextStep := session.NextPendingStep(step); nextStep > 0 {
+		nextNode, _ := session.NodeByNumber(nextStep)
+		return fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d --note=%s", session.ID, nextStep, quoteArg("Beginning: "+nextNode.Title))
+	}
+	if session.IsComplete() {
+		return fmt.Sprintf("stripe coop agent next-action --session=%s", session.ID)
+	}
+	return fmt.Sprintf("stripe coop status --session=%s", session.ID)
+}
+
+func nextInChapterOrStatus(session *coop.Session, chapterIndex, afterStep int) string {
+	if nextStep := helpers.NextPendingStepInChapter(session, chapterIndex, afterStep); nextStep > 0 {
+		nextNode, _ := session.NodeByNumber(nextStep)
+		return fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d --note=%s", session.ID, nextStep, quoteArg("Beginning: "+nextNode.Title))
+	}
+	return fmt.Sprintf("stripe coop status --session=%s", session.ID)
+}
+
+func alreadyMovedResponse(session *coop.Session, step int, state coop.StepState) coop.CommandResponse {
+	msg := fmt.Sprintf("Step %d is already %s.", step, state)
+	if session.IsComplete() {
+		msg = fmt.Sprintf("Step %d confirmed. All steps done. Run next-action now.", step)
+	}
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Step:      step,
+		State:     string(state),
+		Message:   msg,
+		Next:      nextAfterStep(session, step),
+	}
+}
+
+func confirmedResponse(session *coop.Session, step int) coop.CommandResponse {
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Step:      step,
+		State:     "confirmed",
+		Message:   fmt.Sprintf("Step %d confirmed by developer. Proceed to next step.", step),
+		Next:      nextAfterStep(session, step),
+	}
+}
+
+func rejectedResponse(session *coop.Session, step int, node *coop.SessionNode) coop.CommandResponse {
+	msg := fmt.Sprintf("Step %d rejected by developer.", step)
+	if node.RejectionNote != "" {
+		msg += fmt.Sprintf("\nFeedback: %s", node.RejectionNote)
+	}
+	msg += "\nRedo the step."
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Step:      step,
+		State:     "rejected",
+		Message:   msg,
+		Next:      fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --file=<path> --note=\"<what you fixed>\"", session.ID, step),
+	}
+}
+
+func timeoutResponse(sessionID string, step int) coop.CommandResponse {
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: sessionID,
+		Step:      step,
+		State:     "timeout",
+		Message:   "Timed out waiting for developer confirmation. Re-run await-review to wait again.",
+		Next:      fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", sessionID, step),
+	}
+}
+
+func errorResponse(err error, hint string) coop.CommandResponse {
+	return coop.CommandResponse{OK: false, Error: err.Error(), Hint: hint}
+}
+
+func language(session *coop.Session) string {
+	if session != nil && session.Settings != nil && session.Settings["language"] != "" {
+		return session.Settings["language"]
+	}
+	return "node"
+}
+
+func quoteArg(value string) string {
+	return fmt.Sprintf("%q", value)
+}
+
+func contains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/coop/workflow/service_test.go
+++ b/pkg/coop/workflow/service_test.go
@@ -1,0 +1,119 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestStartWorkTransitionsStepAndReturnsTypedNextCommand(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store, WithSnippetFetcher(func(path, method string, params interface{}, language string) (string, error) {
+		return "", nil
+	}))
+
+	resp, err := service.StartWork(session.ID, 1, "Scanning")
+	require.NoError(t, err)
+	require.True(t, resp.OK)
+	assert.Equal(t, "active", resp.State)
+	assert.Contains(t, resp.Next, "stripe coop agent report-work")
+
+	loaded, err := store.Read(session.ID)
+	require.NoError(t, err)
+	node, err := loaded.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.StepActive, node.State)
+	assert.Equal(t, "Scanning", node.Activity)
+}
+
+func TestReportWorkContinuesChapterBeforeReview(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store)
+
+	_, err := service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	resp, err := service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go", Note: "Done"}, false)
+	require.NoError(t, err)
+	require.True(t, resp.OK)
+	assert.Equal(t, "review", resp.State)
+	assert.Contains(t, resp.Message, "Continue the section")
+	assert.Contains(t, resp.Next, "--step=2")
+}
+
+func TestReportWorkRoutesToAwaitReviewWhenChapterReady(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store)
+
+	_, err := service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go"}, false)
+	require.NoError(t, err)
+	_, err = service.StartWork(session.ID, 2, "Second")
+	require.NoError(t, err)
+	resp, err := service.ReportWork(session.ID, 2, ReportWorkInput{File: "client.go"}, false)
+	require.NoError(t, err)
+	require.True(t, resp.OK)
+	assert.Contains(t, resp.Message, "Section ready for review")
+	assert.Contains(t, resp.Next, "stripe coop agent await-review")
+}
+
+func TestConfirmAndRequestChangesUseCentralWorkflow(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store)
+
+	_, err := service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go"}, false)
+	require.NoError(t, err)
+
+	updated, err := service.ConfirmReview(session.ID, []int{1})
+	require.NoError(t, err)
+	node, err := updated.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.StepDone, node.State)
+}
+
+func TestRequestChangesMovesReviewStepBackToActive(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store)
+
+	_, err := service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go"}, false)
+	require.NoError(t, err)
+	updated, err := service.RequestChanges(session.ID, []int{1}, "Needs tests")
+	require.NoError(t, err)
+	node, err := updated.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.StepActive, node.State)
+	assert.Equal(t, "Needs tests", node.RejectionNote)
+	assert.Nil(t, node.Implementation)
+}
+
+func workflowTestStore(t *testing.T) (*coop.Store, *coop.Session) {
+	t.Helper()
+	store, err := coop.NewStoreAt(t.TempDir())
+	require.NoError(t, err)
+	session := &coop.Session{
+		SchemaVersion: coop.CurrentSessionSchemaVersion,
+		ID:            "workflow_test",
+		Blueprint:     "test",
+		Status:        coop.SessionActive,
+		Chapters: []coop.SessionChapter{
+			{
+				Key:               "chapter",
+				Title:             "Chapter",
+				ReviewGranularity: coop.ReviewGranularityChapter,
+				Nodes: []coop.SessionNode{
+					{Key: "one", Title: "One", State: coop.StepPending},
+					{Key: "two", Title: "Two", State: coop.StepPending},
+				},
+			},
+		},
+	}
+	require.NoError(t, store.Write(session))
+	return store, session
+}


### PR DESCRIPTION
## What this adds

This PR adds the agent-facing co-op protocol on top of the domain model from #1664. It still does not expose the feature from the root CLI and does not add the TUI launcher.

- Adds the workflow service that owns lifecycle transitions: start work, report work, report checks, skip, await review, confirm/request changes, and next action
- Adds typed JSON-producing `stripe coop` subcommands for agents
- Adds blueprint recommendation and session status/stop commands
- Adds core post-completion next actions: write a summary, add another integration, or finish
- Adds tests around workflow state transitions and command behavior

## Why this is split out

The agent protocol is the contract between an LLM agent and the session store. This PR lets reviewers focus on that contract before reviewing any Bubble Tea rendering or tmux orchestration.

## Review focus

- Whether the JSON command protocol is clear and stable enough for agents
- Whether workflow transitions correctly protect review boundaries
- Whether command responses give actionable `next` guidance
- Whether error/hint behavior is useful without adding unnecessary alternate input paths

## Stack

Base: #1664
Next: #1666

Full stack: #1664 -> this PR -> #1666 -> #1667 -> #1668 -> #1669

## Validation

- `go test ./pkg/coop/... ./pkg/cmd/coop -count=1`