### PR TITLE
12/12 Register co-op command and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,4 +195,14 @@ protoc-gen-plugin:
 	@echo "Successfully compiled proto files for plugins"
 .PHONY: protoc-plugin
 
+sync-blueprints:
+	@if [ -z "$$BLUEPRINT_SOURCE" ]; then \
+		echo "Set BLUEPRINT_SOURCE to a directory of exported blueprint JSON files."; \
+		echo "Example: BLUEPRINT_SOURCE=/path/to/raw-exports make sync-blueprints"; \
+		exit 1; \
+	fi
+	@echo "Exporting blueprints from $$BLUEPRINT_SOURCE..."
+	@cd scripts/export-blueprints && npm install && npm run export -- --source "$$BLUEPRINT_SOURCE" --out ../../pkg/coop/blueprints
+.PHONY: sync-blueprints
+
 .DEFAULT_GOAL := build

--- a/pkg/cmd/logs/tail_test.go
+++ b/pkg/cmd/logs/tail_test.go
@@ -31,7 +31,7 @@ func containsZeroValueStrings(x interface{}) bool {
 	v := reflect.ValueOf(x)
 
 	// If it's a pointer, dereference it
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/term"
 
+	coopcmd "github.com/stripe/stripe-cli/pkg/cmd/coop"
 	"github.com/stripe/stripe-cli/pkg/cmd/pluginhints"
 	"github.com/stripe/stripe-cli/pkg/cmd/resource"
 	"github.com/stripe/stripe-cli/pkg/cmd/resources"
@@ -140,11 +141,14 @@ func Execute(ctx context.Context) {
 
 	if err := rootCmd.ExecuteContext(updatedCtx); err != nil {
 		errString := err.Error()
+		var renderedCoopError coopcmd.RenderedError
 
 		isLoginRequiredError := errString == validators.ErrAPIKeyNotConfigured.Error() || errString == validators.ErrDeviceNameNotConfigured.Error()
 		projectNameFlag := rootCmd.Flag("project-name").Value.String()
 
 		switch {
+		case errors.As(err, &renderedCoopError):
+			// Co-op agent-facing commands already rendered structured JSON.
 		case errors.Is(err, errNotAuthenticated):
 			// whoami already printed output; just exit non-zero
 		case requests.IsAPIKeyExpiredError(err):
@@ -259,6 +263,15 @@ func init() {
 	rootCmd.AddCommand(newPostinstallCmd(&Config).cmd)
 	rootCmd.AddCommand(newCommunityCmd().cmd)
 	rootCmd.AddCommand(newSandboxCmd().cmd)
+	rootCmd.AddCommand(coopcmd.New(coopcmd.Options{
+		ConfigFolder: func() string {
+			return Config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+		},
+		SandboxClaimURL: func() string {
+			return viper.GetString(Config.Profile.GetConfigField("sandbox_claim_url"))
+		},
+		AIAgentHelpAnnotationKey: AIAgentHelpAnnotationKey,
+	}))
 	rootCmd.AddCommand(newPluginCmd().cmd)
 	resources.AddAllResourcesCmds(rootCmd, &Config)
 	registerHTTPCmds(rootCmd)

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -63,7 +63,7 @@ func TestHelpFlag(t *testing.T) {
 func TestExampleCommands(t *testing.T) {
 	{
 		_, err := executeCommand(rootCmd, "foo")
-		require.Equal(t, err.Error(), "unknown command \"foo\" for \"stripe\"")
+		require.Equal(t, "unknown command \"foo\" for \"stripe\"\n\nDid you mean this?\n\tcoop\n", err.Error())
 	}
 	{
 		_, err := executeCommand(rootCmd, "listen", "foo")

--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -1,0 +1,251 @@
+# Co-op Mode
+
+Co-op mode enables an AI agent and a human developer to build Stripe integrations together in real time. The agent writes code and reports progress; the developer watches in a terminal UI, reviews work, and confirms each step.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ tmux session                                                │
+│                                                             │
+│  ┌──────────────────────┐   ┌────────────────────────────┐ │
+│  │  TUI (coop join)     │   │  Agent (Claude/Codex)      │ │
+│  │                      │   │                            │ │
+│  │  Reads session.json  │   │  Writes session.json via   │ │
+│  │  every 500ms         │   │  stripe coop agent commands│ │
+│  │                      │   │                            │ │
+│  └──────────┬───────────┘   └──────────────┬─────────────┘ │
+│             │                              │               │
+│             └──────────┬───────────────────┘               │
+│                        ▼                                   │
+│              ~/.config/stripe/coop/                         │
+│              ├── coop_abc123.json        (session file)     │
+│              └── coop_abc123.json.heartbeat (agent alive)   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+No server, no HTTP, no WebSocket. Communication is through a shared JSON session file with atomic writes (write to .tmp, rename).
+
+## Step State Machine
+
+```
+pending ──→ active ──→ review ──→ done     (normal flow)
+   │          │          │
+   │          │          └──→ active        (request changes: developer entered feedback)
+   │          │
+   │          └──→ done                     (auto_confirm nodes skip review)
+   │          └──→ skipped                  (agent decides node doesn't apply)
+   │
+   └──→ skipped                             (agent skips from pending)
+```
+
+**Terminal states:** `done`, `skipped` — no transitions out.
+
+**Transitions are validated** — `session.TransitionNode()` returns an error for invalid transitions (e.g. pending→done, done→active).
+
+## Session States
+
+```
+active ──→ completed    (all nodes done/skipped, or "stripe coop stop")
+   │
+   └──→ aborted         ("stripe coop stop --abort")
+```
+
+## Commands
+
+### User-facing (human runs these)
+| Command | Purpose |
+|---------|---------|
+| `stripe coop start [blueprint]` | Launch tmux split with agent + TUI |
+| `stripe coop join [session-id]` | Open the TUI for an existing session |
+| `stripe coop status` | Show session summary |
+| `stripe coop stop` | End the session |
+| `stripe coop recommend` | List available blueprints |
+
+### Agent-facing (AI agent runs these)
+| Command | Purpose |
+|---------|---------|
+| `stripe coop run <blueprint>` | Create a session (outputs JSON with instructions) |
+| `stripe coop agent start-work --step <n>` | Mark node as active |
+| `stripe coop agent report-work --step <n>` | Mark node as complete (→ review or → done if auto_confirm) |
+| `stripe coop agent report-check --step <n>` | Add a verification check |
+| `stripe coop agent skip --step <n>` | Skip a node |
+| `stripe coop agent await-review --step <n>` | Block until developer confirms or requests changes |
+| `stripe coop agent next-action` | Show post-completion options (blocks until selection) |
+
+All agent commands output JSON with an `ok` field and a `next` field suggesting the next command.
+
+## TUI Keybindings
+
+| Key | Action |
+|-----|--------|
+| `↑`/`k` | Move cursor up |
+| `↓`/`j` | Move cursor down |
+| `e` / `Enter` | Toggle detail panel for selected step or node |
+| `c` | Confirm the selected review item |
+| `r` | Request changes for the selected review item |
+| `f` | Resume following the active/review node after manual navigation |
+| `o` | Open claim URL in browser (when sandbox is unclaimed) |
+| `q` / `Ctrl+C` | Quit TUI |
+
+When requesting changes, `r` opens a feedback prompt. Press `Enter` to submit a note and move the reviewed node or step back to `active`; press `Esc` to cancel.
+
+In the completion view:
+| Key | Action |
+|-----|--------|
+| `↑`/`↓` | Navigate suggestions |
+| `Enter` | Select a suggestion |
+| `q` | Quit |
+
+## Example Flow
+
+```bash
+# Developer starts a session (launches tmux with agent + TUI)
+$ stripe coop start one-time-payment --language=node
+
+# What happens behind the scenes:
+# 1. Agent (Claude/Codex) is launched in right pane
+# 2. TUI appears in left pane showing step progress
+# 3. Agent runs: stripe coop run one-time-payment --language=node
+# 4. Agent works through steps, calling:
+#      stripe coop agent start-work --session=coop_abc123 --step=1 --note="Scanning project"
+#      stripe coop agent report-work --session=coop_abc123 --step=1 --note="Found Next.js app"
+#      stripe coop agent start-work --session=coop_abc123 --step=2 --note="Creating product"
+#      stripe coop agent report-work --session=coop_abc123 --step=2 --file=server.js --lines=5-20 --note="Created product"
+#      stripe coop agent await-review --session=coop_abc123 --step=2   ← blocks until developer confirms
+# 5. Developer sees progress live, presses 'c' to confirm
+# 6. Agent continues to next step
+# 7. After all steps: agent runs "stripe coop agent next-action --session=coop_abc123"
+# 8. Developer picks what to do next from TUI suggestions
+```
+
+Post-completion choices are written into the session file for the agent. Deploy follow-ups use `stripe coop run deploy-stripe-projects --parent-session=<id> --parent-step=<selection>` so the child session can return to the completed parent and mark that next step done.
+
+## Auto-Confirm
+
+Nodes with `"auto_confirm": true` skip human review:
+- `agent report-work` transitions directly to `done` (not `review`)
+- `agent await-review` returns immediately if the step is auto-confirmed
+- The prepended "Understand the project" step is always auto-confirmed
+- Blueprint nodes can set `"auto_confirm": true` for mechanical steps
+
+## Heartbeat
+
+When the agent runs `stripe coop agent await-review`, it writes a `.heartbeat` file every 500ms. The TUI checks this file:
+- **Fresh heartbeat (< 5s old):** Agent is actively waiting for confirmation
+- **No heartbeat + no session update in 2min:** Show idle warning
+
+The heartbeat file is cleaned up when `await` exits.
+
+## Resuming
+
+`stripe coop join` is the recovery path. With no session ID, it opens the most
+recent active session, falling back to the latest session if none are active.
+Use `stripe coop join --resume` to pick from recent sessions.
+
+| Issue | What to do |
+|-------|------------|
+| Step is active | Rejoin the session and check the agent pane/TUI state |
+| Step is in review | Rejoin the session and confirm or request changes |
+| Agent appears idle | Rejoin the session; the TUI shows heartbeat/idle state |
+| Need a specific older session | Run `stripe coop join --resume` |
+
+## Blueprint Format
+
+Blueprints are embedded JSON in `pkg/coop/blueprints/`. Each has:
+- `id` — unique identifier (also the filename without .json)
+- `title`, `description` — human-readable
+- `prompt` — optional custom agent instructions (overrides generic preamble)
+- `steps` — ordered groups of nodes
+
+Each node has:
+- `type` — `apiRequest`, `asyncHandler`, `uiComponent`, `cliCommand`, `testHelper`
+- `auto_confirm` — skip human review for this node
+- `description` — what the agent should do (source of truth)
+- `review_prompt` — what the human should check before confirming
+- `request` — API request details (for `apiRequest` nodes with SDK snippet support)
+- `events` — webhook events (for `asyncHandler` nodes)
+
+Steps may set `review_granularity` to `step` to group multiple reviewable nodes into one human approval milestone.
+
+### Custom Agent Prompt
+
+The optional `prompt` field overrides the generic agent instructions. Use it when a blueprint isn't about writing application code:
+
+```json
+{
+  "id": "deploy-stripe-projects",
+  "prompt": "The developer wants to configure their project for deployment using the Stripe Projects CLI plugin. Use `stripe projects --help` to discover available options...",
+  "steps": [...]
+}
+```
+
+Without `prompt`, the agent gets: "You are building a working Stripe integration: <title>"
+
+### Adding a Blueprint
+
+1. Create `pkg/coop/blueprints/your-blueprint.json`
+2. Follow the schema above
+3. Test: `go run ./cmd/stripe coop run your-blueprint`
+4. Prefix matching works: short prefixes resolve to full IDs if unambiguous
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| TUI shows "Agent appears idle" | Agent crashed or stopped | Check the agent pane; restart with `stripe coop start` |
+| Agent stuck on "await" | Developer hasn't confirmed | Press `c` in TUI to confirm, or `r` to request changes |
+| "Version conflict" error | TUI and agent wrote simultaneously | Agent retries the command (safe to re-run) |
+| TUI shows wrong session | Multiple sessions exist | Use `stripe coop join <session-id>` with the correct ID |
+| Steps not updating in TUI | Agent created a duplicate session | Check `stripe coop status` for the correct session ID |
+| Agent ignores "next" hint | LLM didn't follow instructions | Copy the `next` value and run it manually, or restart |
+| Double footer / layout broken | Terminal resize not detected | Resize the terminal window (triggers recalculation) |
+| "Blueprint not found" | Typo in blueprint ID | Run `stripe coop recommend` to see available IDs |
+
+## Optimistic Locking
+
+`Store.Write()` checks the file's current version before writing. If another writer changed the file since you read it, the write fails with a version conflict error. This prevents the TUI and agent from clobbering each other's changes.
+
+## File Structure
+
+```
+pkg/coop/
+  types.go          — Session, Node, Step types and constants
+  session.go        — State machine, validation, queries
+  store.go          — Atomic file I/O, heartbeat, optimistic locking
+  blueprint.go      — Blueprint type, embed loader, prefix matching
+  snippet.go        — SDK snippet fetcher (docs.stripe.com)
+  blueprints/       — Embedded JSON blueprints
+
+pkg/coop/tui/
+  app.go            — tea.Program entry points
+  model.go          — Bubbletea model, Update, key handling
+  view.go           — All rendering (header, steps, detail, footer, completion)
+  commands.go       — Async commands (polling, snippets, session discovery)
+  helpers.go        — Word wrap, formatting, browser open
+  messages.go       — Custom message types
+  theme.go          — Sail Design System colors
+
+pkg/coop/workflow/
+  service.go        — Shared lifecycle operations for agent commands and TUI review actions
+
+pkg/coop/helpers/
+  nextaction.go     — Post-completion suggestions, environment detection, and next-action responses
+  prompt.go         — Shared Huh prompt helpers using Sail-styled prompts
+  review.go         — Shared step-review navigation rules
+
+pkg/cmd/coop/
+  coop.go           — Parent command, subcommand registration, command-package options
+  coop_start.go     — User-facing orchestrator (tmux launcher)
+  coop_launcher.go  — Agent detection and tmux/process management
+  coop_run.go       — Agent-facing session creator
+  coop_agent.go     — Typed agent lifecycle commands
+  coop_join.go      — TUI launcher
+  coop_status.go    — Session status display
+  coop_stop.go      — End session
+  coop_recommend.go — Blueprint discovery
+```
+
+## Local Harness Artifacts
+
+The repository-level `bin/` directory remains ignored. Tmux harness isolation files under `bin/` are treated as local development artifacts unless a specific script or fixture is moved into a tracked source path with tests. Do not commit the ignored `bin/` directory wholesale.

--- a/scripts/export-blueprints/README.md
+++ b/scripts/export-blueprints/README.md
@@ -1,0 +1,56 @@
+# Blueprint Exporter
+
+Converts Workbench Blueprint TypeScript definitions into CLI-friendly JSON for co-op mode.
+
+## Pipeline
+
+```
+pay-server/blueprintDefinitions/*.tsx
+    ↓  (this script)
+pkg/coop/blueprints/*.json  (checked into stripe-cli and embedded via //go:embed)
+```
+
+## Usage
+
+### From pre-exported JSON (recommended for CI)
+
+If someone has already exported the raw blueprint objects as JSON:
+
+```bash
+cd scripts/export-blueprints
+npm install
+npm run export -- --source ./raw-exports --out ../../pkg/coop/blueprints
+```
+
+### From pay-server source (requires module context)
+
+The TypeScript blueprints use `MessageDescriptor` objects and React components
+that require pay-server's module resolution. To export from source:
+
+1. Copy this script into the pay-server tree (or symlink)
+2. Add an entry point that imports `rawBlueprintsList` from the definitions index
+3. Call `transformBlueprint` on each entry and write to the output directory
+
+### After exporting
+
+Run the Make target from the repository root to update the embedded blueprints:
+
+```bash
+BLUEPRINT_SOURCE=/path/to/raw-exports make sync-blueprints
+```
+
+## What gets stripped
+
+- `MessageDescriptor` objects → resolved to `defaultMessage` string
+- React JSX components (`display`, `messageDescriptorFormatters`) → removed
+- Dashboard-only nodes (`settingsUpdate`, `contactStripe`, etc.) → removed
+- Environment conditions (`hiddenIfEnvMatchesOne`, etc.) → removed
+
+## What gets kept
+
+- Blueprint structure: id, title, description, type, chapters
+- Node types: apiRequest, asyncHandler, uiComponent, testHelper, dashboard
+- API request details: path, method, params (from first configuredDetails)
+- Interpolation strings: `${node.chapter.node:field}` preserved as-is
+- Event types for asyncHandler nodes
+- Product metadata

--- a/scripts/export-blueprints/export.ts
+++ b/scripts/export-blueprints/export.ts
@@ -1,0 +1,217 @@
+/**
+ * Blueprint Exporter for Stripe CLI Co-op Mode
+ *
+ * This script imports Blueprint definitions from pay-server's TypeScript source
+ * and exports them as CLI-friendly JSON files. It:
+ *
+ * 1. Resolves MessageDescriptor objects to their defaultMessage strings
+ * 2. Strips React/JSX components (display, messageDescriptorFormatters)
+ * 3. Retains the structural data: chapters, nodes, requests, events
+ * 4. Writes one JSON file per blueprint to the output directory
+ *
+ * Usage:
+ *   cd scripts/export-blueprints
+ *   npm install
+ *   npm run export -- --source <path-to-blueprintDefinitions> --out <output-dir>
+ *
+ * Example:
+ *   npm run export -- \
+ *     --source ../../pay-server/frontend/workbench/shared/blueprints/src/blueprintDefinitions \
+ *     --out ../../api/blueprints
+ */
+
+import { writeFileSync, mkdirSync, existsSync, readdirSync, readFileSync } from 'fs';
+import { join, resolve, basename } from 'path';
+import { parseArgs } from 'util';
+
+const { values } = parseArgs({
+  options: {
+    source: { type: 'string' },
+    out: { type: 'string', default: '../../api/blueprints' },
+  },
+});
+
+if (!values.source) {
+  console.error('Usage: npm run export -- --source <path-to-blueprintDefinitions> --out <output-dir>');
+  console.error('');
+  console.error('The --source should point to the blueprintDefinitions directory in pay-server:');
+  console.error('  e.g. ../../../mint/pay-server/frontend/workbench/shared/blueprints/src/blueprintDefinitions');
+  process.exit(1);
+}
+
+const sourceDir = resolve(values.source);
+const outDir = resolve(values.out!);
+
+if (!existsSync(sourceDir)) {
+  console.error(`Source directory not found: ${sourceDir}`);
+  process.exit(1);
+}
+
+mkdirSync(outDir, { recursive: true });
+
+/**
+ * Resolve a MessageDescriptor-like object to its plain string.
+ * MessageDescriptors have shape: { id: string, defaultMessage: string, description?: string }
+ */
+function resolveMessage(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value && typeof value === 'object' && 'defaultMessage' in value) {
+    return (value as { defaultMessage: string }).defaultMessage;
+  }
+  return '';
+}
+
+/**
+ * Transform a node from the TypeScript definition to CLI-friendly JSON.
+ */
+function transformNode(node: Record<string, unknown>): Record<string, unknown> | null {
+  const type = node.type as string;
+
+  // Skip node types we can't handle in CLI
+  if (['settingsUpdate', 'contactStripe', 'enableCustomFeature', 'installApp'].includes(type)) {
+    return null;
+  }
+
+  const result: Record<string, unknown> = {
+    type,
+    key: node.key,
+    title: resolveMessage(node.title),
+  };
+
+  if (node.description) {
+    result.description = resolveMessage(node.description);
+  }
+
+  // API Request nodes
+  if (type === 'apiRequest' && node.request) {
+    const req = node.request as Record<string, unknown>;
+    const transformed: Record<string, unknown> = {
+      key: req.key,
+      path: req.path,
+      method: req.method,
+    };
+
+    // Get params from configuredDetails or direct params
+    if (req.configuredDetails && Array.isArray(req.configuredDetails) && req.configuredDetails.length > 0) {
+      const first = req.configuredDetails[0] as Record<string, unknown>;
+      if (first.params) {
+        transformed.params = first.params;
+      }
+    } else if (req.params) {
+      transformed.params = req.params;
+    }
+
+    result.request = transformed;
+  }
+
+  // Async handler nodes
+  if (type === 'asyncHandler' && node.events) {
+    const events = (node.events as Array<Record<string, unknown>>)
+      .map(e => e.eventType as string)
+      .filter(Boolean);
+    result.events = events;
+  }
+
+  return result;
+}
+
+/**
+ * Transform a chapter from the TypeScript definition.
+ */
+function transformChapter(chapter: Record<string, unknown>): Record<string, unknown> | null {
+  const nodes = (chapter.nodes as Array<Record<string, unknown>> || [])
+    .map(transformNode)
+    .filter((n): n is Record<string, unknown> => n !== null);
+
+  if (nodes.length === 0) return null;
+
+  const result: Record<string, unknown> = {
+    key: chapter.key,
+    title: resolveMessage(chapter.title),
+    nodes,
+  };
+
+  if (chapter.description) {
+    result.description = resolveMessage(chapter.description);
+  }
+  if (chapter.required) {
+    result.required = true;
+  }
+
+  return result;
+}
+
+/**
+ * Transform a full blueprint definition.
+ */
+function transformBlueprint(id: string, blueprint: Record<string, unknown>): Record<string, unknown> | null {
+  const chapters = (blueprint.chapters as Array<Record<string, unknown>> || [])
+    .map(transformChapter)
+    .filter((c): c is Record<string, unknown> => c !== null);
+
+  if (chapters.length === 0) return null;
+
+  const result: Record<string, unknown> = {
+    id,
+    title: resolveMessage(blueprint.title),
+    type: blueprint.blueprintType || 'learning',
+    chapters,
+  };
+
+  if (blueprint.listViewDescription) {
+    result.description = resolveMessage(blueprint.listViewDescription);
+  }
+
+  if (blueprint.metadata && typeof blueprint.metadata === 'object') {
+    const meta = blueprint.metadata as Record<string, unknown>;
+    if (meta.products) {
+      result.products = meta.products;
+    }
+  }
+
+  return result;
+}
+
+// Main execution
+console.log(`Exporting blueprints from: ${sourceDir}`);
+console.log(`Output directory: ${outDir}`);
+console.log('');
+
+// This script is designed to be run with the actual TypeScript source
+// For now, it provides the framework - actual import requires the pay-server
+// module resolution context.
+console.log('NOTE: This script requires running within the pay-server module context');
+console.log('to resolve TypeScript imports. For standalone use, place pre-exported');
+console.log('blueprint objects in a JSON format and use this as a transformer.');
+console.log('');
+console.log('To use with pay-server:');
+console.log('  1. Add this script to pay-server devDependencies context');
+console.log('  2. Import rawBlueprintsList from the definitions index');
+console.log('  3. Run transformBlueprint on each entry');
+console.log('');
+
+// For manual/CI usage: check if source has pre-exported JSON files
+const jsonFiles = readdirSync(sourceDir).filter(f => f.endsWith('.json'));
+if (jsonFiles.length > 0) {
+  console.log(`Found ${jsonFiles.length} JSON files in source, transforming...`);
+  for (const file of jsonFiles) {
+    try {
+      const raw = JSON.parse(readFileSync(join(sourceDir, file), 'utf-8'));
+      const id = basename(file, '.json');
+      const transformed = transformBlueprint(id, raw);
+      if (transformed) {
+        const outPath = join(outDir, `${id}.json`);
+        writeFileSync(outPath, JSON.stringify(transformed, null, 2) + '\n');
+        console.log(`  ✓ ${id}`);
+      }
+    } catch (err) {
+      console.error(`  ✗ ${file}: ${(err as Error).message}`);
+    }
+  }
+} else {
+  console.log('No JSON source files found. To export from TypeScript:');
+  console.log('  Create a wrapper that imports rawBlueprintsList and calls transformBlueprint.');
+}
+
+console.log('');
+console.log('Done.');

--- a/scripts/export-blueprints/package.json
+++ b/scripts/export-blueprints/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "stripe-cli-export-blueprints",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Exports Blueprint definitions from pay-server into CLI-friendly JSON",
+  "type": "module",
+  "scripts": {
+    "export": "tsx export.ts"
+  },
+  "dependencies": {
+    "glob": "^11.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}


### PR DESCRIPTION
## What this adds
Registers the co-op command in the root CLI, adds docs and blueprint export tooling, and updates affected command tests for the final integrated CLI surface.

## Review focus
Review this PR as one slice of the co-op stack. It should be understandable on its own against `tomer/coop-split-deploy`.

## Stack
Base: `tomer/coop-split-deploy`  
Head: `tomer/coop-split-root-docs`

## Validation
Ran `go test ./pkg/cmd ./pkg/cmd/coop ./pkg/coop/... -count=1` and `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./pkg/coop/... ./pkg/cmd/coop/...`.