### PR TITLE
3/12 Add co-op blueprint loader

### DIFF
--- a/pkg/coop/blueprint.go
+++ b/pkg/coop/blueprint.go
@@ -1,0 +1,207 @@
+package coop
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+//go:embed blueprints/*.json
+var blueprintFS embed.FS
+
+// BlueprintNode is a node definition within a blueprint step.
+type BlueprintNode struct {
+	Type          NodeType    `json:"type"`
+	Key           string      `json:"key"`
+	Title         string      `json:"title"`
+	Description   string      `json:"description,omitempty"`
+	ReviewPrompt  string      `json:"review_prompt,omitempty"`
+	ReviewCommand string      `json:"review_command,omitempty"`
+	AutoConfirm   bool        `json:"auto_confirm,omitempty"`
+	Request       *APIRequest `json:"request,omitempty"`
+	Events        []string    `json:"events,omitempty"`
+}
+
+// BlueprintStep is a step definition within a blueprint.
+type BlueprintStep struct {
+	Key               string            `json:"key"`
+	Title             string            `json:"title"`
+	Description       string            `json:"description,omitempty"`
+	ReviewGranularity ReviewGranularity `json:"review_granularity,omitempty"`
+	Required          bool              `json:"required,omitempty"`
+	Nodes             []BlueprintNode   `json:"nodes"`
+}
+
+// Blueprint is the CLI-friendly representation of a Workbench Blueprint.
+type Blueprint struct {
+	ID          string             `json:"id"`
+	Title       string             `json:"title"`
+	Description string             `json:"description,omitempty"`
+	Prompt      string             `json:"prompt,omitempty"`
+	Type        string             `json:"type"`
+	Products    []string           `json:"products,omitempty"`
+	Settings    []BlueprintSetting `json:"settings,omitempty"`
+	Params      []BlueprintParam   `json:"params,omitempty"`
+	Steps       []BlueprintStep    `json:"steps"`
+}
+
+// BlueprintSetting defines a configurable setting for a blueprint.
+type BlueprintSetting struct {
+	Key         string   `json:"key"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Type        string   `json:"type"`
+	Default     string   `json:"default,omitempty"`
+	Options     []string `json:"options,omitempty"`
+}
+
+// BlueprintParam defines a variable value used while implementing a blueprint.
+type BlueprintParam struct {
+	Key         string   `json:"key"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Type        string   `json:"type"`
+	Default     string   `json:"default,omitempty"`
+	Options     []string `json:"options,omitempty"`
+}
+
+// LoadBlueprint loads a blueprint by ID from the embedded filesystem.
+// If no exact match is found, it tries prefix matching (e.g. "deploy" → "deploy-stripe-projects").
+func LoadBlueprint(id string) (*Blueprint, error) {
+	filename := fmt.Sprintf("blueprints/%s.json", id)
+	data, err := blueprintFS.ReadFile(filename)
+	if err != nil {
+		// Try prefix match
+		match, matchErr := prefixMatchBlueprint(id)
+		if matchErr != nil {
+			return nil, matchErr
+		}
+		data, err = blueprintFS.ReadFile(fmt.Sprintf("blueprints/%s.json", match))
+		if err != nil {
+			return nil, fmt.Errorf("blueprint %q not found", id)
+		}
+	}
+
+	var bp Blueprint
+	if err := json.Unmarshal(data, &bp); err != nil {
+		return nil, fmt.Errorf("parsing blueprint %q: %w", id, err)
+	}
+
+	return &bp, nil
+}
+
+func prefixMatchBlueprint(prefix string) (string, error) {
+	ids, err := ListBlueprints()
+	if err != nil {
+		return "", fmt.Errorf("blueprint %q not found", prefix)
+	}
+
+	var matches []string
+	for _, id := range ids {
+		if strings.HasPrefix(id, prefix) {
+			matches = append(matches, id)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("blueprint %q not found", prefix)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("ambiguous blueprint prefix %q matches: %s", prefix, strings.Join(matches, ", "))
+	}
+}
+
+// ListBlueprints returns all available blueprint IDs.
+func ListBlueprints() ([]string, error) {
+	entries, err := blueprintFS.ReadDir("blueprints")
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		ids = append(ids, strings.TrimSuffix(e.Name(), ".json"))
+	}
+	return ids, nil
+}
+
+// ListBlueprintsWithMetadata returns all blueprints with their metadata.
+func ListBlueprintsWithMetadata() ([]Blueprint, error) {
+	ids, err := ListBlueprints()
+	if err != nil {
+		return nil, err
+	}
+
+	var blueprints []Blueprint
+	for _, id := range ids {
+		bp, err := LoadBlueprint(id)
+		if err != nil {
+			continue
+		}
+		blueprints = append(blueprints, *bp)
+	}
+	return blueprints, nil
+}
+
+// NewSessionFromBlueprint creates a new Session from a Blueprint definition.
+// A context-gathering step is prepended so the agent scans the project first.
+func NewSessionFromBlueprint(bp *Blueprint, sessionID string, settings, params map[string]string) *Session {
+	// Prepend a context-gathering step (auto-confirmed, no human sign-off needed)
+	contextStep := SessionStep{
+		Key:   "context-step",
+		Title: "Project context",
+		Nodes: []SessionNode{
+			{
+				Key:         "scan-project",
+				Type:        NodeTestHelper,
+				Title:       "Understand the project",
+				Description: "Scan the codebase to identify language, framework, dependencies, and existing Stripe code. Report what you find.",
+				AutoConfirm: true,
+				State:       NodePending,
+			},
+		},
+	}
+
+	steps := make([]SessionStep, 0, len(bp.Steps)+1)
+	steps = append(steps, contextStep)
+
+	for _, ch := range bp.Steps {
+		nodes := make([]SessionNode, len(ch.Nodes))
+		for j, n := range ch.Nodes {
+			nodes[j] = SessionNode{
+				Key:           n.Key,
+				Type:          n.Type,
+				Title:         n.Title,
+				Description:   n.Description,
+				ReviewPrompt:  n.ReviewPrompt,
+				ReviewCommand: n.ReviewCommand,
+				AutoConfirm:   n.AutoConfirm,
+				State:         NodePending,
+				Request:       n.Request,
+				Events:        n.Events,
+			}
+		}
+		steps = append(steps, SessionStep{
+			Key:               ch.Key,
+			Title:             ch.Title,
+			ReviewGranularity: ch.ReviewGranularity,
+			Nodes:             nodes,
+		})
+	}
+
+	return &Session{
+		SchemaVersion: CurrentSessionSchemaVersion,
+		ID:            sessionID,
+		Blueprint:     bp.ID,
+		Status:        SessionActive,
+		Settings:      settings,
+		Params:        params,
+		Steps:         steps,
+	}
+}

--- a/pkg/coop/blueprint.go
+++ b/pkg/coop/blueprint.go
@@ -14,9 +14,11 @@ var blueprintFS embed.FS
 // BlueprintStep is a step definition within a blueprint.
 type BlueprintStep struct {
 	StepDefinition
-	Description string           `json:"description,omitempty"`
-	Required    bool             `json:"required,omitempty"`
-	Nodes       []NodeDefinition `json:"nodes"`
+	Description string             `json:"description,omitempty"`
+	Required    bool               `json:"required,omitempty"`
+	Settings    []BlueprintSetting `json:"settings,omitempty"`
+	Params      []BlueprintParam   `json:"params,omitempty"`
+	Nodes       []NodeDefinition   `json:"nodes"`
 }
 
 // Blueprint is the CLI-friendly representation of a Workbench Blueprint.

--- a/pkg/coop/blueprint.go
+++ b/pkg/coop/blueprint.go
@@ -5,32 +5,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 //go:embed blueprints/*.json
 var blueprintFS embed.FS
 
-// BlueprintNode is a node definition within a blueprint step.
-type BlueprintNode struct {
-	Type          NodeType    `json:"type"`
-	Key           string      `json:"key"`
-	Title         string      `json:"title"`
-	Description   string      `json:"description,omitempty"`
-	ReviewPrompt  string      `json:"review_prompt,omitempty"`
-	ReviewCommand string      `json:"review_command,omitempty"`
-	AutoConfirm   bool        `json:"auto_confirm,omitempty"`
-	Request       *APIRequest `json:"request,omitempty"`
-	Events        []string    `json:"events,omitempty"`
-}
-
 // BlueprintStep is a step definition within a blueprint.
 type BlueprintStep struct {
-	Key               string            `json:"key"`
-	Title             string            `json:"title"`
-	Description       string            `json:"description,omitempty"`
-	ReviewGranularity ReviewGranularity `json:"review_granularity,omitempty"`
-	Required          bool              `json:"required,omitempty"`
-	Nodes             []BlueprintNode   `json:"nodes"`
+	StepDefinition
+	Description string           `json:"description,omitempty"`
+	Required    bool             `json:"required,omitempty"`
+	Nodes       []NodeDefinition `json:"nodes"`
 }
 
 // Blueprint is the CLI-friendly representation of a Workbench Blueprint.
@@ -38,10 +24,9 @@ type Blueprint struct {
 	ID          string             `json:"id"`
 	Title       string             `json:"title"`
 	Description string             `json:"description,omitempty"`
-	Prompt      string             `json:"prompt,omitempty"`
 	Type        string             `json:"type"`
 	Products    []string           `json:"products,omitempty"`
-	Settings    []BlueprintSetting `json:"settings,omitempty"`
+	Settings    []BlueprintSetting `json:"settings"`
 	Params      []BlueprintParam   `json:"params,omitempty"`
 	Steps       []BlueprintStep    `json:"steps"`
 }
