### PR TITLE
5/12 Add co-op workflow service

### DIFF
--- a/pkg/coop/helpers/nextaction.go
+++ b/pkg/coop/helpers/nextaction.go
@@ -10,6 +10,9 @@ import (
 )
 
 var ErrNoSession = errors.New("no session found")
+var ErrSelectionTimeout = errors.New("timed out waiting for next-action selection")
+
+const NextActionSelectionTimeout = 10 * time.Minute
 
 type Input struct {
 	SessionID string
@@ -97,8 +100,16 @@ func ShowSuggestions(store Store, session *coop.Session, suggestions []Suggestio
 }
 
 func WaitForSelection(store Store, sessionID string) (string, error) {
+	return waitForSelection(store, sessionID, NextActionSelectionTimeout, time.Now, time.Sleep)
+}
+
+func waitForSelection(store Store, sessionID string, timeout time.Duration, now func() time.Time, sleep func(time.Duration)) (string, error) {
+	deadline := now().Add(timeout)
 	for {
-		time.Sleep(500 * time.Millisecond)
+		if now().After(deadline) {
+			return "", ErrSelectionTimeout
+		}
+		sleep(500 * time.Millisecond)
 		session, err := store.Read(sessionID)
 		if err != nil {
 			continue

--- a/pkg/coop/helpers/nextaction.go
+++ b/pkg/coop/helpers/nextaction.go
@@ -1,0 +1,214 @@
+// Package helpers contains shared support logic for co-op commands and workflows.
+package helpers
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+var ErrNoSession = errors.New("no session found")
+
+type Input struct {
+	SessionID string
+	Completed string
+}
+
+type Store interface {
+	Read(id string) (*coop.Session, error)
+	LatestSession() (*coop.Session, error)
+	Write(session *coop.Session) error
+}
+
+type Suggestion struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Available   bool   `json:"available"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+type Response struct {
+	OK          bool         `json:"ok"`
+	SessionID   string       `json:"session_id"`
+	Completed   string       `json:"completed"`
+	Suggestions []Suggestion `json:"suggestions"`
+	AgentPrompt string       `json:"agent_prompt"`
+	Next        string       `json:"next"`
+}
+
+type Environment struct {
+}
+
+func Run(store Store, input Input) (Response, error) {
+	var session *coop.Session
+	var err error
+	if input.SessionID != "" {
+		session, err = store.Read(input.SessionID)
+	} else {
+		session, err = store.LatestSession()
+	}
+	if err != nil {
+		return Response{}, ErrNoSession
+	}
+
+	suggestions := BuildSuggestions(session, DetectProjectEnvironment())
+	if err := ShowSuggestions(store, session, suggestions, input.Completed); err != nil {
+		return Response{}, err
+	}
+
+	selected, err := WaitForSelection(store, session.ID)
+	if err != nil {
+		return Response{}, err
+	}
+	return BuildResponse(session, suggestions, selected), nil
+}
+
+func ShowSuggestions(store Store, session *coop.Session, suggestions []Suggestion, completed string) error {
+	var tuiSuggestions []coop.NextStepSuggestion
+	for _, s := range suggestions {
+		tuiSuggestions = append(tuiSuggestions, coop.NextStepSuggestion{
+			ID:          s.ID,
+			Title:       s.Title,
+			Description: s.Description,
+			Reason:      s.Reason,
+		})
+	}
+
+	if session.NextSteps == nil {
+		session.NextSteps = &coop.NextStepsState{}
+	}
+	session.NextSteps.Suggestions = tuiSuggestions
+	session.NextSteps.Selected = ""
+	session.Status = coop.SessionCompleted
+	if err := store.Write(session); err != nil {
+		return fmt.Errorf("writing next-action suggestions: %w", err)
+	}
+
+	if completed != "" {
+		session.NextSteps.Completed = append(session.NextSteps.Completed, completed)
+		if err := store.Write(session); err != nil {
+			return fmt.Errorf("marking next-action completed: %w", err)
+		}
+	}
+	return nil
+}
+
+func WaitForSelection(store Store, sessionID string) (string, error) {
+	for {
+		time.Sleep(500 * time.Millisecond)
+		session, err := store.Read(sessionID)
+		if err != nil {
+			continue
+		}
+		if session.NextSteps == nil || session.NextSteps.Selected == "" {
+			continue
+		}
+
+		selected := session.NextSteps.Selected
+		session.NextSteps.Selected = ""
+		if err := store.Write(session); err != nil {
+			return "", fmt.Errorf("clearing next-action selection: %w", err)
+		}
+		return selected, nil
+	}
+}
+
+func BuildSuggestions(session *coop.Session, env Environment) []Suggestion {
+	var suggestions []Suggestion
+
+	suggestions = append(suggestions, Suggestion{
+		ID:          "summarize",
+		Title:       "Write a STRIPE.md summary",
+		Description: "Generate a STRIPE.md with what was built, API resources created, environment setup, and how to run",
+		Available:   true,
+	})
+
+	suggestions = append(suggestions, Suggestion{
+		ID:          "add-integration",
+		Title:       "Add another Stripe feature",
+		Description: "Subscriptions, Connect, billing portal, and more",
+		Available:   true,
+	})
+
+	suggestions = append(suggestions, Suggestion{
+		ID:          "done",
+		Title:       "Finish",
+		Description: "Close this session",
+		Available:   true,
+	})
+
+	return suggestions
+}
+
+func BuildResponse(session *coop.Session, suggestions []Suggestion, selected string) Response {
+	switch selected {
+	case "summarize":
+		return Response{
+			OK:          true,
+			SessionID:   session.ID,
+			Completed:   session.Blueprint,
+			Suggestions: suggestions,
+			AgentPrompt: BuildSummarizePrompt(session),
+			Next:        fmt.Sprintf("Write STRIPE.md, then run: stripe coop agent next-action --session=%s --completed=summarize", session.ID),
+		}
+	case "add-integration":
+		return Response{
+			OK:          true,
+			SessionID:   session.ID,
+			Completed:   session.Blueprint,
+			Suggestions: suggestions,
+			AgentPrompt: fmt.Sprintf("The developer wants to add another Stripe feature. Run 'stripe coop recommend' and ask what they need, then start a new session with --parent-session=%s --parent-step=add-integration.", session.ID),
+			Next:        "stripe coop recommend",
+		}
+	case "done":
+		return Response{
+			OK:          true,
+			SessionID:   session.ID,
+			Completed:   session.Blueprint,
+			AgentPrompt: "The developer is done. End the session.",
+			Next:        fmt.Sprintf("stripe coop stop --session=%s", session.ID),
+		}
+	default:
+		return Response{
+			OK:          true,
+			SessionID:   session.ID,
+			Completed:   session.Blueprint,
+			AgentPrompt: fmt.Sprintf("The developer selected: %s", selected),
+			Next:        "stripe coop stop",
+		}
+	}
+}
+
+func BuildSummarizePrompt(session *coop.Session) string {
+	return fmt.Sprintf(`The developer wants a STRIPE.md summary. Create a STRIPE.md file in the project root with:
+
+## What was built
+- Integration: %s
+- Blueprint steps completed
+
+## Stripe resources created
+- List any product IDs, price IDs, customer IDs created during the session
+
+## Environment variables
+- STRIPE_SECRET_KEY — your Stripe test secret key
+- STRIPE_WEBHOOK_SECRET — webhook signing secret (from stripe listen)
+
+## How to run
+- Commands to install deps and start the server
+
+## Webhook events handled
+- List the events this integration listens for
+
+## Useful links
+- Stripe Dashboard: https://dashboard.stripe.com/test
+- API docs: https://docs.stripe.com/api
+
+After writing the file, run "stripe coop agent next-action --session=%s --completed=summarize" again to offer more options.`, session.Blueprint, session.ID)
+}
+
+func DetectProjectEnvironment() Environment {
+	return Environment{}
+}

--- a/pkg/coop/helpers/nextaction_test.go
+++ b/pkg/coop/helpers/nextaction_test.go
@@ -1,9 +1,12 @@
 package helpers
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/coop"
 )
@@ -16,4 +19,67 @@ func TestBuildSuggestionsIncludesCoreNextActions(t *testing.T) {
 	assert.Equal(t, "summarize", suggestions[0].ID)
 	assert.Equal(t, "add-integration", suggestions[1].ID)
 	assert.Equal(t, "done", suggestions[2].ID)
+}
+
+func TestWaitForSelectionTimesOut(t *testing.T) {
+	store := &nextActionTestStore{
+		session: &coop.Session{
+			ID:        "sess_123",
+			NextSteps: &coop.NextStepsState{},
+		},
+	}
+	now := time.Unix(0, 0)
+
+	selected, err := waitForSelection(
+		store,
+		"sess_123",
+		time.Second,
+		func() time.Time { return now },
+		func(time.Duration) { now = now.Add(500 * time.Millisecond) },
+	)
+
+	assert.Empty(t, selected)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSelectionTimeout))
+}
+
+func TestWaitForSelectionClearsSelectedAction(t *testing.T) {
+	store := &nextActionTestStore{
+		session: &coop.Session{
+			ID: "sess_123",
+			NextSteps: &coop.NextStepsState{
+				Selected: "done",
+			},
+		},
+	}
+	now := time.Unix(0, 0)
+
+	selected, err := waitForSelection(
+		store,
+		"sess_123",
+		time.Second,
+		func() time.Time { return now },
+		func(time.Duration) { now = now.Add(500 * time.Millisecond) },
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "done", selected)
+	assert.Empty(t, store.session.NextSteps.Selected)
+}
+
+type nextActionTestStore struct {
+	session *coop.Session
+}
+
+func (s *nextActionTestStore) Read(id string) (*coop.Session, error) {
+	return s.session, nil
+}
+
+func (s *nextActionTestStore) LatestSession() (*coop.Session, error) {
+	return s.session, nil
+}
+
+func (s *nextActionTestStore) Write(session *coop.Session) error {
+	s.session = session
+	return nil
 }

--- a/pkg/coop/helpers/nextaction_test.go
+++ b/pkg/coop/helpers/nextaction_test.go
@@ -1,0 +1,19 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestBuildSuggestionsIncludesCoreNextActions(t *testing.T) {
+	session := &coop.Session{ID: "sess_123", Blueprint: "one-time-payment"}
+
+	suggestions := BuildSuggestions(session, Environment{})
+
+	assert.Equal(t, "summarize", suggestions[0].ID)
+	assert.Equal(t, "add-integration", suggestions[1].ID)
+	assert.Equal(t, "done", suggestions[2].ID)
+}

--- a/pkg/coop/helpers/review.go
+++ b/pkg/coop/helpers/review.go
@@ -1,0 +1,21 @@
+package helpers
+
+import "github.com/stripe/stripe-cli/pkg/coop"
+
+func NextPendingNodeInStep(session *coop.Session, stepIndex, afterNode int) int {
+	nodeNumber := 0
+	for i := range session.Steps {
+		for j := range session.Steps[i].Nodes {
+			nodeNumber++
+			if i == stepIndex && nodeNumber > afterNode && session.Steps[i].Nodes[j].State == coop.NodePending {
+				return nodeNumber
+			}
+		}
+	}
+	return 0
+}
+
+func StepReviewApplies(session *coop.Session, nodeNumber int) bool {
+	_, err := session.NodeByNumber(nodeNumber)
+	return err == nil
+}

--- a/pkg/coop/helpers/review.go
+++ b/pkg/coop/helpers/review.go
@@ -2,20 +2,15 @@ package helpers
 
 import "github.com/stripe/stripe-cli/pkg/coop"
 
-func NextPendingNodeInStep(session *coop.Session, stepIndex, afterNode int) int {
+func NextPendingNodeInStep(session *coop.Session, stepNumber, afterNode int) int {
 	nodeNumber := 0
 	for i := range session.Steps {
 		for j := range session.Steps[i].Nodes {
 			nodeNumber++
-			if i == stepIndex && nodeNumber > afterNode && session.Steps[i].Nodes[j].State == coop.NodePending {
+			if i+1 == stepNumber && nodeNumber > afterNode && session.Steps[i].Nodes[j].State == coop.NodePending {
 				return nodeNumber
 			}
 		}
 	}
 	return 0
-}
-
-func StepReviewApplies(session *coop.Session, nodeNumber int) bool {
-	_, err := session.NodeByNumber(nodeNumber)
-	return err == nil
 }

--- a/pkg/coop/helpers/review_test.go
+++ b/pkg/coop/helpers/review_test.go
@@ -1,0 +1,44 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestNextPendingNodeInStep(t *testing.T) {
+	session := &coop.Session{
+		Steps: []coop.SessionStep{
+			{
+				Nodes: []coop.SessionNode{
+					{State: coop.NodeDone},
+					{State: coop.NodePending},
+				},
+			},
+			{
+				Nodes: []coop.SessionNode{
+					{State: coop.NodePending},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, 2, NextPendingNodeInStep(session, 0, 1))
+	assert.Equal(t, 0, NextPendingNodeInStep(session, 0, 2))
+	assert.Equal(t, 3, NextPendingNodeInStep(session, 1, 0))
+}
+
+func TestStepReviewApplies(t *testing.T) {
+	session := &coop.Session{
+		Steps: []coop.SessionStep{
+			{
+				Nodes: []coop.SessionNode{{State: coop.NodeReview}},
+			},
+		},
+	}
+
+	assert.True(t, StepReviewApplies(session, 1))
+	assert.False(t, StepReviewApplies(session, 99))
+}

--- a/pkg/coop/helpers/review_test.go
+++ b/pkg/coop/helpers/review_test.go
@@ -25,20 +25,7 @@ func TestNextPendingNodeInStep(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, 2, NextPendingNodeInStep(session, 0, 1))
-	assert.Equal(t, 0, NextPendingNodeInStep(session, 0, 2))
-	assert.Equal(t, 3, NextPendingNodeInStep(session, 1, 0))
-}
-
-func TestStepReviewApplies(t *testing.T) {
-	session := &coop.Session{
-		Steps: []coop.SessionStep{
-			{
-				Nodes: []coop.SessionNode{{State: coop.NodeReview}},
-			},
-		},
-	}
-
-	assert.True(t, StepReviewApplies(session, 1))
-	assert.False(t, StepReviewApplies(session, 99))
+	assert.Equal(t, 2, NextPendingNodeInStep(session, 1, 1))
+	assert.Equal(t, 0, NextPendingNodeInStep(session, 1, 2))
+	assert.Equal(t, 3, NextPendingNodeInStep(session, 2, 0))
 }

--- a/pkg/coop/workflow/service.go
+++ b/pkg/coop/workflow/service.go
@@ -203,7 +203,7 @@ func (s *Service) ConfirmReview(sessionID string, nodeNumbers []int) (*coop.Sess
 			if err != nil {
 				return err
 			}
-			if node.State == coop.NodeDone {
+			if node.State == coop.NodeDone || node.State == coop.NodeSkipped {
 				continue
 			}
 			if err := session.TransitionNode(nodeNumber, coop.NodeDone); err != nil {
@@ -254,7 +254,7 @@ func (s *Service) AwaitReview(sessionID string, nodeNumber int) (coop.CommandRes
 	if node.AutoConfirm && node.State == coop.NodeReview {
 		return s.autoConfirm(sessionID, nodeNumber)
 	}
-	if helpers.StepReviewApplies(session, nodeNumber) && node.State == coop.NodeReview {
+	if node.State == coop.NodeReview {
 		step, stepIndex, _, err := session.StepByNodeNumber(nodeNumber)
 		if err != nil {
 			return errorResponse(err, "stripe coop status"), nil
@@ -395,27 +395,25 @@ func (s *Service) awaitStepReview(sessionID, stepTitle string, stepIndex, nodeNu
 
 func (s *Service) reportWorkResponse(session *coop.Session, node *coop.SessionNode, nodeNumber int, targetState coop.NodeState) coop.CommandResponse {
 	if targetState == coop.NodeReview {
-		if helpers.StepReviewApplies(session, nodeNumber) {
-			step, stepIndex, _, err := session.StepByNodeNumber(nodeNumber)
-			if err == nil && !session.StepReadyForReview(stepIndex) {
-				return coop.CommandResponse{
-					OK:        true,
-					SessionID: session.ID,
-					Node:      nodeNumber,
-					State:     string(coop.NodeReview),
-					Message:   fmt.Sprintf("Ready: %s. Continue the step before asking for human review.", node.Title),
-					Next:      nextInStepOrStatus(session, stepIndex, nodeNumber),
-				}
+		step, stepIndex, _, err := session.StepByNodeNumber(nodeNumber)
+		if err == nil && !session.StepReadyForReview(stepIndex) {
+			return coop.CommandResponse{
+				OK:        true,
+				SessionID: session.ID,
+				Node:      nodeNumber,
+				State:     string(coop.NodeReview),
+				Message:   fmt.Sprintf("Ready: %s. Continue the step before asking for human review.", node.Title),
+				Next:      nextInStepOrStatus(session, stepIndex, nodeNumber),
 			}
-			if err == nil {
-				return coop.CommandResponse{
-					OK:        true,
-					SessionID: session.ID,
-					Node:      nodeNumber,
-					State:     string(coop.NodeReview),
-					Message:   fmt.Sprintf("Step ready for review: %s. Run relevant checks, keep useful servers running, share local URLs or test data, then await review.", step.Title),
-					Next:      fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", session.ID, nodeNumber),
-				}
+		}
+		if err == nil {
+			return coop.CommandResponse{
+				OK:        true,
+				SessionID: session.ID,
+				Node:      nodeNumber,
+				State:     string(coop.NodeReview),
+				Message:   fmt.Sprintf("Step ready for review: %s. Run relevant checks, keep useful servers running, share local URLs or test data, then await review.", step.Title),
+				Next:      fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", session.ID, nodeNumber),
 			}
 		}
 		return coop.CommandResponse{
@@ -455,7 +453,7 @@ func nextAfterNode(session *coop.Session, nodeNumber int) string {
 }
 
 func nextInStepOrStatus(session *coop.Session, stepIndex, afterNode int) string {
-	if nextNodeNumber := helpers.NextPendingNodeInStep(session, stepIndex, afterNode); nextNodeNumber > 0 {
+	if nextNodeNumber := helpers.NextPendingNodeInStep(session, stepIndex+1, afterNode); nextNodeNumber > 0 {
 		nextNode, _ := session.NodeByNumber(nextNodeNumber)
 		return fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d --note=%s", session.ID, nextNodeNumber, quoteArg("Beginning: "+nextNode.Title))
 	}

--- a/pkg/coop/workflow/service.go
+++ b/pkg/coop/workflow/service.go
@@ -1,0 +1,540 @@
+// Package workflow applies co-op agent lifecycle transitions to sessions.
+package workflow
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/helpers"
+)
+
+const AwaitTimeout = 10 * time.Minute
+
+type Store interface {
+	Read(id string) (*coop.Session, error)
+	Update(id string, fn func(*coop.Session) error) (*coop.Session, error)
+	WriteHeartbeat(id string) error
+	RemoveHeartbeat(id string) error
+}
+
+type Service struct {
+	store        Store
+	fetchSnippet func(path, method string, params interface{}, language string) (string, error)
+	now          func() time.Time
+	sleep        func(time.Duration)
+	awaitTimeout time.Duration
+}
+
+type Option func(*Service)
+
+func WithSnippetFetcher(fetch func(path, method string, params interface{}, language string) (string, error)) Option {
+	return func(s *Service) {
+		s.fetchSnippet = fetch
+	}
+}
+
+func WithClock(now func() time.Time, sleep func(time.Duration)) Option {
+	return func(s *Service) {
+		if now != nil {
+			s.now = now
+		}
+		if sleep != nil {
+			s.sleep = sleep
+		}
+	}
+}
+
+func WithAwaitTimeout(timeout time.Duration) Option {
+	return func(s *Service) {
+		s.awaitTimeout = timeout
+	}
+}
+
+func NewService(store Store, opts ...Option) *Service {
+	s := &Service{
+		store:        store,
+		fetchSnippet: coop.FetchSDKSnippet,
+		now:          time.Now,
+		sleep:        time.Sleep,
+		awaitTimeout: AwaitTimeout,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+type ReportWorkInput struct {
+	File    string
+	Lines   string
+	Snippet string
+	Note    string
+}
+
+func (s *Service) StartWork(sessionID string, nodeNumber int, note string) (coop.CommandResponse, error) {
+	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		if err := session.TransitionNode(nodeNumber, coop.NodeActive); err != nil {
+			return err
+		}
+		node, _ := session.NodeByNumber(nodeNumber)
+		node.Activity = note
+		return nil
+	})
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+
+	node, _ := session.NodeByNumber(nodeNumber)
+	resp := coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Node:      nodeNumber,
+		State:     string(coop.NodeActive),
+		Message:   fmt.Sprintf("Started: %s", node.Title),
+		Next:      fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --file=<path> --note=\"<what you did>\"", session.ID, nodeNumber),
+	}
+	if node.Type == coop.NodeAPIRequest && node.Request != nil {
+		resp.APIRequest = node.Request
+		if snippet, err := s.fetchSnippet(node.Request.Path, node.Request.Method, node.Request.Params, language(session)); err == nil {
+			resp.SDKExample = snippet
+		}
+	}
+	return resp, nil
+}
+
+func (s *Service) ReportWork(sessionID string, nodeNumber int, input ReportWorkInput, autoConfirm bool) (coop.CommandResponse, error) {
+	var targetState coop.NodeState
+	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		node, err := session.NodeByNumber(nodeNumber)
+		if err != nil {
+			return err
+		}
+		targetState = coop.NodeReview
+		if autoConfirm || node.AutoConfirm {
+			targetState = coop.NodeDone
+		}
+		if err := session.TransitionNode(nodeNumber, targetState); err != nil {
+			return err
+		}
+		node, _ = session.NodeByNumber(nodeNumber)
+		if input.File != "" || input.Snippet != "" || input.Note != "" {
+			node.Implementation = &coop.Implementation{
+				File:    input.File,
+				Lines:   input.Lines,
+				Snippet: input.Snippet,
+				Note:    input.Note,
+			}
+		}
+		node.Activity = ""
+		if session.IsComplete() {
+			session.Status = coop.SessionCompleted
+		}
+		return nil
+	})
+	if err != nil {
+		return errorResponse(err, fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d", sessionID, nodeNumber)), nil
+	}
+	node, _ := session.NodeByNumber(nodeNumber)
+	return s.reportWorkResponse(session, node, nodeNumber, targetState), nil
+}
+
+func (s *Service) ReportCheck(sessionID string, nodeNumber int, check string, passed bool) (coop.CommandResponse, error) {
+	if strings.TrimSpace(check) == "" {
+		return errorResponse(fmt.Errorf("--check flag is required"), fmt.Sprintf("stripe coop agent report-check --session=%s --step=%d --check=\"<label>\" --passed", sessionID, nodeNumber)), nil
+	}
+	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		node, err := session.NodeByNumber(nodeNumber)
+		if err != nil {
+			return err
+		}
+		node.Verifications = append(node.Verifications, coop.Verification{Check: check, Passed: passed})
+		return nil
+	})
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+	node, _ := session.NodeByNumber(nodeNumber)
+	status := "failed"
+	if passed {
+		status = "passed"
+	}
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Node:      nodeNumber,
+		State:     string(node.State),
+		Message:   fmt.Sprintf("Verification %s: %s", status, check),
+		Next:      fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --file=<path> --note=\"<what you did>\"", session.ID, nodeNumber),
+	}, nil
+}
+
+func (s *Service) Skip(sessionID string, nodeNumber int, note string) (coop.CommandResponse, error) {
+	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		if err := session.TransitionNode(nodeNumber, coop.NodeSkipped); err != nil {
+			return err
+		}
+		node, _ := session.NodeByNumber(nodeNumber)
+		node.Activity = note
+		if session.IsComplete() {
+			session.Status = coop.SessionCompleted
+		}
+		return nil
+	})
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+	node, _ := session.NodeByNumber(nodeNumber)
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Node:      nodeNumber,
+		State:     string(coop.NodeSkipped),
+		Message:   fmt.Sprintf("Skipped: %s", node.Title),
+		Next:      nextAfterNode(session, nodeNumber),
+	}, nil
+}
+
+func (s *Service) ConfirmReview(sessionID string, nodeNumbers []int) (*coop.Session, error) {
+	return s.store.Update(sessionID, func(session *coop.Session) error {
+		for _, nodeNumber := range nodeNumbers {
+			node, err := session.NodeByNumber(nodeNumber)
+			if err != nil {
+				return err
+			}
+			if node.State == coop.NodeDone {
+				continue
+			}
+			if err := session.TransitionNode(nodeNumber, coop.NodeDone); err != nil {
+				return err
+			}
+		}
+		if session.IsComplete() {
+			session.Status = coop.SessionCompleted
+		}
+		return nil
+	})
+}
+
+func (s *Service) RequestChanges(sessionID string, nodeNumbers []int, note string) (*coop.Session, error) {
+	if strings.TrimSpace(note) == "" {
+		return nil, fmt.Errorf("request changes note is required")
+	}
+	return s.store.Update(sessionID, func(session *coop.Session) error {
+		for _, nodeNumber := range nodeNumbers {
+			node, err := session.NodeByNumber(nodeNumber)
+			if err != nil {
+				return err
+			}
+			if node.State != coop.NodeActive {
+				if err := session.TransitionNode(nodeNumber, coop.NodeActive); err != nil {
+					return err
+				}
+				node, _ = session.NodeByNumber(nodeNumber)
+			}
+			node.RejectionNote = note
+			node.Implementation = nil
+			node.Verifications = nil
+		}
+		return nil
+	})
+}
+
+func (s *Service) AwaitReview(sessionID string, nodeNumber int) (coop.CommandResponse, error) {
+	session, err := s.store.Read(sessionID)
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+	node, err := session.NodeByNumber(nodeNumber)
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+
+	if node.AutoConfirm && node.State == coop.NodeReview {
+		return s.autoConfirm(sessionID, nodeNumber)
+	}
+	if helpers.StepReviewApplies(session, nodeNumber) && node.State == coop.NodeReview {
+		step, stepIndex, _, err := session.StepByNodeNumber(nodeNumber)
+		if err != nil {
+			return errorResponse(err, "stripe coop status"), nil
+		}
+		if !session.StepReadyForReview(stepIndex) {
+			return coop.CommandResponse{
+				OK:        true,
+				SessionID: session.ID,
+				Node:      nodeNumber,
+				State:     string(coop.NodeReview),
+				Message:   fmt.Sprintf("Node %d is ready. Continue the step before asking for human review.", nodeNumber),
+				Next:      nextInStepOrStatus(session, stepIndex, nodeNumber),
+			}, nil
+		}
+		return s.awaitStepReview(session.ID, step.Title, stepIndex, nodeNumber)
+	}
+	if node.State != coop.NodeReview {
+		return alreadyMovedResponse(session, nodeNumber, node.State), nil
+	}
+	return s.awaitNodeReview(session.ID, nodeNumber)
+}
+
+func (s *Service) SelectNextAction(sessionID, selected, completed string, suggestions []coop.NextStepSuggestion) (*coop.Session, error) {
+	return s.store.Update(sessionID, func(session *coop.Session) error {
+		if session.NextSteps == nil {
+			session.NextSteps = &coop.NextStepsState{}
+		}
+		if len(suggestions) > 0 {
+			session.NextSteps.Suggestions = suggestions
+		}
+		if completed != "" && !contains(session.NextSteps.Completed, completed) {
+			session.NextSteps.Completed = append(session.NextSteps.Completed, completed)
+		}
+		session.NextSteps.Selected = selected
+		session.Status = coop.SessionCompleted
+		return nil
+	})
+}
+
+func (s *Service) autoConfirm(sessionID string, nodeNumber int) (coop.CommandResponse, error) {
+	session, err := s.ConfirmReview(sessionID, []int{nodeNumber})
+	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Node:      nodeNumber,
+		State:     "confirmed",
+		Message:   fmt.Sprintf("Node %d auto-confirmed. Proceed to next node.", nodeNumber),
+		Next:      nextAfterNode(session, nodeNumber),
+	}, nil
+}
+
+func (s *Service) awaitNodeReview(sessionID string, nodeNumber int) (coop.CommandResponse, error) {
+	if err := s.store.WriteHeartbeat(sessionID); err != nil {
+		return coop.CommandResponse{}, err
+	}
+	defer func() {
+		_ = s.store.RemoveHeartbeat(sessionID)
+	}()
+
+	deadline := s.now().Add(s.awaitTimeout)
+	for {
+		if s.now().After(deadline) {
+			return timeoutResponse(sessionID, nodeNumber), nil
+		}
+		s.sleep(500 * time.Millisecond)
+		if err := s.store.WriteHeartbeat(sessionID); err != nil {
+			return coop.CommandResponse{}, err
+		}
+
+		session, err := s.store.Read(sessionID)
+		if err != nil {
+			return coop.CommandResponse{}, err
+		}
+		node, err := session.NodeByNumber(nodeNumber)
+		if err != nil {
+			return coop.CommandResponse{}, err
+		}
+		if node.State == coop.NodeReview {
+			continue
+		}
+		if node.State == coop.NodeDone {
+			return confirmedResponse(session, nodeNumber), nil
+		}
+		if node.State == coop.NodeActive {
+			return rejectedResponse(session, nodeNumber, node), nil
+		}
+		return alreadyMovedResponse(session, nodeNumber, node.State), nil
+	}
+}
+
+func (s *Service) awaitStepReview(sessionID, stepTitle string, stepIndex, nodeNumber int) (coop.CommandResponse, error) {
+	if err := s.store.WriteHeartbeat(sessionID); err != nil {
+		return coop.CommandResponse{}, err
+	}
+	defer func() {
+		_ = s.store.RemoveHeartbeat(sessionID)
+	}()
+
+	deadline := s.now().Add(s.awaitTimeout)
+	for {
+		if s.now().After(deadline) {
+			return timeoutResponse(sessionID, nodeNumber), nil
+		}
+		s.sleep(500 * time.Millisecond)
+		if err := s.store.WriteHeartbeat(sessionID); err != nil {
+			return coop.CommandResponse{}, err
+		}
+
+		session, err := s.store.Read(sessionID)
+		if err != nil {
+			return coop.CommandResponse{}, err
+		}
+		if activeNodeNumber := session.FirstActiveNodeInStep(stepIndex); activeNodeNumber > 0 {
+			activeNode, _ := session.NodeByNumber(activeNodeNumber)
+			msg := fmt.Sprintf("Step %q requested changes.", stepTitle)
+			if activeNode != nil && activeNode.RejectionNote != "" {
+				msg += fmt.Sprintf("\nFeedback: %s", activeNode.RejectionNote)
+			}
+			msg += "\nRedo the step from the first affected node."
+			return coop.CommandResponse{
+				OK:        true,
+				SessionID: session.ID,
+				Node:      activeNodeNumber,
+				State:     "rejected",
+				Message:   msg,
+				Next:      fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d --note=%s", session.ID, activeNodeNumber, quoteArg("Redoing: "+activeNode.Title)),
+			}, nil
+		}
+		if session.StepHasReview(stepIndex) {
+			continue
+		}
+		return confirmedResponse(session, nodeNumber), nil
+	}
+}
+
+func (s *Service) reportWorkResponse(session *coop.Session, node *coop.SessionNode, nodeNumber int, targetState coop.NodeState) coop.CommandResponse {
+	if targetState == coop.NodeReview {
+		if helpers.StepReviewApplies(session, nodeNumber) {
+			step, stepIndex, _, err := session.StepByNodeNumber(nodeNumber)
+			if err == nil && !session.StepReadyForReview(stepIndex) {
+				return coop.CommandResponse{
+					OK:        true,
+					SessionID: session.ID,
+					Node:      nodeNumber,
+					State:     string(coop.NodeReview),
+					Message:   fmt.Sprintf("Ready: %s. Continue the step before asking for human review.", node.Title),
+					Next:      nextInStepOrStatus(session, stepIndex, nodeNumber),
+				}
+			}
+			if err == nil {
+				return coop.CommandResponse{
+					OK:        true,
+					SessionID: session.ID,
+					Node:      nodeNumber,
+					State:     string(coop.NodeReview),
+					Message:   fmt.Sprintf("Step ready for review: %s. Run relevant checks, keep useful servers running, share local URLs or test data, then await review.", step.Title),
+					Next:      fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", session.ID, nodeNumber),
+				}
+			}
+		}
+		return coop.CommandResponse{
+			OK:        true,
+			SessionID: session.ID,
+			Node:      nodeNumber,
+			State:     string(coop.NodeReview),
+			Message:   fmt.Sprintf("Ready for review: %s", node.Title),
+			Next:      fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", session.ID, nodeNumber),
+		}
+	}
+
+	msg := fmt.Sprintf("Completed: %s", node.Title)
+	next := nextAfterNode(session, nodeNumber)
+	if session.IsComplete() {
+		msg += " All nodes complete. Run next-action so the developer can choose what happens next."
+	}
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Node:      nodeNumber,
+		State:     string(targetState),
+		Message:   msg,
+		Next:      next,
+	}
+}
+
+func nextAfterNode(session *coop.Session, nodeNumber int) string {
+	if nextNodeNumber := session.NextPendingNode(nodeNumber); nextNodeNumber > 0 {
+		nextNode, _ := session.NodeByNumber(nextNodeNumber)
+		return fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d --note=%s", session.ID, nextNodeNumber, quoteArg("Beginning: "+nextNode.Title))
+	}
+	if session.IsComplete() {
+		return fmt.Sprintf("stripe coop agent next-action --session=%s", session.ID)
+	}
+	return fmt.Sprintf("stripe coop status --session=%s", session.ID)
+}
+
+func nextInStepOrStatus(session *coop.Session, stepIndex, afterNode int) string {
+	if nextNodeNumber := helpers.NextPendingNodeInStep(session, stepIndex, afterNode); nextNodeNumber > 0 {
+		nextNode, _ := session.NodeByNumber(nextNodeNumber)
+		return fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d --note=%s", session.ID, nextNodeNumber, quoteArg("Beginning: "+nextNode.Title))
+	}
+	return fmt.Sprintf("stripe coop status --session=%s", session.ID)
+}
+
+func alreadyMovedResponse(session *coop.Session, nodeNumber int, state coop.NodeState) coop.CommandResponse {
+	msg := fmt.Sprintf("Node %d is already %s.", nodeNumber, state)
+	if session.IsComplete() {
+		msg = fmt.Sprintf("Node %d confirmed. All nodes done. Run next-action now.", nodeNumber)
+	}
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Node:      nodeNumber,
+		State:     string(state),
+		Message:   msg,
+		Next:      nextAfterNode(session, nodeNumber),
+	}
+}
+
+func confirmedResponse(session *coop.Session, nodeNumber int) coop.CommandResponse {
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Node:      nodeNumber,
+		State:     "confirmed",
+		Message:   fmt.Sprintf("Node %d confirmed by developer. Proceed to next node.", nodeNumber),
+		Next:      nextAfterNode(session, nodeNumber),
+	}
+}
+
+func rejectedResponse(session *coop.Session, nodeNumber int, node *coop.SessionNode) coop.CommandResponse {
+	msg := fmt.Sprintf("Node %d rejected by developer.", nodeNumber)
+	if node.RejectionNote != "" {
+		msg += fmt.Sprintf("\nFeedback: %s", node.RejectionNote)
+	}
+	msg += "\nRedo the node."
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Node:      nodeNumber,
+		State:     "rejected",
+		Message:   msg,
+		Next:      fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --file=<path> --note=\"<what you fixed>\"", session.ID, nodeNumber),
+	}
+}
+
+func timeoutResponse(sessionID string, nodeNumber int) coop.CommandResponse {
+	return coop.CommandResponse{
+		OK:        true,
+		SessionID: sessionID,
+		Node:      nodeNumber,
+		State:     "timeout",
+		Message:   "Timed out waiting for developer confirmation. Re-run await-review to wait again.",
+		Next:      fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", sessionID, nodeNumber),
+	}
+}
+
+func errorResponse(err error, hint string) coop.CommandResponse {
+	return coop.CommandResponse{OK: false, Error: err.Error(), Hint: hint}
+}
+
+func language(session *coop.Session) string {
+	if session != nil && session.Settings != nil && session.Settings["language"] != "" {
+		return session.Settings["language"]
+	}
+	return "node"
+}
+
+func quoteArg(value string) string {
+	return fmt.Sprintf("%q", value)
+}
+
+func contains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/coop/workflow/service_test.go
+++ b/pkg/coop/workflow/service_test.go
@@ -1,0 +1,126 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestStartWorkTransitionsNodeAndReturnsTypedNextCommand(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store, WithSnippetFetcher(func(path, method string, params interface{}, language string) (string, error) {
+		return "", nil
+	}))
+
+	resp, err := service.StartWork(session.ID, 1, "Scanning")
+	require.NoError(t, err)
+	require.True(t, resp.OK)
+	assert.Equal(t, "active", resp.State)
+	assert.Contains(t, resp.Next, "stripe coop agent report-work")
+
+	loaded, err := store.Read(session.ID)
+	require.NoError(t, err)
+	node, err := loaded.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodeActive, node.State)
+	assert.Equal(t, "Scanning", node.Activity)
+}
+
+func TestReportWorkContinuesStepBeforeReview(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store)
+
+	_, err := service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	resp, err := service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go", Note: "Done"}, false)
+	require.NoError(t, err)
+	require.True(t, resp.OK)
+	assert.Equal(t, "review", resp.State)
+	assert.Contains(t, resp.Message, "Continue the step")
+	assert.Contains(t, resp.Next, "--step=2")
+}
+
+func TestReportWorkRoutesToAwaitReviewWhenStepReady(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store)
+
+	_, err := service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go"}, false)
+	require.NoError(t, err)
+	_, err = service.StartWork(session.ID, 2, "Second")
+	require.NoError(t, err)
+	resp, err := service.ReportWork(session.ID, 2, ReportWorkInput{File: "client.go"}, false)
+	require.NoError(t, err)
+	require.True(t, resp.OK)
+	assert.Contains(t, resp.Message, "Step ready for review")
+	assert.Contains(t, resp.Next, "stripe coop agent await-review")
+}
+
+func TestConfirmAndRequestChangesUseCentralWorkflow(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store)
+
+	_, err := service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go"}, false)
+	require.NoError(t, err)
+
+	updated, err := service.ConfirmReview(session.ID, []int{1})
+	require.NoError(t, err)
+	node, err := updated.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodeDone, node.State)
+}
+
+func TestRequestChangesMovesReviewNodeBackToActive(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store)
+
+	_, err := service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go"}, false)
+	require.NoError(t, err)
+	updated, err := service.RequestChanges(session.ID, []int{1}, "Needs tests")
+	require.NoError(t, err)
+	node, err := updated.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodeActive, node.State)
+	assert.Equal(t, "Needs tests", node.RejectionNote)
+	assert.Nil(t, node.Implementation)
+}
+
+func workflowTestStore(t *testing.T) (*coop.Store, *coop.Session) {
+	t.Helper()
+	store, err := coop.NewStoreAt(t.TempDir())
+	require.NoError(t, err)
+	session := &coop.Session{
+		SchemaVersion: coop.CurrentSessionSchemaVersion,
+		ID:            "workflow_test",
+		Blueprint:     "test",
+		Status:        coop.SessionActive,
+		Steps: []coop.SessionStep{
+			{
+				StepDefinition: coop.StepDefinition{
+					Key:   "step",
+					Title: "Step",
+				},
+				Nodes: []coop.SessionNode{
+					{
+						NodeDefinition: coop.NodeDefinition{Key: "one", Title: "One"},
+						State:          coop.NodePending,
+					},
+					{
+						NodeDefinition: coop.NodeDefinition{Key: "two", Title: "Two"},
+						State:          coop.NodePending,
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, store.Write(session))
+	return store, session
+}

--- a/pkg/coop/workflow/service_test.go
+++ b/pkg/coop/workflow/service_test.go
@@ -76,6 +76,20 @@ func TestConfirmAndRequestChangesUseCentralWorkflow(t *testing.T) {
 	assert.Equal(t, coop.NodeDone, node.State)
 }
 
+func TestConfirmReviewTreatsSkippedNodesAsTerminal(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store)
+
+	_, err := service.Skip(session.ID, 1, "Not needed")
+	require.NoError(t, err)
+
+	updated, err := service.ConfirmReview(session.ID, []int{1})
+	require.NoError(t, err)
+	node, err := updated.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodeSkipped, node.State)
+}
+
 func TestRequestChangesMovesReviewNodeBackToActive(t *testing.T) {
 	store, session := workflowTestStore(t)
 	service := NewService(store)


### PR DESCRIPTION
## What this adds
Adds the workflow service that applies agent lifecycle transitions, review/next-action helper logic, command responses, snippet lookup integration, and workflow tests.

## Review focus
Review this PR as one slice of the co-op stack. It should be understandable on its own against `tomer/coop-split-blueprint-catalog`.

## Stack
Base: `tomer/coop-split-blueprint-catalog`  
Head: `tomer/coop-split-workflow`

## Validation
Ran `go test ./pkg/coop/... -count=1` and `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./pkg/coop/...`.