### PR TITLE
Add co-op launcher and debug harness

### DIFF
--- a/pkg/cmd/coop/coop.go
+++ b/pkg/cmd/coop/coop.go
@@ -86,3 +86,9 @@ func mustMarkFlagRequired(cmd *cobra.Command, name string) {
 		panic("marking required flag " + name + ": " + err.Error())
 	}
 }
+
+func mustMarkFlagHidden(cmd *cobra.Command, name string) {
+	if err := cmd.Flags().MarkHidden(name); err != nil {
+		panic("hiding flag " + name + ": " + err.Error())
+	}
+}

--- a/pkg/cmd/coop/coop.go
+++ b/pkg/cmd/coop/coop.go
@@ -54,11 +54,14 @@ The developer confirms each step before the agent moves on.`,
 		},
 	}
 
+	cc.cmd.AddCommand(newCoopRunCmd().cmd)
 	cc.cmd.AddCommand(newCoopStartCmd().cmd)
+	cc.cmd.AddCommand(newCoopJoinCmd().cmd)
 	cc.cmd.AddCommand(newCoopAgentCmd().cmd)
 	cc.cmd.AddCommand(newCoopStatusCmd().cmd)
 	cc.cmd.AddCommand(newCoopStopCmd().cmd)
 	cc.cmd.AddCommand(newCoopRecommendCmd().cmd)
+	cc.cmd.AddCommand(newCoopDebugAgentCmd().cmd)
 
 	return cc
 }

--- a/pkg/cmd/coop/coop_debug_agent.go
+++ b/pkg/cmd/coop/coop_debug_agent.go
@@ -1,0 +1,355 @@
+package coopcmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/helpers"
+	"github.com/stripe/stripe-cli/pkg/coop/workflow"
+)
+
+type coopDebugAgentCmd struct {
+	cmd     *cobra.Command
+	session string
+	delay   time.Duration
+}
+
+func newCoopDebugAgentCmd() *coopDebugAgentCmd {
+	dc := &coopDebugAgentCmd{delay: 650 * time.Millisecond}
+	dc.cmd = &cobra.Command{
+		Use:    "debug-agent",
+		Short:  "Run a deterministic fake co-op agent",
+		Hidden: true,
+		RunE:   dc.runDebugAgentCmd,
+	}
+
+	dc.cmd.Flags().StringVar(&dc.session, "session", "", "Session ID to drive")
+	dc.cmd.Flags().DurationVar(&dc.delay, "delay", dc.delay, "Delay between active and review states")
+	mustMarkFlagHidden(dc.cmd, "delay")
+
+	return dc
+}
+
+func (dc *coopDebugAgentCmd) runDebugAgentCmd(cmd *cobra.Command, args []string) error {
+	if dc.session == "" {
+		return fmt.Errorf("--session is required")
+	}
+
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+
+	agent := &coopDebugAgent{
+		store:                    store,
+		sessionID:                dc.session,
+		delay:                    dc.delay,
+		pollInterval:             500 * time.Millisecond,
+		out:                      os.Stdout,
+		waitForNextStepSelection: true,
+	}
+	return agent.run(cmd.Context())
+}
+
+type coopDebugAgent struct {
+	store                    *coop.Store
+	sessionID                string
+	delay                    time.Duration
+	pollInterval             time.Duration
+	out                      io.Writer
+	waitForNextStepSelection bool
+}
+
+func (a *coopDebugAgent) run(ctx context.Context) error {
+	a.logf("debug agent attached to %s", a.sessionID)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		session, err := a.store.Read(a.sessionID)
+		if err != nil {
+			return err
+		}
+
+		if session.IsComplete() {
+			return a.completeSession(ctx, session)
+		}
+
+		if step := firstStepWithState(session, coop.StepActive); step > 0 {
+			if err := a.completeActiveStep(ctx, step); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if step := firstStepWithState(session, coop.StepReview); step > 0 {
+			if shouldContinueChapterBeforeReview(session, step) {
+				chapter, chapterIndex, _, err := session.ChapterByStepNumber(step)
+				if err != nil {
+					return err
+				}
+				if next := helpers.NextPendingStepInChapter(session, chapterIndex, step); next > 0 {
+					a.logf("section %q still has pending work; continuing with step %d", chapter.Title, next)
+					if err := a.startStep(next); err != nil {
+						return err
+					}
+					continue
+				}
+			}
+			if err := a.awaitReview(ctx, step); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if step := firstStepWithState(session, coop.StepPending); step > 0 {
+			if err := a.startStep(step); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := a.sleep(ctx, a.pollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+func (a *coopDebugAgent) startStep(step int) error {
+	session, err := a.store.Read(a.sessionID)
+	if err != nil {
+		return err
+	}
+	node, err := session.NodeByNumber(step)
+	if err != nil {
+		return err
+	}
+	if node.State != coop.StepPending {
+		return nil
+	}
+
+	resp, err := workflow.NewService(a.store).StartWork(a.sessionID, step, "Debug agent working: "+node.Title)
+	if err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	a.logf("step %d active: %s", step, node.Title)
+	return nil
+}
+
+func (a *coopDebugAgent) completeActiveStep(ctx context.Context, step int) error {
+	if err := a.sleep(ctx, a.delay); err != nil {
+		return err
+	}
+
+	session, err := a.store.Read(a.sessionID)
+	if err != nil {
+		return err
+	}
+	node, err := session.NodeByNumber(step)
+	if err != nil {
+		return err
+	}
+	if node.State != coop.StepActive {
+		return nil
+	}
+
+	service := workflow.NewService(a.store)
+	resp, err := service.ReportCheck(a.sessionID, step, "Debug agent deterministic check", true)
+	if err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	resp, err = service.ReportWork(a.sessionID, step, workflow.ReportWorkInput{
+		File:  "debug/" + safeDebugFileName(node.Key) + ".txt",
+		Lines: "1-1",
+		Note:  "Deterministic debug agent completed " + node.Title,
+	}, false)
+	if err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	a.logf("step %d %s: %s", step, resp.State, node.Title)
+	return nil
+}
+
+func (a *coopDebugAgent) awaitReview(ctx context.Context, step int) error {
+	session, err := a.store.Read(a.sessionID)
+	if err != nil {
+		return err
+	}
+	node, err := session.NodeByNumber(step)
+	if err != nil {
+		return err
+	}
+
+	if helpers.ChapterReviewApplies(session, step) {
+		chapter, chapterIndex, _, err := session.ChapterByStepNumber(step)
+		if err != nil {
+			return err
+		}
+		a.logf("waiting for section review: %s", chapter.Title)
+		return a.awaitChapterReview(ctx, chapterIndex)
+	}
+
+	a.logf("waiting for review: step %d %s", step, node.Title)
+	for {
+		a.store.WriteHeartbeat(a.sessionID)
+		if err := a.sleep(ctx, a.pollInterval); err != nil {
+			a.store.RemoveHeartbeat(a.sessionID)
+			return err
+		}
+
+		session, err = a.store.Read(a.sessionID)
+		if err != nil {
+			a.store.RemoveHeartbeat(a.sessionID)
+			return err
+		}
+		node, err = session.NodeByNumber(step)
+		if err != nil {
+			a.store.RemoveHeartbeat(a.sessionID)
+			return err
+		}
+		if node.State != coop.StepReview {
+			a.store.RemoveHeartbeat(a.sessionID)
+			a.logf("review released: step %d is %s", step, node.State)
+			return nil
+		}
+	}
+}
+
+func (a *coopDebugAgent) awaitChapterReview(ctx context.Context, chapterIndex int) error {
+	for {
+		a.store.WriteHeartbeat(a.sessionID)
+		if err := a.sleep(ctx, a.pollInterval); err != nil {
+			a.store.RemoveHeartbeat(a.sessionID)
+			return err
+		}
+
+		session, err := a.store.Read(a.sessionID)
+		if err != nil {
+			a.store.RemoveHeartbeat(a.sessionID)
+			return err
+		}
+		if active := session.FirstActiveStepInChapter(chapterIndex); active > 0 {
+			a.store.RemoveHeartbeat(a.sessionID)
+			a.logf("section requested changes; rerunning from step %d", active)
+			return nil
+		}
+		if !session.ChapterHasReview(chapterIndex) {
+			a.store.RemoveHeartbeat(a.sessionID)
+			a.logf("section review released")
+			return nil
+		}
+	}
+}
+
+func (a *coopDebugAgent) completeSession(ctx context.Context, session *coop.Session) error {
+	if session.Status != coop.SessionCompleted || session.NextSteps == nil || len(session.NextSteps.Suggestions) == 0 {
+		suggestions := helpers.BuildSuggestions(session, helpers.DetectProjectEnvironment())
+		a.logf("all steps complete; showing next steps")
+		if err := helpers.ShowSuggestions(a.store, session, suggestions, ""); err != nil {
+			if isVersionConflict(err) {
+				return nil
+			}
+			return err
+		}
+	}
+
+	if !a.waitForNextStepSelection {
+		return nil
+	}
+
+	for {
+		if err := a.sleep(ctx, a.pollInterval); err != nil {
+			return err
+		}
+
+		session, err := a.store.Read(a.sessionID)
+		if err != nil {
+			return err
+		}
+		if session.NextSteps == nil || session.NextSteps.Selected == "" {
+			continue
+		}
+
+		selected := session.NextSteps.Selected
+		session.NextSteps.Selected = ""
+		if err := a.store.Write(session); err != nil && !isVersionConflict(err) {
+			return err
+		}
+		a.logf("next step selected: %s", selected)
+		return nil
+	}
+}
+
+func firstStepWithState(session *coop.Session, state coop.StepState) int {
+	step := 0
+	for i := range session.Chapters {
+		for j := range session.Chapters[i].Nodes {
+			step++
+			if session.Chapters[i].Nodes[j].State == state {
+				return step
+			}
+		}
+	}
+	return 0
+}
+
+func shouldContinueChapterBeforeReview(session *coop.Session, step int) bool {
+	if !helpers.ChapterReviewApplies(session, step) {
+		return false
+	}
+	_, chapterIndex, _, err := session.ChapterByStepNumber(step)
+	if err != nil {
+		return false
+	}
+	return !session.ChapterReadyForReview(chapterIndex)
+}
+
+func safeDebugFileName(key string) string {
+	if key == "" {
+		return "step"
+	}
+	return strings.NewReplacer("/", "_", "\\", "_", " ", "_").Replace(key)
+}
+
+func isVersionConflict(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "version conflict")
+}
+
+func (a *coopDebugAgent) sleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (a *coopDebugAgent) logf(format string, args ...interface{}) {
+	if a.out == nil {
+		return
+	}
+	fmt.Fprintf(a.out, "[debug-agent] "+format+"\n", args...)
+}

--- a/pkg/cmd/coop/coop_debug_agent_test.go
+++ b/pkg/cmd/coop/coop_debug_agent_test.go
@@ -1,0 +1,178 @@
+package coopcmd
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestCoopStartDebugAgentFlagIsHidden(t *testing.T) {
+	rc := newCoopRunCmd()
+	flag := rc.cmd.Flags().Lookup("debug-agent")
+	require.NotNil(t, flag)
+	assert.True(t, flag.Hidden)
+}
+
+func TestCoopStartDebugAgentRequiresBlueprint(t *testing.T) {
+	rc := &coopRunCmd{debugAgent: true}
+	err := rc.runCmd(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--debug-agent requires a blueprint ID")
+}
+
+func TestDebugAgentPaneCommandUsesStripeBinaryAndSession(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg config")
+	rc := &coopRunCmd{}
+	cmd, cleanup, err := rc.debugAgentPaneCommandBuilder("/tmp/stripe bin")("coop_123")
+	require.NoError(t, err)
+	assert.Nil(t, cleanup)
+	assert.Equal(t, "XDG_CONFIG_HOME=\"/tmp/xdg config\" \"/tmp/stripe bin\" coop debug-agent --session \"coop_123\"", cmd)
+}
+
+func TestCoopDebugAgentRerunsRequestedChanges(t *testing.T) {
+	store, session := setupDebugAgentSession(t, []coop.SessionChapter{
+		{
+			Key:   "chapter",
+			Title: "Section",
+			Nodes: []coop.SessionNode{
+				{Key: "checkout", Title: "Build Checkout", State: coop.StepPending, Type: coop.NodeAPIRequest},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := runDebugAgentForTest(ctx, store, session.ID)
+
+	waitForDebugSession(t, store, session.ID, func(s *coop.Session) bool {
+		node, _ := s.NodeByNumber(1)
+		return node.State == coop.StepReview
+	})
+	waitForDebugHeartbeat(t, store, session.ID)
+
+	current, err := store.Read(session.ID)
+	require.NoError(t, err)
+	require.NoError(t, current.TransitionStep(1, coop.StepActive))
+	node, _ := current.NodeByNumber(1)
+	node.RejectionNote = "Use the stored price ID"
+	node.Implementation = nil
+	node.Verifications = nil
+	require.NoError(t, store.Write(current))
+
+	waitForDebugSession(t, store, session.ID, func(s *coop.Session) bool {
+		node, _ := s.NodeByNumber(1)
+		return node.State == coop.StepReview && len(node.Verifications) > 0 && node.Implementation != nil
+	})
+
+	current, err = store.Read(session.ID)
+	require.NoError(t, err)
+	require.NoError(t, current.TransitionStep(1, coop.StepDone))
+	require.NoError(t, store.Write(current))
+
+	require.NoError(t, <-done)
+	finalSession, err := store.Read(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, coop.SessionCompleted, finalSession.Status)
+	assert.NotEmpty(t, finalSession.NextSteps.Suggestions)
+}
+
+func TestCoopDebugAgentWaitsForChapterReviewAfterChapterIsReady(t *testing.T) {
+	store, session := setupDebugAgentSession(t, []coop.SessionChapter{
+		{
+			Key:   "chapter",
+			Title: "Section",
+			Nodes: []coop.SessionNode{
+				{Key: "product", Title: "Create product", State: coop.StepPending, Type: coop.NodeAPIRequest},
+				{Key: "checkout", Title: "Build Checkout", State: coop.StepPending, Type: coop.NodeAPIRequest},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := runDebugAgentForTest(ctx, store, session.ID)
+
+	waitForDebugSession(t, store, session.ID, func(s *coop.Session) bool {
+		node1, _ := s.NodeByNumber(1)
+		node2, _ := s.NodeByNumber(2)
+		return node1.State == coop.StepReview && node2.State == coop.StepReview
+	})
+
+	current, err := store.Read(session.ID)
+	require.NoError(t, err)
+	require.NoError(t, current.TransitionStep(1, coop.StepDone))
+	require.NoError(t, current.TransitionStep(2, coop.StepDone))
+	require.NoError(t, store.Write(current))
+
+	require.NoError(t, <-done)
+	finalSession, err := store.Read(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, coop.SessionCompleted, finalSession.Status)
+}
+
+func setupDebugAgentSession(t *testing.T, chapters []coop.SessionChapter) (*coop.Store, *coop.Session) {
+	t.Helper()
+	store, err := coop.NewStoreAt(t.TempDir())
+	require.NoError(t, err)
+	session := &coop.Session{
+		ID:        "debug_agent_session",
+		Blueprint: "debug-blueprint",
+		Status:    coop.SessionActive,
+		Settings:  map[string]string{"language": "node"},
+		Chapters:  chapters,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, store.Write(session))
+	return store, session
+}
+
+func runDebugAgentForTest(ctx context.Context, store *coop.Store, sessionID string) <-chan error {
+	done := make(chan error, 1)
+	agent := &coopDebugAgent{
+		store:                    store,
+		sessionID:                sessionID,
+		delay:                    time.Millisecond,
+		pollInterval:             5 * time.Millisecond,
+		out:                      io.Discard,
+		waitForNextStepSelection: false,
+	}
+	go func() {
+		done <- agent.run(ctx)
+	}()
+	return done
+}
+
+func waitForDebugSession(t *testing.T, store *coop.Store, sessionID string, predicate func(*coop.Session) bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		session, err := store.Read(sessionID)
+		require.NoError(t, err)
+		if predicate(session) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	session, err := store.Read(sessionID)
+	require.NoError(t, err)
+	require.True(t, predicate(session), "session did not reach expected state: %+v", session)
+}
+
+func waitForDebugHeartbeat(t *testing.T, store *coop.Store, sessionID string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if store.HeartbeatAge(sessionID) >= 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.True(t, store.HeartbeatAge(sessionID) >= 0, "debug agent did not write heartbeat")
+}

--- a/pkg/cmd/coop/coop_join.go
+++ b/pkg/cmd/coop/coop_join.go
@@ -1,0 +1,136 @@
+package coopcmd
+
+import (
+	"fmt"
+
+	"charm.land/huh/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/helpers"
+	"github.com/stripe/stripe-cli/pkg/coop/tui"
+)
+
+type coopJoinCmd struct {
+	cmd    *cobra.Command
+	resume bool
+	wait   bool
+}
+
+func newCoopJoinCmd() *coopJoinCmd {
+	jc := &coopJoinCmd{}
+	jc.cmd = &cobra.Command{
+		Use:   "join [session-id]",
+		Short: "Join a co-op session and watch progress in the terminal UI",
+		Long: `Launches the co-op terminal UI to watch an agent work through a blueprint
+in real time. Press 'c' to confirm completed steps, 'e' to expand details.
+
+If no session ID is given, joins the most recently updated active session.
+Use --resume to pick from all recent sessions.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: jc.runJoinCmd,
+	}
+
+	jc.cmd.Flags().BoolVar(&jc.resume, "resume", false, "Pick from recent sessions")
+	jc.cmd.Flags().BoolVar(&jc.wait, "wait", false, "Wait for a new session to be created (used by coop run)")
+	jc.cmd.Flags().MarkHidden("wait")
+
+	return jc
+}
+
+func (jc *coopJoinCmd) runJoinCmd(cmd *cobra.Command, args []string) error {
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+
+	// Wait mode: launch TUI immediately and poll for a new session
+	if jc.wait {
+		existingIDs := make(map[string]bool)
+		if ids, err := store.List(); err == nil {
+			for _, id := range ids {
+				existingIDs[id] = true
+			}
+		}
+		return tui.RunWaiting(store, existingIDs)
+	}
+
+	var session *coop.Session
+
+	switch {
+	case len(args) > 0:
+		session, err = store.Read(args[0])
+		if err != nil {
+			return fmt.Errorf("session %q not found: %w", args[0], err)
+		}
+	case jc.resume:
+		session, err = jc.pickSession(store)
+		if err != nil {
+			return err
+		}
+	default:
+		// Try active first, then fall back to latest (including completed sessions with next-action suggestions).
+		session, err = store.LatestActiveSession()
+		if err != nil {
+			session, err = store.LatestSession()
+		}
+		if err != nil {
+			return fmt.Errorf("no session found. Use --resume to pick from recent sessions, or start a new one with 'stripe coop start'")
+		}
+	}
+
+	// Show reconnection notice if session is already in progress
+	summary := session.StepSummary()
+	if summary[coop.StepDone] > 0 || summary[coop.StepActive] > 0 || summary[coop.StepReview] > 0 {
+		fmt.Printf("Reconnecting to %s (%s) — %d/%d done\n",
+			session.ID, session.Blueprint, summary[coop.StepDone], session.TotalSteps())
+		fmt.Println()
+	}
+
+	return tui.Run(store, session.ID)
+}
+
+func (jc *coopJoinCmd) pickSession(store *coop.Store) (*coop.Session, error) {
+	ids, err := store.List()
+	if err != nil || len(ids) == 0 {
+		return nil, fmt.Errorf("no sessions found. Start one with 'stripe coop start <blueprint>'")
+	}
+
+	// Load sessions and build options (most recent first)
+	type sessionEntry struct {
+		session *coop.Session
+		label   string
+	}
+	var entries []sessionEntry
+
+	for _, id := range ids {
+		s, err := store.Read(id)
+		if err != nil {
+			continue
+		}
+		summary := s.StepSummary()
+		status := string(s.Status)
+		label := fmt.Sprintf("%s  %s  %d/%d done  [%s]",
+			s.ID, s.Blueprint, summary[coop.StepDone], s.TotalSteps(), status)
+		entries = append(entries, sessionEntry{session: s, label: label})
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no readable sessions found")
+	}
+
+	// Build huh options
+	var options []huh.Option[string]
+	for _, e := range entries {
+		options = append(options, huh.NewOption(e.label, e.session.ID))
+	}
+
+	var choice string
+
+	err = helpers.Select("Pick a session to resume:", options, &choice)
+	if err != nil {
+		return nil, err
+	}
+
+	return store.Read(choice)
+}

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -1,0 +1,362 @@
+package coopcmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"charm.land/huh/v2"
+	"github.com/google/uuid"
+	"golang.org/x/term"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/helpers"
+	"github.com/stripe/stripe-cli/pkg/coop/tui"
+)
+
+type agentInfo struct {
+	name string // "claude" or "codex"
+	path string
+}
+
+type coopPaneCommandBuilder func(sessionID string) (string, func(), error)
+
+const (
+	defaultCoopTmuxSessionWidth  = 200
+	defaultCoopTmuxSessionHeight = 50
+)
+
+func (rc *coopRunCmd) detectAgent() (*agentInfo, error) {
+	if rc.agent != "" {
+		path, err := exec.LookPath(rc.agent)
+		if err != nil {
+			return nil, fmt.Errorf("agent %q not found in PATH", rc.agent)
+		}
+		name := rc.agent
+		if strings.Contains(path, "claude") {
+			name = "claude"
+		} else if strings.Contains(path, "codex") {
+			name = "codex"
+		}
+		return &agentInfo{name: name, path: path}, nil
+	}
+
+	claudePath, claudeErr := exec.LookPath("claude")
+	codexPath, codexErr := exec.LookPath("codex")
+
+	hasClaude := claudeErr == nil
+	hasCodex := codexErr == nil
+
+	switch {
+	case hasClaude && hasCodex:
+		var choice string
+		err := helpers.Select("Multiple agents detected. Which would you like to use?",
+			[]huh.Option[string]{
+				huh.NewOption("Claude Code", "claude"),
+				huh.NewOption("Codex", "codex"),
+			},
+			&choice,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if choice == "codex" {
+			return &agentInfo{name: "codex", path: codexPath}, nil
+		}
+		return &agentInfo{name: "claude", path: claudePath}, nil
+
+	case hasClaude:
+		return &agentInfo{name: "claude", path: claudePath}, nil
+	case hasCodex:
+		return &agentInfo{name: "codex", path: codexPath}, nil
+	default:
+		return nil, fmt.Errorf("no AI agent found in PATH.\n  Install Claude Code: https://docs.anthropic.com/en/docs/claude-code\n  Or specify a custom agent: --agent=<command>")
+	}
+}
+
+func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) bool {
+	var choice string
+
+	var title string
+	switch agent.name {
+	case "claude":
+		title = "Permission mode for Claude Code:"
+	case "codex":
+		title = "Permission mode for Codex:"
+	default:
+		return false
+	}
+
+	err := helpers.Select(title,
+		[]huh.Option[string]{
+			huh.NewOption("Normal — agent asks before running commands", "normal"),
+			huh.NewOption("Auto-approve — skip all permission prompts (faster, less safe)", "auto"),
+		},
+		&choice,
+	)
+	if err != nil {
+		return false
+	}
+	return choice == "auto"
+}
+
+func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApprove bool) (string, error) {
+	launcherPath := promptPath + ".sh"
+	var script string
+
+	switch agent.name {
+	case "claude":
+		flags := ""
+		if autoApprove {
+			flags = " --dangerously-skip-permissions"
+		}
+		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
+			strconv.Quote(promptPath), strconv.Quote(promptPath), strconv.Quote(launcherPath), strconv.Quote(agent.path), flags)
+
+	case "codex":
+		flags := ""
+		if autoApprove {
+			flags = " --dangerously-bypass-approvals-and-sandbox"
+		}
+		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
+			strconv.Quote(promptPath), strconv.Quote(promptPath), strconv.Quote(launcherPath), strconv.Quote(agent.path), flags)
+
+	default:
+		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s \"$prompt\"\n",
+			strconv.Quote(promptPath), strconv.Quote(promptPath), strconv.Quote(launcherPath), strconv.Quote(agent.path))
+	}
+
+	if err := os.WriteFile(launcherPath, []byte(script), 0700); err != nil {
+		return "", fmt.Errorf("creating agent launcher: %w", err)
+	}
+	return launcherPath, nil
+}
+
+func (rc *coopRunCmd) hasTmux() bool {
+	_, err := exec.LookPath("tmux")
+	return err == nil
+}
+
+func (rc *coopRunCmd) agentPaneCommandBuilder(agent *agentInfo, agentPrompt string, autoApprove bool) coopPaneCommandBuilder {
+	return func(sessionID string) (string, func(), error) {
+		promptPath, err := writePromptFile(agentPrompt)
+		if err != nil {
+			return "", nil, err
+		}
+
+		agentCmd, err := rc.buildAgentCmd(agent, promptPath, autoApprove)
+		if err != nil {
+			os.Remove(promptPath)
+			return "", nil, err
+		}
+		return agentCmd, func() {
+			os.Remove(promptPath)
+			os.Remove(agentCmd)
+		}, nil
+	}
+}
+
+func (rc *coopRunCmd) debugAgentPaneCommandBuilder(stripeBin string) coopPaneCommandBuilder {
+	return func(sessionID string) (string, func(), error) {
+		cmd := fmt.Sprintf("%s coop debug-agent --session %s", strconv.Quote(stripeBin), strconv.Quote(sessionID))
+		if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+			cmd = fmt.Sprintf("XDG_CONFIG_HOME=%s %s", strconv.Quote(xdgConfigHome), cmd)
+		}
+		return cmd, nil, nil
+	}
+}
+
+func (rc *coopRunCmd) runInTmuxSplit(stripeBin string, agent *agentInfo, agentPrompt string, autoApprove bool, blueprintID string) error {
+	return rc.runInTmuxSplitWithCommand(stripeBin, blueprintID, rc.agentPaneCommandBuilder(agent, agentPrompt, autoApprove))
+}
+
+func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprintID string, buildPaneCmd coopPaneCommandBuilder) error {
+	sessionID := ""
+	if blueprintID != "" {
+		var err error
+		sessionID, err = rc.startSessionQuietly(blueprintID)
+		if err != nil {
+			return err
+		}
+	}
+
+	paneCmd, cleanup, err := buildPaneCmd(sessionID)
+	if err != nil {
+		return err
+	}
+
+	split := exec.Command("tmux", "split-window", "-h", "-p", "60", "bash", "-c", paneCmd)
+	if err := split.Run(); err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		return fmt.Errorf("tmux split failed: %w", err)
+	}
+
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return err
+	}
+
+	if blueprintID != "" {
+		return tui.Run(store, sessionID)
+	}
+
+	return runCoopTUIWait(store)
+}
+
+func (rc *coopRunCmd) runInNewTmux(stripeBin string, agent *agentInfo, agentPrompt string, autoApprove bool, blueprintID string) error {
+	return rc.runInNewTmuxWithCommand(stripeBin, blueprintID, rc.agentPaneCommandBuilder(agent, agentPrompt, autoApprove))
+}
+
+func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprintID string, buildPaneCmd coopPaneCommandBuilder) error {
+	sessionName := "stripe-coop"
+
+	// Check for existing session
+	if err := exec.Command("tmux", "has-session", "-t", sessionName).Run(); err == nil {
+		var choice string
+		if err := helpers.Select("A co-op tmux session already exists. What would you like to do?",
+			[]huh.Option[string]{
+				huh.NewOption("Reattach to existing session", "attach"),
+				huh.NewOption("Start fresh (kills existing session)", "fresh"),
+			},
+			&choice,
+		); err != nil {
+			return err
+		}
+
+		if choice == "attach" {
+			attach := exec.Command("tmux", "attach-session", "-t", sessionName)
+			attach.Stdin = os.Stdin
+			attach.Stdout = os.Stdout
+			attach.Stderr = os.Stderr
+			return attach.Run()
+		}
+		exec.Command("tmux", "kill-session", "-t", sessionName).Run()
+	}
+
+	sessionID := ""
+	if blueprintID != "" {
+		var err error
+		sessionID, err = rc.startSessionQuietly(blueprintID)
+		if err != nil {
+			return err
+		}
+	}
+
+	tuiCmd := fmt.Sprintf("%s coop join", strconv.Quote(stripeBin))
+	if blueprintID == "" {
+		tuiCmd += " --wait"
+	} else {
+		tuiCmd += " " + sessionID
+	}
+	paneCmd, cleanup, err := buildPaneCmd(sessionID)
+	if err != nil {
+		return err
+	}
+
+	width, height := coopTmuxSessionDimensions()
+	create := exec.Command("tmux", "new-session", "-d", "-s", sessionName, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height),
+		"bash", "-c", tuiCmd)
+	if err := create.Run(); err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		return fmt.Errorf("tmux new-session failed: %w", err)
+	}
+
+	split := exec.Command("tmux", "split-window", "-h", "-t", sessionName, "-p", "60",
+		"bash", "-c", paneCmd)
+	if err := split.Run(); err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		return fmt.Errorf("tmux split-window failed: %w", err)
+	}
+
+	exec.Command("tmux", "select-pane", "-t", sessionName+":0.1").Run()
+
+	attach := exec.Command("tmux", "attach-session", "-t", sessionName)
+	attach.Stdin = os.Stdin
+	attach.Stdout = os.Stdout
+	attach.Stderr = os.Stderr
+	return attach.Run()
+}
+
+func coopTmuxSessionDimensions() (int, int) {
+	width, height, err := term.GetSize(int(os.Stdout.Fd()))
+	return normalizeCoopTmuxSessionDimensions(width, height, err)
+}
+
+func normalizeCoopTmuxSessionDimensions(width, height int, err error) (int, int) {
+	if err != nil || width <= 0 || height <= 0 {
+		return defaultCoopTmuxSessionWidth, defaultCoopTmuxSessionHeight
+	}
+	return width, height
+}
+
+func (rc *coopRunCmd) runFallback(stripeBin string, agent *agentInfo, agentPrompt string, autoApprove bool, blueprintID string) error {
+	return rc.runFallbackWithCommand(stripeBin, blueprintID, rc.agentPaneCommandBuilder(agent, agentPrompt, autoApprove))
+}
+
+func (rc *coopRunCmd) runFallbackWithCommand(stripeBin string, blueprintID string, buildPaneCmd coopPaneCommandBuilder) error {
+	fmt.Println("tmux not found — running agent in this terminal.")
+
+	sessionID := ""
+	if blueprintID != "" {
+		var err error
+		sessionID, err = rc.startSessionQuietly(blueprintID)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Session started: %s\n", sessionID)
+		fmt.Printf("Open another terminal and run: stripe coop join %s\n", sessionID)
+	} else {
+		fmt.Println("Open another terminal and run: stripe coop join --wait")
+	}
+	fmt.Println()
+
+	paneCmd, cleanup, err := buildPaneCmd(sessionID)
+	if err != nil {
+		return err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	agentExec := exec.Command("bash", "-c", paneCmd)
+	agentExec.Stdin = os.Stdin
+	agentExec.Stdout = os.Stdout
+	agentExec.Stderr = os.Stderr
+	return agentExec.Run()
+}
+
+func generateShortID() string {
+	return uuid.New().String()[:8]
+}
+
+func writePromptFile(prompt string) (string, error) {
+	f, err := os.CreateTemp("", "stripe-coop-prompt-*.txt")
+	if err != nil {
+		return "", fmt.Errorf("creating prompt file: %w", err)
+	}
+	if _, err := f.WriteString(prompt); err != nil {
+		f.Close()
+		return "", fmt.Errorf("writing prompt file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("closing prompt file: %w", err)
+	}
+	return f.Name(), nil
+}
+
+func runCoopTUIWait(store *coop.Store) error {
+	existingIDs := make(map[string]bool)
+	if ids, err := store.List(); err == nil {
+		for _, id := range ids {
+			existingIDs[id] = true
+		}
+	}
+	return tui.RunWaiting(store, existingIDs)
+}

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -1,0 +1,39 @@
+package coopcmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeCoopTmuxSessionDimensionsUsesTerminalSize(t *testing.T) {
+	width, height := normalizeCoopTmuxSessionDimensions(260, 60, nil)
+
+	assert.Equal(t, 260, width)
+	assert.Equal(t, 60, height)
+}
+
+func TestNormalizeCoopTmuxSessionDimensionsFallsBack(t *testing.T) {
+	tests := []struct {
+		name   string
+		width  int
+		height int
+		err    error
+	}{
+		{name: "size error", width: 260, height: 60, err: errors.New("not a terminal")},
+		{name: "zero width", width: 0, height: 60},
+		{name: "zero height", width: 260, height: 0},
+		{name: "negative width", width: -1, height: 60},
+		{name: "negative height", width: 260, height: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			width, height := normalizeCoopTmuxSessionDimensions(tt.width, tt.height, tt.err)
+
+			assert.Equal(t, defaultCoopTmuxSessionWidth, width)
+			assert.Equal(t, defaultCoopTmuxSessionHeight, height)
+		})
+	}
+}

--- a/pkg/cmd/coop/coop_start.go
+++ b/pkg/cmd/coop/coop_start.go
@@ -1,0 +1,151 @@
+package coopcmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type coopRunCmd struct {
+	cmd        *cobra.Command
+	language   string
+	settings   []string
+	agent      string
+	debugAgent bool
+}
+
+func newCoopRunCmd() *coopRunCmd {
+	rc := &coopRunCmd{}
+	rc.cmd = &cobra.Command{
+		Use:   "start [blueprint-id]",
+		Short: "Launch a co-op session with an AI agent in split-screen",
+		Long: `Starts a co-op session and launches an AI agent (Claude Code) in a
+split terminal view. The TUI shows on one side, the agent works on the other.
+
+If no blueprint is provided, the agent will explore your codebase,
+understand your needs, and pick the right integration via the recommender.
+
+Requires tmux (detected automatically). If already in a tmux session,
+splits the current window. Otherwise creates a new tmux session.`,
+		Example: `  stripe coop start
+  stripe coop start one-time-payment --language=node
+  stripe coop start --language=python`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: rc.runCmd,
+	}
+
+	rc.cmd.Flags().StringVar(&rc.language, "language", "", "Programming language for the integration")
+	rc.cmd.Flags().StringArrayVar(&rc.settings, "setting", nil, "Blueprint settings as key=value pairs")
+	rc.cmd.Flags().StringVar(&rc.agent, "agent", "", "Agent to use (default: auto-detect claude/codex)")
+	rc.cmd.Flags().BoolVar(&rc.debugAgent, "debug-agent", false, "Use a deterministic fake agent for local TUI debugging")
+	mustMarkFlagHidden(rc.cmd, "debug-agent")
+
+	return rc
+}
+
+func (rc *coopRunCmd) runCmd(cmd *cobra.Command, args []string) error {
+	hasTmux := rc.hasTmux()
+	inTmux := os.Getenv("TMUX") != ""
+
+	var blueprintID string
+	if len(args) > 0 {
+		blueprintID = args[0]
+		if _, err := coop.LoadBlueprint(blueprintID); err != nil {
+			return fmt.Errorf("blueprint %q not found. Run 'stripe coop recommend' to see available blueprints", blueprintID)
+		}
+	}
+
+	stripeBin, _ := os.Executable()
+	if rc.debugAgent {
+		if blueprintID == "" {
+			return fmt.Errorf("--debug-agent requires a blueprint ID, e.g. stripe coop start one-time-payment --debug-agent")
+		}
+		buildDebugPane := rc.debugAgentPaneCommandBuilder(stripeBin)
+		if inTmux {
+			return rc.runInTmuxSplitWithCommand(stripeBin, blueprintID, buildDebugPane)
+		} else if hasTmux {
+			return rc.runInNewTmuxWithCommand(stripeBin, blueprintID, buildDebugPane)
+		}
+		return rc.runFallbackWithCommand(stripeBin, blueprintID, buildDebugPane)
+	}
+
+	agent, err := rc.detectAgent()
+	if err != nil {
+		return err
+	}
+
+	autoApprove := rc.promptAutoApprove(agent)
+	fmt.Println()
+
+	agentPrompt := rc.buildAgentPrompt(blueprintID)
+
+	if inTmux {
+		return rc.runInTmuxSplit(stripeBin, agent, agentPrompt, autoApprove, blueprintID)
+	} else if hasTmux {
+		return rc.runInNewTmux(stripeBin, agent, agentPrompt, autoApprove, blueprintID)
+	}
+
+	return rc.runFallback(stripeBin, agent, agentPrompt, autoApprove, blueprintID)
+}
+
+func (rc *coopRunCmd) buildAgentPrompt(blueprintID string) string {
+	if blueprintID != "" {
+		return `You are running a Stripe co-op integration session.
+
+A developer is watching your progress in a live terminal UI (the other pane).
+
+The session is already created. Run "stripe coop status" to see the current state and steps, then start from step 1.
+
+Important: Run "stripe whoami" first to check auth. If not logged in OR if it shows "Test mode key: not available", run "stripe sandbox create --from-git" to provision a sandbox. The claim URL will appear automatically in the TUI.`
+	}
+
+	langHint := ""
+	if rc.language != "" {
+		langHint = fmt.Sprintf("\nThe developer is working in %s.", rc.language)
+	}
+
+	return fmt.Sprintf(`You are helping a developer add Stripe to their project.
+
+A developer is watching your progress in a live terminal UI (the other pane).%s
+
+Your first job is to understand what they're building and what they need from Stripe. Do NOT assume they know Stripe product names.
+
+Steps:
+1. Look at the codebase to understand the language, framework, and what the project does.
+2. Based on what you find:
+   IF code exists: Summarize what the project does in 1-2 sentences and ask the developer
+   to confirm. Then ask: "What would you like to build with Stripe?"
+   IF no code exists (empty project): Ask "What are you looking to build?"
+   WAIT for their response. Do NOT proceed until they answer.
+   Do NOT assume what they need. Let them tell you in their own words.
+3. Based on their answer, run "stripe coop recommend --query=<description of what they need>"
+4. Explain what you found in simple terms: "I'll set up X which lets you do Y" and confirm.
+5. Only after confirmation, run "stripe coop run <blueprint-id> --language=<lang>".
+6. Follow the instructions in the JSON response and work through each step.
+
+The developer will confirm each step in the TUI before you proceed.
+
+Important: Run "stripe whoami" first to check auth. If not logged in OR if it shows "Test mode key: not available", run "stripe sandbox create --from-git" to provision a sandbox. The claim URL will appear automatically in the TUI.`, langHint)
+}
+
+func (rc *coopRunCmd) startSessionQuietly(blueprintID string) (string, error) {
+	bp, err := coop.LoadBlueprint(blueprintID)
+	if err != nil {
+		return "", err
+	}
+
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return "", err
+	}
+
+	sessionID := "coop_" + generateShortID()
+	session := newCoopSession(bp, sessionID, rc.language, rc.settings, "", "")
+	if err := store.Write(session); err != nil {
+		return "", err
+	}
+	return sessionID, nil
+}