@@ -94,7 +79,7 @@ func LoadBlueprint(id string) (*Blueprint, error) {
 func prefixMatchBlueprint(prefix string) (string, error) {
 	ids, err := ListBlueprints()
 	if err != nil {
-		return "", fmt.Errorf("blueprint %q not found", prefix)
+		return "", fmt.Errorf("loading blueprints: %w", err)
 	}
 
 	var matches []string
@@ -142,7 +127,7 @@ func ListBlueprintsWithMetadata() ([]Blueprint, error) {
 	for _, id := range ids {
 		bp, err := LoadBlueprint(id)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("loading blueprint metadata for %q: %w", id, err)
 		}
 		blueprints = append(blueprints, *bp)
 	}
@@ -152,18 +137,24 @@ func ListBlueprintsWithMetadata() ([]Blueprint, error) {
 // NewSessionFromBlueprint creates a new Session from a Blueprint definition.
 // A context-gathering step is prepended so the agent scans the project first.
 func NewSessionFromBlueprint(bp *Blueprint, sessionID string, settings, params map[string]string) *Session {
+	now := time.Now().UTC()
+
 	// Prepend a context-gathering step (auto-confirmed, no human sign-off needed)
 	contextStep := SessionStep{
-		Key:   "context-step",
-		Title: "Project context",
+		StepDefinition: StepDefinition{
+			Key:   "context-step",
+			Title: "Project context",
+		},
 		Nodes: []SessionNode{
 			{
-				Key:         "scan-project",
-				Type:        NodeTestHelper,
-				Title:       "Understand the project",
-				Description: "Scan the codebase to identify language, framework, dependencies, and existing Stripe code. Report what you find.",
-				AutoConfirm: true,
-				State:       NodePending,
+				NodeDefinition: NodeDefinition{
+					Key:         "scan-project",
+					Type:        NodeTestHelper,
+					Title:       "Understand the project",
+					Description: "Scan the codebase to identify language, framework, dependencies, and existing Stripe code. Report what you find.",
+					AutoConfirm: true,
+				},
+				State: NodePending,
 			},
 		},
 	}
@@ -175,23 +166,13 @@ func NewSessionFromBlueprint(bp *Blueprint, sessionID string, settings, params m
 		nodes := make([]SessionNode, len(ch.Nodes))
 		for j, n := range ch.Nodes {
 			nodes[j] = SessionNode{
-				Key:           n.Key,
-				Type:          n.Type,
-				Title:         n.Title,
-				Description:   n.Description,
-				ReviewPrompt:  n.ReviewPrompt,
-				ReviewCommand: n.ReviewCommand,
-				AutoConfirm:   n.AutoConfirm,
-				State:         NodePending,
-				Request:       n.Request,
-				Events:        n.Events,
+				NodeDefinition: n,
+				State:          NodePending,
 			}
 		}
 		steps = append(steps, SessionStep{
-			Key:               ch.Key,
-			Title:             ch.Title,
-			ReviewGranularity: ch.ReviewGranularity,
-			Nodes:             nodes,
+			StepDefinition: ch.StepDefinition,
+			Nodes:          nodes,
 		})
 	}
 
@@ -203,5 +184,7 @@ func NewSessionFromBlueprint(bp *Blueprint, sessionID string, settings, params m
 		Settings:      settings,
 		Params:        params,
 		Steps:         steps,
+		CreatedAt:     now,
+		UpdatedAt:     now,
 	}
 }

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -446,8 +446,8 @@ func TestAllEmbeddedBlueprintsAreStructurallyValid(t *testing.T) {
 						assert.NotEmpty(t, n.Request.Path)
 						assert.NotEmpty(t, n.Request.Method)
 					}
-					if n.Type == NodeTestHelper && len(n.Requests) > 0 {
-						for _, req := range n.Requests {
+					if n.Type == NodeTestHelper && len(n.TestRequests) > 0 {
+						for _, req := range n.TestRequests {
 							assert.NotEmpty(t, req.Key, "testHelper node %q request should have key", n.Key)
 							assert.NotEmpty(t, req.Path, "testHelper node %q request %q should have path", n.Key, req.Key)
 							assert.NotEmpty(t, req.Method, "testHelper node %q request %q should have method", n.Key, req.Key)

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -310,9 +310,9 @@ func TestEmbeddedBlueprintsDoNotCarryAPIRequestKeys(t *testing.T) {
 			require.NoError(t, json.Unmarshal(raw, &document))
 			assertNoRequestKey(t, document)
 
-			text := string(raw)
-			assert.NotContains(t, text, "-request:", "node interpolation should not include API request keys")
-			assert.NotContains(t, text, "Request:", "node interpolation should not include API request keys")
+			bp, err := LoadBlueprint(id)
+			require.NoError(t, err)
+			assertNoAPIRequestNodeKeyInterpolation(t, bp, string(raw))
 		})
 	}
 }
@@ -331,6 +331,24 @@ func assertNoRequestKey(t *testing.T, value any) {
 	case []any:
 		for _, child := range v {
 			assertNoRequestKey(t, child)
+		}
+	}
+}
+
+func assertNoAPIRequestNodeKeyInterpolation(t *testing.T, bp *Blueprint, raw string) {
+	t.Helper()
+
+	for _, step := range bp.Steps {
+		for _, node := range step.Nodes {
+			if node.Type != NodeAPIRequest {
+				continue
+			}
+			assert.NotContains(
+				t,
+				raw,
+				"${node."+step.Key+"."+node.Key+".",
+				"apiRequest node interpolation should not include request keys",
+			)
 		}
 	}
 }
@@ -427,6 +445,13 @@ func TestAllEmbeddedBlueprintsAreStructurallyValid(t *testing.T) {
 						require.NotNil(t, n.Request, "apiRequest node %q should have request field", n.Key)
 						assert.NotEmpty(t, n.Request.Path)
 						assert.NotEmpty(t, n.Request.Method)
+					}
+					if n.Type == NodeTestHelper && len(n.Requests) > 0 {
+						for _, req := range n.Requests {
+							assert.NotEmpty(t, req.Key, "testHelper node %q request should have key", n.Key)
+							assert.NotEmpty(t, req.Path, "testHelper node %q request %q should have path", n.Key, req.Key)
+							assert.NotEmpty(t, req.Method, "testHelper node %q request %q should have method", n.Key, req.Key)
+						}
 					}
 				}
 			}

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -1,6 +1,7 @@
 package coop
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -14,8 +15,8 @@ func TestLoadBlueprint(t *testing.T) {
 	assert.Equal(t, "one-time-payment", bp.ID)
 	assert.Equal(t, "Accept a one-time payment", bp.Title)
 	assert.Contains(t, bp.Products, "Payments")
-	assert.Len(t, bp.Steps, 4)
-	assert.Equal(t, "setup-step", bp.Steps[0].Key)
+	assert.Len(t, bp.Steps, 3)
+	assert.Equal(t, "setup-chapter", bp.Steps[0].Key)
 	assert.Equal(t, NodeAPIRequest, bp.Steps[0].Nodes[0].Type)
 }
 
@@ -138,8 +139,8 @@ func TestNewSessionFromBlueprint(t *testing.T) {
 	assert.Equal(t, SessionActive, session.Status)
 	assert.Equal(t, "node", session.Settings["language"])
 	assert.Equal(t, "Jenny Rosen", session.Params["account_name"])
-	// 4 blueprint steps + 1 prepended context step
-	assert.Len(t, session.Steps, 5)
+	// 3 blueprint steps + 1 prepended context step
+	assert.Len(t, session.Steps, 4)
 
 	// First step is always the context-gathering step
 	assert.Equal(t, "context-step", session.Steps[0].Key)
@@ -152,10 +153,9 @@ func TestNewSessionFromBlueprint(t *testing.T) {
 		}
 	}
 
-	// Total steps = blueprint steps (6) + context step (1)
-	assert.Equal(t, 7, session.TotalNodes())
+	// Total nodes = blueprint nodes (4) + context node (1)
+	assert.Equal(t, 5, session.TotalNodes())
 
-	assert.Empty(t, session.Steps[2].ReviewGranularity)
 	assert.NotEmpty(t, session.Steps[1].Nodes[0].ReviewPrompt)
 	assert.Equal(t, "stripe trigger checkout.session.completed", session.Steps[3].Nodes[0].ReviewCommand)
 }
@@ -272,6 +272,116 @@ func TestNewSessionFromBlueprintPreservesEvents(t *testing.T) {
 		}
 	}
 	t.Fatal("expected to find asyncHandler node")
