### PR TITLE
1/12 Add co-op session domain model

### DIFF
--- a/pkg/coop/session.go
+++ b/pkg/coop/session.go
@@ -1,0 +1,230 @@
+package coop
+
+import (
+	"fmt"
+	"time"
+)
+
+// validTransitions defines allowed state transitions.
+var validTransitions = map[NodeState][]NodeState{
+	NodePending: {NodeActive, NodeSkipped},
+	NodeActive:  {NodeReview, NodeDone, NodeSkipped},
+	NodeReview:  {NodeDone, NodeActive, NodeSkipped}, // active = rejected, redo
+}
+
+// TotalNodes returns the total number of nodes across all steps.
+func (s *Session) TotalNodes() int {
+	count := 0
+	for _, ch := range s.Steps {
+		count += len(ch.Nodes)
+	}
+	return count
+}
+
+// NodeByNumber returns a pointer to the node at the given 1-based index,
+// counting sequentially across steps. Returns an error if out of range.
+func (s *Session) NodeByNumber(n int) (*SessionNode, error) {
+	if n < 1 {
+		return nil, fmt.Errorf("node number must be >= 1, got %d", n)
+	}
+	idx := 0
+	for i := range s.Steps {
+		for j := range s.Steps[i].Nodes {
+			idx++
+			if idx == n {
+				return &s.Steps[i].Nodes[j], nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("node %d out of range (session has %d nodes)", n, s.TotalNodes())
+}
+
+// StepByNodeNumber returns the step containing a 1-based node number.
+func (s *Session) StepByNodeNumber(n int) (*SessionStep, int, int, error) {
+	if n < 1 {
+		return nil, -1, -1, fmt.Errorf("node number must be >= 1, got %d", n)
+	}
+	idx := 0
+	for i := range s.Steps {
+		for j := range s.Steps[i].Nodes {
+			idx++
+			if idx == n {
+				return &s.Steps[i], i, j, nil
+			}
+		}
+	}
+	return nil, -1, -1, fmt.Errorf("node %d out of range (session has %d nodes)", n, s.TotalNodes())
+}
+
+// ReviewGranularityForNode returns the effective review granularity for a node.
+func (s *Session) ReviewGranularityForNode(n int) ReviewGranularity {
+	ch, _, _, err := s.StepByNodeNumber(n)
+	if err != nil || ch.ReviewGranularity == "" {
+		return ReviewGranularityNode
+	}
+	return ch.ReviewGranularity
+}
+
+// StepReadyForReview returns true when every reviewable node in a step is
+// no longer pending or active.
+func (s *Session) StepReadyForReview(stepIndex int) bool {
+	if stepIndex < 0 || stepIndex >= len(s.Steps) {
+		return false
+	}
+	hasReviewable := false
+	for _, n := range s.Steps[stepIndex].Nodes {
+		if n.AutoConfirm {
+			continue
+		}
+		hasReviewable = true
+		switch n.State {
+		case NodeReview, NodeDone, NodeSkipped:
+		default:
+			return false
+		}
+	}
+	return hasReviewable
+}
+
+// StepHasReview returns true if any node in the step is waiting for human review.
+func (s *Session) StepHasReview(stepIndex int) bool {
+	if stepIndex < 0 || stepIndex >= len(s.Steps) {
+		return false
+	}
+	for _, n := range s.Steps[stepIndex].Nodes {
+		if n.State == NodeReview {
+			return true
+		}
+	}
+	return false
+}
+
+// FirstReviewNodeInStep returns the 1-based node number of the first review node.
+func (s *Session) FirstReviewNodeInStep(stepIndex int) int {
+	if stepIndex < 0 || stepIndex >= len(s.Steps) {
+		return 0
+	}
+	nodeNumber := 0
+	for i := range s.Steps {
+		for j := range s.Steps[i].Nodes {
+			nodeNumber++
+			if i == stepIndex && s.Steps[i].Nodes[j].State == NodeReview {
+				return nodeNumber
+			}
+		}
+	}
+	return 0
+}
+
+// FirstActiveNodeInStep returns the 1-based node number of the first active node.
+func (s *Session) FirstActiveNodeInStep(stepIndex int) int {
+	if stepIndex < 0 || stepIndex >= len(s.Steps) {
+		return 0
+	}
+	nodeNumber := 0
+	for i := range s.Steps {
+		for j := range s.Steps[i].Nodes {
+			nodeNumber++
+			if i == stepIndex && s.Steps[i].Nodes[j].State == NodeActive {
+				return nodeNumber
+			}
+		}
+	}
+	return 0
+}
+
+// ActiveNode returns the first node in active state, or nil.
+func (s *Session) ActiveNode() (*SessionNode, int) {
+	idx := 0
+	for i := range s.Steps {
+		for j := range s.Steps[i].Nodes {
+			idx++
+			if s.Steps[i].Nodes[j].State == NodeActive {
+				return &s.Steps[i].Nodes[j], idx
+			}
+		}
+	}
+	return nil, 0
+}
+
+// TransitionNode validates and applies a state transition on node n.
+func (s *Session) TransitionNode(n int, to NodeState) error {
+	node, err := s.NodeByNumber(n)
+	if err != nil {
+		return err
+	}
+
+	allowed, ok := validTransitions[node.State]
+	if !ok {
+		return fmt.Errorf("node %d is in terminal state %q, cannot transition", n, node.State)
+	}
+
+	valid := false
+	for _, target := range allowed {
+		if target == to {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		return fmt.Errorf("invalid transition: node %d is %q, cannot move to %q", n, node.State, to)
+	}
+
+	node.State = to
+	now := time.Now().UTC()
+
+	switch to {
+	case NodeActive:
+		if node.StartedAt == nil {
+			node.StartedAt = &now
+		}
+		node.CompletedAt = nil
+	case NodeDone:
+		node.CompletedAt = &now
+		node.RejectionNote = ""
+	case NodeReview:
+		node.CompletedAt = &now
+	case NodeSkipped:
+		node.CompletedAt = &now
+	}
+
+	return nil
+}
+
+// NextPendingNode returns the number of the next pending node after n, or 0.
+func (s *Session) NextPendingNode(after int) int {
+	idx := 0
+	for i := range s.Steps {
+		for j := range s.Steps[i].Nodes {
+			idx++
+			if idx > after && s.Steps[i].Nodes[j].State == NodePending {
+				return idx
+			}
+		}
+	}
+	return 0
+}
+
+// IsComplete returns true when all nodes are done or skipped.
+func (s *Session) IsComplete() bool {
+	for i := range s.Steps {
+		for j := range s.Steps[i].Nodes {
+			state := s.Steps[i].Nodes[j].State
+			if state != NodeDone && state != NodeSkipped {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// NodeSummary returns counts of each state.
+func (s *Session) NodeSummary() map[NodeState]int {
+	summary := make(map[NodeState]int)
+	for i := range s.Steps {
+		for j := range s.Steps[i].Nodes {
+			summary[s.Steps[i].Nodes[j].State]++
+		}
+	}
+	return summary
+}

--- a/pkg/coop/session_test.go
+++ b/pkg/coop/session_test.go
@@ -1,0 +1,413 @@
+package coop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSession() *Session {
+	return &Session{
+		ID:        "test_abc123",
+		Blueprint: "one-time-payment",
+		Status:    SessionActive,
+		Steps: []SessionStep{
+			{
+				Key:   "step-1",
+				Title: "Step 1",
+				Nodes: []SessionNode{
+					{Key: "node-1", Title: "Step 1", State: NodePending},
+					{Key: "node-2", Title: "Step 2", State: NodePending},
+				},
+			},
+			{
+				Key:   "step-2",
+				Title: "Step 2",
+				Nodes: []SessionNode{
+					{Key: "node-3", Title: "Step 3", State: NodePending},
+				},
+			},
+		},
+	}
+}
+
+func TestTotalNodes(t *testing.T) {
+	s := newTestSession()
+	assert.Equal(t, 3, s.TotalNodes())
+}
+
+func TestNodeByNumber(t *testing.T) {
+	s := newTestSession()
+
+	node, err := s.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, "node-1", node.Key)
+
+	node, err = s.NodeByNumber(3)
+	require.NoError(t, err)
+	assert.Equal(t, "node-3", node.Key)
+
+	_, err = s.NodeByNumber(0)
+	assert.Error(t, err)
+
+	_, err = s.NodeByNumber(4)
+	assert.Error(t, err)
+}
+
+func TestTransitionNode(t *testing.T) {
+	s := newTestSession()
+
+	// pending -> active
+	err := s.TransitionNode(1, NodeActive)
+	require.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, NodeActive, node.State)
+	assert.NotNil(t, node.StartedAt)
+
+	// active -> review
+	err = s.TransitionNode(1, NodeReview)
+	require.NoError(t, err)
+	node, _ = s.NodeByNumber(1)
+	assert.Equal(t, NodeReview, node.State)
+
+	// review -> done
+	err = s.TransitionNode(1, NodeDone)
+	require.NoError(t, err)
+	node, _ = s.NodeByNumber(1)
+	assert.Equal(t, NodeDone, node.State)
+
+	// done -> active (invalid)
+	err = s.TransitionNode(1, NodeActive)
+	assert.Error(t, err)
+}
+
+func TestTransitionNodeSkip(t *testing.T) {
+	s := newTestSession()
+
+	// pending -> skipped
+	err := s.TransitionNode(1, NodeSkipped)
+	require.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, NodeSkipped, node.State)
+}
+
+func TestActiveNode(t *testing.T) {
+	s := newTestSession()
+
+	node, num := s.ActiveNode()
+	assert.Nil(t, node)
+	assert.Equal(t, 0, num)
+
+	s.TransitionNode(2, NodeActive)
+	node, num = s.ActiveNode()
+	assert.Equal(t, "node-2", node.Key)
+	assert.Equal(t, 2, num)
+}
+
+func TestNextPendingNode(t *testing.T) {
+	s := newTestSession()
+
+	assert.Equal(t, 1, s.NextPendingNode(0))
+	assert.Equal(t, 2, s.NextPendingNode(1))
+	assert.Equal(t, 3, s.NextPendingNode(2))
+	assert.Equal(t, 0, s.NextPendingNode(3))
+}
+
+func TestIsComplete(t *testing.T) {
+	s := newTestSession()
+	assert.False(t, s.IsComplete())
+
+	for i := 1; i <= 3; i++ {
+		s.TransitionNode(i, NodeActive)
+		s.TransitionNode(i, NodeDone)
+	}
+	assert.True(t, s.IsComplete())
+}
+
+func TestNodeSummary(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeActive)
+	s.TransitionNode(1, NodeDone)
+
+	summary := s.NodeSummary()
+	assert.Equal(t, 1, summary[NodeDone])
+	assert.Equal(t, 2, summary[NodePending])
+}
+
+func TestTransitionNodeInvalidFromDone(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeActive)
+	s.TransitionNode(1, NodeDone)
+
+	// Can't go anywhere from done
+	assert.Error(t, s.TransitionNode(1, NodeActive))
+	assert.Error(t, s.TransitionNode(1, NodePending))
+	assert.Error(t, s.TransitionNode(1, NodeReview))
+}
+
+func TestTransitionNodeInvalidFromSkipped(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeSkipped)
+
+	// Can't go anywhere from skipped
+	assert.Error(t, s.TransitionNode(1, NodeActive))
+	assert.Error(t, s.TransitionNode(1, NodeDone))
+}
+
+func TestTransitionNodeInvalidPendingToDone(t *testing.T) {
+	s := newTestSession()
+	// Can't go directly from pending to done
+	assert.Error(t, s.TransitionNode(1, NodeDone))
+}
+
+func TestTransitionNodeInvalidPendingToReview(t *testing.T) {
+	s := newTestSession()
+	// Can't go directly from pending to review
+	assert.Error(t, s.TransitionNode(1, NodeReview))
+}
+
+func TestTransitionNodeActiveToDone(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeActive)
+	// Can go directly from active to done (--auto-confirm)
+	err := s.TransitionNode(1, NodeDone)
+	assert.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, NodeDone, node.State)
+	assert.NotNil(t, node.CompletedAt)
+}
+
+func TestTransitionNodeSetsTimestamps(t *testing.T) {
+	s := newTestSession()
+
+	s.TransitionNode(1, NodeActive)
+	node, _ := s.NodeByNumber(1)
+	assert.NotNil(t, node.StartedAt)
+	assert.Nil(t, node.CompletedAt)
+
+	s.TransitionNode(1, NodeReview)
+	node, _ = s.NodeByNumber(1)
+	assert.NotNil(t, node.CompletedAt)
+}
+
+func TestTransitionNodePreservesOriginalStartedAt(t *testing.T) {
+	s := newTestSession()
+
+	require.NoError(t, s.TransitionNode(1, NodeActive))
+	node, _ := s.NodeByNumber(1)
+	firstStartedAt := node.StartedAt
+	require.NotNil(t, firstStartedAt)
+
+	require.NoError(t, s.TransitionNode(1, NodeReview))
+	require.NoError(t, s.TransitionNode(1, NodeActive))
+	node, _ = s.NodeByNumber(1)
+	require.NotNil(t, node.StartedAt)
+	assert.True(t, node.StartedAt.Equal(*firstStartedAt))
+	assert.Nil(t, node.CompletedAt)
+}
+
+func TestTransitionNodeSkippedSetsCompletedAt(t *testing.T) {
+	s := newTestSession()
+
+	require.NoError(t, s.TransitionNode(1, NodeSkipped))
+	node, _ := s.NodeByNumber(1)
+	assert.NotNil(t, node.CompletedAt)
+}
+
+func TestNextPendingNodeSkipsNonPending(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeActive)
+	s.TransitionNode(2, NodeSkipped)
+
+	// After step 1 (active), next pending should be step 3 (skipping 2 which is skipped)
+	assert.Equal(t, 3, s.NextPendingNode(1))
+}
+
+func TestIsCompleteWithSkipped(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeActive)
+	s.TransitionNode(1, NodeDone)
+	s.TransitionNode(2, NodeSkipped)
+	s.TransitionNode(3, NodeActive)
+	s.TransitionNode(3, NodeDone)
+
+	assert.True(t, s.IsComplete())
+}
+
+func TestNodeByNumberAcrossSteps(t *testing.T) {
+	s := &Session{
+		Steps: []SessionStep{
+			{Key: "ch1", Nodes: []SessionNode{{Key: "a"}, {Key: "b"}}},
+			{Key: "ch2", Nodes: []SessionNode{{Key: "c"}}},
+			{Key: "ch3", Nodes: []SessionNode{{Key: "d"}, {Key: "e"}, {Key: "f"}}},
+		},
+	}
+
+	node, _ := s.NodeByNumber(3)
+	assert.Equal(t, "c", node.Key)
+
+	node, _ = s.NodeByNumber(6)
+	assert.Equal(t, "f", node.Key)
+
+	assert.Equal(t, 6, s.TotalNodes())
+}
+
+func TestStepByNodeNumber(t *testing.T) {
+	s := newTestSession()
+
+	ch, stepIndex, nodeIndex, err := s.StepByNodeNumber(3)
+	require.NoError(t, err)
+	assert.Equal(t, "step-2", ch.Key)
+	assert.Equal(t, 1, stepIndex)
+	assert.Equal(t, 0, nodeIndex)
+
+	ch, stepIndex, nodeIndex, err = s.StepByNodeNumber(0)
+	assert.Nil(t, ch)
+	assert.Equal(t, -1, stepIndex)
+	assert.Equal(t, -1, nodeIndex)
+	assert.Error(t, err)
+
+	ch, stepIndex, nodeIndex, err = s.StepByNodeNumber(4)
+	assert.Nil(t, ch)
+	assert.Equal(t, -1, stepIndex)
+	assert.Equal(t, -1, nodeIndex)
+	assert.Error(t, err)
+}
+
+func TestReviewGranularityForNode(t *testing.T) {
+	s := newTestSession()
+	s.Steps[0].ReviewGranularity = ReviewGranularityStep
+	s.Steps[1].ReviewGranularity = ReviewGranularityAuto
+
+	assert.Equal(t, ReviewGranularityStep, s.ReviewGranularityForNode(1))
+	assert.Equal(t, ReviewGranularityStep, s.ReviewGranularityForNode(2))
+	assert.Equal(t, ReviewGranularityAuto, s.ReviewGranularityForNode(3))
+	assert.Equal(t, ReviewGranularityNode, s.ReviewGranularityForNode(4))
+}
+
+func TestStepReadyForReview(t *testing.T) {
+	s := newTestSession()
+	assert.False(t, s.StepReadyForReview(-1))
+	assert.False(t, s.StepReadyForReview(99))
+
+	s.Steps[0].Nodes[0].State = NodeReview
+	s.Steps[0].Nodes[1].State = NodePending
+	assert.False(t, s.StepReadyForReview(0))
+
+	s.Steps[0].Nodes[1].State = NodeSkipped
+	assert.True(t, s.StepReadyForReview(0))
+
+	s.Steps[0].Nodes[0].State = NodeActive
+	assert.False(t, s.StepReadyForReview(0))
+}
+
+func TestStepReadyForReviewIgnoresAutoConfirmNodes(t *testing.T) {
+	s := &Session{
+		Steps: []SessionStep{
+			{Nodes: []SessionNode{
+				{Key: "a", State: NodeReview},
+				{Key: "auto", State: NodePending, AutoConfirm: true},
+			}},
+			{Nodes: []SessionNode{
+				{Key: "only-auto", State: NodePending, AutoConfirm: true},
+			}},
+		},
+	}
+
+	assert.True(t, s.StepReadyForReview(0))
+	assert.False(t, s.StepReadyForReview(1))
+}
+
+func TestStepReviewStateHelpers(t *testing.T) {
+	s := newTestSession()
+	s.Steps[0].Nodes[0].State = NodeDone
+	s.Steps[0].Nodes[1].State = NodeReview
+	s.Steps[1].Nodes[0].State = NodeActive
+
+	assert.True(t, s.StepHasReview(0))
+	assert.False(t, s.StepHasReview(1))
+	assert.False(t, s.StepHasReview(-1))
+
+	assert.Equal(t, 2, s.FirstReviewNodeInStep(0))
+	assert.Equal(t, 0, s.FirstReviewNodeInStep(1))
+	assert.Equal(t, 0, s.FirstReviewNodeInStep(99))
+
+	assert.Equal(t, 0, s.FirstActiveNodeInStep(0))
+	assert.Equal(t, 3, s.FirstActiveNodeInStep(1))
+	assert.Equal(t, 0, s.FirstActiveNodeInStep(-1))
+}
+
+func TestActiveNodeReturnsFirst(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeActive)
+	s.Steps[1].Nodes[0].State = NodeActive // manually set step 3 active too
+
+	node, num := s.ActiveNode()
+	// Should return the FIRST active node
+	assert.Equal(t, "node-1", node.Key)
+	assert.Equal(t, 1, num)
+}
+
+func TestTransitionNodeReviewToActive(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeActive)
+	s.TransitionNode(1, NodeReview)
+
+	// Rejection: review -> active
+	err := s.TransitionNode(1, NodeActive)
+	assert.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, NodeActive, node.State)
+}
+
+func TestTransitionNodeActiveToSkipped(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeActive)
+
+	err := s.TransitionNode(1, NodeSkipped)
+	assert.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, NodeSkipped, node.State)
+}
+
+func TestIsCompleteAllSkipped(t *testing.T) {
+	s := newTestSession()
+	for i := 1; i <= s.TotalNodes(); i++ {
+		s.TransitionNode(i, NodeSkipped)
+	}
+	assert.True(t, s.IsComplete())
+}
+
+func TestIsCompletePartialDone(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeActive)
+	s.TransitionNode(1, NodeDone)
+	// Steps 2 and 3 still pending
+	assert.False(t, s.IsComplete())
+}
+
+func TestNodeByNumberNegative(t *testing.T) {
+	s := newTestSession()
+	_, err := s.NodeByNumber(-1)
+	assert.Error(t, err)
+}
+
+func TestTransitionNodeActiveToActive(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeActive)
+	// Can't transition active -> active (not in valid transitions)
+	err := s.TransitionNode(1, NodeActive)
+	assert.Error(t, err)
+}
+
+func TestTransitionNodeReviewToSkipped(t *testing.T) {
+	s := newTestSession()
+	s.TransitionNode(1, NodeActive)
+	s.TransitionNode(1, NodeReview)
+
+	err := s.TransitionNode(1, NodeSkipped)
+	assert.NoError(t, err)
+	node, _ := s.NodeByNumber(1)
+	assert.Equal(t, NodeSkipped, node.State)
+}

