### PR TITLE
Fix winget release and improve make release UX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
             stripe-cli
             homebrew-stripe-cli
             scoop-stripe-cli
-            winget-pkgs
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -112,7 +111,6 @@ jobs:
             stripe-cli
             homebrew-stripe-cli
             scoop-stripe-cli
-            winget-pkgs
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -126,7 +124,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          WINGET_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The GitHub App token is scoped to the stripe org and cannot create
+          # PRs on microsoft/winget-pkgs, so winget still requires a PAT.
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
 
   upload-to-virustotal:
     needs: [build-windows]

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,13 @@ release:
 	  *) echo "Error: version must start with 'v'" && exit 1 ;; \
 	esac; \
 	git tag $$version && \
-	git push origin refs/tags/$$version
+	git push origin refs/tags/$$version && \
+	echo "" && \
+	echo "Tag $$version pushed. Next steps:" && \
+	echo "" && \
+	echo "  1. Request approval to run the release workflow in #stripe-cli on Slack." && \
+	echo "  2. Monitor the release at:" && \
+	echo "       https://github.com/stripe/stripe-cli/actions/workflows/release.yml"
 .PHONY: release
 
 clean:


### PR DESCRIPTION
- Restore WINGET_GITHUB_TOKEN to use a PAT: the GitHub App token is scoped to the stripe org and cannot create PRs on microsoft/winget-pkgs
- Remove winget-pkgs from the GitHub App token repository list since the app token is no longer used for winget
- Print next steps after pushing a release tag


Committed-By-Agent: claude