+}
+
+func TestEmbeddedBlueprintsUseCanonicalJSON(t *testing.T) {
+	ids, err := ListBlueprints()
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			raw, err := blueprintFS.ReadFile("blueprints/" + id + ".json")
+			require.NoError(t, err)
+
+			var bp Blueprint
+			require.NoError(t, json.Unmarshal(raw, &bp))
+
+			normalized, err := json.MarshalIndent(bp, "", "  ")
+			require.NoError(t, err)
+			normalized = append(normalized, '\n')
+
+			assert.Equal(t, string(normalized), string(raw), "blueprint JSON should be normalized through the Blueprint schema")
+		})
+	}
+}
+
+func TestEmbeddedBlueprintsDoNotCarryAPIRequestKeys(t *testing.T) {
+	ids, err := ListBlueprints()
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			raw, err := blueprintFS.ReadFile("blueprints/" + id + ".json")
+			require.NoError(t, err)
+
+			var document any
+			require.NoError(t, json.Unmarshal(raw, &document))
+			assertNoRequestKey(t, document)
+
+			text := string(raw)
+			assert.NotContains(t, text, "-request:", "node interpolation should not include API request keys")
+			assert.NotContains(t, text, "Request:", "node interpolation should not include API request keys")
+		})
+	}
+}
+
+func assertNoRequestKey(t *testing.T, value any) {
+	t.Helper()
+
+	switch v := value.(type) {
+	case map[string]any:
+		if request, ok := v["request"].(map[string]any); ok {
+			assert.NotContains(t, request, "key", "apiRequest nodes only carry one request, so request.key is redundant")
+		}
+		for _, child := range v {
+			assertNoRequestKey(t, child)
+		}
+	case []any:
+		for _, child := range v {
+			assertNoRequestKey(t, child)
+		}
+	}
+}
+
+func TestEmbeddedBlueprintTopologyMatchesSourceDefinitions(t *testing.T) {
+	// These topologies are copied from pay-server Workbench blueprint definitions.
+	// Do not add CLI-only steps or nodes here; update the source blueprint and then
+	// refresh this subset from pay-server.
+	expected := map[string][][]string{
+		"flat-fee-and-overages": {
+			{"create-customer-chapter", "createCustomer"},
+			{"create-pricing-plan-chapter", "createEmptyPricingPlan", "createMeter"},
+			{"create-rate-card-chapter", "createRateCard", "createMeteredItem", "addGraduatedRateToRateCard", "attachRateCardToPricingPlan"},
+			{"create-licensed-fee-chapter", "createLicensedItem", "createLicenseFee", "attachLicenseFeeToPricingPlan"},
+			{"subscribe-customer-chapter", "setLiveVersion", "createCheckoutSession", "completeCheckout", "waitForServicingActivated"},
+		},
+		"flat-subscription-with-entitlements": {
+			{"create-products-chapter", "create-basic-product", "create-basic-feature", "attach-feature-to-product"},
+			{"setup-chapter", "create-test-clock", "create-customer"},
+			{"subscribe-chapter", "create-checkout-session", "complete-checkout", "track-subscription-creation", "check-entitlements"},
+			{"next-billing-cycle-chapter", "advance-time", "wait-for-invoice-created", "view-invoice"},
+			{"cleanup-chapter", "test-clock-advanced", "delete-test-clock"},
+		},
+		"one-time-payment": {
+			{"setup-chapter", "create-product"},
+			{"checkout-chapter", "create-checkout-session", "complete-checkout"},
+			{"webhook-chapter", "handle-checkout-completed"},
+		},
+		"setup-future-payments": {
+			{"create-new-customer-chapter", "create-new-customer"},
+			{"create-checkout-session-chapter", "create-checkout-session", "complete-checkout", "wait-for-checkout-completed"},
+			{"charge-payment-method-later-chapter", "retrieve-setup-intent", "charge-payment-method-later", "wait-for-payment-intent-succeeded"},
+		},
+	}
+
+	for id, expectedSteps := range expected {
+		t.Run(id, func(t *testing.T) {
+			bp, err := LoadBlueprint(id)
+			require.NoError(t, err)
+			require.Len(t, bp.Steps, len(expectedSteps))
+
+			for i, expectedStep := range expectedSteps {
+				require.NotEmpty(t, expectedStep)
+				assert.Equal(t, expectedStep[0], bp.Steps[i].Key)
+				require.Len(t, bp.Steps[i].Nodes, len(expectedStep)-1)
+				for j, expectedNode := range expectedStep[1:] {
+					assert.Equal(t, expectedNode, bp.Steps[i].Nodes[j].Key)
+				}
+			}
+		})
+	}
 }
 
 func TestAllEmbeddedBlueprintsAreStructurallyValid(t *testing.T) {

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -1,0 +1,332 @@
+package coop
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadBlueprint(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+	assert.Equal(t, "one-time-payment", bp.ID)
+	assert.Equal(t, "Accept a one-time payment", bp.Title)
+	assert.Contains(t, bp.Products, "Payments")
+	assert.Len(t, bp.Steps, 4)
+	assert.Equal(t, "setup-step", bp.Steps[0].Key)
+	assert.Equal(t, NodeAPIRequest, bp.Steps[0].Nodes[0].Type)
+}
+
+func TestAllEmbeddedBlueprintsHaveQualityMetadata(t *testing.T) {
+	ids, err := ListBlueprints()
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+
+	weakPhrases := []string{
+		"do the thing",
+		"verify it works",
+		"todo",
+		"tbd",
+		"placeholder",
+		"lorem ipsum",
+	}
+
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			bp, err := LoadBlueprint(id)
+			require.NoError(t, err)
+
+			assertQualityText(t, "blueprint title", bp.Title, 4, weakPhrases)
+			if bp.Description != "" {
+				assertQualityText(t, "blueprint description", bp.Description, 20, weakPhrases)
+			}
+			assert.True(t, bp.Description != "" || len(bp.Products) > 0, "blueprint should include description or product metadata")
+
+			for _, ch := range bp.Steps {
+				assertQualityText(t, "step title "+ch.Key, ch.Title, 4, weakPhrases)
+				for _, n := range ch.Nodes {
+					assertQualityText(t, "node title "+n.Key, n.Title, 4, weakPhrases)
+					assert.NotEqual(t, "api request", strings.ToLower(strings.TrimSpace(n.Title)), "node %q should have a product-specific title", n.Key)
+					if n.Description != "" {
+						assertQualityText(t, "node description "+n.Key, n.Description, 20, weakPhrases)
+					}
+					if !n.AutoConfirm {
+						assertQualityText(t, "node review prompt "+n.Key, n.ReviewPrompt, 20, weakPhrases)
+						assertObservableGuidance(t, n.Key, n.ReviewPrompt)
+					}
+
+					switch n.Type {
+					case NodeAPIRequest:
+						require.NotNil(t, n.Request, "apiRequest node %q should have request metadata", n.Key)
+					case NodeAsyncHandler:
+						assert.NotEmpty(t, n.Events, "asyncHandler node %q should name webhook events to verify", n.Key)
+					case NodeCLICommand, NodeTestHelper, NodeSetUpWebhooks:
+						if n.Description != "" {
+							assertObservableGuidance(t, n.Key, n.Description)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func assertQualityText(t *testing.T, label, value string, minLen int, weakPhrases []string) {
+	t.Helper()
+	trimmed := strings.TrimSpace(value)
+	require.NotEmpty(t, trimmed, "%s should not be empty", label)
+	assert.GreaterOrEqual(t, len(trimmed), minLen, "%s should be specific enough", label)
+
+	lower := strings.ToLower(trimmed)
+	for _, phrase := range weakPhrases {
+		assert.NotContains(t, lower, phrase, "%s contains weak placeholder text", label)
+	}
+}
+
+func assertObservableGuidance(t *testing.T, key, description string) {
+	t.Helper()
+	lower := strings.ToLower(description)
+	observableTerms := []string{"verify", "confirm", "report", "check", "run", "summarize", "ask", "open"}
+	for _, term := range observableTerms {
+		if strings.Contains(lower, term) {
+			return
+		}
+	}
+	assert.Failf(t, "weak verification guidance", "node %q should name an observable check or reported outcome", key)
+}
+
+func TestLoadBlueprintNotFound(t *testing.T) {
+	_, err := LoadBlueprint("nonexistent-blueprint")
+	assert.Error(t, err)
+}
+
+func TestLoadBlueprintPrefixMatchUnique(t *testing.T) {
+	bp, err := LoadBlueprint("one-time")
+	require.NoError(t, err)
+	assert.Equal(t, "one-time-payment", bp.ID)
+}
+
+func TestLoadBlueprintPrefixMatchAmbiguous(t *testing.T) {
+	// "flat" matches both "flat-fee-and-overages" and "flat-subscription-with-entitlements"
+	_, err := LoadBlueprint("flat")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+}
+
+func TestListBlueprints(t *testing.T) {
+	ids, err := ListBlueprints()
+	require.NoError(t, err)
+	assert.Contains(t, ids, "one-time-payment")
+	assert.Contains(t, ids, "setup-future-payments")
+}
+
+func TestNewSessionFromBlueprint(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	session := NewSessionFromBlueprint(
+		bp,
+		"coop_test123",
+		map[string]string{"language": "node"},
+		map[string]string{"account_name": "Jenny Rosen"},
+	)
+
+	assert.Equal(t, "coop_test123", session.ID)
+	assert.Equal(t, "one-time-payment", session.Blueprint)
+	assert.Equal(t, SessionActive, session.Status)
+	assert.Equal(t, "node", session.Settings["language"])
+	assert.Equal(t, "Jenny Rosen", session.Params["account_name"])
+	// 4 blueprint steps + 1 prepended context step
+	assert.Len(t, session.Steps, 5)
+
+	// First step is always the context-gathering step
+	assert.Equal(t, "context-step", session.Steps[0].Key)
+	assert.Equal(t, "Understand the project", session.Steps[0].Nodes[0].Title)
+
+	// All nodes should be pending
+	for _, ch := range session.Steps {
+		for _, n := range ch.Nodes {
+			assert.Equal(t, NodePending, n.State)
+		}
+	}
+
+	// Total steps = blueprint steps (6) + context step (1)
+	assert.Equal(t, 7, session.TotalNodes())
+
+	assert.Empty(t, session.Steps[2].ReviewGranularity)
+	assert.NotEmpty(t, session.Steps[1].Nodes[0].ReviewPrompt)
+	assert.Equal(t, "stripe trigger checkout.session.completed", session.Steps[3].Nodes[0].ReviewCommand)
+}
+
+func TestListBlueprintsWithMetadata(t *testing.T) {
+	bps, err := ListBlueprintsWithMetadata()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(bps), 2)
+
+	found := false
+	for _, bp := range bps {
+		if bp.ID == "setup-future-payments" {
+			found = true
+			assert.Equal(t, "Save a card for future payments", bp.Title)
+		}
+	}
+	assert.True(t, found, "expected to find setup-future-payments")
+}
+
+func TestLoadBlueprintStepStructure(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	// Verify step keys are unique
+	keys := make(map[string]bool)
+	for _, ch := range bp.Steps {
+		assert.False(t, keys[ch.Key], "duplicate step key: %s", ch.Key)
+		keys[ch.Key] = true
+		assert.NotEmpty(t, ch.Title)
+		assert.NotEmpty(t, ch.Nodes)
+
+		// Verify node keys are unique within step
+		nodeKeys := make(map[string]bool)
+		for _, n := range ch.Nodes {
+			assert.False(t, nodeKeys[n.Key], "duplicate node key: %s", n.Key)
+			nodeKeys[n.Key] = true
+			assert.NotEmpty(t, n.Title)
+			assert.NotEmpty(t, n.Type)
+		}
+	}
+}
+
+func TestLoadBlueprintNodeTypes(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	typesSeen := make(map[NodeType]bool)
+	for _, ch := range bp.Steps {
+		for _, n := range ch.Nodes {
+			typesSeen[n.Type] = true
+		}
+	}
+
+	assert.True(t, typesSeen[NodeAPIRequest], "expected apiRequest nodes")
+	assert.True(t, typesSeen[NodeUIComponent], "expected uiComponent nodes")
+	assert.True(t, typesSeen[NodeAsyncHandler], "expected asyncHandler nodes")
+}
+
+func TestLoadBlueprintAPIRequestHasRequest(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	for _, ch := range bp.Steps {
+		for _, n := range ch.Nodes {
+			if n.Type == NodeAPIRequest {
+				assert.NotNil(t, n.Request, "apiRequest node %q should have request field", n.Key)
+				assert.NotEmpty(t, n.Request.Path)
+				assert.NotEmpty(t, n.Request.Method)
+			}
+		}
+	}
+}
+
+func TestLoadBlueprintAsyncHandlerHasEvents(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	for _, ch := range bp.Steps {
+		for _, n := range ch.Nodes {
+			if n.Type == NodeAsyncHandler {
+				assert.NotEmpty(t, n.Events, "asyncHandler node %q should have events", n.Key)
+			}
+		}
+	}
+}
+
+func TestNewSessionFromBlueprintPreservesRequest(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	session := NewSessionFromBlueprint(bp, "test_123", nil, nil)
+
+	// First blueprint node (after context step) is apiRequest — should preserve the request
+	firstBlueprintNode := session.Steps[1].Nodes[0]
+	assert.Equal(t, NodeAPIRequest, firstBlueprintNode.Type)
+	assert.NotNil(t, firstBlueprintNode.Request)
+	assert.Equal(t, "/v1/products", firstBlueprintNode.Request.Path)
+	assert.Equal(t, "post", firstBlueprintNode.Request.Method)
+}
+
+func TestNewSessionFromBlueprintPreservesEvents(t *testing.T) {
+	bp, err := LoadBlueprint("one-time-payment")
+	require.NoError(t, err)
+
+	session := NewSessionFromBlueprint(bp, "test_123", nil, nil)
+
+	// Find the asyncHandler node
+	for _, ch := range session.Steps {
+		for _, n := range ch.Nodes {
+			if n.Type == NodeAsyncHandler {
+				assert.Contains(t, n.Events, "checkout.session.completed")
+				return
+			}
+		}
+	}
+	t.Fatal("expected to find asyncHandler node")
+}
+
+func TestAllEmbeddedBlueprintsAreStructurallyValid(t *testing.T) {
+	ids, err := ListBlueprints()
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+
+	allowedTypes := map[NodeType]bool{
+		NodeAPIRequest:    true,
+		NodeAsyncHandler:  true,
+		NodeUIComponent:   true,
+		NodeTestHelper:    true,
+		NodeCLICommand:    true,
+		NodeDashboard:     true,
+		NodeSetUpWebhooks: true,
+	}
+
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			bp, err := LoadBlueprint(id)
+			require.NoError(t, err)
+			assert.Equal(t, id, bp.ID)
+			assert.NotEmpty(t, bp.Title)
+			require.NotEmpty(t, bp.Steps)
+
+			stepKeys := make(map[string]bool)
+			for _, ch := range bp.Steps {
+				assert.NotEmpty(t, ch.Key)
+				assert.False(t, stepKeys[ch.Key], "duplicate step key: %s", ch.Key)
+				stepKeys[ch.Key] = true
+				assert.NotEmpty(t, ch.Title)
+				require.NotEmpty(t, ch.Nodes)
+
+				nodeKeys := make(map[string]bool)
+				for _, n := range ch.Nodes {
+					assert.NotEmpty(t, n.Key)
+					assert.False(t, nodeKeys[n.Key], "duplicate node key: %s", n.Key)
+					nodeKeys[n.Key] = true
+					assert.NotEmpty(t, n.Title)
+					assert.True(t, allowedTypes[n.Type], "unsupported node type: %s", n.Type)
+
+					if n.Type == NodeAPIRequest {
+						require.NotNil(t, n.Request, "apiRequest node %q should have request field", n.Key)
+						assert.NotEmpty(t, n.Request.Path)
+						assert.NotEmpty(t, n.Request.Method)
+					}
+				}
+			}
+
+			session := NewSessionFromBlueprint(bp, "test_"+id, map[string]string{"language": "node"}, nil)
+			assert.Equal(t, id, session.Blueprint)
+			require.NotEmpty(t, session.Steps)
+			require.NotEmpty(t, session.Steps[0].Nodes)
+			assert.Equal(t, "Understand the project", session.Steps[0].Nodes[0].Title)
+			assert.Equal(t, len(bp.Steps)+1, len(session.Steps))
+		})
+	}
+}

--- a/pkg/coop/blueprints/flat-fee-and-overages.json
+++ b/pkg/coop/blueprints/flat-fee-and-overages.json
@@ -3,132 +3,167 @@
   "title": "Set up flat fee and overages pricing",
   "description": "Charge customers a flat recurring fee with overage charges for usage beyond included limits.",
   "type": "learning",
-  "products": [],
+  "products": [
+    "Billing"
+  ],
   "settings": [],
   "steps": [
     {
-      "key": "main",
-      "title": "Set up flat fee and overages pricing",
+      "key": "create-customer-chapter",
+      "title": "Create a customer",
+      "description": "Create the customer that will subscribe to the pricing plan.",
+      "required": true,
       "nodes": [
         {
           "type": "apiRequest",
           "key": "createCustomer",
           "title": "Create a customer",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v1/customers",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
-        },
+          }
+        }
+      ]
+    },
+    {
+      "key": "create-pricing-plan-chapter",
+      "title": "Create a pricing plan",
+      "description": "Create a pricing plan and usage meter for the overage component.",
+      "required": true,
+      "nodes": [
         {
           "type": "apiRequest",
           "key": "createEmptyPricingPlan",
           "title": "Create a Pricing Plan",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/pricing_plans",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          }
         },
         {
           "type": "apiRequest",
           "key": "createMeter",
           "title": "Create a meter",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v1/billing/meters",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
-        },
+          }
+        }
+      ]
+    },
+    {
+      "key": "create-rate-card-chapter",
+      "title": "Create a rate card",
+      "description": "Create the rate card, metered item, and graduated overage rate.",
+      "required": true,
+      "nodes": [
         {
           "type": "apiRequest",
           "key": "createRateCard",
           "title": "Create a rate card",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/rate_cards",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          }
         },
         {
           "type": "apiRequest",
           "key": "createMeteredItem",
           "title": "Create a metered item",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/metered_items",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          }
         },
         {
           "type": "apiRequest",
           "key": "addGraduatedRateToRateCard",
           "title": "Add graduated rate to rate card",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
-            "path": "/v2/billing/rate_cards/${node.create-rate-card-step.createRateCard.createRateCardRequest:id}/rates",
+            "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard:id}/rates",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          }
         },
         {
           "type": "apiRequest",
           "key": "attachRateCardToPricingPlan",
           "title": "Attach rate card to Pricing Plan",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
-            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-step.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan:id}/components",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
-        },
+          }
+        }
+      ]
+    },
+    {
+      "key": "create-licensed-fee-chapter",
+      "title": "Create a license fee",
+      "description": "Create the licensed item and flat recurring license fee.",
+      "required": true,
+      "nodes": [
         {
           "type": "apiRequest",
           "key": "createLicensedItem",
           "title": "Create a licensed item",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/licensed_items",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          }
         },
         {
           "type": "apiRequest",
           "key": "createLicenseFee",
           "title": "Create a license fee",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/license_fees",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          }
         },
         {
           "type": "apiRequest",
           "key": "attachLicenseFeeToPricingPlan",
           "title": "Attach license fee to Pricing Plan",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
-            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-step.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan:id}/components",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
-        },
+          }
+        }
+      ]
+    },
+    {
+      "key": "subscribe-customer-chapter",
+      "title": "Subscribe the customer",
+      "description": "Set the live pricing plan version and create a Checkout Session for the subscription.",
+      "nodes": [
         {
           "type": "apiRequest",
           "key": "setLiveVersion",
           "title": "Set live version to latest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
-            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-step.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan:id}",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          }
         },
         {
           "type": "apiRequest",
           "key": "createCheckoutSession",
           "title": "Create checkout session",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          }
         },
         {
           "type": "uiComponent",
@@ -140,10 +175,11 @@
           "type": "asyncHandler",
           "key": "waitForServicingActivated",
           "title": "Wait for servicing activated event",
+          "review_prompt": "Run `stripe trigger v2.billing.pricing_plan_subscription.servicing_activated` and confirm the handler processes the signed event correctly.",
+          "review_command": "stripe trigger v2.billing.pricing_plan_subscription.servicing_activated",
           "events": [
             "v2.billing.pricing_plan_subscription.servicing_activated"
-          ],
-          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
+          ]
         }
       ]
     }