--- a/pkg/coop/DEBUG_AGENT.md
+++ b/pkg/coop/DEBUG_AGENT.md
@@ -1,0 +1,42 @@
+# Co-op Debug Agent
+
+The debug agent is a deterministic fake agent for local TUI debugging. It runs the normal Co-op TUI flow, but the right-hand pane is driven by scripted session updates instead of a real Claude/Codex agent.
+
+## Manual TUI debugging
+
+Build the local CLI:
+
+```bash
+go build -o bin/stripe cmd/stripe/main.go
+```
+
+Start a debug session:
+
+```bash
+bin/stripe coop start one-time-payment --language=node --debug-agent
+```
+
+This opens the same tmux split as `coop start`:
+
+- left pane: the Co-op TUI
+- right pane: deterministic debug-agent logs
+
+The fake agent advances steps quickly, pauses at review cards, handles `c` confirm, handles `r` request changes, and eventually drives the completion / next-steps view.
+
+## Automated tmux smoke test
+
+Run:
+
+```bash
+scripts/test-coop-debug-agent-tmux.sh
+```
+
+This builds a temporary CLI binary, launches a `173x50` tmux session, checks the approximate `69x50` TUI pane, requests changes once, confirms remaining reviews, and asserts the completion view appears.
+
+Use this script for regression checks. Use `bin/stripe coop start ... --debug-agent` when manually inspecting layout, copy, spacing, or interactions.
+
+## Notes
+
+- `--debug-agent` is hidden and intended only for local development.
+- The internal `stripe coop debug-agent --session <id>` command is launched automatically by `coop start --debug-agent`; you normally should not run it directly.
+- The flow uses normal Co-op session files under your configured Stripe CLI config directory, so use a local build when testing unmerged TUI changes.

