### PR TITLE
2/12 Add co-op session store

### DIFF
--- a/pkg/coop/store.go
+++ b/pkg/coop/store.go
@@ -1,0 +1,389 @@
+package coop
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Store manages session persistence with atomic writes.
+type Store struct {
+	baseDir string
+}
+
+var (
+	ErrInvalidSessionID = errors.New("invalid session id")
+	ErrSessionNotFound  = errors.New("session not found")
+	ErrVersionConflict  = errors.New("version conflict")
+	ErrLockTimeout      = errors.New("timed out waiting for session lock")
+	ErrCorruptSession   = errors.New("corrupt session")
+)
+
+var (
+	sessionLockTimeout      = 5 * time.Second
+	sessionLockPollInterval = 25 * time.Millisecond
+)
+
+// NewStore creates a Store, ensuring the coop directory exists.
+func NewStore(configFolder string) (*Store, error) {
+	dir := filepath.Join(configFolder, "coop")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("creating coop directory: %w", err)
+	}
+	return &Store{baseDir: dir}, nil
+}
+
+// NewStoreAt creates a Store at a specific path (for testing).
+func NewStoreAt(dir string) (*Store, error) {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("creating coop directory: %w", err)
+	}
+	return &Store{baseDir: dir}, nil
+}
+
+func (s *Store) sessionPath(id string) (string, error) {
+	// Validate ID to prevent path traversal
+	base := filepath.Base(id)
+	if base != id || id == "" || id == "." || id == ".." {
+		return "", fmt.Errorf("%w: %q", ErrInvalidSessionID, id)
+	}
+	return filepath.Join(s.baseDir, id+".json"), nil
+}
+
+// Write atomically persists a session (write to .tmp then rename).
+// Uses optimistic locking: checks that the file's current version matches
+// the session's version before writing. Returns an error on conflict.
+func (s *Store) Write(session *Session) error {
+	path, err := s.sessionPath(session.ID)
+	if err != nil {
+		return err
+	}
+	return s.writePath(path, session)
+}
+
+func (s *Store) writePath(path string, session *Session) error {
+	unlock, err := s.acquireSessionLock(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	if existing, err := os.ReadFile(path); err == nil {
+		var current Session
+		if json.Unmarshal(existing, &current) == nil {
+			if current.Version != session.Version {
+				return fmt.Errorf("%w: expected %d, file has %d", ErrVersionConflict, session.Version, current.Version)
+			}
+		}
+	}
+
+	ensureSessionSchemaVersion(session)
+	session.UpdatedAt = time.Now().UTC()
+	session.Version++
+
+	return s.writeUnlocked(path, session)
+}
+
+func replaceSessionFile(tmpPath, path string) error {
+	if err := os.Rename(tmpPath, path); err == nil {
+		return nil
+	} else if runtime.GOOS != "windows" {
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+
+	// Windows does not replace an existing destination with os.Rename.
+	// Writers are already serialized by the session lock, so remove first.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing existing session file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) acquireSessionLock(path string) (func(), error) {
+	lockPath := path + ".lock"
+	deadline := time.Now().Add(sessionLockTimeout)
+
+	for {
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+		if err == nil {
+			f.Close()
+			return func() { os.Remove(lockPath) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, fmt.Errorf("creating lock file: %w", err)
+		}
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("%w: %s is still present; if no stripe coop command is running, remove this lock file and retry", ErrLockTimeout, lockPath)
+		}
+		time.Sleep(sessionLockPollInterval)
+	}
+}
+
+// Read loads a session from disk.
+func (s *Store) Read(id string) (*Session, error) {
+	path, err := s.sessionPath(id)
+	if err != nil {
+		return nil, err
+	}
+	data, err := readSessionFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: %q", ErrSessionNotFound, id)
+		}
+		return nil, fmt.Errorf("reading session %q: %w", id, err)
+	}
+
+	var session Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("%w: parsing session %q: %v", ErrCorruptSession, id, err)
+	}
+	ensureSessionSchemaVersion(&session)
+
+	return &session, nil
+}
+
+func ensureSessionSchemaVersion(session *Session) {
+	if session.SchemaVersion == 0 {
+		session.SchemaVersion = CurrentSessionSchemaVersion
+	}
+}
+
+func readSessionFile(path string) ([]byte, error) {
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil || !isWindowsTransientReadError(err) || time.Now().After(deadline) {
+			return data, err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func isWindowsTransientReadError(err error) bool {
+	return runtime.GOOS == "windows" && (os.IsNotExist(err) || strings.Contains(err.Error(), "being used by another process"))
+}
+
+// Update loads, mutates, and atomically writes a session with optimistic locking.
+func (s *Store) Update(id string, fn func(*Session) error) (*Session, error) {
+	path, err := s.sessionPath(id)
+	if err != nil {
+		return nil, err
+	}
+
+	unlock, err := s.acquireSessionLock(path)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: %q", ErrSessionNotFound, id)
+		}
+		return nil, fmt.Errorf("reading session %q: %w", id, err)
+	}
+
+	var session Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("%w: parsing session %q: %v", ErrCorruptSession, id, err)
+	}
+	if err := fn(&session); err != nil {
+		return nil, err
+	}
+	ensureSessionSchemaVersion(&session)
+	session.UpdatedAt = time.Now().UTC()
+	session.Version++
+
+	if err := s.writeUnlocked(path, &session); err != nil {
+		return nil, err
+	}
+	return &session, nil
+}
+
+func (s *Store) writeUnlocked(path string, session *Session) error {
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling session: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(s.baseDir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := replaceSessionFile(tmpPath, path); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ModTime returns the file modification time (for polling).
+func (s *Store) ModTime(id string) (time.Time, error) {
+	path, err := s.sessionPath(id)
+	if err != nil {
+		return time.Time{}, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return info.ModTime(), nil
+}
+
+// List returns all session IDs found on disk.
+func (s *Store) List() ([]string, error) {
+	entries, err := os.ReadDir(s.baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var ids []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		ids = append(ids, strings.TrimSuffix(e.Name(), ".json"))
+	}
+	return ids, nil
+}
+
+type sessionEntry struct {
+	id      string
+	modTime time.Time
+}
+
+func (s *Store) sortedSessionEntries() ([]sessionEntry, error) {
+	ids, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("no coop sessions found")
+	}
+
+	var entries []sessionEntry
+	for _, id := range ids {
+		mt, err := s.ModTime(id)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, sessionEntry{id: id, modTime: mt})
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no readable coop sessions found")
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].modTime.After(entries[j].modTime)
+	})
+
+	return entries, nil
+}
+
+// LatestSession returns the most recently updated session.
+func (s *Store) LatestSession() (*Session, error) {
+	entries, err := s.sortedSessionEntries()
+	if err != nil {
+		return nil, err
+	}
+	return s.Read(entries[0].id)
+}
+
+// LatestActiveSession returns the most recently updated session with status "active".
+func (s *Store) LatestActiveSession() (*Session, error) {
+	entries, err := s.sortedSessionEntries()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range entries {
+		session, err := s.Read(e.id)
+		if err != nil {
+			continue
+		}
+		if session.Status == SessionActive {
+			return session, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no active coop sessions found")
+}
+
+// Delete removes a session file.
+func (s *Store) Delete(id string) error {
+	path, err := s.sessionPath(id)
+	if err != nil {
+		return err
+	}
+	return os.Remove(path)
+}
+
+func (s *Store) heartbeatPath(id string) (string, error) {
+	path, err := s.sessionPath(id)
+	if err != nil {
+		return "", err
+	}
+	return path + ".heartbeat", nil
+}
+
+// WriteHeartbeat updates the heartbeat file for a session (signals agent is polling).
+func (s *Store) WriteHeartbeat(id string) error {
+	path, err := s.heartbeatPath(id)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(time.Now().UTC().Format(time.RFC3339)), 0600)
+}
+
+// HeartbeatAge returns how long ago the heartbeat was updated.
+// Returns -1 if no heartbeat file exists.
+func (s *Store) HeartbeatAge(id string) (time.Duration, error) {
+	path, err := s.heartbeatPath(id)
+	if err != nil {
+		return 0, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return -1, nil
+		}
+		return 0, err
+	}
+	return time.Since(info.ModTime()), nil
+}
+
+// RemoveHeartbeat cleans up the heartbeat file.
+func (s *Store) RemoveHeartbeat(id string) error {
+	path, err := s.heartbeatPath(id)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/pkg/coop/store_test.go
+++ b/pkg/coop/store_test.go
@@ -1,0 +1,353 @@
+package coop
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreWriteRead(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	session := &Session{
+		ID:        "test_001",
+		Blueprint: "one-time-payment",
+		Status:    SessionActive,
+		Steps: []SessionStep{
+			{
+				Key:   "ch-1",
+				Title: "Step 1",
+				Nodes: []SessionNode{
+					{Key: "n-1", Title: "Step 1", State: NodePending},
+				},
+			},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	err = store.Write(session)
+	require.NoError(t, err)
+	assert.Equal(t, 1, session.Version)
+
+	loaded, err := store.Read("test_001")
+	require.NoError(t, err)
+	assert.Equal(t, "test_001", loaded.ID)
+	assert.Equal(t, "one-time-payment", loaded.Blueprint)
+	assert.Equal(t, CurrentSessionSchemaVersion, loaded.SchemaVersion)
+	assert.Equal(t, 1, loaded.Version)
+	assert.Equal(t, NodePending, loaded.Steps[0].Nodes[0].State)
+}
+
+func TestStoreWriteIncrementsVersion(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	session := &Session{ID: "test_002", Status: SessionActive}
+	store.Write(session)
+	assert.Equal(t, 1, session.Version)
+
+	store.Write(session)
+	assert.Equal(t, 2, session.Version)
+}
+
+func TestStoreWriteDetectsVersionConflict(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	session := &Session{ID: "conflict_test", Status: SessionActive}
+	require.NoError(t, store.Write(session))
+
+	stale := *session
+	require.NoError(t, store.Write(session))
+
+	err = store.Write(&stale)
+	require.ErrorIs(t, err, ErrVersionConflict)
+}
+
+func TestStoreUpdateMutatesAndVersionsSession(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	session := &Session{
+		ID:     "update_test",
+		Status: SessionActive,
+		Steps:  []SessionStep{{Key: "step", Nodes: []SessionNode{{Key: "step", Title: "Step", State: NodePending}}}},
+	}
+	require.NoError(t, store.Write(session))
+
+	updated, err := store.Update("update_test", func(session *Session) error {
+		node, err := session.NodeByNumber(1)
+		require.NoError(t, err)
+		node.Activity = "working"
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, updated.Version)
+	assert.Equal(t, CurrentSessionSchemaVersion, updated.SchemaVersion)
+	assert.Equal(t, "working", updated.Steps[0].Nodes[0].Activity)
+
+	loaded, err := store.Read("update_test")
+	require.NoError(t, err)
+	assert.Equal(t, "working", loaded.Steps[0].Nodes[0].Activity)
+}
+
+func TestStoreDefaultsSchemaOnReadWriteAndUpdate(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	rawPath := filepath.Join(dir, "missing_schema.json")
+	require.NoError(t, os.WriteFile(rawPath, []byte(`{"id":"missing_schema","status":"active","version":7}`), 0600))
+
+	readSession, err := store.Read("missing_schema")
+	require.NoError(t, err)
+	assert.Equal(t, CurrentSessionSchemaVersion, readSession.SchemaVersion)
+
+	updated, err := store.Update("missing_schema", func(session *Session) error {
+		session.Blueprint = "updated"
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, CurrentSessionSchemaVersion, updated.SchemaVersion)
+
+	written := &Session{ID: "new_missing_schema", Status: SessionActive}
+	require.NoError(t, store.Write(written))
+	assert.Equal(t, CurrentSessionSchemaVersion, written.SchemaVersion)
+}
+
+func TestStoreUpdateInvalidSessionID(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	_, err = store.Update("../bad", func(session *Session) error { return nil })
+	require.ErrorIs(t, err, ErrInvalidSessionID)
+}
+
+func TestStoreList(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "sess_a", Status: SessionActive})
+	store.Write(&Session{ID: "sess_b", Status: SessionActive})
+
+	ids, err := store.List()
+	require.NoError(t, err)
+	assert.Len(t, ids, 2)
+	assert.Contains(t, ids, "sess_a")
+	assert.Contains(t, ids, "sess_b")
+}
+
+func TestStoreLatestSession(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "old", Status: SessionActive})
+	time.Sleep(10 * time.Millisecond)
+	store.Write(&Session{ID: "new", Status: SessionActive})
+
+	latest, err := store.LatestSession()
+	require.NoError(t, err)
+	assert.Equal(t, "new", latest.ID)
+}
+
+func TestStoreModTime(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "timed", Status: SessionActive})
+
+	mt, err := store.ModTime("timed")
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now(), mt, 2*time.Second)
+}
+
+func TestStoreDelete(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "doomed", Status: SessionActive})
+	err = store.Delete("doomed")
+	require.NoError(t, err)
+
+	_, err = store.Read("doomed")
+	assert.Error(t, err)
+}
+
+func TestStoreReadNotFound(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	_, err = store.Read("nonexistent")
+	assert.Error(t, err)
+}
+
+func TestStoreLatestActiveSession(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	// Write a completed session
+	store.Write(&Session{ID: "completed_one", Status: SessionCompleted})
+	time.Sleep(10 * time.Millisecond)
+
+	// Write an active session
+	store.Write(&Session{ID: "active_one", Status: SessionActive})
+	time.Sleep(10 * time.Millisecond)
+
+	// Write an aborted session (most recent, but not active)
+	store.Write(&Session{ID: "aborted_one", Status: SessionAborted})
+
+	// Should find the active one
+	session, err := store.LatestActiveSession()
+	require.NoError(t, err)
+	assert.Equal(t, "active_one", session.ID)
+}
+
+func TestStoreLatestActiveSessionNoneActive(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "done", Status: SessionCompleted})
+	store.Write(&Session{ID: "aborted", Status: SessionAborted})
+
+	_, err = store.LatestActiveSession()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no active")
+}
+
+func TestStoreLatestActiveSessionEmpty(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	_, err = store.LatestActiveSession()
+	assert.Error(t, err)
+}
+
+func TestStoreAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	session := &Session{ID: "atomic_test", Status: SessionActive}
+	err = store.Write(session)
+	require.NoError(t, err)
+
+	// Verify no .tmp file left behind
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		assert.False(t, strings.HasSuffix(e.Name(), ".tmp"), "temp file should be cleaned up")
+	}
+}
+
+func TestStoreWriteCleansLockAndTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	session := &Session{ID: "clean_test", Status: SessionActive}
+	require.NoError(t, store.Write(session))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasSuffix(e.Name(), ".tmp"), "temp file should be cleaned up")
+		assert.False(t, strings.HasSuffix(e.Name(), ".lock"), "lock file should be cleaned up")
+	}
+}
+
+func TestStoreWriteLockTimeoutIncludesRecoveryHint(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	originalTimeout := sessionLockTimeout
+	originalPollInterval := sessionLockPollInterval
+	sessionLockTimeout = 10 * time.Millisecond
+	sessionLockPollInterval = time.Millisecond
+	t.Cleanup(func() {
+		sessionLockTimeout = originalTimeout
+		sessionLockPollInterval = originalPollInterval
+	})
+
+	lockPath := filepath.Join(dir, "locked.json.lock")
+	require.NoError(t, os.WriteFile(lockPath, []byte("locked"), 0600))
+
+	err = store.Write(&Session{ID: "locked", Status: SessionActive})
+	require.ErrorIs(t, err, ErrLockTimeout)
+	assert.Contains(t, err.Error(), lockPath)
+	assert.Contains(t, err.Error(), "remove this lock file")
+}
+
+func TestStoreListIgnoresTmpFiles(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	store.Write(&Session{ID: "real", Status: SessionActive})
+	// Simulate a leftover tmp file
+	os.WriteFile(dir+"/orphan.json.tmp", []byte("{}"), 0600)
+
+	ids, err := store.List()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"real"}, ids)
+}
+
+func TestStoreHeartbeatLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, store.Write(&Session{ID: "heartbeat", Status: SessionActive}))
+
+	age, err := store.HeartbeatAge("heartbeat")
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(-1), age)
+
+	require.NoError(t, store.WriteHeartbeat("heartbeat"))
+
+	age, err = store.HeartbeatAge("heartbeat")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, age, time.Duration(0))
+	assert.Less(t, age, 2*time.Second)
+
+	require.NoError(t, store.RemoveHeartbeat("heartbeat"))
+
+	age, err = store.HeartbeatAge("heartbeat")
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(-1), age)
+}
+
+func TestStoreHeartbeatInvalidSessionID(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStoreAt(dir)
+	require.NoError(t, err)
+
+	require.ErrorIs(t, store.WriteHeartbeat("../bad"), ErrInvalidSessionID)
+
+	_, err = store.HeartbeatAge("../bad")
+	require.ErrorIs(t, err, ErrInvalidSessionID)
+
+	require.ErrorIs(t, store.RemoveHeartbeat("../bad"), ErrInvalidSessionID)
+
+	_, err = os.Stat(filepath.Join(dir, "invalid.heartbeat"))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+}


### PR DESCRIPTION
## What this adds
Adds JSON session persistence, optimistic version checks, lock files, heartbeat files, session listing, latest-session lookup, deletion, and Windows-safe session replacement.

## Review focus
Review this PR as one slice of the co-op stack. It should be understandable on its own against `tomer/coop-split-domain-core`.

## Stack
Base: `tomer/coop-split-domain-core`  
Head: `tomer/coop-split-domain-store`

## Validation
Ran `go test ./pkg/coop -count=1` and `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./pkg/coop/...`.