--- a/pkg/coop/blueprints/flat-fee-and-overages.json
+++ b/pkg/coop/blueprints/flat-fee-and-overages.json
@@ -39,7 +39,12 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/pricing_plans",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "currency": "usd",
+              "display_name": "Flat Fee and Overages Pricing Plan",
+              "tax_behavior": "exclusive"
+            }
           }
         },
         {
@@ -49,7 +54,14 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v1/billing/meters",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "default_aggregation": {
+                "formula": "sum"
+              },
+              "display_name": "API Requests Meter",
+              "event_name": "blueprint_flat_fee_meter+${env:randomName}"
+            }
           }
         }
       ]
@@ -67,7 +79,14 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/rate_cards",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "currency": "usd",
+              "display_name": "Overages Rate Card",
+              "service_interval": "month",
+              "service_interval_count": 1,
+              "tax_behavior": "exclusive"
+            }
           }
         },
         {
@@ -77,7 +96,11 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/metered_items",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "display_name": "API Usage Metered Item",
+              "meter": "${node.create-pricing-plan-chapter.createMeter:id}"
+            }
           }
         },
         {
@@ -87,7 +110,21 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/rate_cards/${node.create-rate-card-chapter.createRateCard:id}/rates",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "metered_item": "${node.create-rate-card-chapter.createMeteredItem:id}",
+              "tiering_mode": "graduated",
+              "tiers": [
+                {
+                  "unit_amount": "0",
+                  "up_to_decimal": "1000"
+                },
+                {
+                  "unit_amount": "5",
+                  "up_to_inf": "inf"
+                }
+              ]
+            }
           }
         },
         {
@@ -97,7 +134,14 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan:id}/components",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "rate_card": {
+                "id": "${node.create-rate-card-chapter.createRateCard:id}",
+                "version": "${node.create-rate-card-chapter.createRateCard:latest_version}"
+              },
+              "type": "rate_card"
+            }
           }
         }
       ]
@@ -115,7 +159,11 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/licensed_items",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "display_name": "Per Seat License",
+              "lookup_key": "seat-license+${env:randomName}"
+            }
           }
         },
         {
@@ -125,7 +173,16 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/license_fees",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "currency": "usd",
+              "display_name": "Per Seat License Fee",
+              "licensed_item": "${node.create-licensed-fee-chapter.createLicensedItem:id}",
+              "service_interval": "month",
+              "service_interval_count": 1,
+              "tax_behavior": "exclusive",
+              "unit_amount": "2000"
+            }
           }
         },
         {
@@ -135,7 +192,15 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan:id}/components",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "license_fee": {
+                "id": "${node.create-licensed-fee-chapter.createLicenseFee:id}",
+                "version": "${node.create-licensed-fee-chapter.createLicenseFee:latest_version}"
+              },
+              "lookup_key": "${node.create-licensed-fee-chapter.createLicensedItem:lookup_key}",
+              "type": "license_fee"
+            }
           }
         }
       ]
