### PR TITLE
Use GitHub App token instead of PATs in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ jobs:
           client-id: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_PRIVATE_KEY }}
           owner: stripe
+          repositories: |
+            stripe-cli
+            homebrew-stripe-cli
+            scoop-stripe-cli
+            winget-pkgs
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -103,6 +108,11 @@ jobs:
           client-id: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_PRIVATE_KEY }}
           owner: stripe
+          repositories: |
+            stripe-cli
+            homebrew-stripe-cli
+            scoop-stripe-cli
+            winget-pkgs
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,9 @@ jobs:
           fetch-depth: 0
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_CLIENT_ID }}
+          client-id: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_PRIVATE_KEY }}
           owner: stripe
       - name: Set up Go
@@ -98,9 +98,9 @@ jobs:
           fetch-depth: 0
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_CLIENT_ID }}
+          client-id: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_PRIVATE_KEY }}
           owner: stripe
       - name: Set up Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_PRIVATE_KEY }}
+          owner: stripe
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -44,7 +51,7 @@ jobs:
           args: release -f .goreleaser/mac.yml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GORELEASER_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   build-linux:
     needs: [approve-release]
@@ -89,6 +96,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_PRIVATE_KEY }}
+          owner: stripe
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -101,8 +115,8 @@ jobs:
           args: release -f .goreleaser/windows.yml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
-          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+          GORELEASER_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          WINGET_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   upload-to-virustotal:
     needs: [build-windows]


### PR DESCRIPTION
### Summary

Our release workflow requires GitHub PATs to create PRs in all the package manager repos ([brew](https://github.com/stripe/homebrew-stripe-cli), [scoop](https://github.com/stripe/scoop-stripe-cli), [winget](https://github.com/stripe/winget-pkgs)). We have to regenerate these PATs monthly because of our org policy, which is really annoying.

This PR updates the release workflow to use [GitHub app installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation) instead, using a new GitHub app that we just created ([Stripe CLI Releaser](https://github.com/organizations/stripe/settings/apps/stripe-cli-releaser)). This should no longer require us to manually regenerate any tokens.

I think the only way I can test this is to try it for real, so I plan on doing that after merging. This should be safe because we aren't changing the core logic of the release workflow, only how it's authenticated.