### PR TITLE
4/12 Add bundled co-op blueprint catalog

### DIFF
--- a/pkg/coop/blueprints/invoice-payments.json
+++ b/pkg/coop/blueprints/invoice-payments.json
@@ -1,0 +1,122 @@
+{
+  "id": "invoice-payments",
+  "title": "Invoice payment with hosted page",
+  "description": "Learn how to create and collect payment on an invoice using a hosted payment page.",
+  "type": "learning",
+  "settings": [],
+  "steps": [
+    {
+      "key": "main",
+      "title": "Invoice payment with hosted page",
+      "nodes": [
+        {
+          "type": "testHelper",
+          "key": "create-test-clock",
+          "title": "Create a test clock",
+          "review_prompt": "Run these test-helper requests to advance Stripe test state; do not implement them in the application. Confirm the expected result is observable.",
+          "requests": [
+            {
+              "key": "create-test-clock-request",
+              "path": "/v1/test_helpers/test_clocks",
+              "method": "post",
+              "params": {
+                "frozen_time": "${env:currentTime}",
+                "name": "Example Invoice with Hosted Payment Page"
+              }
+            }
+          ]
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-product",
+          "title": "Create a product with a price",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/products",
+            "method": "post",
+            "params": {
+              "default_price_data": {
+                "currency": "usd",
+                "unit_amount": 10000
+              },
+              "name": "Example Services"
+            }
+          }
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-customer",
+          "title": "Create a customer",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/customers",
+            "method": "post",
+            "params": {
+              "description": "Customer to Invoice",
+              "email": "${env:userEmail}",
+              "test_clock": "${node.main.create-test-clock.create-test-clock-request:id}"
+            }
+          }
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-invoice",
+          "title": "Create an invoice",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/invoices",
+            "method": "post",
+            "params": {
+              "collection_method": "send_invoice",
+              "customer": "${node.main.create-customer:id}",
+              "days_until_due": 30
+            }
+          }
+        },
+        {
+          "type": "apiRequest",
+          "key": "add-invoice-item",
+          "title": "Add an invoice item",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/invoiceitems",
+            "method": "post",
+            "params": {
+              "customer": "${node.main.create-customer:id}",
+              "invoice": "${node.main.create-invoice:id}",
+              "pricing": {
+                "price": "${node.main.create-product:default_price}"
+              }
+            }
+          }
+        },
+        {
+          "type": "apiRequest",
+          "key": "send-invoice",
+          "title": "Send the invoice",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/invoices/${node.main.create-invoice:id}/send",
+            "method": "post",
+            "params": {}
+          }
+        },
+        {
+          "type": "uiComponent",
+          "key": "view-invoice",
+          "title": "View and pay the invoice",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "wait-for-invoice-paid",
+          "title": "Handle invoice payment events",
+          "review_prompt": "Run stripe trigger invoice.paid and confirm the handler processes the signed event correctly.",
+          "events": [
+            "invoice.paid"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/coop/blueprints/metered-subscription.json
+++ b/pkg/coop/blueprints/metered-subscription.json
@@ -1,0 +1,259 @@
+{
+  "id": "metered-subscription",
+  "title": "Metered subscription with entitlements",
+  "description": "Learn how to create a usage-based subscription with metering and entitlements to manage customer feature access.",
+  "type": "learning",
+  "settings": [],
+  "steps": [
+    {
+      "key": "main",
+      "title": "Metered subscription with entitlements",
+      "nodes": [
+        {
+          "type": "apiRequest",
+          "key": "create-meter",
+          "title": "Create a meter",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/billing/meters",
+            "method": "post",
+            "params": {
+              "customer_mapping": {
+                "event_payload_key": "stripe_customer_id",
+                "type": "by_id"
+              },
+              "default_aggregation": {
+                "formula": "sum"
+              },
+              "display_name": "AI tokens",
+              "event_name": "ai_token-${env:randomName}",
+              "value_settings": {
+                "event_payload_key": "value"
+              }
+            }
+          }
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-usage-product",
+          "title": "Create a usage-based product",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/products",
+            "method": "post",
+            "params": {
+              "name": "Usage Based Product"
+            }
+          }
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-usage-price",
+          "title": "Create a metered price",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/prices",
+            "method": "post",
+            "params": {
+              "billing_scheme": "per_unit",
+              "currency": "usd",
+              "product": "${node.main.create-usage-product:id}",
+              "recurring": {
+                "interval": "month",
+                "interval_count": 1,
+                "meter": "${node.main.create-meter:id}",
+                "usage_type": "metered"
+              },
+              "transform_quantity": {
+                "divide_by": 1000,
+                "round": "up"
+              },
+              "unit_amount": 4
+            }
+          }
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-usage-feature",
+          "title": "Create a feature for the usage plan",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/entitlements/features",
+            "method": "post",
+            "params": {
+              "lookup_key": "usage_feature-${env:randomName}",
+              "name": "Usage Feature"
+            }
+          }
+        },
+        {
+          "type": "apiRequest",
+          "key": "attach-feature-to-product",
+          "title": "Attach the feature to the product",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/products/${node.main.create-usage-product:id}/features",
+            "method": "post",
+            "params": {
+              "entitlement_feature": "${node.main.create-usage-feature:id}"
+            }
+          }
+        },
+        {
+          "type": "testHelper",
+          "key": "create-test-clock",
+          "title": "Create a test clock",
+          "review_prompt": "Run these test-helper requests to advance Stripe test state; do not implement them in the application. Confirm the expected result is observable.",
+          "requests": [
+            {
+              "key": "create-test-clock-request",
+              "path": "/v1/test_helpers/test_clocks",
+              "method": "post",
+              "params": {
+                "frozen_time": "${env:currentTime}",
+                "name": "Example Usage based Subscription with Checkout"
+              }
+            }
+          ]
+        },
+        {
+          "type": "testHelper",
+          "key": "create-customer",
+          "title": "Create a customer",
+          "review_prompt": "Run these test-helper requests to advance Stripe test state; do not implement them in the application. Confirm the expected result is observable.",
+          "requests": [
+            {
+              "key": "create-customer-request",
+              "path": "/v1/customers",
+              "method": "post",
+              "params": {
+                "email": "customer@example.com",
+                "name": "Metered Usage Customer",
+                "test_clock": "${node.main.create-test-clock.create-test-clock-request:id}"
+              }
+            }
+          ]
+        },
+        {
+          "type": "apiRequest",
+          "key": "create-checkout-session",
+          "title": "Create a checkout session",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/checkout/sessions",
+            "method": "post",
+            "params": {
+              "customer": "${node.main.create-customer.create-customer-request:id}",
+              "line_items": [
+                {
+                  "price": "${node.main.create-usage-price:id}"
+                }
+              ],
+              "mode": "subscription",
+              "success_url": "https://example.com/success"
+            }
+          }
+        },
+        {
+          "type": "uiComponent",
+          "key": "complete-checkout",
+          "title": "Complete the checkout process",
+          "review_prompt": "Open the app and confirm the user-facing flow works as described."
+        },
+        {
+          "type": "asyncHandler",
+          "key": "check-entitlements",
+          "title": "Check customer entitlements",
+          "review_prompt": "Run stripe trigger entitlements.active_entitlement_summary.updated and confirm the handler processes the signed event correctly.",
+          "events": [
+            "entitlements.active_entitlement_summary.updated"
+          ]
+        },
+        {
+          "type": "asyncHandler",
+          "key": "track-subscription-creation",
+          "title": "Track subscription creation",
+          "review_prompt": "Run stripe trigger customer.subscription.created and confirm the handler processes the signed event correctly.",
+          "events": [
+            "customer.subscription.created"
+          ]
+        },
+        {
+          "type": "apiRequest",
+          "key": "report-usage",
+          "title": "Report customer usage",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/billing/meter_events",
+            "method": "post",
+            "params": {
+              "event_name": "${node.main.create-meter:event_name}",
+              "payload": {
+                "stripe_customer_id": "${node.main.create-customer.create-customer-request:id}",
+                "value": "100000"
+              }
+            }
+          }
+        },
+        {
+          "type": "testHelper",
+          "key": "advance-time",
+          "title": "Advance time to billing date",
+          "review_prompt": "Run these test-helper requests to advance Stripe test state; do not implement them in the application. Confirm the expected result is observable.",
+          "requests": [
+            {
+              "key": "advance-time-request",
+              "path": "/v1/test_helpers/test_clocks/${node.main.create-test-clock.create-test-clock-request:id}/advance",
+              "method": "post",
+              "params": {
+                "frozen_time": "${env:currentTimePlus31Days}"
+              }
+            }
+          ]
+        },
+        {
+          "type": "asyncHandler",
+          "key": "wait-for-invoice-created",
+          "title": "Wait for the invoice to be created",
+          "review_prompt": "Run stripe trigger invoice.created and confirm the handler processes the signed event correctly.",
+          "events": [
+            "invoice.created"
+          ]
+        },
+        {
+          "type": "apiRequest",
+          "key": "view-invoice",
+          "title": "View the invoice created",
+          "review_prompt": "Confirm the implementation calls the intended Stripe API and reuses any IDs needed by later steps.",
+          "request": {
+            "path": "/v1/invoices/${node.main.wait-for-invoice-created:id}",
+            "method": "get"
+          }
+        },
+        {
+          "type": "asyncHandler",
+          "key": "test-clock-advanced",
+          "title": "Wait for test clock to be ready.",
+          "review_prompt": "Run stripe trigger test_helpers.test_clock.ready and confirm the handler processes the signed event correctly.",
+          "events": [
+            "test_helpers.test_clock.ready"
+          ]
+        },
+        {
+          "type": "testHelper",
+          "key": "delete-test-clock",
+          "title": "Delete the test clock",
+          "review_prompt": "Run these test-helper requests to advance Stripe test state; do not implement them in the application. Confirm the expected result is observable.",
+          "requests": [
+            {
+              "key": "delete-test-clock-request",
+              "path": "/v1/test_helpers/test_clocks/${node.main.create-test-clock.create-test-clock-request:id}",
+              "method": "delete",
+              "params": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What this adds
Adds the remaining bundled co-op integration blueprints as catalog data, keeping the loader/review mechanics separate from the larger JSON review.

## Review focus
Review this PR as one slice of the co-op stack. It should be understandable on its own against `tomer/coop-split-blueprint-core`.

## Stack
Base: `tomer/coop-split-blueprint-core`  
Head: `tomer/coop-split-blueprint-catalog`

## Validation
Ran `go test ./pkg/coop -count=1` and `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./pkg/coop/...`.