@@ -152,7 +217,10 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-chapter.createEmptyPricingPlan:id}",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "live_version": "latest"
+            }
           }
         },
         {
@@ -162,7 +230,29 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v1/checkout/sessions",
-            "method": "post"
+            "method": "post",
+            "headers": {
+              "stripe-version": "2025-06-30.preview;checkout_product_catalog_preview=v1"
+            },
+            "params": {
+              "checkout_items": [
+                {
+                  "pricing_plan_subscription_item": {
+                    "component_configurations": {
+                      "${node.create-licensed-fee-chapter.createLicensedItem:lookup_key}": {
+                        "license_fee_component": {
+                          "quantity": 1
+                        },
+                        "type": "license_fee_component"
+                      }
+                    },
+                    "pricing_plan": "${node.create-pricing-plan-chapter.createEmptyPricingPlan:id}"
+                  },
+                  "type": "pricing_plan_subscription_item"
+                }
+              ],
+              "success_url": "https://example.com/success"
+            }
           }
         },
         {

--- a/pkg/coop/blueprints/flat-fee-and-overages.json
+++ b/pkg/coop/blueprints/flat-fee-and-overages.json
@@ -1,0 +1,151 @@
+{
+  "id": "flat-fee-and-overages",
+  "title": "Set up flat fee and overages pricing",
+  "description": "Charge customers a flat recurring fee with overage charges for usage beyond included limits.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "steps": [
+    {
+      "key": "main",
+      "title": "Set up flat fee and overages pricing",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "createCustomer",
+          "title": "Create a customer",
+          "request": {
+            "path": "/v1/customers",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createEmptyPricingPlan",
+          "title": "Create a Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createMeter",
+          "title": "Create a meter",
+          "request": {
+            "path": "/v1/billing/meters",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createRateCard",
+          "title": "Create a rate card",
+          "request": {
+            "path": "/v2/billing/rate_cards",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createMeteredItem",
+          "title": "Create a metered item",
+          "request": {
+            "path": "/v2/billing/metered_items",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "addGraduatedRateToRateCard",
+          "title": "Add graduated rate to rate card",
+          "request": {
+            "path": "/v2/billing/rate_cards/${node.create-rate-card-step.createRateCard.createRateCardRequest:id}/rates",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attachRateCardToPricingPlan",
+          "title": "Attach rate card to Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-step.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createLicensedItem",
+          "title": "Create a licensed item",
+          "request": {
+            "path": "/v2/billing/licensed_items",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createLicenseFee",
+          "title": "Create a license fee",
+          "request": {
+            "path": "/v2/billing/license_fees",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attachLicenseFeeToPricingPlan",
+          "title": "Attach license fee to Pricing Plan",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-step.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}/components",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "setLiveVersion",
+          "title": "Set live version to latest",
+          "request": {
+            "path": "/v2/billing/pricing_plans/${node.create-pricing-plan-step.createEmptyPricingPlan.createEmptyPricingPlanRequest:id}",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "createCheckoutSession",
+          "title": "Create checkout session",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "completeCheckout",
+          "title": "Complete the checkout",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "waitForServicingActivated",
+          "title": "Wait for servicing activated event",
+          "events": [
+            "v2.billing.pricing_plan_subscription.servicing_activated"
+          ],
+          "review_prompt": "Run stripe trigger v2.billing.pricing_plan_subscription.servicing_activated and confirm the handler processes the signed event correctly."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/flat-subscription-with-entitlements.json
+++ b/pkg/coop/blueprints/flat-subscription-with-entitlements.json
@@ -3,64 +3,87 @@
   "title": "Flat rate subscription with entitlements",
   "description": "Learn how to create a flat rate subscription with entitlements to manage customer feature access.",
   "type": "learning",
-  "products": [],
+  "products": [
+    "Billing",
+    "Checkout"
+  ],
   "settings": [],
   "steps": [
     {
-      "key": "main",
-      "title": "Flat rate subscription with entitlements",
+      "key": "create-products-chapter",
+      "title": "Create products",
+      "required": true,
       "nodes": [
         {
           "type": "apiRequest",
           "key": "create-basic-product",
           "title": "Create a Basic product tier",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v1/products",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          }
         },
         {
           "type": "apiRequest",
           "key": "create-basic-feature",
           "title": "Create a feature for the Basic tier",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v1/entitlements/features",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          }
         },
         {
           "type": "apiRequest",
           "key": "attach-feature-to-product",
           "title": "Attach the feature to the product",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
-            "path": "/v1/products/${node.create-products-step.create-basic-product.create-basic-product-request:id}/features",
-            "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
-        },
+            "path": "/v1/products/${node.create-products-chapter.create-basic-product:id}/features",
+            "method": "post",
+            "params": {
+              "entitlement_feature": "${node.create-products-chapter.create-basic-feature:id}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "key": "setup-chapter",
+      "title": "Set up customer state",
+      "required": true,
+      "nodes": [
         {
           "type": "testHelper",
           "key": "create-test-clock",
           "title": "Create a test clock",
+          "description": "Run the test-clock setup and confirm the subscription billing flow can use the created clock.",
           "review_prompt": "Run the described test flow and confirm the expected result is observable."
         },
         {
           "type": "testHelper",
           "key": "create-customer",
           "title": "Create a customer",
+          "description": "Run the customer setup and confirm the customer is attached to the test clock.",
           "review_prompt": "Run the described test flow and confirm the expected result is observable."
-        },
+        }
+      ]
+    },
+    {
+      "key": "subscribe-chapter",
+      "title": "Subscribe the customer",
+      "required": true,
+      "nodes": [
         {
           "type": "apiRequest",
           "key": "create-checkout-session",
           "title": "Create a checkout session",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v1/checkout/sessions",
             "method": "post"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+          }
         },
         {
           "type": "uiComponent",
@@ -72,58 +95,77 @@
           "type": "asyncHandler",
           "key": "track-subscription-creation",
           "title": "Track subscription creation",
+          "review_prompt": "Run `stripe trigger customer.subscription.created` and confirm the handler processes the signed event correctly.",
+          "review_command": "stripe trigger customer.subscription.created",
           "events": [
             "customer.subscription.created"
-          ],
-          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly."
+          ]
         },
         {
           "type": "asyncHandler",
           "key": "check-entitlements",
           "title": "Check customer entitlements",
+          "review_prompt": "Run `stripe trigger entitlements.active_entitlement_summary.updated` and confirm the handler processes the signed event correctly.",
+          "review_command": "stripe trigger entitlements.active_entitlement_summary.updated",
           "events": [
             "entitlements.active_entitlement_summary.updated"
-          ],
-          "review_prompt": "Run stripe trigger entitlements.active_entitlement_summary.updated and confirm the handler processes the signed event correctly."
-        },
+          ]
+        }
+      ]
+    },
+    {
+      "key": "next-billing-cycle-chapter",
+      "title": "Advance to the next billing cycle",
+      "required": true,
+      "nodes": [
         {
           "type": "testHelper",
           "key": "advance-time",
           "title": "Advance time to billing date",
+          "description": "Run the clock advance and confirm it moves to the next billing cycle.",
           "review_prompt": "Run the described test flow and confirm the expected result is observable."
         },
         {
           "type": "asyncHandler",
           "key": "wait-for-invoice-created",
           "title": "View the invoice created",
+          "review_prompt": "Run `stripe trigger invoice.created` and confirm the handler processes the signed event correctly.",
+          "review_command": "stripe trigger invoice.created",
           "events": [
             "invoice.created"
-          ],
-          "review_prompt": "Run stripe trigger invoice.created and confirm the handler processes the signed event correctly."
+          ]
         },
         {
           "type": "apiRequest",
           "key": "view-invoice",
           "title": "View the invoice created",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
-            "path": "/v1/invoices/${node.next-billing-cycle-step.wait-for-invoice-created.0:id}",
+            "path": "/v1/invoices/${node.next-billing-cycle-chapter.wait-for-invoice-created.0:id}",
             "method": "get"
-          },
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
-        },
+          }
+        }
+      ]
+    },
+    {
+      "key": "cleanup-chapter",
+      "title": "Clean up the test clock",
+      "nodes": [
         {
           "type": "asyncHandler",
           "key": "test-clock-advanced",
           "title": "Wait for test clock to be ready.",
+          "review_prompt": "Run `stripe trigger test_helpers.test_clock.ready` and confirm the handler processes the signed event correctly.",
+          "review_command": "stripe trigger test_helpers.test_clock.ready",
           "events": [
             "test_helpers.test_clock.ready"
-          ],
-          "review_prompt": "Run stripe trigger test_helpers.test_clock.ready and confirm the handler processes the signed event correctly."
+          ]
         },
         {
           "type": "testHelper",
           "key": "delete-test-clock",
           "title": "Delete the test clock",
+          "description": "Run the cleanup and confirm the test clock is deleted after verification.",
           "review_prompt": "Run the described test flow and confirm the expected result is observable."
         }
       ]

--- a/pkg/coop/blueprints/flat-subscription-with-entitlements.json
+++ b/pkg/coop/blueprints/flat-subscription-with-entitlements.json
@@ -21,7 +21,18 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v1/products",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "default_price_data": {
+                "currency": "usd",
+                "recurring": {
+                  "interval": "month",
+                  "interval_count": 1
+                },
+                "unit_amount": 10000
+              },
+              "name": "Basic Product"
+            }
           }
         },
         {
@@ -31,7 +42,11 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v1/entitlements/features",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "lookup_key": "basic-${env:randomName}",
+              "name": "Basic Feature"
+            }
           }
         },
         {
@@ -59,14 +74,37 @@
           "key": "create-test-clock",
           "title": "Create a test clock",
           "description": "Run the test-clock setup and confirm the subscription billing flow can use the created clock.",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run these test-helper requests to advance Stripe test state; do not implement them in the application. Confirm the expected result is observable.",
+          "requests": [
+            {
+              "key": "create-test-clock-request",
+              "path": "/v1/test_helpers/test_clocks",
+              "method": "post",
+              "params": {
+                "frozen_time": "${env:currentTime}",
+                "name": "Example Flat Subscription with Checkout"
+              }
+            }
+          ]
         },
         {
           "type": "testHelper",
           "key": "create-customer",
           "title": "Create a customer",
           "description": "Run the customer setup and confirm the customer is attached to the test clock.",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run these test-helper requests to advance Stripe test state; do not implement them in the application. Confirm the expected result is observable.",
+          "requests": [
+            {
+              "key": "create-customer-request",
+              "path": "/v1/customers",
+              "method": "post",
+              "params": {
+                "email": "customer@example.com",
+                "name": "Metered Usage Customer",
+                "test_clock": "${node.setup-chapter.create-test-clock.create-test-clock-request:id}"
+              }
+            }
+          ]
         }
       ]
     },
@@ -82,7 +120,20 @@
           "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
             "path": "/v1/checkout/sessions",
-            "method": "post"
+            "method": "post",
+            "params": {
+              "line_items": [
+                {
+                  "price": "${node.create-products-chapter.create-basic-product:default_price}",
+                  "quantity": 1
+                }
+              ],
+              "mode": "subscription",
+              "success_url": "https://example.com/success"
+            },
+            "hidden_params": {
+              "customer": "${node.setup-chapter.create-customer.create-customer-request:id}"
+            }
           }
         },
         {
@@ -123,7 +174,17 @@
           "key": "advance-time",
           "title": "Advance time to billing date",
           "description": "Run the clock advance and confirm it moves to the next billing cycle.",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run these test-helper requests to advance Stripe test state; do not implement them in the application. Confirm the expected result is observable.",
+          "requests": [
+            {
+              "key": "advance-time-request",
+              "path": "/v1/test_helpers/test_clocks/${node.setup-chapter.create-test-clock.create-test-clock-request:id}/advance",
+              "method": "post",
+              "params": {
+                "frozen_time": "${env:currentTimePlus31Days}"
+              }
+            }
+          ]
         },
         {
           "type": "asyncHandler",
@@ -166,7 +227,15 @@
           "key": "delete-test-clock",
           "title": "Delete the test clock",
           "description": "Run the cleanup and confirm the test clock is deleted after verification.",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+          "review_prompt": "Run these test-helper requests to advance Stripe test state; do not implement them in the application. Confirm the expected result is observable.",
+          "requests": [
+            {
+              "key": "delete-test-clock-request",
+              "path": "/v1/test_helpers/test_clocks/${node.setup-chapter.create-test-clock.create-test-clock-request:id}",
+              "method": "delete",
+              "params": {}
+            }
+          ]
         }
       ]
     }