--- a/scripts/test-coop-debug-agent-tmux.sh
+++ b/scripts/test-coop-debug-agent-tmux.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp_dir="${TMPDIR:-/tmp}/coop-debug-agent-tmux-$$"
+stripe_bin="$tmp_dir/stripe"
+tmux_session=""
+pass=0
+fail=0
+tui_pane=""
+agent_pane=""
+
+cleanup() {
+  if [ -n "$tmux_session" ]; then
+    tmux kill-session -t "$tmux_session" 2>/dev/null || true
+  fi
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+record_pass() {
+  pass=$((pass + 1))
+  echo "  ✓ $1"
+}
+
+record_fail() {
+  fail=$((fail + 1))
+  echo "  ✗ $1"
+  echo "  ┌─ TUI capture"
+  capture_tui | sed 's/^/  │ /'
+  echo "  ├─ agent capture"
+  capture_agent | sed 's/^/  │ /'
+  echo "  └─────────"
+}
+
+capture_tui() {
+  tmux capture-pane -t "$tui_pane" -p 2>/dev/null || true
+}
+
+capture_agent() {
+  tmux capture-pane -t "$agent_pane" -p 2>/dev/null || true
+}
+
+wait_for_tui() {
+  local pattern="$1" timeout="${2:-10}" i=0
+  while [ "$i" -lt $((timeout * 4)) ]; do
+    capture_tui | rg -q "$pattern" && return 0
+    sleep 0.25
+    i=$((i + 1))
+  done
+  return 1
+}
+
+assert_tui_visible() {
+  local pattern="$1" label="$2"
+  if capture_tui | rg -q "$pattern"; then
+    record_pass "$label"
+  else
+    record_fail "$label (missing: $pattern)"
+  fi
+}
+
+assert_agent_visible() {
+  local pattern="$1" label="$2"
+  if capture_agent | rg -q "$pattern"; then
+    record_pass "$label"
+  else
+    record_fail "$label (agent missing: $pattern)"
+  fi
+}
+
+echo "[debug-agent-tmux] building test stripe binary"
+mkdir -p "$tmp_dir"
+(cd "$repo_root" && go build -o "$stripe_bin" cmd/stripe/main.go)
+
+run_smoke() {
+  local name="$1" session_width="$2" min_tui_width="$3" max_tui_width="$4" expect_wide="$5"
+  local xdg_config_home="$tmp_dir/xdg-$name"
+
+  tmux_session="coop-debug-agent-test-$name-$$"
+  tui_pane=""
+  agent_pane=""
+  mkdir -p "$xdg_config_home"
+
+  echo "[debug-agent-tmux] launching $name coop start --debug-agent"
+  tmux new-session -d -s "$tmux_session" -x "$session_width" -y 50 \
+    "XDG_CONFIG_HOME='$xdg_config_home' '$stripe_bin' coop start one-time-payment --language=node --debug-agent; echo TUI_EXIT:\$?; sleep 60"
+  tui_pane="$(tmux display-message -p -t "$tmux_session" '#{pane_id}')"
+
+  if ! wait_for_tui "Stripe Co-op" 10; then
+    agent_pane="$tui_pane"
+    record_fail "$name TUI started"
+  else
+    record_pass "$name TUI started"
+  fi
+
+  agent_pane="$(tmux list-panes -t "$tmux_session" -F '#{pane_id} #{pane_width}' | sort -k2,2nr | sed -n '1s/ .*//p')"
+  if [ "$agent_pane" = "$tui_pane" ]; then
+    agent_pane="$(tmux list-panes -t "$tmux_session" -F '#{pane_id}' | sed -n '2p')"
+  fi
+
+  local tui_size tui_width tui_height
+  tui_size="$(tmux display-message -p -t "$tui_pane" '#{pane_width}x#{pane_height}')"
+  tui_width="${tui_size%x*}"
+  tui_height="${tui_size#*x}"
+  if [ "$tui_width" -ge "$min_tui_width" ] && [ "$tui_width" -le "$max_tui_width" ] && [ "$tui_height" = "50" ]; then
+    record_pass "$name TUI pane width is expected ($tui_size)"
+  else
+    record_fail "$name unexpected TUI pane size $tui_size"
+  fi
+
+  if [ "$expect_wide" = "true" ]; then
+    if wait_for_tui "Press enter to inspect this (step|section)" 10; then
+      record_pass "$name split workspace prompt visible"
+    else
+      record_fail "$name split workspace prompt visible"
+    fi
+  fi
+
+  if wait_for_tui "Review" 10; then
+    record_pass "$name debug agent reaches first review"
+  else
+    record_fail "$name debug agent reaches first review"
+  fi
+  assert_tui_visible "Confirmation steps" "$name review acceptance check visible"
+  assert_agent_visible "\\[debug-agent\\]" "$name debug agent logs visible"
+
+  tmux send-keys -t "$tui_pane" "r"
+  sleep 0.5
+  tmux send-keys -t "$tui_pane" "Please tighten the debug checkout path"
+  sleep 0.25
+  tmux send-keys -t "$tui_pane" Enter
+  if wait_for_tui "Review" 10; then
+    record_pass "$name debug agent reruns after request changes"
+  else
+    record_fail "$name debug agent reruns after request changes"
+  fi
+
+  for _ in $(seq 1 20); do
+    local pane
+    pane="$(capture_tui)"
+    if echo "$pane" | rg -q "Integration complete"; then
+      break
+    fi
+    if echo "$pane" | rg -q "confirm all"; then
+      tmux send-keys -t "$tui_pane" "c"
+    elif echo "$pane" | rg -q "Waiting for you: review section"; then
+      tmux send-keys -t "$tui_pane" "f"
+    elif echo "$pane" | rg -q "Review"; then
+      tmux send-keys -t "$tui_pane" "c"
+    fi
+    sleep 0.75
+  done
+
+  if wait_for_tui "Integration complete" 10; then
+    record_pass "$name debug agent reaches completion view"
+  else
+    record_fail "$name debug agent reaches completion view"
+  fi
+
+  tmux kill-session -t "$tmux_session" 2>/dev/null || true
+  tmux_session=""
+}
+
+run_smoke narrow 173 68 70 false
+run_smoke wide 260 102 106 true
+
+echo "[debug-agent-tmux] results: $pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## What this adds

This PR adds the developer-facing launch and debug experience on top of the core TUI from #1666.

- Adds `stripe coop start` for launching a co-op session with an agent and TUI side by side
- Adds `stripe coop join` for rejoining or waiting for sessions
- Adds tmux split/new-session orchestration with dynamic sizing from the current terminal
- Adds fallback behavior when tmux is unavailable
- Adds hidden `--debug-agent` support and a deterministic fake agent for local TUI debugging
- Adds the tmux regression harness used to test narrow and wide terminal flows

## Why this is split out

The launcher is operationally different from the TUI itself. This PR lets reviewers focus on process management, tmux behavior, rejoin/recovery paths, and debug tooling after the core UI has been reviewed.

## Review focus

- tmux command construction and pane sizing
- behavior inside and outside existing tmux sessions
- cleanup of temporary prompt/launcher files
- debug-agent determinism and usefulness for manual testing
- whether `join` and rejoin behavior are clear enough for recovery

## Stack

Base: #1666
Next: #1668

Full stack: #1664 -> #1665 -> #1666 -> this PR -> #1668 -> #1669

## Validation

- `go test ./pkg/coop/... ./pkg/cmd/coop -count=1`
- tmux harness lives at `scripts/test-coop-debug-agent-tmux.sh`