--- a/pkg/coop/snippet.go
+++ b/pkg/coop/snippet.go
@@ -1,0 +1,62 @@
+package coop
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+var snippetEndpoint = "https://docs.stripe.com/_endpoint/generate-example-snippet"
+
+var httpClient = &http.Client{Timeout: 5 * time.Second}
+
+// FetchSDKSnippet fetches a generated SDK code snippet from the docs endpoint.
+// path is the API path (e.g. "/v1/customers"), method is "post"/"get"/etc,
+// params is the JSON-encoded request params, and language is "node"/"python"/etc.
+func FetchSDKSnippet(path, method string, params interface{}, language string) (string, error) {
+	argsJSON := "{}"
+	if params != nil {
+		data, err := json.Marshal(params)
+		if err != nil {
+			return "", fmt.Errorf("marshaling snippet params: %w", err)
+		}
+		argsJSON = string(data)
+	}
+
+	u, _ := url.Parse(snippetEndpoint)
+	q := u.Query()
+	q.Set("path", path)
+	q.Set("verb", method)
+	q.Set("args", argsJSON)
+	u.RawQuery = q.Encode()
+
+	resp, err := httpClient.Get(u.String())
+	if err != nil {
+		return "", fmt.Errorf("fetching snippet: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("snippet API returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading snippet response: %w", err)
+	}
+
+	var snippets map[string]string
+	if err := json.Unmarshal(body, &snippets); err != nil {
+		return "", fmt.Errorf("parsing snippet response: %w", err)
+	}
+
+	snippet, ok := snippets[language]
+	if !ok {
+		return "", fmt.Errorf("language %q not available (have: curl, node, python, ruby, php, java, go, dotnet)", language)
+	}
+
+	return snippet, nil
+}

--- a/pkg/coop/snippet_test.go
+++ b/pkg/coop/snippet_test.go
@@ -1,0 +1,78 @@
+package coop
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchSDKSnippet(t *testing.T) {
+	snippets := map[string]string{
+		"node":   "const stripe = require('stripe')('sk_test');\nawait stripe.customers.create({name: 'Test'});",
+		"python": "import stripe\nstripe.Customer.create(name='Test')",
+		"ruby":   "Stripe::Customer.create(name: 'Test')",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/customers", r.URL.Query().Get("path"))
+		assert.Equal(t, "post", r.URL.Query().Get("verb"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(snippets)
+	}))
+	defer server.Close()
+
+	// Override the endpoint for testing
+	origEndpoint := snippetEndpoint
+	snippetEndpoint = server.URL
+	defer func() { snippetEndpoint = origEndpoint }()
+
+	snippet, err := FetchSDKSnippet("/v1/customers", "post", map[string]string{"name": "Test"}, "node")
+	require.NoError(t, err)
+	assert.Contains(t, snippet, "stripe.customers.create")
+
+	snippet, err = FetchSDKSnippet("/v1/customers", "post", nil, "python")
+	require.NoError(t, err)
+	assert.Contains(t, snippet, "stripe.Customer.create")
+}
+
+func TestFetchSDKSnippetInvalidLanguage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"node": "code"})
+	}))
+	defer server.Close()
+
+	origEndpoint := snippetEndpoint
+	snippetEndpoint = server.URL
+	defer func() { snippetEndpoint = origEndpoint }()
+
+	_, err := FetchSDKSnippet("/v1/customers", "post", nil, "cobol")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cobol")
+}
+
+func TestFetchSDKSnippetServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer server.Close()
+
+	origEndpoint := snippetEndpoint
+	snippetEndpoint = server.URL
+	defer func() { snippetEndpoint = origEndpoint }()
+
+	_, err := FetchSDKSnippet("/v1/customers", "post", nil, "node")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestFetchSDKSnippetReturnsParamMarshalError(t *testing.T) {
+	_, err := FetchSDKSnippet("/v1/customers", "post", map[string]interface{}{"bad": func() {}}, "node")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshaling snippet params")
+}

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -1,0 +1,149 @@
+// Package coop implements the co-op mode feature for collaborative
+// AI agent + human developer Stripe integration building.
+package coop
+
+import "time"
+
+// NodeState represents the lifecycle state of a single blueprint node.
+type NodeState string
+
+const (
+	CurrentSessionSchemaVersion = 2
+)
+
+const (
+	NodePending NodeState = "pending"
+	NodeActive  NodeState = "active"
+	NodeReview  NodeState = "review"
+	NodeDone    NodeState = "done"
+	NodeSkipped NodeState = "skipped"
+)
+
+// NodeType represents the type of a blueprint node.
+type NodeType string
+
+const (
+	NodeAPIRequest    NodeType = "apiRequest"
+	NodeAsyncHandler  NodeType = "asyncHandler"
+	NodeUIComponent   NodeType = "uiComponent"
+	NodeTestHelper    NodeType = "testHelper"
+	NodeCLICommand    NodeType = "cliCommand"
+	NodeDashboard     NodeType = "dashboard"
+	NodeSetUpWebhooks NodeType = "setUpWebhooks"
+)
+
+// ReviewGranularity controls where human approval happens.
+type ReviewGranularity string
+
+const (
+	ReviewGranularityNode ReviewGranularity = "node"
+	ReviewGranularityStep ReviewGranularity = "step"
+	ReviewGranularityAuto ReviewGranularity = "auto"
+)
+
+// SessionStatus represents the overall session lifecycle.
+type SessionStatus string
+
+const (
+	SessionActive    SessionStatus = "active"
+	SessionCompleted SessionStatus = "completed"
+	SessionAborted   SessionStatus = "aborted"
+)
+
+// Implementation captures what the agent did for a node.
+type Implementation struct {
+	File    string `json:"file,omitempty"`
+	Lines   string `json:"lines,omitempty"`
+	Snippet string `json:"snippet,omitempty"`
+	Note    string `json:"note,omitempty"`
+}
+
+// Verification is a single check the agent ran.
+type Verification struct {
+	Check  string `json:"check"`
+	Passed bool   `json:"passed"`
+}
+
+// APIRequest describes the expected API call for a node.
+type APIRequest struct {
+	Key    string      `json:"key,omitempty"`
+	Path   string      `json:"path"`
+	Method string      `json:"method"`
+	Params interface{} `json:"params,omitempty"`
+}
+
+// SessionNode is a single action within a session step.
+type SessionNode struct {
+	Key            string          `json:"key"`
+	Type           NodeType        `json:"type"`
+	Title          string          `json:"title"`
+	Description    string          `json:"description,omitempty"`
+	ReviewPrompt   string          `json:"review_prompt,omitempty"`
+	ReviewCommand  string          `json:"review_command,omitempty"`
+	AutoConfirm    bool            `json:"auto_confirm,omitempty"`
+	State          NodeState       `json:"state"`
+	Activity       string          `json:"activity,omitempty"`
+	Implementation *Implementation `json:"implementation,omitempty"`
+	Verifications  []Verification  `json:"verifications,omitempty"`
+	Request        *APIRequest     `json:"request,omitempty"`
+	Events         []string        `json:"events,omitempty"`
+	RejectionNote  string          `json:"rejection_note,omitempty"`
+	StartedAt      *time.Time      `json:"started_at,omitempty"`
+	CompletedAt    *time.Time      `json:"completed_at,omitempty"`
+}
+
+// SessionStep groups nodes under a titled step.
+type SessionStep struct {
+	Key               string            `json:"key"`
+	Title             string            `json:"title"`
+	ReviewGranularity ReviewGranularity `json:"review_granularity,omitempty"`
+	Nodes             []SessionNode     `json:"nodes"`
+}
+
+// Session is the shared state file between agent and TUI.
+type Session struct {
+	SchemaVersion   int               `json:"schema_version"`
+	ID              string            `json:"id"`
+	Blueprint       string            `json:"blueprint"`
+	Status          SessionStatus     `json:"status"`
+	Settings        map[string]string `json:"settings,omitempty"`
+	Params          map[string]string `json:"params,omitempty"`
+	Steps           []SessionStep     `json:"steps"`
+	UsedSandbox     bool              `json:"used_sandbox,omitempty"`
+	NextSteps       *NextStepsState   `json:"next_steps,omitempty"`
+	ParentSessionID string            `json:"parent_session_id,omitempty"`
+	ParentStepID    string            `json:"parent_step_id,omitempty"` // which next-step this session fulfills
+	CreatedAt       time.Time         `json:"created_at"`
+	UpdatedAt       time.Time         `json:"updated_at"`
+	Version         int               `json:"version"`
+}
+
+// NextStepsState tracks post-completion suggestions and selection.
+type NextStepsState struct {
+	Suggestions []NextStepSuggestion `json:"suggestions"`
+	Selected    string               `json:"selected,omitempty"`
+	Completed   []string             `json:"completed,omitempty"`
+}
+
+// NextStepSuggestion is a post-completion recommendation.
+type NextStepSuggestion struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+// CommandResponse is the JSON output format for agent-facing commands.
+type CommandResponse struct {
+	OK          bool        `json:"ok"`
+	SessionID   string      `json:"session_id,omitempty"`
+	Node        int         `json:"node,omitempty"`
+	State       string      `json:"state,omitempty"`
+	Message     string      `json:"message,omitempty"`
+	Next        string      `json:"next,omitempty"`
+	AgentPrompt string      `json:"agent_prompt,omitempty"`
+	APIRequest  *APIRequest `json:"api_request,omitempty"`
+	SDKExample  string      `json:"sdk_example,omitempty"`
+	Error       string      `json:"error,omitempty"`
+	Hint        string      `json:"hint,omitempty"`
+}


### PR DESCRIPTION
## What this adds
Introduces the core co-op session types, step state machine, session navigation helpers, and SDK snippet fetching used by later agent and TUI layers.

## Review focus
Review this PR as one slice of the co-op stack. It should be understandable on its own against `tomer/coop-stack-base`.

## Stack
Base: `tomer/coop-stack-base`  
Head: `tomer/coop-split-domain-core`

## Validation
Ran `go test ./pkg/coop -count=1` and `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./pkg/coop/...`.