--- a/pkg/coop/blueprints/flat-subscription-with-entitlements.json
+++ b/pkg/coop/blueprints/flat-subscription-with-entitlements.json
@@ -1,0 +1,132 @@
+{
+  "id": "flat-subscription-with-entitlements",
+  "title": "Flat rate subscription with entitlements",
+  "description": "Learn how to create a flat rate subscription with entitlements to manage customer feature access.",
+  "type": "learning",
+  "products": [],
+  "settings": [],
+  "steps": [
+    {
+      "key": "main",
+      "title": "Flat rate subscription with entitlements",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "create-basic-product",
+          "title": "Create a Basic product tier",
+          "request": {
+            "path": "/v1/products",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-basic-feature",
+          "title": "Create a feature for the Basic tier",
+          "request": {
+            "path": "/v1/entitlements/features",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "apiRequest",
+          "key": "attach-feature-to-product",
+          "title": "Attach the feature to the product",
+          "request": {
+            "path": "/v1/products/${node.create-products-step.create-basic-product.create-basic-product-request:id}/features",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "testHelper",
+          "key": "create-test-clock",
+          "title": "Create a test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        },
+        {
+          "type": "testHelper",
+          "key": "create-customer",
+          "title": "Create a customer",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-checkout-session",
+          "title": "Create a checkout session",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "uiComponent",
+          "key": "complete-checkout",
+          "title": "Complete the checkout process",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "track-subscription-creation",
+          "title": "Track subscription creation",
+          "events": [
+            "customer.subscription.created"
+          ],
+          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "check-entitlements",
+          "title": "Check customer entitlements",
+          "events": [
+            "entitlements.active_entitlement_summary.updated"
+          ],
+          "review_prompt": "Run stripe trigger entitlements.active_entitlement_summary.updated and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "testHelper",
+          "key": "advance-time",
+          "title": "Advance time to billing date",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "wait-for-invoice-created",
+          "title": "View the invoice created",
+          "events": [
+            "invoice.created"
+          ],
+          "review_prompt": "Run stripe trigger invoice.created and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "apiRequest",
+          "key": "view-invoice",
+          "title": "View the invoice created",
+          "request": {
+            "path": "/v1/invoices/${node.next-billing-cycle-step.wait-for-invoice-created.0:id}",
+            "method": "get"
+          },
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "test-clock-advanced",
+          "title": "Wait for test clock to be ready.",
+          "events": [
+            "test_helpers.test_clock.ready"
+          ],
+          "review_prompt": "Run stripe trigger test_helpers.test_clock.ready and confirm the handler processes the signed event correctly."
+        },
+        {
+          "type": "testHelper",
+          "key": "delete-test-clock",
+          "title": "Delete the test clock",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/one-time-payment.json
+++ b/pkg/coop/blueprints/one-time-payment.json
@@ -1,0 +1,116 @@
+{
+  "steps": [
+    {
+      "description": "Create a product and price in your Stripe account.",
+      "key": "setup-step",
+      "nodes": [
+        {
+          "description": "Create a Stripe Product with inline default_price_data, then save the returned default_price ID for the Checkout Session. Do not put generated IDs in .env files.",
+          "key": "create-product",
+          "request": {
+            "key": "create-product-request",
+            "method": "post",
+            "params": {
+              "default_price_data": {
+                "currency": "usd",
+                "unit_amount": 2000
+              },
+              "name": "T-shirt"
+            },
+            "path": "/v1/products"
+          },
+          "title": "Create a product",
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        }
+      ],
+      "required": true,
+      "title": "Set up your product catalog"
+    },
+    {
+      "description": "Build a server endpoint that creates a Checkout Session and redirects the customer.",
+      "key": "checkout-step",
+      "nodes": [
+        {
+          "description": "Create a Checkout Session with the price from the previous step.",
+          "key": "create-checkout-session",
+          "request": {
+            "key": "create-checkout-session-request",
+            "method": "post",
+            "params": {
+              "cancel_url": "https://example.com/cancel",
+              "line_items": [
+                {
+                  "price": "${node.setup-step.create-product.create-product-request:default_price}",
+                  "quantity": 1
+                }
+              ],
+              "mode": "payment",
+              "success_url": "https://example.com/success"
+            },
+            "path": "/v1/checkout/sessions"
+          },
+          "title": "Create a Checkout Session",
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "description": "Add a button or link that redirects the customer to the Checkout page.",
+          "key": "redirect-to-checkout",
+          "title": "Redirect to Checkout",
+          "type": "uiComponent",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "description": "Create a page to show after the customer completes payment.",
+          "key": "add-success-page",
+          "title": "Add a success page",
+          "type": "uiComponent",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        }
+      ],
+      "title": "Create a Checkout Session"
+    },
+    {
+      "description": "Listen for webhook events to handle fulfillment.",
+      "key": "webhook-step",
+      "nodes": [
+        {
+          "description": "Set up a webhook endpoint to receive the checkout.session.completed event and fulfill the order.",
+          "events": [
+            "checkout.session.completed"
+          ],
+          "key": "handle-checkout-completed",
+          "title": "Handle checkout.session.completed",
+          "type": "asyncHandler",
+          "review_prompt": "Run `stripe trigger checkout.session.completed` and confirm fulfillment happens only after verifying the Stripe signature.",
+          "review_command": "stripe trigger checkout.session.completed"
+        }
+      ],
+      "title": "Handle post-payment events"
+    },
+    {
+      "description": "Verify the complete flow works end to end.",
+      "key": "test-step",
+      "nodes": [
+        {
+          "description": "Run through the complete payment flow using a test card number.",
+          "key": "test-payment-flow",
+          "title": "Make a test payment",
+          "type": "testHelper",
+          "review_prompt": "Run the described test flow and confirm the expected result is observable."
+        }
+      ],
+      "title": "Test the integration"
+    }
+  ],
+  "description": "Set up Checkout to accept a one-time payment with a prebuilt, hosted payment page.",
+  "id": "one-time-payment",
+  "products": [
+    "Payments",
+    "Checkout"
+  ],
+  "settings": [],
+  "title": "Accept a one-time payment",
+  "type": "learning"
+}

--- a/pkg/coop/blueprints/one-time-payment.json
+++ b/pkg/coop/blueprints/one-time-payment.json
@@ -1,14 +1,27 @@
 {
+  "id": "one-time-payment",
+  "title": "Accept a one-time payment",
+  "description": "Set up Checkout to accept a one-time payment with a prebuilt, hosted payment page.",
+  "type": "learning",
+  "products": [
+    "Payments"
+  ],
+  "settings": [],
   "steps": [
     {
+      "key": "setup-chapter",
+      "title": "Set up your product catalog",
       "description": "Create a product and price in your Stripe account.",
-      "key": "setup-step",
+      "required": true,
       "nodes": [
         {
-          "description": "Create a Stripe Product with inline default_price_data, then save the returned default_price ID for the Checkout Session. Do not put generated IDs in .env files.",
+          "type": "apiRequest",
           "key": "create-product",
+          "title": "Create a product",
+          "description": "Create a Stripe Product with inline default_price_data, then save the returned default_price ID for the Checkout Session. Do not put generated IDs in .env files.",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
-            "key": "create-product-request",
+            "path": "/v1/products",
             "method": "post",
             "params": {
               "default_price_data": {
@@ -16,101 +29,64 @@
                 "unit_amount": 2000
               },
               "name": "T-shirt"
-            },
-            "path": "/v1/products"
-          },
-          "title": "Create a product",
-          "type": "apiRequest",
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+            }
+          }
         }
-      ],
-      "required": true,
-      "title": "Set up your product catalog"
+      ]
     },
     {
+      "key": "checkout-chapter",
+      "title": "Create a Checkout Session",
       "description": "Build a server endpoint that creates a Checkout Session and redirects the customer.",
-      "key": "checkout-step",
       "nodes": [
         {
-          "description": "Create a Checkout Session with the price from the previous step.",
+          "type": "apiRequest",
           "key": "create-checkout-session",
+          "title": "Create a Checkout Session",
+          "description": "Create a Checkout Session with the price from the previous step.",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
-            "key": "create-checkout-session-request",
+            "path": "/v1/checkout/sessions",
             "method": "post",
             "params": {
               "cancel_url": "https://example.com/cancel",
               "line_items": [
                 {
-                  "price": "${node.setup-step.create-product.create-product-request:default_price}",
+                  "price": "${node.setup-chapter.create-product:default_price}",
                   "quantity": 1
                 }
               ],
               "mode": "payment",
               "success_url": "https://example.com/success"
-            },
-            "path": "/v1/checkout/sessions"
-          },
-          "title": "Create a Checkout Session",
-          "type": "apiRequest",
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+            }
+          }
         },
         {
+          "type": "uiComponent",
+          "key": "complete-checkout",
+          "title": "Complete the checkout",
           "description": "Add a button or link that redirects the customer to the Checkout page.",
-          "key": "redirect-to-checkout",
-          "title": "Redirect to Checkout",
-          "type": "uiComponent",
-          "review_prompt": "Open the app and confirm the user-facing flow works as described."
-        },
-        {
-          "description": "Create a page to show after the customer completes payment.",
-          "key": "add-success-page",
-          "title": "Add a success page",
-          "type": "uiComponent",
           "review_prompt": "Open the app and confirm the user-facing flow works as described."
         }
-      ],
-      "title": "Create a Checkout Session"
+      ]
     },
     {
+      "key": "webhook-chapter",
+      "title": "Handle post-payment events",
       "description": "Listen for webhook events to handle fulfillment.",
-      "key": "webhook-step",
       "nodes": [
         {
-          "description": "Set up a webhook endpoint to receive the checkout.session.completed event and fulfill the order.",
-          "events": [
-            "checkout.session.completed"
-          ],
+          "type": "asyncHandler",
           "key": "handle-checkout-completed",
           "title": "Handle checkout.session.completed",
-          "type": "asyncHandler",
+          "description": "Set up a webhook endpoint to receive the checkout.session.completed event and fulfill the order.",
           "review_prompt": "Run `stripe trigger checkout.session.completed` and confirm fulfillment happens only after verifying the Stripe signature.",
-          "review_command": "stripe trigger checkout.session.completed"
+          "review_command": "stripe trigger checkout.session.completed",
+          "events": [
+            "checkout.session.completed"
+          ]
         }
-      ],
-      "title": "Handle post-payment events"
-    },
-    {
-      "description": "Verify the complete flow works end to end.",
-      "key": "test-step",
-      "nodes": [
-        {
-          "description": "Run through the complete payment flow using a test card number.",
-          "key": "test-payment-flow",
-          "title": "Make a test payment",
-          "type": "testHelper",
-          "review_prompt": "Run the described test flow and confirm the expected result is observable."
-        }
-      ],
-      "title": "Test the integration"
+      ]
     }
-  ],
-  "description": "Set up Checkout to accept a one-time payment with a prebuilt, hosted payment page.",
-  "id": "one-time-payment",
-  "products": [
-    "Payments",
-    "Checkout"
-  ],
-  "settings": [],
-  "title": "Accept a one-time payment",
-  "type": "learning"
+  ]
 }

