### PR TITLE
Add co-op deploy follow-up support

### DIFF
--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -102,6 +102,12 @@ func TestLoadBlueprintNotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestLoadBlueprintPrefixMatch(t *testing.T) {
+	bp, err := LoadBlueprint("deploy")
+	require.NoError(t, err)
+	assert.Equal(t, "deploy-stripe-projects", bp.ID)
+}
+
 func TestLoadBlueprintPrefixMatchUnique(t *testing.T) {
 	bp, err := LoadBlueprint("one-time")
 	require.NoError(t, err)

--- a/pkg/coop/blueprints/deploy-stripe-projects.json
+++ b/pkg/coop/blueprints/deploy-stripe-projects.json
@@ -1,0 +1,106 @@
+{
+  "id": "deploy-stripe-projects",
+  "title": "Deploy with Stripe Projects",
+  "description": "Configure and deploy your local project using the Stripe Projects CLI plugin.",
+  "prompt": "The developer wants to configure their local project for deployment using the Stripe Projects CLI plugin. You will walk them through the setup using `stripe projects` commands. Use `stripe projects --help` and `stripe projects <subcommand> --help` to discover available options. All stripe CLI commands output JSON when passed --json. Report command output to the developer via the coop agent commands.\n\nIMPORTANT: If any step fails because the account is a claimable sandbox (errors mentioning 'claim', 'unclaimed', or permission issues), tell the developer they need to claim their sandbox first. Show them the claim URL from `stripe coop status` (the claim_url field) or from `stripe whoami`. Once they've claimed it, tell them to re-run the session with: stripe coop start deploy",
+  "type": "learning",
+  "products": [
+    "Projects"
+  ],
+  "settings": [],
+  "chapters": [
+    {
+      "key": "detect-chapter",
+      "title": "Detect project setup",
+      "description": "Ensure the projects plugin is available and scan the codebase.",
+      "required": true,
+      "nodes": [
+        {
+          "type": "cliCommand",
+          "key": "install-projects-plugin",
+          "title": "Check for Stripe Projects plugin",
+          "description": "Run `stripe projects --help`. If it returns 'unknown command', install it with `stripe plugin install projects`. Confirm it's available before proceeding.",
+          "auto_confirm": true
+        },
+        {
+          "type": "testHelper",
+          "key": "scan-project",
+          "title": "Scan project and plan deployment",
+          "description": "Explore the codebase: identify framework, existing hosting config, database usage, auth providers, env vars. Summarize findings — don't ask the developer to explain what you can read from the code.",
+          "auto_confirm": true
+        }
+      ]
+    },
+    {
+      "key": "init-chapter",
+      "title": "Initialize project",
+      "description": "Link your code to Stripe Projects.",
+      "required": true,
+      "nodes": [
+        {
+          "type": "cliCommand",
+          "key": "init-project",
+          "title": "Initialize Stripe Project",
+          "description": "Run `stripe projects init --help` to see available flags, then run `stripe projects init` with appropriate options for the detected framework. Report what was detected and what stripe.json contains.",
+          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
+        }
+      ]
+    },
+    {
+      "key": "secrets-chapter",
+      "title": "Configure secrets",
+      "description": "Set production API keys and environment variables.",
+      "nodes": [
+        {
+          "type": "cliCommand",
+          "key": "stripe-keys",
+          "title": "Set Stripe keys as project secrets",
+          "description": "Run `stripe projects secrets --help` to discover the command interface. Set STRIPE_SECRET_KEY and STRIPE_PUBLISHABLE_KEY using the keys from `stripe whoami --json`. Tell the developer which keys you're using.",
+          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
+        },
+        {
+          "type": "cliCommand",
+          "key": "other-secrets",
+          "title": "Set additional secrets",
+          "description": "Scan .env, .env.local, .env.example for variables NOT already handled (not STRIPE_ keys). If NONE remain → SKIP. If found → use `stripe projects secrets set` to configure them. Ask the developer for production values only if they differ from what's in .env.",
+          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
+        }
+      ]
+    },
+    {
+      "key": "deploy-chapter",
+      "title": "Deploy",
+      "description": "Push to production and verify.",
+      "nodes": [
+        {
+          "type": "cliCommand",
+          "key": "first-deploy",
+          "title": "Run first deployment",
+          "description": "Run `stripe projects deploy --help` to check available flags, then run `stripe projects deploy`. Report the build output and deployment URL.",
+          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
+        },
+        {
+          "type": "testHelper",
+          "key": "verify-live",
+          "title": "Verify deployment is live",
+          "description": "Ask the developer to visit the deployment URL and confirm it works. If it's a payment flow, suggest testing with card number 4242424242424242.",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        }
+      ]
+    },
+    {
+      "key": "webhooks-chapter",
+      "title": "Configure production webhooks",
+      "description": "Register webhook endpoint for the deployed app.",
+      "nodes": [
+        {
+          "type": "cliCommand",
+          "key": "register-endpoint",
+          "title": "Register webhook endpoint",
+          "description": "Look for webhook handling code (stripe.webhooks.constructEvent, /webhook routes). If found → construct the production URL (deployment URL + webhook path) and use `stripe projects webhooks --help` to discover how to register it. Set STRIPE_WEBHOOK_SECRET as a project secret and report the registered endpoint. If NOT found → SKIP.",
+          "review_prompt": "Confirm the command completed successfully and the reported output matches the step description."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/helpers/nextaction.go
+++ b/pkg/coop/helpers/nextaction.go
@@ -4,6 +4,7 @@ package helpers
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/stripe/stripe-cli/pkg/coop"
@@ -40,6 +41,11 @@ type Response struct {
 }
 
 type Environment struct {
+	HasStripeProjects bool
+	HasVercel         bool
+	HasFly            bool
+	HasNetlify        bool
+	HasExistingDeploy bool
 }
 
 func Run(store Store, input Input) (Response, error) {
@@ -119,6 +125,34 @@ func WaitForSelection(store Store, sessionID string) (string, error) {
 func BuildSuggestions(session *coop.Session, env Environment) []Suggestion {
 	var suggestions []Suggestion
 
+	switch {
+	case env.HasStripeProjects:
+		suggestions = append(suggestions, Suggestion{
+			ID:          "deploy",
+			Title:       "Deploy with Stripe Projects",
+			Description: "Your project is already configured — run stripe projects deploy",
+			Available:   true,
+			Reason:      "stripe.json found",
+		})
+	case !env.HasExistingDeploy:
+		suggestions = append(suggestions, Suggestion{
+			ID:          "deploy",
+			Title:       "Deploy with Stripe Projects",
+			Description: "Set up hosting, CI/CD, and environment management",
+			Available:   true,
+			Reason:      "No deploy configuration detected",
+		})
+	default:
+		target := env.deployTarget()
+		suggestions = append(suggestions, Suggestion{
+			ID:          "deploy-update",
+			Title:       "Deploy your changes",
+			Description: fmt.Sprintf("Push your new integration code to %s", target),
+			Available:   true,
+			Reason:      fmt.Sprintf("Detected: %s", target),
+		})
+	}
+
 	suggestions = append(suggestions, Suggestion{
 		ID:          "summarize",
 		Title:       "Write a STRIPE.md summary",
@@ -153,6 +187,20 @@ func BuildResponse(session *coop.Session, suggestions []Suggestion, selected str
 			Suggestions: suggestions,
 			AgentPrompt: BuildSummarizePrompt(session),
 			Next:        fmt.Sprintf("Write STRIPE.md, then run: stripe coop agent next-action --session=%s --completed=summarize", session.ID),
+		}
+	case "deploy", "deploy-update":
+		lang := session.Settings["language"]
+		if lang == "" {
+			lang = "node"
+		}
+		next := fmt.Sprintf("stripe coop run deploy-stripe-projects --language=%s --parent-session=%s --parent-step=%s", lang, session.ID, selected)
+		return Response{
+			OK:          true,
+			SessionID:   session.ID,
+			Completed:   session.Blueprint,
+			Suggestions: suggestions,
+			AgentPrompt: "The developer wants to deploy. Start a new co-op session with the deploy blueprint.",
+			Next:        next,
 		}
 	case "add-integration":
 		return Response{
@@ -210,5 +258,36 @@ After writing the file, run "stripe coop agent next-action --session=%s --comple
 }
 
 func DetectProjectEnvironment() Environment {
-	return Environment{}
+	env := Environment{}
+	env.HasStripeProjects = fileExists("stripe.json") || dirExists(".stripe")
+	env.HasVercel = fileExists("vercel.json") || fileExists(".vercel/project.json")
+	env.HasFly = fileExists("fly.toml")
+	env.HasNetlify = fileExists("netlify.toml")
+	hasDocker := fileExists("Dockerfile") || fileExists("docker-compose.yml") || fileExists("docker-compose.yaml")
+	hasRailway := fileExists("railway.json") || fileExists("railway.toml")
+	env.HasExistingDeploy = env.HasVercel || env.HasFly || hasDocker || hasRailway || env.HasNetlify
+	return env
+}
+
+func (env Environment) deployTarget() string {
+	switch {
+	case env.HasVercel:
+		return "Vercel"
+	case env.HasFly:
+		return "Fly.io"
+	case env.HasNetlify:
+		return "Netlify"
+	default:
+		return "existing infrastructure"
+	}
+}
+
+func fileExists(name string) bool {
+	_, err := os.Stat(name)
+	return err == nil
+}
+
+func dirExists(name string) bool {
+	info, err := os.Stat(name)
+	return err == nil && info.IsDir()
 }

--- a/pkg/coop/helpers/nextaction_test.go
+++ b/pkg/coop/helpers/nextaction_test.go
@@ -8,12 +8,37 @@ import (
 	"github.com/stripe/stripe-cli/pkg/coop"
 )
 
-func TestBuildSuggestionsIncludesCoreNextActions(t *testing.T) {
+func TestBuildSuggestionsUsesStripeProjectsWhenConfigured(t *testing.T) {
 	session := &coop.Session{ID: "sess_123", Blueprint: "one-time-payment"}
 
-	suggestions := BuildSuggestions(session, Environment{})
+	suggestions := BuildSuggestions(session, Environment{HasStripeProjects: true})
 
-	assert.Equal(t, "summarize", suggestions[0].ID)
-	assert.Equal(t, "add-integration", suggestions[1].ID)
-	assert.Equal(t, "done", suggestions[2].ID)
+	assert.Equal(t, "deploy", suggestions[0].ID)
+	assert.Equal(t, "stripe.json found", suggestions[0].Reason)
+	assert.Equal(t, "summarize", suggestions[1].ID)
+	assert.Equal(t, "add-integration", suggestions[2].ID)
+	assert.Equal(t, "done", suggestions[3].ID)
+}
+
+func TestBuildSuggestionsUsesExistingDeployTarget(t *testing.T) {
+	session := &coop.Session{ID: "sess_123", Blueprint: "one-time-payment"}
+
+	suggestions := BuildSuggestions(session, Environment{HasExistingDeploy: true, HasVercel: true})
+
+	assert.Equal(t, "deploy-update", suggestions[0].ID)
+	assert.Equal(t, "Detected: Vercel", suggestions[0].Reason)
+}
+
+func TestBuildResponseForDeploy(t *testing.T) {
+	session := &coop.Session{
+		ID:        "sess_123",
+		Blueprint: "one-time-payment",
+		Settings:  map[string]string{"language": "go"},
+	}
+
+	resp := BuildResponse(session, nil, "deploy")
+
+	assert.True(t, resp.OK)
+	assert.Equal(t, "sess_123", resp.SessionID)
+	assert.Equal(t, "stripe coop run deploy-stripe-projects --language=go --parent-session=sess_123 --parent-step=deploy", resp.Next)
 }

--- a/pkg/coop/tui/commands.go
+++ b/pkg/coop/tui/commands.go
@@ -146,5 +146,5 @@ func (m Model) shouldTransitionToNewSession() bool {
 		return false
 	}
 	id := suggestions[m.cursor].id
-	return id == "add-integration"
+	return id == "deploy" || id == "deploy-update" || id == "add-integration"
 }

--- a/pkg/coop/tui/completion.go
+++ b/pkg/coop/tui/completion.go
@@ -246,6 +246,12 @@ func (m Model) getCompletionSuggestions() []completionSuggestion {
 		suggestions = append(suggestions, completionSuggestion{id: "summarize", title: "Write a STRIPE.md summary", desc: "Generate a summary of what was built, API keys used, endpoints created, and how to run it"})
 	}
 
+	if completed["deploy"] || completed["deploy-update"] {
+		suggestions = append(suggestions, completionSuggestion{id: "deploy", title: "Redeploy", desc: "Push latest changes to production"})
+	} else {
+		suggestions = append(suggestions, completionSuggestion{id: "deploy", title: "Deploy with Stripe Projects", desc: "Set up hosting, CI/CD, and environment management"})
+	}
+
 	suggestions = append(suggestions, completionSuggestion{id: "add-integration", title: "Add another Stripe feature", desc: "Subscriptions, Connect, billing portal, and more"})
 	suggestions = append(suggestions, completionSuggestion{id: "done", title: "Finish", desc: "Close this session"})
 

--- a/pkg/coop/tui/model.go
+++ b/pkg/coop/tui/model.go
@@ -698,6 +698,9 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 			cmd := m.selectCompletionOption()
 
 			switch selected.id {
+			case "deploy", "deploy-update":
+				m.enterWaitingMode("Waiting for agent to start the deploy session...")
+				return m, cmd
 			case "add-integration":
 				m.enterWaitingMode("Waiting for agent to ask which Stripe feature to add...")
 				return m, cmd

--- a/pkg/coop/tui/model_test.go
+++ b/pkg/coop/tui/model_test.go
@@ -764,7 +764,7 @@ func TestSpinnerTickDoesNotPanic(t *testing.T) {
 	})
 }
 
-func TestCompletionEnterAddIntegrationWaitsForAgentSession(t *testing.T) {
+func TestCompletionEnterDeployWaitsForAgentSession(t *testing.T) {
 	dir := t.TempDir()
 	store, _ := coop.NewStoreAt(dir)
 
@@ -778,9 +778,10 @@ func TestCompletionEnterAddIntegrationWaitsForAgentSession(t *testing.T) {
 	m.session.ID = "parent_session"
 	store.Write(m.session)
 
+	// Find deploy position in default suggestions
 	suggestions := m.getCompletionSuggestions()
 	for i, s := range suggestions {
-		if s.id == "add-integration" {
+		if s.id == "deploy" || s.id == "deploy-update" {
 			m.cursor = i
 			break
 		}
@@ -794,7 +795,8 @@ func TestCompletionEnterAddIntegrationWaitsForAgentSession(t *testing.T) {
 	assert.Equal(t, suggestions[m.cursor].id, session.NextSteps.Selected)
 	assert.True(t, updated.waiting)
 
-	assert.Equal(t, "add-integration", session.NextSteps.Selected)
+	_, err = store.Read("coop_deploy")
+	assert.Error(t, err)
 }
 
 func TestSelectCompletionOptionSummarize(t *testing.T) {
@@ -945,8 +947,9 @@ func TestShouldTransitionToNewSession(t *testing.T) {
 
 	suggestions := m.getCompletionSuggestions()
 
+	// Find deploy
 	for i, s := range suggestions {
-		if s.id == "add-integration" {
+		if s.id == "deploy" || s.id == "deploy-update" {
 			m.cursor = i
 			assert.True(t, m.shouldTransitionToNewSession())
 			break

--- a/pkg/coop/tui/view_test.go
+++ b/pkg/coop/tui/view_test.go
@@ -445,7 +445,7 @@ func TestRenderCompletionView(t *testing.T) {
 	assertContainsPlain(t, view, "Confirm the saved price ID is reused by Checkout.")
 	assertContainsPlain(t, view, "Next steps")
 	assertContainsPlain(t, view, "STRIPE.md")
-	assertContainsPlain(t, view, "Add another Stripe feature")
+	assertContainsPlain(t, view, "Deploy")
 	assertContainsPlain(t, view, "Finish")
 }
 
@@ -525,9 +525,9 @@ func TestGetCompletionSuggestionsDefault(t *testing.T) {
 	m := testModel()
 	suggestions := m.getCompletionSuggestions()
 
-	assert.Len(t, suggestions, 3)
+	assert.Len(t, suggestions, 4)
 	assert.Equal(t, "Write a STRIPE.md summary", suggestions[0].title)
-	assert.Equal(t, "Finish", suggestions[2].title)
+	assert.Equal(t, "Finish", suggestions[3].title)
 }
 
 func TestGetCompletionSuggestionsFromSession(t *testing.T) {
@@ -853,6 +853,28 @@ func TestStepIconAllStates(t *testing.T) {
 		icon := m.stepIcon(node)
 		assert.Contains(t, ansi.Strip(icon), tc.contains, "state %s should contain %s", tc.state, tc.contains)
 	}
+}
+
+func TestGetCompletionSuggestionsWithDeployDone(t *testing.T) {
+	m := testModel()
+	for i := range m.session.Chapters {
+		for j := range m.session.Chapters[i].Nodes {
+			m.session.Chapters[i].Nodes[j].State = coop.StepDone
+		}
+	}
+	m.session.NextSteps = &coop.NextStepsState{
+		Completed: []string{"deploy"},
+	}
+
+	suggestions := m.getCompletionSuggestions()
+	// Should show "Redeploy" instead of "Deploy with Stripe Projects"
+	found := false
+	for _, s := range suggestions {
+		if s.id == "deploy" && s.title == "Redeploy" {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected 'Redeploy' after deploy completed")
 }
 
 func TestClampLines(t *testing.T) {


### PR DESCRIPTION
## What this adds

This PR adds deploy as an explicit follow-up capability after core co-op completion. It is separated from the core TUI so deployment semantics can be reviewed independently.

- Adds the `deploy-stripe-projects` blueprint for configuring and deploying with the Stripe Projects CLI plugin
- Adds deploy/redeploy next-action suggestions based on local project environment detection
- Detects Stripe Projects, Vercel, Fly.io, Netlify, Docker, and Railway configuration as deployment signals
- Adds parent/child session wiring so a deploy follow-up session can return to the completed parent and mark the deploy action done
- Restores deploy-specific completion UI behavior and tests

## Why this is split out

Deploy support is a product opinion layered on top of co-op. Keeping it separate makes the core human/agent workflow easier to review and gives deploy reviewers a focused PR for Stripe Projects behavior.

## Review focus

- Whether deploy should be suggested and how environment detection should work
- The deploy blueprint steps and agent instructions
- Parent/child session completion behavior
- Completion UI behavior for deploy/redeploy

## Stack

Base: #1667
Next: #1669

Full stack: #1664 -> #1665 -> #1666 -> #1667 -> this PR -> #1669

## Validation

- `go test ./pkg/coop/... ./pkg/cmd/coop -count=1`