--- a/pkg/coop/blueprints/setup-future-payments.json
+++ b/pkg/coop/blueprints/setup-future-payments.json
@@ -1,109 +1,127 @@
 {
+  "id": "setup-future-payments",
+  "title": "Save a card for future payments",
+  "description": "Use Checkout in setup mode to collect payment details and charge customers later.",
+  "type": "learning",
+  "products": [
+    "Payments"
+  ],
+  "settings": [],
   "steps": [
     {
-      "description": "Create a Checkout Session in setup mode to collect payment details.",
-      "key": "setup-step",
+      "key": "create-new-customer-chapter",
+      "title": "Create a new customer",
+      "description": "Create a customer to attach the saved payment method to.",
+      "required": true,
       "nodes": [
         {
+          "type": "apiRequest",
+          "key": "create-new-customer",
+          "title": "Create a new customer",
           "description": "Create a customer to attach the saved payment method to.",
-          "key": "create-customer",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
-            "key": "create-customer-request",
+            "path": "/v1/customers",
             "method": "post",
             "params": {
-              "email": "jenny@example.com",
+              "description": "customer description",
+              "email": "jennyrosen@example.com",
               "name": "Jenny Rosen"
-            },
-            "path": "/v1/customers"
-          },
-          "title": "Create a customer",
-          "type": "apiRequest",
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
-        },
-        {
-          "description": "Create a Checkout Session with mode=setup to save a payment method.",
-          "key": "create-setup-session",
-          "request": {
-            "key": "create-setup-session-request",
-            "method": "post",
-            "params": {
-              "cancel_url": "https://example.com/cancel",
-              "customer": "${node.setup-step.create-customer.create-customer-request:id}",
-              "mode": "setup",
-              "payment_method_types": [
-                "card"
-              ],
-              "success_url": "https://example.com/success"
-            },
-            "path": "/v1/checkout/sessions"
-          },
-          "title": "Create a Checkout Session (setup mode)",
-          "type": "apiRequest",
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+            }
+          }
         }
-      ],
-      "required": true,
-      "title": "Create a Setup Session"
+      ]
     },
     {
-      "description": "Redirect the customer and handle the result.",
-      "key": "complete-step",
+      "key": "create-checkout-session-chapter",
+      "title": "Create a Checkout Session",
+      "description": "Create a Checkout Session in setup mode to collect payment details.",
       "nodes": [
         {
-          "description": "Redirect the customer to the Checkout Session URL.",
-          "key": "redirect-to-setup",
-          "title": "Redirect to setup page",
+          "type": "apiRequest",
+          "key": "create-checkout-session",
+          "title": "Create a Checkout Session",
+          "description": "Create a Checkout Session with mode=setup to save a payment method.",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post",
+            "params": {
+              "currency": "usd",
+              "customer": "${node.create-new-customer-chapter.create-new-customer:id}",
+              "mode": "setup",
+              "success_url": "https://example.com/success"
+            }
+          }
+        },
+        {
           "type": "uiComponent",
+          "key": "complete-checkout",
+          "title": "Complete the checkout",
+          "description": "Redirect the customer to Checkout so they can save their payment method.",
           "review_prompt": "Open the app and confirm the user-facing flow works as described."
         },
         {
-          "description": "Listen for the setup_intent.succeeded event to confirm the payment method was saved.",
-          "events": [
-            "setup_intent.succeeded"
-          ],
-          "key": "handle-setup-completed",
-          "title": "Handle setup_intent.succeeded",
           "type": "asyncHandler",
-          "review_prompt": "Run stripe trigger setup_intent.succeeded and confirm the handler processes the signed event correctly."
+          "key": "wait-for-checkout-completed",
+          "title": "Handle checkout.session.completed",
+          "description": "Listen for the checkout.session.completed event to confirm the setup flow completed.",
+          "review_prompt": "Run `stripe trigger checkout.session.completed` and confirm the handler processes the signed event correctly.",
+          "review_command": "stripe trigger checkout.session.completed",
+          "events": [
+            "checkout.session.completed"
+          ]
         }
-      ],
-      "title": "Complete the setup"
+      ]
     },
     {
+      "key": "charge-payment-method-later-chapter",
+      "title": "Charge the payment method later",
       "description": "Create a PaymentIntent using the saved payment method.",
-      "key": "charge-step",
+      "required": true,
       "nodes": [
         {
-          "description": "Charge the customer using their saved payment method.",
-          "key": "create-payment-intent",
+          "type": "apiRequest",
+          "key": "retrieve-setup-intent",
+          "title": "Retrieve the SetupIntent",
+          "description": "Retrieve the SetupIntent from the completed Checkout Session to find the saved payment method.",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
           "request": {
-            "key": "create-payment-intent-request",
+            "path": "/v1/setup_intents/${node.create-checkout-session-chapter.create-checkout-session:setup_intent}",
+            "method": "get"
+          }
+        },
+        {
+          "type": "apiRequest",
+          "key": "charge-payment-method-later",
+          "title": "Charge the payment method later",
+          "description": "Charge the customer using their saved payment method.",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/payment_intents",
             "method": "post",
             "params": {
               "amount": 1099,
               "confirm": true,
               "currency": "usd",
-              "customer": "${node.setup-step.create-customer.create-customer-request:id}",
+              "customer": "${node.create-new-customer-chapter.create-new-customer:id}",
               "off_session": true,
-              "payment_method": "${node.complete-step.handle-setup-completed:payment_method}"
-            },
-            "path": "/v1/payment_intents"
-          },
-          "title": "Create a PaymentIntent off-session",
-          "type": "apiRequest",
-          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+              "payment_method": "${node.charge-payment-method-later-chapter.retrieve-setup-intent:payment_method}"
+            }
+          }
+        },
+        {
+          "type": "asyncHandler",
+          "key": "wait-for-payment-intent-succeeded",
+          "title": "Handle payment_intent.succeeded",
+          "description": "Listen for the payment_intent.succeeded event to confirm the off-session payment succeeded.",
+          "review_prompt": "Run `stripe trigger payment_intent.succeeded` and confirm the handler processes the signed event correctly.",
+          "review_command": "stripe trigger payment_intent.succeeded",
+          "events": [
+            "payment_intent.succeeded"
+          ]
         }
-      ],
-      "title": "Charge the saved card"
+      ]
     }
-  ],
-  "description": "Use Checkout in setup mode to collect payment details and charge customers later.",
-  "id": "setup-future-payments",
-  "products": [
-    "Payments",
-    "Checkout"
-  ],
-  "settings": [],
-  "title": "Save a card for future payments",
-  "type": "learning"
+  ]
 }

--- a/pkg/coop/blueprints/setup-future-payments.json
+++ b/pkg/coop/blueprints/setup-future-payments.json
@@ -1,0 +1,109 @@
+{
+  "steps": [
+    {
+      "description": "Create a Checkout Session in setup mode to collect payment details.",
+      "key": "setup-step",
+      "nodes": [
+        {
+          "description": "Create a customer to attach the saved payment method to.",
+          "key": "create-customer",
+          "request": {
+            "key": "create-customer-request",
+            "method": "post",
+            "params": {
+              "email": "jenny@example.com",
+              "name": "Jenny Rosen"
+            },
+            "path": "/v1/customers"
+          },
+          "title": "Create a customer",
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        },
+        {
+          "description": "Create a Checkout Session with mode=setup to save a payment method.",
+          "key": "create-setup-session",
+          "request": {
+            "key": "create-setup-session-request",
+            "method": "post",
+            "params": {
+              "cancel_url": "https://example.com/cancel",
+              "customer": "${node.setup-step.create-customer.create-customer-request:id}",
+              "mode": "setup",
+              "payment_method_types": [
+                "card"
+              ],
+              "success_url": "https://example.com/success"
+            },
+            "path": "/v1/checkout/sessions"
+          },
+          "title": "Create a Checkout Session (setup mode)",
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        }
+      ],
+      "required": true,
+      "title": "Create a Setup Session"
+    },
+    {
+      "description": "Redirect the customer and handle the result.",
+      "key": "complete-step",
+      "nodes": [
+        {
+          "description": "Redirect the customer to the Checkout Session URL.",
+          "key": "redirect-to-setup",
+          "title": "Redirect to setup page",
+          "type": "uiComponent",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "description": "Listen for the setup_intent.succeeded event to confirm the payment method was saved.",
+          "events": [
+            "setup_intent.succeeded"
+          ],
+          "key": "handle-setup-completed",
+          "title": "Handle setup_intent.succeeded",
+          "type": "asyncHandler",
+          "review_prompt": "Run stripe trigger setup_intent.succeeded and confirm the handler processes the signed event correctly."
+        }
+      ],
+      "title": "Complete the setup"
+    },
+    {
+      "description": "Create a PaymentIntent using the saved payment method.",
+      "key": "charge-step",
+      "nodes": [
+        {
+          "description": "Charge the customer using their saved payment method.",
+          "key": "create-payment-intent",
+          "request": {
+            "key": "create-payment-intent-request",
+            "method": "post",
+            "params": {
+              "amount": 1099,
+              "confirm": true,
+              "currency": "usd",
+              "customer": "${node.setup-step.create-customer.create-customer-request:id}",
+              "off_session": true,
+              "payment_method": "${node.complete-step.handle-setup-completed:payment_method}"
+            },
+            "path": "/v1/payment_intents"
+          },
+          "title": "Create a PaymentIntent off-session",
+          "type": "apiRequest",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps."
+        }
+      ],
+      "title": "Charge the saved card"
+    }
+  ],
+  "description": "Use Checkout in setup mode to collect payment details and charge customers later.",
+  "id": "setup-future-payments",
+  "products": [
+    "Payments",
+    "Checkout"
+  ],
+  "settings": [],
+  "title": "Save a card for future payments",
+  "type": "learning"
+}

--- a/pkg/coop/session.go
+++ b/pkg/coop/session.go
@@ -56,15 +56,6 @@ func (s *Session) StepByNodeNumber(n int) (*SessionStep, int, int, error) {
 	return nil, -1, -1, fmt.Errorf("node %d out of range (session has %d nodes)", n, s.TotalNodes())
 }
 
-// ReviewGranularityForNode returns the effective review granularity for a node.
-func (s *Session) ReviewGranularityForNode(n int) ReviewGranularity {
-	ch, _, _, err := s.StepByNodeNumber(n)
-	if err != nil || ch.ReviewGranularity == "" {
-		return ReviewGranularityNode
-	}
-	return ch.ReviewGranularity
-}
-
 // StepReadyForReview returns true when every reviewable node in a step is
 // no longer pending or active.
 func (s *Session) StepReadyForReview(stepIndex int) bool {

--- a/pkg/coop/session_test.go
+++ b/pkg/coop/session_test.go
@@ -7,6 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func testSessionNode(key, title string, state NodeState) SessionNode {
+	return SessionNode{
+		NodeDefinition: NodeDefinition{Key: key, Title: title},
+		State:          state,
+	}
+}
+
 func newTestSession() *Session {
 	return &Session{
 		ID:        "test_abc123",
@@ -14,18 +21,16 @@ func newTestSession() *Session {
 		Status:    SessionActive,
 		Steps: []SessionStep{
 			{
-				Key:   "step-1",
-				Title: "Step 1",
+				StepDefinition: StepDefinition{Key: "step-1", Title: "Step 1"},
 				Nodes: []SessionNode{
-					{Key: "node-1", Title: "Step 1", State: NodePending},
-					{Key: "node-2", Title: "Step 2", State: NodePending},
+					testSessionNode("node-1", "Step 1", NodePending),
+					testSessionNode("node-2", "Step 2", NodePending),
 				},
 			},
 			{
-				Key:   "step-2",
-				Title: "Step 2",
+				StepDefinition: StepDefinition{Key: "step-2", Title: "Step 2"},
 				Nodes: []SessionNode{
-					{Key: "node-3", Title: "Step 3", State: NodePending},
+					testSessionNode("node-3", "Step 3", NodePending),
 				},
 			},
 		},
@@ -238,9 +243,9 @@ func TestIsCompleteWithSkipped(t *testing.T) {
 func TestNodeByNumberAcrossSteps(t *testing.T) {
 	s := &Session{
 		Steps: []SessionStep{
-			{Key: "ch1", Nodes: []SessionNode{{Key: "a"}, {Key: "b"}}},
-			{Key: "ch2", Nodes: []SessionNode{{Key: "c"}}},
-			{Key: "ch3", Nodes: []SessionNode{{Key: "d"}, {Key: "e"}, {Key: "f"}}},
+			{StepDefinition: StepDefinition{Key: "ch1"}, Nodes: []SessionNode{testSessionNode("a", "", ""), testSessionNode("b", "", "")}},
+			{StepDefinition: StepDefinition{Key: "ch2"}, Nodes: []SessionNode{testSessionNode("c", "", "")}},
+			{StepDefinition: StepDefinition{Key: "ch3"}, Nodes: []SessionNode{testSessionNode("d", "", ""), testSessionNode("e", "", ""), testSessionNode("f", "", "")}},
 		},
 	}
 
@@ -275,17 +280,6 @@ func TestStepByNodeNumber(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestReviewGranularityForNode(t *testing.T) {
-	s := newTestSession()
-	s.Steps[0].ReviewGranularity = ReviewGranularityStep
-	s.Steps[1].ReviewGranularity = ReviewGranularityAuto
-
-	assert.Equal(t, ReviewGranularityStep, s.ReviewGranularityForNode(1))
-	assert.Equal(t, ReviewGranularityStep, s.ReviewGranularityForNode(2))
-	assert.Equal(t, ReviewGranularityAuto, s.ReviewGranularityForNode(3))
-	assert.Equal(t, ReviewGranularityNode, s.ReviewGranularityForNode(4))
-}
-
 func TestStepReadyForReview(t *testing.T) {
 	s := newTestSession()
 	assert.False(t, s.StepReadyForReview(-1))
@@ -306,11 +300,17 @@ func TestStepReadyForReviewIgnoresAutoConfirmNodes(t *testing.T) {
 	s := &Session{
 		Steps: []SessionStep{
 			{Nodes: []SessionNode{
-				{Key: "a", State: NodeReview},
-				{Key: "auto", State: NodePending, AutoConfirm: true},
+				testSessionNode("a", "", NodeReview),
+				{
+					NodeDefinition: NodeDefinition{Key: "auto", AutoConfirm: true},
+					State:          NodePending,
+				},
 			}},
 			{Nodes: []SessionNode{
-				{Key: "only-auto", State: NodePending, AutoConfirm: true},
+				{
+					NodeDefinition: NodeDefinition{Key: "only-auto", AutoConfirm: true},
+					State:          NodePending,
+				},
 			}},
 		},
 	}

--- a/pkg/coop/store_test.go
+++ b/pkg/coop/store_test.go
@@ -23,10 +23,9 @@ func TestStoreWriteRead(t *testing.T) {
 		Status:    SessionActive,
 		Steps: []SessionStep{
 			{
-				Key:   "ch-1",
-				Title: "Step 1",
+				StepDefinition: StepDefinition{Key: "ch-1", Title: "Step 1"},
 				Nodes: []SessionNode{
-					{Key: "n-1", Title: "Step 1", State: NodePending},
+					testSessionNode("n-1", "Step 1", NodePending),
 				},
 			},
 		},
@@ -82,7 +81,12 @@ func TestStoreUpdateMutatesAndVersionsSession(t *testing.T) {
 	session := &Session{
 		ID:     "update_test",
 		Status: SessionActive,
-		Steps:  []SessionStep{{Key: "step", Nodes: []SessionNode{{Key: "step", Title: "Step", State: NodePending}}}},
+		Steps: []SessionStep{
+			{
+				StepDefinition: StepDefinition{Key: "step"},
+				Nodes:          []SessionNode{testSessionNode("step", "Step", NodePending)},
+			},
+		},
 	}
 	require.NoError(t, store.Write(session))
 

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -57,9 +57,10 @@ type Verification struct {
 
 // APIRequest describes the expected API call for a node.
 type APIRequest struct {
-	Path   string      `json:"path"`
-	Method string      `json:"method"`
-	Params interface{} `json:"params,omitempty"`
+	Path    string            `json:"path"`
+	Method  string            `json:"method"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Params  interface{}       `json:"params,omitempty"`
 }
 
 // NodeDefinition is the source-derived static definition for a node.

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -80,7 +80,7 @@ type NodeDefinition struct {
 	ReviewCommand string              `json:"review_command,omitempty"`
 	AutoConfirm   bool                `json:"auto_confirm,omitempty"`
 	Request       *APIRequest         `json:"request,omitempty"`
-	Requests      []TestHelperRequest `json:"requests,omitempty"`
+	TestRequests  []TestHelperRequest `json:"requests,omitempty"`
 	Events        []string            `json:"events,omitempty"`
 }
 

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -57,23 +57,31 @@ type Verification struct {
 
 // APIRequest describes the expected API call for a node.
 type APIRequest struct {
-	Path    string            `json:"path"`
-	Method  string            `json:"method"`
-	Headers map[string]string `json:"headers,omitempty"`
-	Params  interface{}       `json:"params,omitempty"`
+	Path         string            `json:"path"`
+	Method       string            `json:"method"`
+	Headers      map[string]string `json:"headers,omitempty"`
+	Params       interface{}       `json:"params,omitempty"`
+	HiddenParams interface{}       `json:"hidden_params,omitempty"`
+}
+
+// TestHelperRequest describes an API-backed request used to advance test state.
+type TestHelperRequest struct {
+	Key string `json:"key"`
+	APIRequest
 }
 
 // NodeDefinition is the source-derived static definition for a node.
 type NodeDefinition struct {
-	Type          NodeType    `json:"type"`
-	Key           string      `json:"key"`
-	Title         string      `json:"title"`
-	Description   string      `json:"description,omitempty"`
-	ReviewPrompt  string      `json:"review_prompt,omitempty"`
-	ReviewCommand string      `json:"review_command,omitempty"`
-	AutoConfirm   bool        `json:"auto_confirm,omitempty"`
-	Request       *APIRequest `json:"request,omitempty"`
-	Events        []string    `json:"events,omitempty"`
+	Type          NodeType            `json:"type"`
+	Key           string              `json:"key"`
+	Title         string              `json:"title"`
+	Description   string              `json:"description,omitempty"`
+	ReviewPrompt  string              `json:"review_prompt,omitempty"`
+	ReviewCommand string              `json:"review_command,omitempty"`
+	AutoConfirm   bool                `json:"auto_confirm,omitempty"`
+	Request       *APIRequest         `json:"request,omitempty"`
+	Requests      []TestHelperRequest `json:"requests,omitempty"`
+	Events        []string            `json:"events,omitempty"`
 }
 
 // StepDefinition is the source-derived static definition for a step.

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -32,15 +32,6 @@ const (
 	NodeSetUpWebhooks NodeType = "setUpWebhooks"
 )
 
-// ReviewGranularity controls where human approval happens.
-type ReviewGranularity string
-
-const (
-	ReviewGranularityNode ReviewGranularity = "node"
-	ReviewGranularityStep ReviewGranularity = "step"
-	ReviewGranularityAuto ReviewGranularity = "auto"
-)
-
 // SessionStatus represents the overall session lifecycle.
 type SessionStatus string
 
@@ -66,27 +57,37 @@ type Verification struct {
 
 // APIRequest describes the expected API call for a node.
 type APIRequest struct {
-	Key    string      `json:"key,omitempty"`
 	Path   string      `json:"path"`
 	Method string      `json:"method"`
 	Params interface{} `json:"params,omitempty"`
 }
 
+// NodeDefinition is the source-derived static definition for a node.
+type NodeDefinition struct {
+	Type          NodeType    `json:"type"`
+	Key           string      `json:"key"`
+	Title         string      `json:"title"`
+	Description   string      `json:"description,omitempty"`
+	ReviewPrompt  string      `json:"review_prompt,omitempty"`
+	ReviewCommand string      `json:"review_command,omitempty"`
+	AutoConfirm   bool        `json:"auto_confirm,omitempty"`
+	Request       *APIRequest `json:"request,omitempty"`
+	Events        []string    `json:"events,omitempty"`
+}
+
+// StepDefinition is the source-derived static definition for a step.
+type StepDefinition struct {
+	Key   string `json:"key"`
+	Title string `json:"title"`
+}
+
 // SessionNode is a single action within a session step.
 type SessionNode struct {
-	Key            string          `json:"key"`
-	Type           NodeType        `json:"type"`
-	Title          string          `json:"title"`
-	Description    string          `json:"description,omitempty"`
-	ReviewPrompt   string          `json:"review_prompt,omitempty"`
-	ReviewCommand  string          `json:"review_command,omitempty"`
-	AutoConfirm    bool            `json:"auto_confirm,omitempty"`
+	NodeDefinition
 	State          NodeState       `json:"state"`
 	Activity       string          `json:"activity,omitempty"`
 	Implementation *Implementation `json:"implementation,omitempty"`
 	Verifications  []Verification  `json:"verifications,omitempty"`
-	Request        *APIRequest     `json:"request,omitempty"`
-	Events         []string        `json:"events,omitempty"`
 	RejectionNote  string          `json:"rejection_note,omitempty"`
 	StartedAt      *time.Time      `json:"started_at,omitempty"`
 	CompletedAt    *time.Time      `json:"completed_at,omitempty"`
@@ -94,10 +95,8 @@ type SessionNode struct {
 
 // SessionStep groups nodes under a titled step.
 type SessionStep struct {
-	Key               string            `json:"key"`
-	Title             string            `json:"title"`
-	ReviewGranularity ReviewGranularity `json:"review_granularity,omitempty"`
-	Nodes             []SessionNode     `json:"nodes"`
+	StepDefinition
+	Nodes []SessionNode `json:"nodes"`
 }
 
 // Session is the shared state file between agent and TUI.


### PR DESCRIPTION
## What this adds
Adds embedded blueprint loading, prefix matching, metadata listing, session creation from blueprints, and the minimal fixture catalog needed to validate loader behavior.

## Review focus
Review this PR as one slice of the co-op stack. It should be understandable on its own against `tomer/coop-split-domain-store`.

## Stack
Base: `tomer/coop-split-domain-store`  
Head: `tomer/coop-split-blueprint-core`

## Validation
Ran `go test ./pkg/coop -count=1` and `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./pkg/coop/...`.