### PR TITLE
Remove legacy plugins.toml manifest in favor of local plugin metadata

### DIFF
--- a/pkg/cmd/plugin/install_test.go
+++ b/pkg/cmd/plugin/install_test.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
@@ -42,33 +40,22 @@ func TestRunInstallCmdNonExistentPluginNotLoggedIn(t *testing.T) {
 	cfg.Profile.APIKey = ""
 	cfg.Profile.AccountID = ""
 
-	manifest := testPluginManifest()
-
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
 		case "/ajax/stripecli/plugins_metadata":
 			res.WriteHeader(http.StatusNotFound)
-			res.Write([]byte(`{"error":{"message":"not found"}}`))
-		case "/plugins.toml":
-			res.Write(manifest)
+			_, _ = res.Write([]byte(`{"error":{"message":"not found"}}`))
 		default:
 			res.WriteHeader(http.StatusNotFound)
 		}
 	}))
 	defer server.Close()
 
-	originalPluginData := requests.DefaultPluginData
-	requests.DefaultPluginData = requests.PluginData{
-		PluginBaseURL:       server.URL,
-		AdditionalManifests: nil,
-	}
-	defer func() { requests.DefaultPluginData = originalPluginData }()
-
 	// Redirect stdin to simulate user typing "cancel" to skip login prompt
 	origStdin := os.Stdin
 	r, w, _ := os.Pipe()
-	w.WriteString("cancel\n")
-	w.Close()
+	_, _ = w.WriteString("cancel\n")
+	_ = w.Close()
 	os.Stdin = r
 	defer func() { os.Stdin = origStdin }()
 
@@ -87,28 +74,16 @@ func TestRunInstallCmdNonExistentPluginLoggedIn(t *testing.T) {
 	defer cleanup()
 	cfg.Profile.AccountID = "acct_123"
 
-	manifest := testPluginManifest()
-
-	var serverURL string
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
 		case "/v1/stripecli/get-plugin-metadata":
 			res.WriteHeader(http.StatusNotFound)
-			res.Write([]byte(`{"error":{"message":"not found"}}`))
-		case "/v1/stripecli/get-plugin-url":
-			body, _ := json.Marshal(requests.PluginData{
-				PluginBaseURL:       serverURL,
-				AdditionalManifests: nil,
-			})
-			res.Write(body)
-		case "/plugins.toml":
-			res.Write(manifest)
+			_, _ = res.Write([]byte(`{"error":{"message":"not found"}}`))
 		default:
 			res.WriteHeader(http.StatusNotFound)
 		}
 	}))
 	defer server.Close()
-	serverURL = server.URL
 
 	ic := NewInstallCmd(cfg)
 	ic.fs = fs

--- a/pkg/cmd/plugin/uninstall.go
+++ b/pkg/cmd/plugin/uninstall.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -46,13 +45,9 @@ func (uc *UninstallCmd) runUninstallCmd(cmd *cobra.Command, args []string) error
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
-	plugin, err := plugins.LookUpPlugin(cmd.Context(), uc.cfg, uc.fs, args[0])
+	plugin := plugins.Plugin{Shortname: args[0]}
 
-	if err != nil {
-		return errors.New("this plugin doesn't seem to exist")
-	}
-
-	err = plugin.Uninstall(ctx, uc.cfg, uc.fs)
+	err := plugin.Uninstall(ctx, uc.cfg, uc.fs)
 
 	if err == nil {
 		color := ansi.Color(os.Stdout)

--- a/pkg/cmd/plugin/uninstall.go
+++ b/pkg/cmd/plugin/uninstall.go
@@ -45,6 +45,10 @@ func (uc *UninstallCmd) runUninstallCmd(cmd *cobra.Command, args []string) error
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
+	if err := plugins.ValidatePluginShortname(args[0]); err != nil {
+		return err
+	}
+
 	plugin := plugins.Plugin{Shortname: args[0]}
 
 	err := plugin.Uninstall(ctx, uc.cfg, uc.fs)

--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/plugins"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
@@ -124,7 +125,8 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 	err = plugin.Run(ctx, ptc.cfg, fs, ptc.ParsedArgs, "")
 	plugins.CleanupAllClients()
 	if err == nil {
-		plugins.CheckLatestPluginVersion(ptc.cfg, fs, plugin)
+		dashboardBaseURL := stripe.DashboardBaseURLForAPIBaseURL(stripe.DefaultAPIBaseURL)
+		plugins.CheckLatestPluginVersion(ctx, ptc.cfg, fs, plugin, stripe.DefaultAPIBaseURL, dashboardBaseURL)
 	}
 
 	if err != nil {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -288,6 +288,13 @@ func init() {
 }
 
 func registerInstalledPlugins(root *cobra.Command, cfg *config.Config, fs afero.Fs) map[string]bool {
+	dashboardBaseURL := stripe.DashboardBaseURLForAPIBaseURL(stripe.DefaultAPIBaseURL)
+	if err := plugins.BackfillMissingInstalledPluginMetadata(context.Background(), cfg, fs, stripe.DefaultAPIBaseURL, dashboardBaseURL); err != nil {
+		log.WithFields(log.Fields{
+			"prefix": "cmd.registerInstalledPlugins",
+		}).Debugf("could not backfill installed plugin metadata: %s", err)
+	}
+
 	pluginNames, err := plugins.GetInstalledPluginNames(cfg, fs)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/pkg/plugins/RUNTIME.md
+++ b/pkg/plugins/RUNTIME.md
@@ -4,11 +4,11 @@ This document describes the Node.js runtime installation feature for Stripe CLI 
 
 ## Overview
 
-Plugins can declare runtime dependencies in their `plugins.toml` manifest. When a plugin requires a specific Node.js version, the Stripe CLI will automatically download and install the required runtime during plugin installation.
+Plugins can declare runtime dependencies in their plugin metadata manifest. When a plugin requires a specific Node.js version, the Stripe CLI will automatically download and install the required runtime during plugin installation.
 
 ## Manifest Configuration
 
-In `plugins.toml`, specify the required Node.js version using the `Runtime` field:
+In the plugin manifest, specify the required Node.js version using the `Runtime` field:
 
 ```toml
 [[Plugin.Release]]

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -93,13 +93,17 @@ func (p *Plugin) getPluginInterface() (hcplugin.HandshakeConfig, map[int]hcplugi
 	return handshakeConfig, pluginSetMap
 }
 
-// getPluginInstallPath computes the absolute path of a specific plugin version's installation dir
-func (p *Plugin) getPluginInstallPath(config config.IConfig, version string) string {
+// getPluginInstallPath computes the absolute path of a specific plugin version's installation dir.
+func (p *Plugin) getPluginInstallPath(config config.IConfig, version string) (string, error) {
+	if err := ValidatePluginShortname(p.Shortname); err != nil {
+		return "", err
+	}
+
 	pluginsDir := getPluginsDir(config)
 	pluginPath := filepath.Join(pluginsDir, p.Shortname, version)
 	cleanedPath := filepath.Clean(pluginPath)
 
-	return cleanedPath
+	return cleanedPath, nil
 }
 
 func isLocalDevelopmentVersion(version string) bool {
@@ -107,7 +111,10 @@ func isLocalDevelopmentVersion(version string) bool {
 }
 
 func (p *Plugin) lookUpInstalledVersion(config config.IConfig, fs afero.Fs) (string, error) {
-	localDevPath := p.getPluginInstallPath(config, localDevelopmentVersion)
+	localDevPath, err := p.getPluginInstallPath(config, localDevelopmentVersion)
+	if err != nil {
+		return "", err
+	}
 	localDevExists, err := afero.DirExists(fs, localDevPath)
 	if err != nil {
 		return "", err
@@ -135,9 +142,14 @@ func (p *Plugin) cleanUpPluginPath(config config.IConfig, fs afero.Fs, versionTo
 	})
 	logger.Debug("Cleaning up other plugin versions...")
 
-	pluginsDir := getPluginsDir(config)
-	pluginPath := filepath.Join(pluginsDir, p.Shortname)
-	versionPathToKeep := filepath.Join(pluginPath, versionToKeep)
+	pluginPath, err := p.getPluginInstallPath(config, "")
+	if err != nil {
+		return err
+	}
+	versionPathToKeep, err := p.getPluginInstallPath(config, versionToKeep)
+	if err != nil {
+		return err
+	}
 
 	afero.Walk(fs, pluginPath, filepath.WalkFunc(func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -267,16 +279,21 @@ func (p *Plugin) pluginFromMetadata(pluginManifest string) (*Plugin, error) {
 
 // IsVersionInstalled returns true if the given version of the plugin is already installed on disk.
 func (p *Plugin) IsVersionInstalled(config config.IConfig, fs afero.Fs, version string) bool {
-	pluginDir := p.getPluginInstallPath(config, version)
+	pluginDir, err := p.getPluginInstallPath(config, version)
+	if err != nil {
+		return false
+	}
 	pluginBinaryPath := filepath.Join(pluginDir, p.Binary) + GetBinaryExtension()
-	_, err := fs.Stat(pluginBinaryPath)
+	_, err = fs.Stat(pluginBinaryPath)
 	return err == nil
 }
 
 // InstalledVersion returns the currently installed version of the plugin, or empty string if none.
 func (p *Plugin) InstalledVersion(config config.IConfig, fs afero.Fs) string {
-	pluginsDir := getPluginsDir(config)
-	pluginDir := filepath.Join(pluginsDir, p.Shortname)
+	pluginDir, err := p.getPluginInstallPath(config, "")
+	if err != nil {
+		return ""
+	}
 
 	entries, err := afero.ReadDir(fs, pluginDir)
 	if err != nil {
@@ -393,8 +410,12 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	}
 
 	if err := PersistInstalledPluginState(cfg, fs, *pluginToInstall); err != nil {
-		pluginPath := pluginToInstall.getPluginInstallPath(cfg, version)
-		if cleanupErr := fs.RemoveAll(pluginPath); cleanupErr != nil {
+		pluginPath, pathErr := pluginToInstall.getPluginInstallPath(cfg, version)
+		if pathErr != nil {
+			log.WithFields(log.Fields{
+				"prefix": "plugins.plugin.Install",
+			}).Debugf("could not determine plugin path for cleanup after local metadata write failure: %s", pathErr)
+		} else if cleanupErr := fs.RemoveAll(pluginPath); cleanupErr != nil {
 			log.WithFields(log.Fields{
 				"prefix": "plugins.plugin.Install",
 				"path":   pluginPath,
@@ -433,12 +454,18 @@ func (p *Plugin) Uninstall(ctx context.Context, config config.IConfig, fs afero.
 		}
 	}
 
-	pluginDir := p.getPluginInstallPath(config, "")
+	pluginDir, err := p.getPluginInstallPath(config, "")
+	if err != nil {
+		return err
+	}
 	dirExists, err := afero.DirExists(fs, pluginDir)
 	if err != nil {
 		return err
 	}
-	metadataPath := getLocalPluginMetadataPath(config, p.Shortname)
+	metadataPath, err := getLocalPluginMetadataPath(config, p.Shortname)
+	if err != nil {
+		return err
+	}
 	metadataExists, err := afero.Exists(fs, metadataPath)
 	if err != nil {
 		return err
@@ -493,7 +520,10 @@ func (p *Plugin) verifychecksumAndSavePlugin(pluginData []byte, config config.IC
 		"prefix": "plugins.plugin.Install",
 	})
 
-	pluginDir := p.getPluginInstallPath(config, version)
+	pluginDir, err := p.getPluginInstallPath(config, version)
+	if err != nil {
+		return err
+	}
 	pluginFilePath := filepath.Join(pluginDir, p.Binary)
 	pluginFilePath += GetBinaryExtension()
 
@@ -501,7 +531,7 @@ func (p *Plugin) verifychecksumAndSavePlugin(pluginData []byte, config config.IC
 
 	reader := bytes.NewReader(pluginData)
 
-	err := p.verifyChecksum(reader, version)
+	err = p.verifyChecksum(reader, version)
 	if err != nil {
 		logger.Debug("could not match checksum of plugin")
 		return err
@@ -616,7 +646,10 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 		}
 	}
 
-	pluginDir := p.getPluginInstallPath(config, version)
+	pluginDir, err := p.getPluginInstallPath(config, version)
+	if err != nil {
+		return err
+	}
 	pluginBinaryPath := filepath.Join(pluginDir, p.Binary)
 	pluginBinaryPath += GetBinaryExtension()
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -82,7 +82,9 @@ func TestInstallRollsBackPersistedStateWhenConfigWriteFails(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, fileExists)
 
-	metadataExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "appA"))
+	metadataPath, err := getLocalPluginMetadataPath(config, "appA")
+	require.NoError(t, err)
+	metadataExists, err := afero.Exists(fs, metadataPath)
 	require.NoError(t, err)
 	require.True(t, metadataExists)
 	require.Empty(t, config.GetInstalledPlugins())
@@ -935,7 +937,8 @@ func TestUninstall(t *testing.T) {
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL, testServers.StripeServer.URL)
 	require.Nil(t, err)
-	metadataPath := getLocalPluginMetadataPath(config, "appA")
+	metadataPath, err := getLocalPluginMetadataPath(config, "appA")
+	require.NoError(t, err)
 	cacheExists, err := afero.Exists(fs, metadataPath)
 	require.NoError(t, err)
 	require.True(t, cacheExists)
@@ -976,7 +979,9 @@ func TestUninstallSucceedsWithLocalMetadataOnly(t *testing.T) {
 	err := plugin.Uninstall(context.Background(), config, fs)
 	require.NoError(t, err)
 
-	cacheExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "docs"))
+	metadataPath, err := getLocalPluginMetadataPath(config, "docs")
+	require.NoError(t, err)
+	cacheExists, err := afero.Exists(fs, metadataPath)
 	require.NoError(t, err)
 	require.False(t, cacheExists)
 
@@ -985,6 +990,30 @@ func TestUninstallSucceedsWithLocalMetadataOnly(t *testing.T) {
 	require.False(t, dirExists)
 
 	require.Equal(t, 0, len(config.GetInstalledPlugins()))
+}
+
+func TestUninstallRejectsInvalidPluginShortnames(t *testing.T) {
+	tests := []string{"../victim", "..\\victim"}
+
+	for _, shortname := range tests {
+		t.Run(shortname, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			config := &TestConfig{}
+			config.InitConfig()
+			config.InstalledPlugins = []string{shortname}
+
+			require.NoError(t, fs.MkdirAll("/victim", 0755))
+			require.NoError(t, afero.WriteFile(fs, "/victim/data.txt", []byte("keep me"), 0644))
+
+			err := (&Plugin{Shortname: shortname}).Uninstall(context.Background(), config, fs)
+			require.ErrorContains(t, err, "invalid plugin name")
+
+			victimExists, statErr := afero.Exists(fs, "/victim/data.txt")
+			require.NoError(t, statErr)
+			require.True(t, victimExists)
+			require.Equal(t, []string{shortname}, config.GetInstalledPlugins())
+		})
+	}
 }
 
 func TestUninstallReturnsErrorWithoutRemovingFilesWhenMetadataRemovalFails(t *testing.T) {
@@ -1014,7 +1043,9 @@ func TestUninstallReturnsErrorWithoutRemovingFilesWhenMetadataRemovalFails(t *te
 	err := plugin.Uninstall(context.Background(), config, afero.NewReadOnlyFs(fs))
 	require.Error(t, err)
 
-	cacheExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "docs"))
+	metadataPath, err := getLocalPluginMetadataPath(config, "docs")
+	require.NoError(t, err)
+	cacheExists, err := afero.Exists(fs, metadataPath)
 	require.NoError(t, err)
 	require.True(t, cacheExists)
 
@@ -1054,7 +1085,9 @@ func TestUninstallRollsBackStateWhenConfigWriteFails(t *testing.T) {
 	err := plugin.Uninstall(context.Background(), config, fs)
 	require.ErrorIs(t, err, config.WriteErr)
 
-	cacheExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "docs"))
+	metadataPath, err := getLocalPluginMetadataPath(config, "docs")
+	require.NoError(t, err)
+	cacheExists, err := afero.Exists(fs, metadataPath)
 	require.NoError(t, err)
 	require.True(t, cacheExists)
 
@@ -1098,7 +1131,9 @@ func TestUninstallRollsBackStateWhenPluginRemovalFails(t *testing.T) {
 	err := plugin.Uninstall(context.Background(), config, failingFS)
 	require.ErrorIs(t, err, removeErr)
 
-	cacheExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "docs"))
+	metadataPath, err := getLocalPluginMetadataPath(config, "docs")
+	require.NoError(t, err)
+	cacheExists, err := afero.Exists(fs, metadataPath)
 	require.NoError(t, err)
 	require.True(t, cacheExists)
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -84,7 +84,7 @@ func TestInstallRollsBackPersistedStateWhenConfigWriteFails(t *testing.T) {
 
 	metadataExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "appA"))
 	require.NoError(t, err)
-	require.False(t, metadataExists)
+	require.True(t, metadataExists)
 	require.Empty(t, config.GetInstalledPlugins())
 }
 
@@ -446,28 +446,18 @@ func TestResolvePluginForInstallResolvesLatestVersionFromMetadata(t *testing.T) 
 	require.Equal(t, 1, metadataLookups)
 }
 
-func TestResolvePluginForInstallFallsBackToManifestLookupWhenMetadataFails(t *testing.T) {
-	fs := afero.NewMemMapFs()
+func TestResolvePluginForInstallFallsBackToCachedLocalMetadataWhenMetadataFails(t *testing.T) {
+	fs := setUpFS()
 	config := &TestConfig{}
 	config.InitConfig()
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-	testServers := setUpServers(t, manifestContent, nil)
-	defer testServers.CloseAll()
 
-	var pluginURLLookups int
 	fallbackServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
 		case "/v1/stripecli/get-plugin-metadata":
 			res.WriteHeader(http.StatusInternalServerError)
-			res.Write([]byte(`{"error":{"message":"boom"}}`))
+			_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
 		case "/v1/stripecli/get-plugin-url":
-			pluginURLLookups++
-			body, err := json.Marshal(requests.PluginData{
-				PluginBaseURL:       testServers.ArtifactoryServer.URL,
-				AdditionalManifests: nil,
-			})
-			require.NoError(t, err)
-			res.Write(body)
+			t.Fatalf("install resolution should not fall back to /v1/stripecli/get-plugin-url when cached metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -482,10 +472,6 @@ func TestResolvePluginForInstallFallsBackToManifestLookupWhenMetadataFails(t *te
 	require.Equal(t, "appA", plugin.Shortname)
 	require.Equal(t, "2.0.1", version)
 	require.Empty(t, resolvedPlugin.BinaryURL)
-	require.Equal(t, 1, pluginURLLookups)
-
-	_, err = fs.Stat("/plugins.toml")
-	require.NoError(t, err)
 }
 
 func TestResolvedPluginInstallUsesResolvedMetadataWithoutSecondLookup(t *testing.T) {
@@ -532,25 +518,13 @@ func TestResolvedPluginInstallUsesResolvedMetadataWithoutSecondLookup(t *testing
 	require.Equal(t, 1, metadataLookups)
 }
 
-func TestResolvedPluginInstallRetriesMetadataAfterManifestFallback(t *testing.T) {
+func TestResolvedPluginInstallRetriesMetadataAfterCachedLocalFallback(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
 	config.InitConfig()
 
 	binaryBody := []byte("hello, I am generate_1.0.0")
 	binarySum := fmt.Sprintf("%x", sha256.Sum256(binaryBody))
-	manifestContent := []byte(fmt.Sprintf(`[[Plugin]]
-  Shortname = "generate"
-  Shortdesc = "Generate things"
-  Binary = "stripe-cli-generate"
-  MagicCookieValue = "GENERATE-COOKIE"
-
-  [[Plugin.Release]]
-    Arch = "%s"
-    OS = "%s"
-    Version = "1.0.0"
-    Sum = "%s"
-`, runtime.GOARCH, runtime.GOOS, binarySum))
 
 	metadataManifest := fmt.Sprintf(`[[Plugin]]
   Shortname = "generate"
@@ -572,13 +546,25 @@ func TestResolvedPluginInstallRetriesMetadataAfterManifestFallback(t *testing.T)
 	nodeBinaryPath := GetNodeBinaryPath(config, "20")
 	require.NoError(t, fs.MkdirAll(filepath.Dir(nodeBinaryPath), 0755))
 	require.NoError(t, afero.WriteFile(fs, nodeBinaryPath, []byte("node"), 0755))
+	require.NoError(t, writeLocalPluginMetadata(config, fs, Plugin{
+		Shortname:        "generate",
+		Shortdesc:        "Generate things",
+		Binary:           "stripe-cli-generate",
+		MagicCookieValue: "GENERATE-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     binarySum,
+			},
+		},
+	}))
 
 	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/plugins.toml":
-			res.Write(manifestContent)
 		case fmt.Sprintf("/generate/1.0.0/%s/%s/stripe-cli-generate", runtime.GOOS, runtime.GOARCH):
-			res.Write(binaryBody)
+			_, _ = res.Write(binaryBody)
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -600,7 +586,7 @@ func TestResolvedPluginInstallRetriesMetadataAfterManifestFallback(t *testing.T)
 				PluginManifest: metadataManifest,
 			})
 			require.NoError(t, err)
-			res.Write(body)
+			_, _ = res.Write(body)
 		case "/v1/stripecli/get-plugin-url":
 			pluginURLLookups++
 			body, err := json.Marshal(requests.PluginData{
@@ -608,7 +594,7 @@ func TestResolvedPluginInstallRetriesMetadataAfterManifestFallback(t *testing.T)
 				AdditionalManifests: nil,
 			})
 			require.NoError(t, err)
-			res.Write(body)
+			_, _ = res.Write(body)
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -618,12 +604,12 @@ func TestResolvedPluginInstallRetriesMetadataAfterManifestFallback(t *testing.T)
 	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	require.Equal(t, 1, metadataLookups)
-	require.Equal(t, 1, pluginURLLookups)
+	require.Equal(t, 0, pluginURLLookups)
 
 	err = resolvedPlugin.Install(context.Background(), config, fs, stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	require.Equal(t, 2, metadataLookups)
-	require.Equal(t, 1, pluginURLLookups)
+	require.Equal(t, 0, pluginURLLookups)
 
 	cachedPlugin, err := readLocalPluginMetadata(config, fs, "generate")
 	require.NoError(t, err)
@@ -665,7 +651,7 @@ func TestResolvePluginForAutoInstallPrefersFreshMetadataWhenLocalMetadataIsStale
 	require.Equal(t, "2.0.1", plugin.LookUpLatestVersion())
 }
 
-func TestResolvePluginForAutoInstallFallsBackToCachedManifestWhenFreshLookupFails(t *testing.T) {
+func TestResolvePluginForAutoInstallFallsBackToCachedLocalMetadataWhenFreshLookupFails(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
 	config.InitConfig()
@@ -685,9 +671,6 @@ func TestResolvePluginForAutoInstallFallsBackToCachedManifestWhenFreshLookupFail
 	}
 	require.NoError(t, writeLocalPluginMetadata(config, fs, stalePlugin))
 
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-	require.NoError(t, afero.WriteFile(fs, "/plugins.toml", manifestContent, os.ModePerm))
-
 	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusInternalServerError)
 		_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
@@ -699,8 +682,8 @@ func TestResolvePluginForAutoInstallFallsBackToCachedManifestWhenFreshLookupFail
 	plugin := resolvedPlugin.Plugin
 	version := resolvedPlugin.Version
 	require.NotNil(t, plugin)
-	require.Equal(t, "2.0.1", version)
-	require.Equal(t, "2.0.1", plugin.LookUpLatestVersion())
+	require.Equal(t, "1.0.1", version)
+	require.Equal(t, "1.0.1", plugin.LookUpLatestVersion())
 }
 
 func TestVerifyChecksumSkipsLocalDevelopmentVersion(t *testing.T) {

--- a/pkg/plugins/test_utils.go
+++ b/pkg/plugins/test_utils.go
@@ -63,12 +63,23 @@ func (c *TestConfig) InitConfig() {
 
 // setUpFS Sets up a memMap that contains the manifest
 func setUpFS() afero.Fs {
-	// test plugin manifest
-	// Note that only some of entries have actual checksums that match with what the test server returns.
+	// Populate local plugin metadata from the test manifest.
+	// Note that only some entries have actual checksums that match what the test server returns.
 	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
 	fs := afero.NewMemMapFs()
-	// fs.Mkdir("test_config_folder", os.ModePerm)
-	afero.WriteFile(fs, "/plugins.toml", manifestContent, os.ModePerm)
+
+	pluginList, err := validatePluginManifest(manifestContent)
+	if err != nil {
+		panic(err)
+	}
+
+	config := &TestConfig{}
+	for _, plugin := range pluginList.Plugins {
+		if err := writeLocalPluginMetadata(config, fs, plugin); err != nil {
+			panic(err)
+		}
+	}
+
 	return fs
 }
 

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -355,8 +355,9 @@ func ListPlugins(ctx context.Context, config config.IConfig, apiBaseURL, dashboa
 
 // BackfillMissingInstalledPluginMetadata refreshes local metadata for plugins
 // that were installed before `plugin-metadata/*.toml` became the source of truth.
-// It first migrates from the legacy cached `plugins.toml` on disk, then falls
-// back to the live metadata endpoint for plugins not present in that cache.
+// It first migrates from the legacy cached `plugins.toml` on disk when that
+// cache still describes the installed version, then falls back to the live
+// metadata endpoint for plugins not present in that cache.
 // Failures are best-effort: a failed backfill should not prevent existing
 // plugin commands from being registered via the same cached-manifest fallback.
 func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string) error {
@@ -397,25 +398,6 @@ func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.I
 			continue
 		}
 
-		manifestPlugin, manifestErr := lookUpPluginInCachedManifest(config, fs, pluginName)
-		if manifestErr == nil {
-			if err := PersistInstalledPluginState(config, fs, manifestPlugin); err != nil {
-				log.WithFields(log.Fields{
-					"prefix": "plugins.BackfillMissingInstalledPluginMetadata",
-					"plugin": pluginName,
-				}).Debugf("could not persist backfilled plugin metadata from cached manifest: %s", err)
-			}
-			continue
-		}
-
-		var pluginNotFound *ErrPluginNotFound
-		if !os.IsNotExist(manifestErr) && !errors.As(manifestErr, &pluginNotFound) {
-			log.WithFields(log.Fields{
-				"prefix": "plugins.BackfillMissingInstalledPluginMetadata",
-				"plugin": pluginName,
-			}).Debugf("could not read cached manifest plugin metadata before network fallback: %s", manifestErr)
-		}
-
 		installedVersion, err := (&Plugin{Shortname: pluginName}).lookUpInstalledVersion(config, fs)
 		if err != nil {
 			log.WithFields(log.Fields{
@@ -426,6 +408,33 @@ func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.I
 		}
 		if installedVersion == "" || isLocalDevelopmentVersion(installedVersion) {
 			continue
+		}
+
+		manifestPlugin, manifestErr := lookUpPluginInCachedManifest(config, fs, pluginName)
+		if manifestErr == nil {
+			if manifestPlugin.getReleaseForVersion(installedVersion) != nil {
+				if err := PersistInstalledPluginState(config, fs, manifestPlugin); err != nil {
+					log.WithFields(log.Fields{
+						"prefix": "plugins.BackfillMissingInstalledPluginMetadata",
+						"plugin": pluginName,
+					}).Debugf("could not persist backfilled plugin metadata from cached manifest: %s", err)
+				}
+				continue
+			}
+
+			log.WithFields(log.Fields{
+				"prefix":  "plugins.BackfillMissingInstalledPluginMetadata",
+				"plugin":  pluginName,
+				"version": installedVersion,
+			}).Debug("cached manifest did not include the installed version; falling back to network metadata")
+		}
+
+		var pluginNotFound *ErrPluginNotFound
+		if manifestErr != nil && !os.IsNotExist(manifestErr) && !errors.As(manifestErr, &pluginNotFound) {
+			log.WithFields(log.Fields{
+				"prefix": "plugins.BackfillMissingInstalledPluginMetadata",
+				"plugin": pluginName,
+			}).Debugf("could not read cached manifest plugin metadata before network fallback: %s", manifestErr)
 		}
 
 		resolvedPlugin, err := resolvePluginFromMetadata(ctx, config, fs, pluginName, installedVersion, apiBaseURL, dashboardBaseURL, apiKey)
@@ -484,7 +493,7 @@ func LookUpPlugin(_ context.Context, config config.IConfig, fs afero.Fs, pluginN
 }
 
 // ResolvePluginForInstall resolves the plugin metadata needed by `stripe plugin install`
-// using the metadata endpoint first and cached local metadata as fallback.
+// using the metadata endpoint first and cached plugin metadata as fallback.
 func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
 	if err := ValidatePluginShortname(pluginName); err != nil {
 		return nil, err
@@ -504,9 +513,9 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 		"prefix":  "plugins.ResolvePluginForInstall",
 		"plugin":  pluginName,
 		"version": version,
-	}).Debugf("could not resolve plugin via plugin metadata endpoint, falling back to cached local metadata: %s", err)
+	}).Debugf("could not resolve plugin via plugin metadata endpoint, falling back to cached plugin metadata: %s", err)
 
-	cachedPlugin, cachedErr := resolveCachedPluginForInstall(config, fs, pluginName)
+	cachedPlugin, cachedErr := resolveCachedPluginForInstall(config, fs, pluginName, version)
 	if cachedErr == nil {
 		resolvedVersion := version
 		if resolvedVersion == "" {
@@ -534,7 +543,7 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 
 // ResolvePluginForUpgrade resolves the latest plugin metadata for
 // `stripe plugin upgrade` using the plugin metadata endpoint first and cached
-// local metadata as fallback.
+// plugin metadata as fallback.
 func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
 	if err := ValidatePluginShortname(pluginName); err != nil {
 		return nil, err
@@ -553,7 +562,7 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 	log.WithFields(log.Fields{
 		"prefix": "plugins.ResolvePluginForUpgrade",
 		"plugin": pluginName,
-	}).Debugf("could not resolve latest plugin via plugin metadata endpoint, falling back to cached local metadata: %s", endpointErr)
+	}).Debugf("could not resolve latest plugin via plugin metadata endpoint, falling back to cached plugin metadata: %s", endpointErr)
 
 	cachedPlugin, cachedErr := resolveCachedPluginForUpgrade(config, fs, pluginName)
 	if cachedErr == nil {
@@ -575,40 +584,49 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 	return nil, fmt.Errorf("could not resolve plugin %s via plugin metadata endpoint: %v; cached lookup failed: %w", pluginName, endpointErr, cachedErr)
 }
 
-func resolveCachedPluginForInstall(config config.IConfig, fs afero.Fs, pluginName string) (*Plugin, error) {
-	return readCachedPluginMetadata(config, fs, pluginName, "plugins.ResolvePluginForInstall")
+func resolveCachedPluginForInstall(config config.IConfig, fs afero.Fs, pluginName, version string) (*Plugin, error) {
+	return readCachedPluginMetadata(config, fs, pluginName, "plugins.ResolvePluginForInstall", func(localPlugin, manifestPlugin *Plugin) *Plugin {
+		return selectPluginForInstall(localPlugin, manifestPlugin, version)
+	})
 }
 
 // resolveCachedPluginForUpgrade resolves plugin metadata for upgrade using
-// persisted local metadata only.
+// persisted local metadata and the cached manifest.
 func resolveCachedPluginForUpgrade(config config.IConfig, fs afero.Fs, pluginName string) (*Plugin, error) {
-	return readCachedPluginMetadata(config, fs, pluginName, "plugins.ResolvePluginForUpgrade")
+	return readCachedPluginMetadata(config, fs, pluginName, "plugins.ResolvePluginForUpgrade", selectPluginForUpgrade)
 }
 
-func readCachedPluginMetadata(config config.IConfig, fs afero.Fs, pluginName, logPrefix string) (*Plugin, error) {
+type cachedPluginSelector func(localPlugin, manifestPlugin *Plugin) *Plugin
+
+func readCachedPluginMetadata(config config.IConfig, fs afero.Fs, pluginName, logPrefix string, selector cachedPluginSelector) (*Plugin, error) {
+	var localPlugin *Plugin
 	localPluginValue, err := readLocalPluginMetadata(config, fs, pluginName)
 	if err == nil {
-		return &localPluginValue, nil
-	}
-
-	if !os.IsNotExist(err) {
+		localPlugin = &localPluginValue
+	} else if !os.IsNotExist(err) {
 		log.WithFields(log.Fields{
 			"prefix": logPrefix,
 			"plugin": pluginName,
 		}).Debugf("could not read local plugin metadata: %s", err)
 	}
 
+	var manifestPlugin *Plugin
 	manifestPluginValue, manifestErr := lookUpPluginInCachedManifest(config, fs, pluginName)
 	if manifestErr == nil {
-		return &manifestPluginValue, nil
+		manifestPlugin = &manifestPluginValue
+	} else {
+		var pluginNotFound *ErrPluginNotFound
+		if !os.IsNotExist(manifestErr) && !errors.As(manifestErr, &pluginNotFound) {
+			log.WithFields(log.Fields{
+				"prefix": logPrefix,
+				"plugin": pluginName,
+			}).Debugf("could not read cached manifest plugin metadata: %s", manifestErr)
+		}
 	}
 
-	var pluginNotFound *ErrPluginNotFound
-	if !os.IsNotExist(manifestErr) && !errors.As(manifestErr, &pluginNotFound) {
-		log.WithFields(log.Fields{
-			"prefix": logPrefix,
-			"plugin": pluginName,
-		}).Debugf("could not read cached manifest plugin metadata: %s", manifestErr)
+	plugin := selector(localPlugin, manifestPlugin)
+	if plugin != nil {
+		return plugin, nil
 	}
 
 	if !os.IsNotExist(err) {
@@ -618,8 +636,80 @@ func readCachedPluginMetadata(config config.IConfig, fs afero.Fs, pluginName, lo
 	return nil, manifestErr
 }
 
-// resolvePluginForAutoInstall resolves the freshest plugin metadata to use when
-// a command is invoked but the local plugin binary is missing.
+func selectPluginForInstall(localPlugin, manifestPlugin *Plugin, requestedVersion string) *Plugin {
+	if requestedVersion == "" {
+		return selectPluginForUpgrade(localPlugin, manifestPlugin)
+	}
+
+	localHasVersion := localPlugin != nil && localPlugin.getReleaseForVersion(requestedVersion) != nil
+	manifestHasVersion := manifestPlugin != nil && manifestPlugin.getReleaseForVersion(requestedVersion) != nil
+
+	switch {
+	case localHasVersion && !manifestHasVersion:
+		return mergePluginMetadata(localPlugin, manifestPlugin)
+	case manifestHasVersion && !localHasVersion:
+		return mergePluginMetadata(manifestPlugin, localPlugin)
+	default:
+		return selectPluginForUpgrade(localPlugin, manifestPlugin)
+	}
+}
+
+func selectPluginForUpgrade(localPlugin, manifestPlugin *Plugin) *Plugin {
+	switch {
+	case localPlugin == nil:
+		return mergePluginMetadata(manifestPlugin, nil)
+	case manifestPlugin == nil:
+		return mergePluginMetadata(localPlugin, nil)
+	case comparePluginVersions(localPlugin.LookUpLatestVersion(), manifestPlugin.LookUpLatestVersion()) >= 0:
+		return mergePluginMetadata(localPlugin, manifestPlugin)
+	default:
+		return mergePluginMetadata(manifestPlugin, localPlugin)
+	}
+}
+
+func mergePluginMetadata(primary, fallback *Plugin) *Plugin {
+	if primary == nil {
+		if fallback == nil {
+			return nil
+		}
+		pluginCopy := *fallback
+		return &pluginCopy
+	}
+
+	pluginCopy := *primary
+	if fallback == nil {
+		return &pluginCopy
+	}
+
+	if pluginCopy.Shortdesc == "" {
+		pluginCopy.Shortdesc = fallback.Shortdesc
+	}
+	if pluginCopy.Binary == "" {
+		pluginCopy.Binary = fallback.Binary
+	}
+	if pluginCopy.MagicCookieValue == "" {
+		pluginCopy.MagicCookieValue = fallback.MagicCookieValue
+	}
+	if len(pluginCopy.Commands) == 0 && len(fallback.Commands) > 0 {
+		pluginCopy.Commands = fallback.Commands
+	}
+
+	for i := range pluginCopy.Releases {
+		if len(pluginCopy.Releases[i].Runtime) != 0 {
+			continue
+		}
+
+		fallbackRelease := fallback.getRelease(pluginCopy.Releases[i].Version, pluginCopy.Releases[i].OS, pluginCopy.Releases[i].Arch)
+		if fallbackRelease == nil || len(fallbackRelease.Runtime) == 0 {
+			continue
+		}
+
+		pluginCopy.Releases[i].Runtime = copyRuntime(fallbackRelease.Runtime)
+	}
+
+	return &pluginCopy
+}
+
 func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
 	resolvedPlugin, err := ResolvePluginForInstall(ctx, config, fs, pluginName, "", apiBaseURL, dashboardBaseURL)
 	if err == nil {

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -48,6 +48,27 @@ type ResolvedPluginVersion struct {
 // checkLatestPluginVersionResolver is swappable for test injection.
 var checkLatestPluginVersionResolver = ResolvePluginForUpgrade
 
+// ValidatePluginShortname rejects names that could escape the plugin install or
+// metadata directories when joined onto local filesystem paths.
+func ValidatePluginShortname(pluginName string) error {
+	switch {
+	case pluginName == "":
+		return errors.New("plugin name cannot be empty")
+	case pluginName == "." || pluginName == "..":
+		return fmt.Errorf("invalid plugin name %q", pluginName)
+	case filepath.IsAbs(pluginName):
+		return fmt.Errorf("invalid plugin name %q", pluginName)
+	case strings.ContainsAny(pluginName, `/\`):
+		return fmt.Errorf("invalid plugin name %q", pluginName)
+	case filepath.Clean(pluginName) != pluginName:
+		return fmt.Errorf("invalid plugin name %q", pluginName)
+	case filepath.Base(pluginName) != pluginName:
+		return fmt.Errorf("invalid plugin name %q", pluginName)
+	default:
+		return nil
+	}
+}
+
 // Install installs the resolved plugin version. If the metadata lookup already
 // resolved a concrete binary URL, it reuses that result and skips a second
 // metadata request. Otherwise it retries metadata during install so cached
@@ -97,8 +118,17 @@ func getLocalPluginMetadataDir(config config.IConfig) string {
 	return filepath.Join(configPath, "plugin-metadata")
 }
 
-func getLocalPluginMetadataPath(config config.IConfig, pluginName string) string {
-	return filepath.Join(getLocalPluginMetadataDir(config), pluginName+".toml")
+func getLocalPluginMetadataPath(config config.IConfig, pluginName string) (string, error) {
+	if err := ValidatePluginShortname(pluginName); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(getLocalPluginMetadataDir(config), pluginName+".toml"), nil
+}
+
+func getCachedPluginManifestPath(config config.IConfig) string {
+	configPath := config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	return filepath.Join(configPath, "plugins.toml")
 }
 
 func snapshotInstalledPluginState(config config.IConfig, fs afero.Fs, pluginName string) (installedPluginStateSnapshot, error) {
@@ -106,7 +136,12 @@ func snapshotInstalledPluginState(config config.IConfig, fs afero.Fs, pluginName
 		installedPlugins: append([]string(nil), config.GetInstalledPlugins()...),
 	}
 
-	body, err := afero.ReadFile(fs, getLocalPluginMetadataPath(config, pluginName))
+	metadataPath, err := getLocalPluginMetadataPath(config, pluginName)
+	if err != nil {
+		return installedPluginStateSnapshot{}, err
+	}
+
+	body, err := afero.ReadFile(fs, metadataPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return snapshot, nil
@@ -139,7 +174,12 @@ func rollbackInstalledPluginState(config config.IConfig, fs afero.Fs, pluginName
 
 func restoreLocalPluginMetadata(config config.IConfig, fs afero.Fs, pluginName string, snapshot installedPluginStateSnapshot) error {
 	if snapshot.hasLocalMetadata {
-		return afero.WriteFile(fs, getLocalPluginMetadataPath(config, pluginName), snapshot.localMetadata, 0644)
+		metadataPath, err := getLocalPluginMetadataPath(config, pluginName)
+		if err != nil {
+			return err
+		}
+
+		return afero.WriteFile(fs, metadataPath, snapshot.localMetadata, 0644)
 	}
 
 	return removeLocalPluginMetadata(config, fs, pluginName)
@@ -249,8 +289,8 @@ func RemoveInstalledPlugin(config config.IConfig, pluginName string) error {
 // PersistInstalledPluginState ensures local metadata and installed_plugins are
 // both updated for a locally installed plugin.
 func PersistInstalledPluginState(config config.IConfig, fs afero.Fs, plugin Plugin) error {
-	if plugin.Shortname == "" {
-		return nil
+	if err := ValidatePluginShortname(plugin.Shortname); err != nil {
+		return err
 	}
 
 	previousState, err := snapshotInstalledPluginState(config, fs, plugin.Shortname)
@@ -315,9 +355,10 @@ func ListPlugins(ctx context.Context, config config.IConfig, apiBaseURL, dashboa
 
 // BackfillMissingInstalledPluginMetadata refreshes local metadata for plugins
 // that were installed before `plugin-metadata/*.toml` became the source of truth.
-// It is a no-op once all installed plugins already have a local metadata file.
-// Failures are best-effort: a failed backfill leaves the plugin runnable but
-// without upgrade-hint support until the next successful backfill.
+// It first migrates from the legacy cached `plugins.toml` on disk, then falls
+// back to the live metadata endpoint for plugins not present in that cache.
+// Failures are best-effort: a failed backfill should not prevent existing
+// plugin commands from being registered via the same cached-manifest fallback.
 func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string) error {
 	if dashboardBaseURL == "" {
 		dashboardBaseURL = stripe.DashboardBaseURLForAPIBaseURL(apiBaseURL)
@@ -338,6 +379,14 @@ func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.I
 			continue
 		}
 
+		if err := ValidatePluginShortname(pluginName); err != nil {
+			log.WithFields(log.Fields{
+				"prefix": "plugins.BackfillMissingInstalledPluginMetadata",
+				"plugin": pluginName,
+			}).Debugf("skipping invalid plugin name during backfill: %s", err)
+			continue
+		}
+
 		if _, err := readLocalPluginMetadata(config, fs, pluginName); err == nil {
 			continue
 		} else if !os.IsNotExist(err) {
@@ -346,6 +395,25 @@ func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.I
 				"plugin": pluginName,
 			}).Debugf("could not read local plugin metadata before backfill: %s", err)
 			continue
+		}
+
+		manifestPlugin, manifestErr := lookUpPluginInCachedManifest(config, fs, pluginName)
+		if manifestErr == nil {
+			if err := PersistInstalledPluginState(config, fs, manifestPlugin); err != nil {
+				log.WithFields(log.Fields{
+					"prefix": "plugins.BackfillMissingInstalledPluginMetadata",
+					"plugin": pluginName,
+				}).Debugf("could not persist backfilled plugin metadata from cached manifest: %s", err)
+			}
+			continue
+		}
+
+		var pluginNotFound *ErrPluginNotFound
+		if !os.IsNotExist(manifestErr) && !errors.As(manifestErr, &pluginNotFound) {
+			log.WithFields(log.Fields{
+				"prefix": "plugins.BackfillMissingInstalledPluginMetadata",
+				"plugin": pluginName,
+			}).Debugf("could not read cached manifest plugin metadata before network fallback: %s", manifestErr)
 		}
 
 		installedVersion, err := (&Plugin{Shortname: pluginName}).lookUpInstalledVersion(config, fs)
@@ -382,22 +450,46 @@ func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.I
 	return nil
 }
 
-// LookUpPlugin returns persisted local metadata for an installed plugin.
+// LookUpPlugin returns persisted local metadata for an installed plugin,
+// falling back to the legacy cached manifest during the compatibility window.
 func LookUpPlugin(_ context.Context, config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
 	plugin, err := readLocalPluginMetadata(config, fs, pluginName)
 	if err == nil {
 		return plugin, nil
 	}
-	if os.IsNotExist(err) {
-		return Plugin{}, &ErrPluginNotFound{Name: pluginName}
+
+	if !os.IsNotExist(err) {
+		log.WithFields(log.Fields{
+			"prefix": "plugins.LookUpPlugin",
+			"plugin": pluginName,
+		}).Debugf("could not read local plugin metadata, falling back to cached manifest: %s", err)
 	}
 
-	return Plugin{}, err
+	plugin, manifestErr := lookUpPluginInCachedManifest(config, fs, pluginName)
+	if manifestErr == nil {
+		return plugin, nil
+	}
+
+	var pluginNotFound *ErrPluginNotFound
+	switch {
+	case errors.As(manifestErr, &pluginNotFound):
+		return Plugin{}, pluginNotFound
+	case !os.IsNotExist(err):
+		return Plugin{}, err
+	case os.IsNotExist(manifestErr):
+		return Plugin{}, &ErrPluginNotFound{Name: pluginName}
+	default:
+		return Plugin{}, manifestErr
+	}
 }
 
 // ResolvePluginForInstall resolves the plugin metadata needed by `stripe plugin install`
 // using the metadata endpoint first and cached local metadata as fallback.
 func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
+	if err := ValidatePluginShortname(pluginName); err != nil {
+		return nil, err
+	}
+
 	apiKey, err := config.GetProfile().GetAPIKey(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return nil, err
@@ -444,6 +536,10 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 // `stripe plugin upgrade` using the plugin metadata endpoint first and cached
 // local metadata as fallback.
 func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
+	if err := ValidatePluginShortname(pluginName); err != nil {
+		return nil, err
+	}
+
 	apiKey, err := config.GetProfile().GetAPIKey(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return nil, err
@@ -494,6 +590,7 @@ func readCachedPluginMetadata(config config.IConfig, fs afero.Fs, pluginName, lo
 	if err == nil {
 		return &localPluginValue, nil
 	}
+
 	if !os.IsNotExist(err) {
 		log.WithFields(log.Fields{
 			"prefix": logPrefix,
@@ -501,7 +598,24 @@ func readCachedPluginMetadata(config config.IConfig, fs afero.Fs, pluginName, lo
 		}).Debugf("could not read local plugin metadata: %s", err)
 	}
 
-	return nil, err
+	manifestPluginValue, manifestErr := lookUpPluginInCachedManifest(config, fs, pluginName)
+	if manifestErr == nil {
+		return &manifestPluginValue, nil
+	}
+
+	var pluginNotFound *ErrPluginNotFound
+	if !os.IsNotExist(manifestErr) && !errors.As(manifestErr, &pluginNotFound) {
+		log.WithFields(log.Fields{
+			"prefix": logPrefix,
+			"plugin": pluginName,
+		}).Debugf("could not read cached manifest plugin metadata: %s", manifestErr)
+	}
+
+	if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	return nil, manifestErr
 }
 
 // resolvePluginForAutoInstall resolves the freshest plugin metadata to use when
@@ -577,8 +691,14 @@ func comparePluginVersions(left, right string) int {
 }
 
 func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, apiBaseURL, dashboardBaseURL, apiKey string) (*ResolvedPluginVersion, error) {
+	if err := ValidatePluginShortname(pluginName); err != nil {
+		return nil, err
+	}
+
 	basePlugin := &Plugin{Shortname: pluginName}
 	if cachedPlugin, err := readLocalPluginMetadata(config, fs, pluginName); err == nil {
+		basePlugin = &cachedPlugin
+	} else if cachedPlugin, err := lookUpPluginInCachedManifest(config, fs, pluginName); err == nil {
 		basePlugin = &cachedPlugin
 	}
 
@@ -610,6 +730,22 @@ func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs af
 	}, nil
 }
 
+func getCachedPluginList(config config.IConfig, fs afero.Fs) (PluginList, error) {
+	var pluginList PluginList
+
+	body, err := afero.ReadFile(fs, getCachedPluginManifestPath(config))
+	if err != nil {
+		return pluginList, err
+	}
+
+	validatedPluginList, err := validatePluginManifest(body)
+	if err != nil {
+		return pluginList, err
+	}
+
+	return *validatedPluginList, nil
+}
+
 func getLatestResolvedPluginVersion(pluginName string, plugin *Plugin) (string, error) {
 	if plugin == nil {
 		return "", fmt.Errorf("could not determine latest version for plugin %s", pluginName)
@@ -623,8 +759,31 @@ func getLatestResolvedPluginVersion(pluginName string, plugin *Plugin) (string, 
 	return version, nil
 }
 
+func lookUpPluginInCachedManifest(config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
+	if err := ValidatePluginShortname(pluginName); err != nil {
+		return Plugin{}, err
+	}
+
+	pluginList, err := getCachedPluginList(config, fs)
+	if err != nil {
+		return Plugin{}, err
+	}
+
+	plugin, err := findPlugin(pluginList, pluginName)
+	if err != nil {
+		return Plugin{}, &ErrPluginNotFound{Name: pluginName}
+	}
+
+	return plugin, nil
+}
+
 func readLocalPluginMetadata(config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
-	body, err := afero.ReadFile(fs, getLocalPluginMetadataPath(config, pluginName))
+	metadataPath, err := getLocalPluginMetadataPath(config, pluginName)
+	if err != nil {
+		return Plugin{}, err
+	}
+
+	body, err := afero.ReadFile(fs, metadataPath)
 	if err != nil {
 		return Plugin{}, err
 	}
@@ -638,6 +797,11 @@ func readLocalPluginMetadata(config config.IConfig, fs afero.Fs, pluginName stri
 }
 
 func writeLocalPluginMetadata(config config.IConfig, fs afero.Fs, plugin Plugin) error {
+	metadataPath, err := getLocalPluginMetadataPath(config, plugin.Shortname)
+	if err != nil {
+		return err
+	}
+
 	pluginMetadataDir := getLocalPluginMetadataDir(config)
 	if err := fs.MkdirAll(pluginMetadataDir, 0755); err != nil {
 		return err
@@ -648,11 +812,16 @@ func writeLocalPluginMetadata(config config.IConfig, fs afero.Fs, plugin Plugin)
 		return err
 	}
 
-	return afero.WriteFile(fs, getLocalPluginMetadataPath(config, plugin.Shortname), body.Bytes(), 0644)
+	return afero.WriteFile(fs, metadataPath, body.Bytes(), 0644)
 }
 
 func removeLocalPluginMetadata(config config.IConfig, fs afero.Fs, pluginName string) error {
-	err := fs.Remove(getLocalPluginMetadataPath(config, pluginName))
+	metadataPath, err := getLocalPluginMetadataPath(config, pluginName)
+	if err != nil {
+		return err
+	}
+
+	err = fs.Remove(metadataPath)
 	if os.IsNotExist(err) {
 		return nil
 	}

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -45,6 +45,7 @@ type ResolvedPluginVersion struct {
 	BinaryURL string
 }
 
+// checkLatestPluginVersionResolver is swappable for test injection.
 var checkLatestPluginVersionResolver = ResolvePluginForUpgrade
 
 // Install installs the resolved plugin version. If the metadata lookup already
@@ -314,6 +315,9 @@ func ListPlugins(ctx context.Context, config config.IConfig, apiBaseURL, dashboa
 
 // BackfillMissingInstalledPluginMetadata refreshes local metadata for plugins
 // that were installed before `plugin-metadata/*.toml` became the source of truth.
+// It is a no-op once all installed plugins already have a local metadata file.
+// Failures are best-effort: a failed backfill leaves the plugin runnable but
+// without upgrade-hint support until the next successful backfill.
 func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string) error {
 	if dashboardBaseURL == "" {
 		dashboardBaseURL = stripe.DashboardBaseURLForAPIBaseURL(apiBaseURL)
@@ -840,9 +844,9 @@ func normalizePluginMetadataError(pluginName string, err error) error {
 	}
 
 	switch {
-	case strings.Contains(err.Error(), fmt.Sprintf("plugin metadata response did not include plugin %s", pluginName)):
-		return &ErrPluginNotFound{Name: pluginName}
 	case strings.Contains(err.Error(), fmt.Sprintf("plugin metadata response did not include plugin %s version", pluginName)):
+		return &ErrPluginNotFound{Name: pluginName}
+	case strings.Contains(err.Error(), fmt.Sprintf("plugin metadata response did not include plugin %s", pluginName)):
 		return &ErrPluginNotFound{Name: pluginName}
 	default:
 		return nil

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/config"
-	"github.com/stripe/stripe-cli/pkg/fsutil"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -46,10 +45,12 @@ type ResolvedPluginVersion struct {
 	BinaryURL string
 }
 
+var checkLatestPluginVersionResolver = ResolvePluginForUpgrade
+
 // Install installs the resolved plugin version. If the metadata lookup already
 // resolved a concrete binary URL, it reuses that result and skips a second
-// metadata request. Otherwise it retries metadata during install so manifest or
-// cached fallbacks can still recover fresh release details.
+// metadata request. Otherwise it retries metadata during install so cached
+// local metadata can still recover fresh release details.
 func (r *ResolvedPluginVersion) Install(ctx context.Context, config config.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string) error {
 	switch {
 	case r == nil:
@@ -311,60 +312,87 @@ func ListPlugins(ctx context.Context, config config.IConfig, apiBaseURL, dashboa
 	return pluginList, nil
 }
 
-// GetPluginList reads the cached global plugin manifest from disk and refreshes
-// it when the cache is missing.
-// TODO: Remove this legacy plugins.toml path once the minimum supported CLI
-// version no longer depends on the cached manifest for backward compatibility.
-func GetPluginList(ctx context.Context, config config.IConfig, fs afero.Fs) (PluginList, error) {
-	pluginList, err := getCachedPluginList(config, fs)
-	if os.IsNotExist(err) {
-		log.Debug("The plugin manifest file does not exist. Downloading...")
-		err = RefreshPluginManifest(ctx, config, fs, stripe.DefaultAPIBaseURL)
-		if err != nil {
-			log.Debug("Could not download plugin manifest")
-			return pluginList, err
-		}
-		return getCachedPluginList(config, fs)
+// BackfillMissingInstalledPluginMetadata refreshes local metadata for plugins
+// that were installed before `plugin-metadata/*.toml` became the source of truth.
+func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string) error {
+	if dashboardBaseURL == "" {
+		dashboardBaseURL = stripe.DashboardBaseURLForAPIBaseURL(apiBaseURL)
 	}
 
+	apiKey, err := config.GetProfile().GetAPIKey(false)
+	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
+		return err
+	}
+
+	pluginNames, err := GetInstalledPluginNames(config, fs)
 	if err != nil {
-		return pluginList, err
+		return err
 	}
 
-	return pluginList, nil
+	for _, pluginName := range pluginNames {
+		if pluginName == "" {
+			continue
+		}
+
+		if _, err := readLocalPluginMetadata(config, fs, pluginName); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			log.WithFields(log.Fields{
+				"prefix": "plugins.BackfillMissingInstalledPluginMetadata",
+				"plugin": pluginName,
+			}).Debugf("could not read local plugin metadata before backfill: %s", err)
+			continue
+		}
+
+		installedVersion, err := (&Plugin{Shortname: pluginName}).lookUpInstalledVersion(config, fs)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"prefix": "plugins.BackfillMissingInstalledPluginMetadata",
+				"plugin": pluginName,
+			}).Debugf("could not determine installed plugin version for backfill: %s", err)
+			continue
+		}
+		if installedVersion == "" || isLocalDevelopmentVersion(installedVersion) {
+			continue
+		}
+
+		resolvedPlugin, err := resolvePluginFromMetadata(ctx, config, fs, pluginName, installedVersion, apiBaseURL, dashboardBaseURL, apiKey)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"prefix":  "plugins.BackfillMissingInstalledPluginMetadata",
+				"plugin":  pluginName,
+				"version": installedVersion,
+			}).Debugf("could not backfill local plugin metadata: %s", err)
+			continue
+		}
+
+		if err := PersistInstalledPluginState(config, fs, *resolvedPlugin.Plugin); err != nil {
+			log.WithFields(log.Fields{
+				"prefix":  "plugins.BackfillMissingInstalledPluginMetadata",
+				"plugin":  pluginName,
+				"version": installedVersion,
+			}).Debugf("could not persist backfilled local plugin metadata: %s", err)
+		}
+	}
+
+	return nil
 }
 
-// LookUpPlugin returns the matching plugin object
-func LookUpPlugin(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
+// LookUpPlugin returns persisted local metadata for an installed plugin.
+func LookUpPlugin(_ context.Context, config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
 	plugin, err := readLocalPluginMetadata(config, fs, pluginName)
 	if err == nil {
 		return plugin, nil
 	}
-
-	if !os.IsNotExist(err) {
-		log.WithFields(log.Fields{
-			"prefix": "plugins.LookUpPlugin",
-			"plugin": pluginName,
-		}).Debugf("could not read local plugin metadata, falling back to manifest lookup: %s", err)
+	if os.IsNotExist(err) {
+		return Plugin{}, &ErrPluginNotFound{Name: pluginName}
 	}
 
-	return LookUpPluginInManifest(ctx, config, fs, pluginName)
-}
-
-// LookUpPluginInManifest returns plugin metadata from the cached global manifest.
-// TODO: Keep this only while older plugin flows still require plugins.toml for
-// backward compatibility.
-func LookUpPluginInManifest(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
-	pluginList, err := GetPluginList(ctx, config, fs)
-	if err != nil {
-		return Plugin{}, err
-	}
-
-	return findPlugin(pluginList, pluginName)
+	return Plugin{}, err
 }
 
 // ResolvePluginForInstall resolves the plugin metadata needed by `stripe plugin install`
-// without requiring a manifest refresh on the metadata-backed path.
+// using the metadata endpoint first and cached local metadata as fallback.
 func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
 	apiKey, err := config.GetProfile().GetAPIKey(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
@@ -380,36 +408,37 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 		"prefix":  "plugins.ResolvePluginForInstall",
 		"plugin":  pluginName,
 		"version": version,
-	}).Debugf("could not resolve plugin via plugin metadata endpoint, falling back to manifest lookup: %s", err)
+	}).Debugf("could not resolve plugin via plugin metadata endpoint, falling back to cached local metadata: %s", err)
 
-	// TODO: Remove this manifest fallback after the backward-compatibility
-	// window for clients that still rely on plugins.toml has ended.
-	if err := RefreshPluginManifest(ctx, config, fs, apiBaseURL); err != nil {
-		return nil, err
+	cachedPlugin, cachedErr := resolveCachedPluginForInstall(config, fs, pluginName)
+	if cachedErr == nil {
+		resolvedVersion := version
+		if resolvedVersion == "" {
+			resolvedVersion = cachedPlugin.LookUpLatestVersion()
+		}
+		if resolvedVersion == "" {
+			return nil, fmt.Errorf("could not determine latest version for plugin %s", pluginName)
+		}
+		if cachedPlugin.getReleaseForVersion(resolvedVersion) == nil {
+			return nil, fmt.Errorf("cached plugin metadata did not include plugin %s version %s for %s/%s", pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
+		}
+
+		return &ResolvedPluginVersion{
+			Plugin:  cachedPlugin,
+			Version: resolvedVersion,
+		}, nil
 	}
 
-	manifestPlugin, err := LookUpPluginInManifest(ctx, config, fs, pluginName)
-	if err != nil {
-		return nil, &ErrPluginNotFound{Name: pluginName}
+	if normalizedErr := normalizePluginMetadataError(pluginName, err); normalizedErr != nil && os.IsNotExist(cachedErr) {
+		return nil, normalizedErr
 	}
 
-	manifestVersion := version
-	if manifestVersion == "" {
-		manifestVersion = manifestPlugin.LookUpLatestVersion()
-	}
-	if manifestVersion == "" {
-		return nil, fmt.Errorf("could not determine latest version for plugin %s", pluginName)
-	}
-
-	return &ResolvedPluginVersion{
-		Plugin:  &manifestPlugin,
-		Version: manifestVersion,
-	}, nil
+	return nil, fmt.Errorf("could not resolve plugin %s via plugin metadata endpoint: %v; cached lookup failed: %w", pluginName, err, cachedErr)
 }
 
 // ResolvePluginForUpgrade resolves the latest plugin metadata for
 // `stripe plugin upgrade` using the plugin metadata endpoint first and cached
-// local metadata or the global manifest as fallback.
+// local metadata as fallback.
 func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
 	apiKey, err := config.GetProfile().GetAPIKey(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
@@ -424,17 +453,7 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 	log.WithFields(log.Fields{
 		"prefix": "plugins.ResolvePluginForUpgrade",
 		"plugin": pluginName,
-	}).Debugf("could not resolve latest plugin via plugin metadata endpoint, falling back to cached plugin metadata or manifest: %s", endpointErr)
-
-	// TODO: Remove this manifest refresh once backward compatibility for
-	// plugins.toml-dependent clients is no longer required.
-	refreshErr := RefreshPluginManifest(ctx, config, fs, apiBaseURL)
-	if refreshErr != nil {
-		log.WithFields(log.Fields{
-			"prefix": "plugins.ResolvePluginForUpgrade",
-			"plugin": pluginName,
-		}).Debugf("could not refresh plugin manifest for upgrade fallback: %s", refreshErr)
-	}
+	}).Debugf("could not resolve latest plugin via plugin metadata endpoint, falling back to cached local metadata: %s", endpointErr)
 
 	cachedPlugin, cachedErr := resolveCachedPluginForUpgrade(config, fs, pluginName)
 	if cachedErr == nil {
@@ -449,43 +468,36 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 		}, nil
 	}
 
-	if refreshErr != nil {
-		return nil, fmt.Errorf("could not resolve plugin %s via plugin metadata endpoint: %v; cached lookup failed: %w; manifest refresh failed: %v", pluginName, endpointErr, cachedErr, refreshErr)
+	if normalizedErr := normalizePluginMetadataError(pluginName, endpointErr); normalizedErr != nil && os.IsNotExist(cachedErr) {
+		return nil, normalizedErr
 	}
 
 	return nil, fmt.Errorf("could not resolve plugin %s via plugin metadata endpoint: %v; cached lookup failed: %w", pluginName, endpointErr, cachedErr)
 }
 
+func resolveCachedPluginForInstall(config config.IConfig, fs afero.Fs, pluginName string) (*Plugin, error) {
+	return readCachedPluginMetadata(config, fs, pluginName, "plugins.ResolvePluginForInstall")
+}
+
 // resolveCachedPluginForUpgrade resolves plugin metadata for upgrade using
-// persisted local metadata and the cached global manifest.
+// persisted local metadata only.
 func resolveCachedPluginForUpgrade(config config.IConfig, fs afero.Fs, pluginName string) (*Plugin, error) {
-	var localPlugin *Plugin
-	localPluginValue, localErr := readLocalPluginMetadata(config, fs, pluginName)
-	if localErr == nil {
-		localPlugin = &localPluginValue
-	} else if !os.IsNotExist(localErr) {
+	return readCachedPluginMetadata(config, fs, pluginName, "plugins.ResolvePluginForUpgrade")
+}
+
+func readCachedPluginMetadata(config config.IConfig, fs afero.Fs, pluginName, logPrefix string) (*Plugin, error) {
+	localPluginValue, err := readLocalPluginMetadata(config, fs, pluginName)
+	if err == nil {
+		return &localPluginValue, nil
+	}
+	if !os.IsNotExist(err) {
 		log.WithFields(log.Fields{
-			"prefix": "plugins.ResolvePluginForUpgrade",
+			"prefix": logPrefix,
 			"plugin": pluginName,
-		}).Debugf("could not read local plugin metadata for upgrade: %s", localErr)
+		}).Debugf("could not read local plugin metadata: %s", err)
 	}
 
-	var manifestPlugin *Plugin
-	manifestPluginValue, manifestErr := lookUpPluginInCachedManifest(config, fs, pluginName)
-	if manifestErr == nil {
-		manifestPlugin = &manifestPluginValue
-	}
-
-	plugin := selectPluginForUpgrade(localPlugin, manifestPlugin)
-	if plugin != nil {
-		return plugin, nil
-	}
-
-	if localErr != nil && !os.IsNotExist(localErr) {
-		return nil, localErr
-	}
-
-	return nil, manifestErr
+	return nil, err
 }
 
 // resolvePluginForAutoInstall resolves the freshest plugin metadata to use when
@@ -517,24 +529,6 @@ func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs 
 	}, nil
 }
 
-func getCachedPluginList(config config.IConfig, fs afero.Fs) (PluginList, error) {
-	var pluginList PluginList
-	configPath := config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
-	pluginManifestPath := filepath.Join(configPath, "plugins.toml")
-
-	file, err := afero.ReadFile(fs, pluginManifestPath)
-	if err != nil {
-		return pluginList, err
-	}
-
-	_, err = toml.Decode(string(file), &pluginList)
-	if err != nil {
-		return pluginList, err
-	}
-
-	return pluginList, nil
-}
-
 func findPlugin(pluginList PluginList, pluginName string) (Plugin, error) {
 	for _, p := range pluginList.Plugins {
 		if pluginName == p.Shortname {
@@ -543,19 +537,6 @@ func findPlugin(pluginList PluginList, pluginName string) (Plugin, error) {
 	}
 
 	return Plugin{}, fmt.Errorf("could not find a plugin named %s", pluginName)
-}
-
-func selectPluginForUpgrade(localPlugin, manifestPlugin *Plugin) *Plugin {
-	switch {
-	case localPlugin == nil:
-		return mergePluginMetadata(manifestPlugin, nil)
-	case manifestPlugin == nil:
-		return mergePluginMetadata(localPlugin, nil)
-	case comparePluginVersions(localPlugin.LookUpLatestVersion(), manifestPlugin.LookUpLatestVersion()) >= 0:
-		return mergePluginMetadata(localPlugin, manifestPlugin)
-	default:
-		return mergePluginMetadata(manifestPlugin, localPlugin)
-	}
 }
 
 func comparePluginVersions(left, right string) int {
@@ -591,54 +572,9 @@ func comparePluginVersions(left, right string) int {
 	}
 }
 
-func mergePluginMetadata(primary, fallback *Plugin) *Plugin {
-	if primary == nil {
-		if fallback == nil {
-			return nil
-		}
-		pluginCopy := *fallback
-		return &pluginCopy
-	}
-
-	pluginCopy := *primary
-	if fallback == nil {
-		return &pluginCopy
-	}
-
-	if pluginCopy.Shortdesc == "" {
-		pluginCopy.Shortdesc = fallback.Shortdesc
-	}
-	if pluginCopy.Binary == "" {
-		pluginCopy.Binary = fallback.Binary
-	}
-	if pluginCopy.MagicCookieValue == "" {
-		pluginCopy.MagicCookieValue = fallback.MagicCookieValue
-	}
-	if len(pluginCopy.Commands) == 0 && len(fallback.Commands) > 0 {
-		pluginCopy.Commands = fallback.Commands
-	}
-
-	for i := range pluginCopy.Releases {
-		if len(pluginCopy.Releases[i].Runtime) != 0 {
-			continue
-		}
-
-		fallbackRelease := fallback.getRelease(pluginCopy.Releases[i].Version, pluginCopy.Releases[i].OS, pluginCopy.Releases[i].Arch)
-		if fallbackRelease == nil || len(fallbackRelease.Runtime) == 0 {
-			continue
-		}
-
-		pluginCopy.Releases[i].Runtime = copyRuntime(fallbackRelease.Runtime)
-	}
-
-	return &pluginCopy
-}
-
 func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName, version, apiBaseURL, dashboardBaseURL, apiKey string) (*ResolvedPluginVersion, error) {
 	basePlugin := &Plugin{Shortname: pluginName}
 	if cachedPlugin, err := readLocalPluginMetadata(config, fs, pluginName); err == nil {
-		basePlugin = &cachedPlugin
-	} else if cachedPlugin, err := lookUpPluginInCachedManifest(config, fs, pluginName); err == nil {
 		basePlugin = &cachedPlugin
 	}
 
@@ -681,15 +617,6 @@ func getLatestResolvedPluginVersion(pluginName string, plugin *Plugin) (string, 
 	}
 
 	return version, nil
-}
-
-func lookUpPluginInCachedManifest(config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
-	pluginList, err := getCachedPluginList(config, fs)
-	if err != nil {
-		return Plugin{}, err
-	}
-
-	return findPlugin(pluginList, pluginName)
 }
 
 func readLocalPluginMetadata(config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
@@ -751,90 +678,6 @@ func getLocalPluginMetadataNames(config config.IConfig, fs afero.Fs) ([]string, 
 	sort.Strings(names)
 
 	return names, nil
-}
-
-// RefreshPluginManifest refreshes the legacy cached plugin manifest.
-// TODO: Remove this once all supported clients use the metadata/list endpoints
-// and no longer require plugins.toml for backward compatibility.
-func RefreshPluginManifest(ctx context.Context, config config.IConfig, fs afero.Fs, baseURL string) error {
-	apiKey, err := config.GetProfile().GetAPIKey(false)
-
-	if err != nil {
-		if err != validators.ErrAPIKeyNotConfigured {
-			return err
-		}
-		// If the API key is not configured, that's fine, continue with the fallback plugin data
-	}
-
-	pluginData, err := requests.GetPluginData(ctx, baseURL, stripe.APIVersion, apiKey, config.GetProfile())
-	if err != nil {
-		return err
-	}
-
-	pluginList, err := fetchAndMergeManifests(pluginData)
-	if err != nil {
-		return err
-	}
-
-	configPath := config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
-	pluginManifestPath := filepath.Join(configPath, "plugins.toml")
-
-	if err := fsutil.RefuseWriteThroughSymlink(fs, pluginManifestPath, filepath.Dir(configPath), filepath.Base(pluginManifestPath)); err != nil {
-		return err
-	}
-
-	// Ensure the config directory exists
-	err = fs.MkdirAll(configPath, os.FileMode(0755))
-	if err != nil {
-		return err
-	}
-
-	body := new(bytes.Buffer)
-	if err := toml.NewEncoder(body).Encode(pluginList); err != nil {
-		return err
-	}
-
-	err = afero.WriteFile(fs, pluginManifestPath, body.Bytes(), 0644)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func fetchAndMergeManifests(pluginData requests.PluginData) (*PluginList, error) {
-	pluginList, err := fetchPluginList(pluginData.PluginBaseURL, "plugins.toml")
-	if err != nil {
-		return nil, err
-	}
-
-	additionalPluginLists := []*PluginList{}
-	for _, filename := range pluginData.AdditionalManifests {
-		additionalPluginList, err := fetchPluginList(pluginData.PluginBaseURL, filename)
-		if err != nil {
-			var remoteResourceNotFoundError *remoteResourceNotFoundError
-			if errors.As(err, &remoteResourceNotFoundError) {
-				log.Debugf("Additional plugin manifest not found, silently skipping: url=%s", remoteResourceNotFoundError.URL)
-				continue
-			}
-			return nil, err
-		}
-		additionalPluginLists = append(additionalPluginLists, additionalPluginList)
-	}
-
-	mergePluginLists(pluginList, additionalPluginLists)
-
-	return pluginList, nil
-}
-
-func fetchPluginList(baseURL, manifestFilename string) (*PluginList, error) {
-	pluginManifestURL := fmt.Sprintf("%s/%s", baseURL, manifestFilename)
-	body, err := FetchRemoteResource(pluginManifestURL)
-	if err != nil {
-		return nil, err
-	}
-	return validatePluginManifest(body)
 }
 
 func validatePluginListResponse(pluginList *PluginList) error {
@@ -986,8 +829,28 @@ func (e *remoteResourceNotFoundError) Error() string {
 	return fmt.Sprintf("remote resource not found: url=%s", e.URL)
 }
 
-// ErrPluginNotFound is returned when a plugin cannot be found in either the
-// metadata endpoint or the global manifest.
+func normalizePluginMetadataError(pluginName string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var requestErr requests.RequestError
+	if errors.As(err, &requestErr) && requestErr.StatusCode == http.StatusNotFound {
+		return &ErrPluginNotFound{Name: pluginName}
+	}
+
+	switch {
+	case strings.Contains(err.Error(), fmt.Sprintf("plugin metadata response did not include plugin %s", pluginName)):
+		return &ErrPluginNotFound{Name: pluginName}
+	case strings.Contains(err.Error(), fmt.Sprintf("plugin metadata response did not include plugin %s version", pluginName)):
+		return &ErrPluginNotFound{Name: pluginName}
+	default:
+		return nil
+	}
+}
+
+// ErrPluginNotFound is returned when a plugin cannot be found via the
+// metadata endpoint or in cached local plugin metadata.
 type ErrPluginNotFound struct {
 	Name string
 }
@@ -1039,13 +902,9 @@ func FetchRemoteResource(url string) ([]byte, error) {
 	return body, nil
 }
 
-// CheckLatestPluginVersion prints an upgrade hint to stderr if the cached manifest
+// CheckLatestPluginVersion prints an upgrade hint to stderr if live metadata
 // has a newer version of the plugin than what is currently installed.
-// It is a no-op in local development mode (PluginsPath set) or when the manifest
-// has no version information for the current platform.
-// TODO: Switch this to the metadata/list endpoints once the legacy
-// plugins.toml compatibility path can be retired.
-func CheckLatestPluginVersion(config config.IConfig, fs afero.Fs, plugin Plugin) {
+func CheckLatestPluginVersion(ctx context.Context, config config.IConfig, fs afero.Fs, plugin Plugin, apiBaseURL, dashboardBaseURL string) {
 	if PluginsPath != "" {
 		return
 	}
@@ -1055,12 +914,19 @@ func CheckLatestPluginVersion(config config.IConfig, fs afero.Fs, plugin Plugin)
 		return
 	}
 
-	manifestPlugin, err := lookUpPluginInCachedManifest(config, fs, plugin.Shortname)
+	if dashboardBaseURL == "" {
+		dashboardBaseURL = stripe.DashboardBaseURLForAPIBaseURL(apiBaseURL)
+	}
+
+	resolvedPlugin, err := checkLatestPluginVersionResolver(ctx, config, fs, plugin.Shortname, apiBaseURL, dashboardBaseURL)
 	if err != nil {
 		return
 	}
 
-	latestVersion := manifestPlugin.LookUpLatestVersion()
+	latestVersion := resolvedPlugin.Version
+	if latestVersion == "" && resolvedPlugin.Plugin != nil {
+		latestVersion = resolvedPlugin.Plugin.LookUpLatestVersion()
+	}
 	if latestVersion == "" {
 		return
 	}

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -115,6 +115,21 @@ func TestLookUpPluginUsesLocalMetadata(t *testing.T) {
 	require.Len(t, plugin.Releases, 4)
 }
 
+func TestLookUpPluginFallsBackToCachedManifest(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+
+	manifestContent, err := os.ReadFile("./test_artifacts/plugins.toml")
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(fs, getCachedPluginManifestPath(config), manifestContent, os.ModePerm))
+
+	plugin, err := LookUpPlugin(context.Background(), config, fs, "appA")
+	require.NoError(t, err)
+	require.Equal(t, "appA", plugin.Shortname)
+	require.Equal(t, "stripe-cli-app-a", plugin.Binary)
+	require.NotEmpty(t, plugin.Releases)
+}
+
 func TestLookUpPluginReturnsErrPluginNotFoundWithoutLocalMetadata(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
@@ -230,7 +245,9 @@ func TestPersistInstalledPluginStateRollsBackOnConfigWriteFailure(t *testing.T) 
 	err := PersistInstalledPluginState(config, fs, plugin)
 	require.ErrorIs(t, err, config.WriteErr)
 
-	metadataExists, err := afero.Exists(fs, getLocalPluginMetadataPath(config, "docs"))
+	metadataPath, err := getLocalPluginMetadataPath(config, "docs")
+	require.NoError(t, err)
+	metadataExists, err := afero.Exists(fs, metadataPath)
 	require.NoError(t, err)
 	require.False(t, metadataExists)
 	require.Empty(t, config.GetInstalledPlugins())
@@ -671,6 +688,32 @@ func TestBackfillMissingInstalledPluginMetadataWritesLocalMetadata(t *testing.T)
 
 	require.NoError(t, BackfillMissingInstalledPluginMetadata(context.Background(), config, fs, stripeServer.URL, stripeServer.URL))
 	require.Equal(t, "2.0.1", requestedVersion)
+
+	plugin, err := readLocalPluginMetadata(config, fs, "appA")
+	require.NoError(t, err)
+	require.Equal(t, "appA", plugin.Shortname)
+	require.Equal(t, []string{"appA"}, config.GetInstalledPlugins())
+}
+
+func TestBackfillMissingInstalledPluginMetadataUsesCachedManifestBeforeNetwork(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.InstalledPlugins = []string{"appA"}
+
+	manifestContent, err := os.ReadFile("./test_artifacts/plugins.toml")
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(fs, getCachedPluginManifestPath(config), manifestContent, os.ModePerm))
+
+	var requestCount int
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		requestCount++
+		t.Fatalf("unexpected network request during cached-manifest backfill: %s", req.URL.String())
+	}))
+	defer stripeServer.Close()
+
+	require.NoError(t, BackfillMissingInstalledPluginMetadata(context.Background(), config, fs, stripeServer.URL, stripeServer.URL))
+	require.Equal(t, 0, requestCount)
 
 	plugin, err := readLocalPluginMetadata(config, fs, "appA")
 	require.NoError(t, err)

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -13,116 +13,24 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/BurntSushi/toml"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
+	cfgpkg "github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
-// CustomTestConfig is a test config that allows overriding the config folder path
+// CustomTestConfig is a test config that allows overriding the config folder path.
 type CustomTestConfig struct {
 	TestConfig
 	customConfigPath string
 }
 
-// GetConfigFolder overrides the TestConfig method to return a custom path
+// GetConfigFolder overrides the TestConfig method to return a custom path.
 func (c *CustomTestConfig) GetConfigFolder(xdgPath string) string {
 	return c.customConfigPath
-}
-
-func TestGetPluginList(t *testing.T) {
-	fs := setUpFS()
-	config := &TestConfig{}
-	config.InitConfig()
-
-	pluginList, err := GetPluginList(context.Background(), config, fs)
-
-	require.Nil(t, err)
-	require.Equal(t, 3, len(pluginList.Plugins))
-	plugin := pluginList.Plugins[0]
-	require.Equal(t, "appA", plugin.Shortname)
-	require.Equal(t, "stripe-cli-app-a", plugin.Binary)
-	require.Equal(t, "0337A75A-C3C4-4DCF-A9EF-E7A144E5A291", plugin.MagicCookieValue)
-
-	require.Equal(t, 12, len(plugin.Releases))
-	release := plugin.Releases[0]
-	require.Equal(t, "amd64", release.Arch)
-	require.Equal(t, "darwin", release.OS)
-	require.Equal(t, "0.0.1", release.Version)
-	require.Equal(t, "125653c37803a51a048f6687f7f66d511be614f675f199cd6c71928b74875238", release.Sum)
-}
-
-func TestGetPluginListIgnoresLocalPluginMetadataOutsideManifest(t *testing.T) {
-	fs := setUpFS()
-	config := &TestConfig{}
-
-	localPlugin := Plugin{
-		Shortname:        "docs",
-		Shortdesc:        "Docs plugin",
-		Binary:           "stripe-cli-docs",
-		MagicCookieValue: "DOCS-COOKIE",
-		Releases: []Release{
-			{
-				Arch:    runtime.GOARCH,
-				OS:      runtime.GOOS,
-				Version: "1.0.0",
-				Sum:     "abc123",
-			},
-		},
-	}
-	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
-
-	pluginList, err := GetPluginList(context.Background(), config, fs)
-	require.NoError(t, err)
-	require.Len(t, pluginList.Plugins, 3)
-
-	_, err = findPlugin(pluginList, "docs")
-	require.Error(t, err)
-	_, err = findPlugin(pluginList, "appA")
-	require.NoError(t, err)
-	_, err = findPlugin(pluginList, "appB")
-	require.NoError(t, err)
-	_, err = findPlugin(pluginList, "appC")
-	require.NoError(t, err)
-}
-
-func TestGetPluginListUsesManifestMetadataForOverlappingPlugin(t *testing.T) {
-	fs := setUpFS()
-	config := &TestConfig{}
-
-	localPlugin := Plugin{
-		Shortname:        "appA",
-		Shortdesc:        "Locally cached App A",
-		Binary:           "stripe-cli-local-app-a",
-		MagicCookieValue: "0337A75A-C3C4-4DCF-A9EF-E7A144E5A291",
-		Releases: []Release{
-			{
-				Arch:    runtime.GOARCH,
-				OS:      runtime.GOOS,
-				Version: "2.0.1",
-				Sum:     "abc123",
-				Runtime: map[string]string{"node": "20"},
-			},
-		},
-	}
-	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
-
-	pluginList, err := GetPluginList(context.Background(), config, fs)
-	require.NoError(t, err)
-	require.Len(t, pluginList.Plugins, 3)
-
-	plugin, err := findPlugin(pluginList, "appA")
-	require.NoError(t, err)
-	require.Equal(t, "stripe-cli-app-a", plugin.Binary)
-	require.Empty(t, plugin.Shortdesc)
-	require.Len(t, plugin.Releases, 12)
-
-	release := plugin.getReleaseForVersion("2.0.1")
-	require.NotNil(t, release)
-	require.Empty(t, release.Runtime)
 }
 
 func TestListPluginsUsesAuthenticatedEndpoint(t *testing.T) {
@@ -195,41 +103,28 @@ func TestListPluginsUsesAnonymousEndpointWhenAPIKeyNotConfigured(t *testing.T) {
 	require.Equal(t, "apps", pluginList.Plugins[0].Shortname)
 }
 
-func TestLookUpPlugin(t *testing.T) {
+func TestLookUpPluginUsesLocalMetadata(t *testing.T) {
 	fs := setUpFS()
 	config := &TestConfig{}
 
 	plugin, err := LookUpPlugin(context.Background(), config, fs, "appB")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "appB", plugin.Shortname)
 	require.Equal(t, "stripe-cli-app-b", plugin.Binary)
 	require.Equal(t, "FDBE6FB9-A149-44BD-9639-4D33D8B594E8", plugin.MagicCookieValue)
-	require.Equal(t, 4, len(plugin.Releases))
+	require.Len(t, plugin.Releases, 4)
 }
 
-func TestLookUpPluginUsesLocalMetadataWhenManifestMissing(t *testing.T) {
+func TestLookUpPluginReturnsErrPluginNotFoundWithoutLocalMetadata(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
 
-	localPlugin := Plugin{
-		Shortname:        "local-plugin",
-		Binary:           "stripe-cli-local-plugin",
-		MagicCookieValue: "LOCAL-PLUGIN-COOKIE",
-		Releases: []Release{
-			{
-				Arch:    runtime.GOARCH,
-				OS:      runtime.GOOS,
-				Version: "1.0.0",
-				Sum:     "abc123",
-			},
-		},
-	}
+	_, err := LookUpPlugin(context.Background(), config, fs, "missing")
+	require.Error(t, err)
 
-	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
-
-	plugin, err := LookUpPlugin(context.Background(), config, fs, "local-plugin")
-	require.NoError(t, err)
-	require.Equal(t, localPlugin, plugin)
+	var pluginNotFound *ErrPluginNotFound
+	require.ErrorAs(t, err, &pluginNotFound)
+	require.Equal(t, "missing", pluginNotFound.Name)
 }
 
 func TestGetInstalledPluginNamesIncludesLocalMetadata(t *testing.T) {
@@ -386,32 +281,6 @@ func TestPersistInstalledPluginStateRestoresPreviousMetadataOnConfigWriteFailure
 	require.Empty(t, config.GetInstalledPlugins())
 }
 
-func TestLookUpPluginInManifestIgnoresLocalMetadata(t *testing.T) {
-	fs := setUpFS()
-	config := &TestConfig{}
-
-	localPlugin := Plugin{
-		Shortname:        "appA",
-		Binary:           "stripe-cli-local-app-a",
-		MagicCookieValue: "LOCAL-APP-A-COOKIE",
-		Releases: []Release{
-			{
-				Arch:    runtime.GOARCH,
-				OS:      runtime.GOOS,
-				Version: "9.9.9",
-				Sum:     "abc123",
-			},
-		},
-	}
-
-	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
-
-	plugin, err := LookUpPluginInManifest(context.Background(), config, fs, "appA")
-	require.NoError(t, err)
-	require.Equal(t, "stripe-cli-app-a", plugin.Binary)
-	require.Equal(t, "0337A75A-C3C4-4DCF-A9EF-E7A144E5A291", plugin.MagicCookieValue)
-}
-
 func TestResolvePluginForInstallUsesLocalMetadataAsMetadataBase(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
@@ -460,7 +329,7 @@ func TestResolvePluginForInstallUsesLocalMetadataAsMetadataBase(t *testing.T) {
 				PluginManifest: metadataManifest,
 			})
 			require.NoError(t, err)
-			res.Write(body)
+			_, _ = res.Write(body)
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -469,12 +338,11 @@ func TestResolvePluginForInstallUsesLocalMetadataAsMetadataBase(t *testing.T) {
 
 	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
-	plugin := resolvedPlugin.Plugin
-	version := resolvedPlugin.Version
-	require.Equal(t, "1.0.0", version)
-	require.Len(t, plugin.Commands, 1)
-	require.Equal(t, "create", plugin.Commands[0].Name)
-	release := plugin.getReleaseForVersion("1.0.0")
+	require.Equal(t, "1.0.0", resolvedPlugin.Version)
+	require.Len(t, resolvedPlugin.Plugin.Commands, 1)
+	require.Equal(t, "create", resolvedPlugin.Plugin.Commands[0].Name)
+
+	release := resolvedPlugin.Plugin.getReleaseForVersion("1.0.0")
 	require.NotNil(t, release)
 	require.Equal(t, "20", release.Runtime["node"])
 }
@@ -501,7 +369,7 @@ func TestResolvePluginForInstallUsesAnonymousMetadataWithoutCachedManifest(t *te
 				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
 			})
 			require.NoError(t, err)
-			res.Write(body)
+			_, _ = res.Write(body)
 		case "/v1/stripecli/get-plugin-url":
 			t.Fatalf("install resolution should not fall back to /v1/stripecli/get-plugin-url when anonymous metadata is available")
 		default:
@@ -512,41 +380,40 @@ func TestResolvePluginForInstallUsesAnonymousMetadataWithoutCachedManifest(t *te
 
 	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", apiServer.URL, dashboardServer.URL)
 	require.NoError(t, err)
-	plugin := resolvedPlugin.Plugin
-	version := resolvedPlugin.Version
-	require.NotNil(t, plugin)
-	require.Equal(t, "appA", plugin.Shortname)
-	require.Equal(t, "2.0.1", version)
+	require.NotNil(t, resolvedPlugin.Plugin)
+	require.Equal(t, "appA", resolvedPlugin.Plugin.Shortname)
+	require.Equal(t, "2.0.1", resolvedPlugin.Version)
 	require.Equal(t, "https://example.test/appA/2.0.1", resolvedPlugin.BinaryURL)
 	require.Equal(t, 1, metadataLookups)
-
-	_, err = fs.Stat("/plugins.toml")
-	require.True(t, os.IsNotExist(err))
 }
 
-func TestResolvePluginForInstallFallsBackToManifestLookupWhenAnonymousMetadataFails(t *testing.T) {
+func TestResolvePluginForInstallFallsBackToCachedLocalMetadataWhenEndpointFails(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
 	config.InitConfig()
-	config.Profile.APIKey = ""
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-	testServers := setUpServers(t, manifestContent, nil)
-	defer testServers.CloseAll()
 
-	originalPluginData := requests.DefaultPluginData
-	requests.DefaultPluginData = requests.PluginData{
-		PluginBaseURL:       testServers.ArtifactoryServer.URL,
-		AdditionalManifests: nil,
+	localPlugin := Plugin{
+		Shortname:        "appA",
+		Binary:           "stripe-cli-app-a",
+		MagicCookieValue: "APP-A-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "2.0.1",
+				Sum:     "abc123",
+			},
+		},
 	}
-	defer func() {
-		requests.DefaultPluginData = originalPluginData
-	}()
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
 
 	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/ajax/stripecli/plugins_metadata":
+		case "/v1/stripecli/get-plugin-metadata":
 			res.WriteHeader(http.StatusInternalServerError)
-			res.Write([]byte(`{"error":{"message":"boom"}}`))
+			_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
+		case "/v1/stripecli/get-plugin-url":
+			t.Fatalf("install resolution should not hit /v1/stripecli/get-plugin-url when cached metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -555,15 +422,9 @@ func TestResolvePluginForInstallFallsBackToManifestLookupWhenAnonymousMetadataFa
 
 	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", failingServer.URL, failingServer.URL)
 	require.NoError(t, err)
-	plugin := resolvedPlugin.Plugin
-	version := resolvedPlugin.Version
-	require.NotNil(t, plugin)
-	require.Equal(t, "appA", plugin.Shortname)
-	require.Equal(t, "2.0.1", version)
+	require.Equal(t, "appA", resolvedPlugin.Plugin.Shortname)
+	require.Equal(t, "2.0.1", resolvedPlugin.Version)
 	require.Empty(t, resolvedPlugin.BinaryURL)
-
-	_, err = fs.Stat("/plugins.toml")
-	require.NoError(t, err)
 }
 
 func TestResolvePluginForUpgradeUsesMetadataEndpointWhenAvailable(t *testing.T) {
@@ -615,7 +476,7 @@ func TestResolvePluginForUpgradeUsesMetadataEndpointWhenAvailable(t *testing.T) 
 `, runtime.GOARCH, runtime.GOOS),
 			})
 			require.NoError(t, err)
-			res.Write(body)
+			_, _ = res.Write(body)
 		case "/v1/stripecli/get-plugin-url":
 			t.Fatalf("upgrade resolution should not fall back to /v1/stripecli/get-plugin-url when plugin metadata is available")
 		default:
@@ -626,16 +487,12 @@ func TestResolvePluginForUpgradeUsesMetadataEndpointWhenAvailable(t *testing.T) 
 
 	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
-	plugin := resolvedPlugin.Plugin
-	require.Equal(t, "0.1.26", plugin.LookUpLatestVersion())
+	require.Equal(t, "0.1.26", resolvedPlugin.Plugin.LookUpLatestVersion())
 	require.Equal(t, "0.1.26", resolvedPlugin.Version)
 	require.Equal(t, "https://example.test/docs/latest", resolvedPlugin.BinaryURL)
-	require.Len(t, plugin.Commands, 1)
-	require.Equal(t, "search", plugin.Commands[0].Name)
+	require.Len(t, resolvedPlugin.Plugin.Commands, 1)
+	require.Equal(t, "search", resolvedPlugin.Plugin.Commands[0].Name)
 	require.Equal(t, 1, metadataLookups)
-
-	_, err = fs.Stat("/plugins.toml")
-	require.True(t, os.IsNotExist(err))
 }
 
 func TestResolvePluginForUpgradeUsesAnonymousMetadataEndpointWhenAPIKeyUnavailable(t *testing.T) {
@@ -693,7 +550,7 @@ func TestResolvePluginForUpgradeUsesAnonymousMetadataEndpointWhenAPIKeyUnavailab
 `, runtime.GOARCH, runtime.GOOS),
 			})
 			require.NoError(t, err)
-			res.Write(body)
+			_, _ = res.Write(body)
 		case "/v1/stripecli/get-plugin-url":
 			t.Fatalf("upgrade resolution should not fall back to /v1/stripecli/get-plugin-url when anonymous plugin metadata is available")
 		default:
@@ -704,16 +561,12 @@ func TestResolvePluginForUpgradeUsesAnonymousMetadataEndpointWhenAPIKeyUnavailab
 
 	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", apiServer.URL, dashboardServer.URL)
 	require.NoError(t, err)
-	plugin := resolvedPlugin.Plugin
-	require.Equal(t, "0.1.26", plugin.LookUpLatestVersion())
+	require.Equal(t, "0.1.26", resolvedPlugin.Plugin.LookUpLatestVersion())
 	require.Equal(t, "0.1.26", resolvedPlugin.Version)
 	require.Equal(t, "https://example.test/docs/latest", resolvedPlugin.BinaryURL)
-	require.Len(t, plugin.Commands, 1)
-	require.Equal(t, "search", plugin.Commands[0].Name)
+	require.Len(t, resolvedPlugin.Plugin.Commands, 1)
+	require.Equal(t, "search", resolvedPlugin.Plugin.Commands[0].Name)
 	require.Equal(t, 1, metadataLookups)
-
-	_, err = fs.Stat("/plugins.toml")
-	require.True(t, os.IsNotExist(err))
 }
 
 func TestResolvePluginForUpgradeFallsBackToCachedMetadataWhenEndpointFails(t *testing.T) {
@@ -751,13 +604,12 @@ func TestResolvePluginForUpgradeFallsBackToCachedMetadataWhenEndpointFails(t *te
 
 	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", failingServer.URL, failingServer.URL)
 	require.NoError(t, err)
-	plugin := resolvedPlugin.Plugin
-	require.Equal(t, localPlugin, *plugin)
+	require.Equal(t, localPlugin, *resolvedPlugin.Plugin)
 	require.Equal(t, "0.1.25", resolvedPlugin.Version)
 	require.Empty(t, resolvedPlugin.BinaryURL)
 }
 
-func TestResolveCachedPluginForUpgradeUsesLocalMetadataWhenManifestMissing(t *testing.T) {
+func TestResolveCachedPluginForUpgradeUsesLocalMetadataWhenPresent(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
 
@@ -788,193 +640,250 @@ func TestResolveCachedPluginForUpgradeUsesLocalMetadataWhenManifestMissing(t *te
 	require.Equal(t, localPlugin, *plugin)
 }
 
-func TestResolveCachedPluginForUpgradePrefersNewerManifestVersion(t *testing.T) {
+func TestBackfillMissingInstalledPluginMetadataWritesLocalMetadata(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.InstalledPlugins = []string{"appA"}
+
+	pluginBinaryPath := filepath.Join(getPluginsDir(config), "appA", "2.0.1", "stripe-cli-app-a"+GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("installed"), 0755))
+
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	var requestedVersion string
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			requestedVersion = req.URL.Query().Get("version")
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "https://example.test/appA/2.0.1",
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			_, _ = res.Write(body)
+		default:
+			t.Fatalf("unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	require.NoError(t, BackfillMissingInstalledPluginMetadata(context.Background(), config, fs, stripeServer.URL, stripeServer.URL))
+	require.Equal(t, "2.0.1", requestedVersion)
+
+	plugin, err := readLocalPluginMetadata(config, fs, "appA")
+	require.NoError(t, err)
+	require.Equal(t, "appA", plugin.Shortname)
+	require.Equal(t, []string{"appA"}, config.GetInstalledPlugins())
+}
+
+func TestResolvePluginForInstallReturnsErrPluginNotFoundWhenLoggedIn(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			res.WriteHeader(http.StatusNotFound)
+			_, _ = res.Write([]byte(`{"error":{"message":"not found"}}`))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer failingServer.Close()
+
+	_, err := ResolvePluginForInstall(context.Background(), config, fs, "nonexistent", "1.0.0", failingServer.URL, failingServer.URL)
+	require.Error(t, err)
+
+	var pluginNotFound *ErrPluginNotFound
+	require.ErrorAs(t, err, &pluginNotFound)
+	require.Equal(t, "nonexistent", pluginNotFound.Name)
+}
+
+func TestResolvePluginForInstallReturnsErrPluginNotFoundWhenNotLoggedIn(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.Profile.APIKey = ""
+
+	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/ajax/stripecli/plugins_metadata":
+			res.WriteHeader(http.StatusNotFound)
+			_, _ = res.Write([]byte(`{"error":{"message":"not found"}}`))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer failingServer.Close()
+
+	_, err := ResolvePluginForInstall(context.Background(), config, fs, "nonexistent", "1.0.0", failingServer.URL, failingServer.URL)
+	require.Error(t, err)
+
+	var pluginNotFound *ErrPluginNotFound
+	require.ErrorAs(t, err, &pluginNotFound)
+	require.Equal(t, "nonexistent", pluginNotFound.Name)
+}
+
+func TestResolvePluginForInstallSucceedsForGAPluginWhenNotLoggedIn(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.Profile.APIKey = ""
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	dashboardServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/ajax/stripecli/plugins_metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "https://example.test/appA/2.0.1",
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			_, _ = res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer dashboardServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		t.Fatalf("anonymous resolution should not hit the API host: %s", req.URL.String())
+	}))
+	defer apiServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", apiServer.URL, dashboardServer.URL)
+	require.NoError(t, err)
+	require.NotNil(t, resolvedPlugin.Plugin)
+	require.Equal(t, "appA", resolvedPlugin.Plugin.Shortname)
+	require.Equal(t, "2.0.1", resolvedPlugin.Version)
+}
+
+func TestCheckLatestPluginVersionPrintsWhenUpgradeAvailable(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
 
-	localPlugin := Plugin{
-		Shortname:        "docs",
-		Shortdesc:        "Docs plugin",
-		Binary:           "stripe-cli-docs",
-		MagicCookieValue: "DOCS-COOKIE",
-		Commands: []CommandInfo{
-			{
-				Name: "search",
-				Desc: "Search docs",
-			},
-		},
+	plugin := Plugin{
+		Shortname:        "myplugin",
+		Binary:           "stripe-cli-myplugin",
+		MagicCookieValue: "MY-COOKIE",
 		Releases: []Release{
-			{
-				Arch:    runtime.GOARCH,
-				OS:      runtime.GOOS,
-				Version: "0.1.25",
-				Sum:     "abc123",
-			},
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.0", Sum: "abc123"},
 		},
 	}
-	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
 
-	manifestContent := fmt.Sprintf(`[[Plugin]]
-  Shortname = "docs"
-  Shortdesc = "Docs plugin"
-  Binary = "stripe-cli-docs"
-  MagicCookieValue = "DOCS-COOKIE"
+	pluginBinaryPath := fmt.Sprintf("/plugins/myplugin/1.0.0/stripe-cli-myplugin%s", GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("binary"), 0755))
 
-  [[Plugin.Release]]
-    Arch = "%s"
-    OS = "%s"
-    Version = "0.1.26"
-    Sum = "def456"
-`, runtime.GOARCH, runtime.GOOS)
-	require.NoError(t, afero.WriteFile(fs, "/plugins.toml", []byte(manifestContent), os.ModePerm))
+	origResolver := checkLatestPluginVersionResolver
+	checkLatestPluginVersionResolver = func(ctx context.Context, cfg cfgpkg.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
+		return &ResolvedPluginVersion{
+			Plugin: &Plugin{
+				Shortname: "myplugin",
+				Releases: []Release{
+					{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.1.0", Sum: "abc123"},
+				},
+			},
+			Version: "1.1.0",
+		}, nil
+	}
+	defer func() { checkLatestPluginVersionResolver = origResolver }()
 
-	plugin, err := resolveCachedPluginForUpgrade(config, fs, "docs")
-	require.NoError(t, err)
-	require.Equal(t, "0.1.26", plugin.LookUpLatestVersion())
-	require.Len(t, plugin.Commands, 1)
-	require.Equal(t, "search", plugin.Commands[0].Name)
+	output := captureStderr(t, func() {
+		CheckLatestPluginVersion(context.Background(), config, fs, plugin, stripe.DefaultAPIBaseURL, "")
+	})
+
+	require.Contains(t, output, "A newer version of the myplugin plugin is available")
+	require.Contains(t, output, "v1.0.0")
+	require.Contains(t, output, "v1.1.0")
+	require.Contains(t, output, "stripe plugin upgrade myplugin")
 }
 
-func TestRefreshPluginManifest(t *testing.T) {
-	fs := setUpFS()
+func TestCheckLatestPluginVersionSilentWhenUpToDate(t *testing.T) {
+	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
-	config.InitConfig()
-	updatedManifestContent, _ := os.ReadFile("./test_artifacts/plugins_updated.toml")
-	testServers := setUpServers(t, updatedManifestContent, nil)
-	defer func() { testServers.CloseAll() }()
 
-	err := RefreshPluginManifest(context.Background(), config, fs, testServers.StripeServer.URL)
-	require.Nil(t, err)
-
-	// We expect the /plugins.toml file in the test fs is updated
-	pluginManifestContent, err := afero.ReadFile(fs, "/plugins.toml")
-	require.Nil(t, err)
-
-	actualPluginList := PluginList{}
-	err = toml.Unmarshal(pluginManifestContent, &actualPluginList)
-	require.Nil(t, err)
-
-	expectedPluginList := PluginList{}
-	err = toml.Unmarshal(updatedManifestContent, &expectedPluginList)
-	require.Nil(t, err)
-
-	require.Equal(t, expectedPluginList, actualPluginList)
-}
-
-func TestRefreshPluginManifestMergesAdditionalManifest(t *testing.T) {
-	fs := setUpFS()
-	config := &TestConfig{}
-	config.InitConfig()
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-	mergedManifestContent, _ := os.ReadFile("./test_artifacts/plugins-merged-foo-1.toml")
-
-	fooManifest, _ := os.ReadFile("./test_artifacts/plugins-foo-1.toml")
-	additionalManifests := map[string][]byte{
-		"plugins-foo-1.toml": fooManifest,
+	plugin := Plugin{
+		Shortname:        "myplugin",
+		Binary:           "stripe-cli-myplugin",
+		MagicCookieValue: "MY-COOKIE",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.1.0", Sum: "abc123"},
+		},
 	}
 
-	testServers := setUpServers(t, manifestContent, additionalManifests)
-	defer func() { testServers.CloseAll() }()
+	pluginBinaryPath := fmt.Sprintf("/plugins/myplugin/1.1.0/stripe-cli-myplugin%s", GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("binary"), 0755))
 
-	err := RefreshPluginManifest(context.Background(), config, fs, testServers.StripeServer.URL)
-	require.Nil(t, err)
+	origResolver := checkLatestPluginVersionResolver
+	checkLatestPluginVersionResolver = func(ctx context.Context, cfg cfgpkg.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
+		return &ResolvedPluginVersion{
+			Plugin:  &plugin,
+			Version: "1.1.0",
+		}, nil
+	}
+	defer func() { checkLatestPluginVersionResolver = origResolver }()
 
-	// We expect the /plugins.toml file in the test fs is updated
-	pluginManifestContent, err := afero.ReadFile(fs, "/plugins.toml")
-	require.Nil(t, err)
+	output := captureStderr(t, func() {
+		CheckLatestPluginVersion(context.Background(), config, fs, plugin, stripe.DefaultAPIBaseURL, "")
+	})
 
-	actualPluginList := PluginList{}
-	err = toml.Unmarshal(pluginManifestContent, &actualPluginList)
-	require.Nil(t, err)
-
-	expectedPluginList := PluginList{}
-	err = toml.Unmarshal(mergedManifestContent, &expectedPluginList)
-	require.Nil(t, err)
-
-	require.Equal(t, expectedPluginList, actualPluginList)
+	require.Empty(t, output)
 }
 
-func TestRefreshPluginManifestMergesExisitingPlugin(t *testing.T) {
-	fs := setUpFS()
+func TestCheckLatestPluginVersionSilentWhenNoInstalledVersion(t *testing.T) {
+	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
-	config.InitConfig()
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins-2.toml")
-	mergedManifestContent, _ := os.ReadFile("./test_artifacts/plugins-2-merged-foo-1.toml")
 
-	fooManifest, _ := os.ReadFile("./test_artifacts/plugins-foo-1.toml")
-	additionalManifests := map[string][]byte{
-		"plugins-foo-1.toml": fooManifest,
+	plugin := Plugin{
+		Shortname:        "myplugin",
+		Binary:           "stripe-cli-myplugin",
+		MagicCookieValue: "MY-COOKIE",
 	}
 
-	testServers := setUpServers(t, manifestContent, additionalManifests)
-	defer func() { testServers.CloseAll() }()
+	output := captureStderr(t, func() {
+		CheckLatestPluginVersion(context.Background(), config, fs, plugin, stripe.DefaultAPIBaseURL, "")
+	})
 
-	err := RefreshPluginManifest(context.Background(), config, fs, testServers.StripeServer.URL)
-	require.Nil(t, err)
-
-	// We expect the /plugins.toml file in the test fs is updated
-	pluginManifestContent, err := afero.ReadFile(fs, "/plugins.toml")
-	require.Nil(t, err)
-
-	actualPluginList := PluginList{}
-	err = toml.Unmarshal(pluginManifestContent, &actualPluginList)
-	require.Nil(t, err)
-
-	expectedPluginList := PluginList{}
-	err = toml.Unmarshal(mergedManifestContent, &expectedPluginList)
-	require.Nil(t, err)
-
-	require.Equal(t, expectedPluginList, actualPluginList)
+	require.Empty(t, output)
 }
 
-func TestRefreshPluginManifestSortsPluginReleases(t *testing.T) {
-	fs := setUpFS()
-	config := &TestConfig{}
-	config.InitConfig()
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins-3.toml")
-	mergedManifestContent, _ := os.ReadFile("./test_artifacts/plugins-3-merged-foo-1.toml")
+func TestCheckLatestPluginVersionSilentInDevMode(t *testing.T) {
+	origPluginsPath := PluginsPath
+	origResolver := checkLatestPluginVersionResolver
+	PluginsPath = "/some/local/dev/path"
+	checkLatestPluginVersionResolver = func(ctx context.Context, cfg cfgpkg.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
+		return &ResolvedPluginVersion{
+			Version: "1.1.0",
+		}, nil
+	}
+	defer func() {
+		PluginsPath = origPluginsPath
+		checkLatestPluginVersionResolver = origResolver
+	}()
 
-	fooManifest, _ := os.ReadFile("./test_artifacts/plugins-foo-1.toml")
-	additionalManifests := map[string][]byte{
-		"plugins-foo-1.toml": fooManifest,
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+
+	plugin := Plugin{
+		Shortname:        "myplugin",
+		Binary:           "stripe-cli-myplugin",
+		MagicCookieValue: "MY-COOKIE",
 	}
 
-	testServers := setUpServers(t, manifestContent, additionalManifests)
-	defer func() { testServers.CloseAll() }()
+	pluginBinaryPath := fmt.Sprintf("/plugins/myplugin/1.0.0/stripe-cli-myplugin%s", GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("binary"), 0755))
 
-	err := RefreshPluginManifest(context.Background(), config, fs, testServers.StripeServer.URL)
-	require.Nil(t, err)
+	output := captureStderr(t, func() {
+		CheckLatestPluginVersion(context.Background(), config, fs, plugin, stripe.DefaultAPIBaseURL, "")
+	})
 
-	// We expect the /plugins.toml file in the test fs is updated
-	pluginManifestContent, err := afero.ReadFile(fs, "/plugins.toml")
-	require.Nil(t, err)
-
-	actualPluginList := PluginList{}
-	err = toml.Unmarshal(pluginManifestContent, &actualPluginList)
-	require.Nil(t, err)
-
-	expectedPluginList := PluginList{}
-	err = toml.Unmarshal(mergedManifestContent, &expectedPluginList)
-	require.Nil(t, err)
-
-	require.Equal(t, expectedPluginList, actualPluginList)
-}
-
-func TestRefreshPluginManifestFailsInvalidManifest(t *testing.T) {
-	fs := setUpFS()
-	config := &TestConfig{}
-	config.InitConfig()
-	emptyManifestContent := []byte{}
-	testServers := setUpServers(t, emptyManifestContent, nil)
-	defer func() { testServers.CloseAll() }()
-
-	err := RefreshPluginManifest(context.Background(), config, fs, testServers.StripeServer.URL)
-	require.NotNil(t, err)
-	require.ErrorContains(t, err, "received an empty plugin manifest")
-	// We expect the /plugins.toml file in the test fs has NOT been updated
-	pluginManifestContent, err := afero.ReadFile(fs, "/plugins.toml")
-	require.Nil(t, err)
-	require.NotEqual(t, emptyManifestContent, pluginManifestContent)
+	require.Empty(t, output)
 }
 
 func TestIsPluginCommand(t *testing.T) {
@@ -986,18 +895,6 @@ func TestIsPluginCommand(t *testing.T) {
 
 	require.True(t, IsPluginCommand(pluginCmd))
 	require.False(t, IsPluginCommand(notPluginCmd))
-}
-
-func TestRefreshPluginManifestSucceedsIfNoAPIKey(t *testing.T) {
-	fs := setUpFS()
-	config := &TestConfig{}
-	config.InitConfig()
-	config.Profile.APIKey = ""
-	testServers := setUpServers(t, nil, nil)
-	defer func() { testServers.CloseAll() }()
-
-	err := RefreshPluginManifest(context.Background(), config, fs, testServers.StripeServer.URL)
-	require.Nil(t, err)
 }
 
 func TestIsValidNodeLTSVersion(t *testing.T) {
@@ -1040,8 +937,7 @@ func TestValidateRuntimeVersionsValid(t *testing.T) {
 		},
 	}
 
-	err := validateRuntimeVersions(pluginList)
-	require.Nil(t, err)
+	require.NoError(t, validateRuntimeVersions(pluginList))
 }
 
 func TestValidateRuntimeVersionsInvalidNonLTS(t *testing.T) {
@@ -1060,7 +956,7 @@ func TestValidateRuntimeVersionsInvalidNonLTS(t *testing.T) {
 	}
 
 	err := validateRuntimeVersions(pluginList)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.ErrorContains(t, err, "invalid Node.js version '19'")
 	require.ErrorContains(t, err, "test-plugin")
 	require.ErrorContains(t, err, "Only LTS major versions are allowed")
@@ -1082,7 +978,7 @@ func TestValidateRuntimeVersionsInvalidOldVersion(t *testing.T) {
 	}
 
 	err := validateRuntimeVersions(pluginList)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.ErrorContains(t, err, "invalid Node.js version '10'")
 }
 
@@ -1100,8 +996,7 @@ func TestValidateRuntimeVersionsNoRuntime(t *testing.T) {
 		},
 	}
 
-	err := validateRuntimeVersions(pluginList)
-	require.Nil(t, err)
+	require.NoError(t, validateRuntimeVersions(pluginList))
 }
 
 func TestValidatePluginManifestWithInvalidRuntime(t *testing.T) {
@@ -1120,7 +1015,7 @@ func TestValidatePluginManifestWithInvalidRuntime(t *testing.T) {
 `
 
 	_, err := validatePluginManifest([]byte(invalidManifest))
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.ErrorContains(t, err, "invalid Node.js version '17'")
 }
 
@@ -1140,49 +1035,10 @@ func TestValidatePluginManifestWithValidRuntime(t *testing.T) {
 `
 
 	pluginList, err := validatePluginManifest([]byte(validManifest))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, pluginList)
-	require.Equal(t, 1, len(pluginList.Plugins))
+	require.Len(t, pluginList.Plugins, 1)
 	require.Equal(t, "24", pluginList.Plugins[0].Releases[0].Runtime["node"])
-}
-
-func TestRefreshPluginSucceedsIfAdditionalManifestNotFound(t *testing.T) {
-	fs := setUpFS()
-	config := &TestConfig{}
-	config.InitConfig()
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-
-	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		switch req.URL.String() {
-		case "/plugins.toml":
-			res.Write(manifestContent)
-		case "/plugins-nonexistent.toml":
-			res.WriteHeader(http.StatusNotFound)
-		default:
-			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
-		}
-	}))
-	defer func() { artifactoryServer.Close() }()
-
-	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		switch url := req.URL.String(); url {
-		case "/v1/stripecli/get-plugin-url":
-			pd := requests.PluginData{
-				PluginBaseURL:       artifactoryServer.URL,
-				AdditionalManifests: []string{"plugins-nonexistent.toml"},
-			}
-			body, err := json.Marshal(pd)
-			if err != nil {
-				t.Error(err)
-			}
-			res.Write(body)
-		default:
-			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
-		}
-	}))
-
-	err := RefreshPluginManifest(context.Background(), config, fs, stripeServer.URL)
-	require.Nil(t, err)
 }
 
 func TestAddPluginToListSortsBySemver(t *testing.T) {
@@ -1199,227 +1055,26 @@ func TestAddPluginToListSortsBySemver(t *testing.T) {
 		},
 	}
 
-	// Add a plugin with versions that would be sorted incorrectly by string comparison
 	newPlugin := Plugin{
 		Shortname:        "test-plugin",
 		MagicCookieValue: "TEST-COOKIE-123",
 		Releases: []Release{
-			{Version: "1.10.0", OS: "darwin", Arch: "amd64"}, // String comparison would put this before 1.2.0
-			{Version: "1.9.0", OS: "darwin", Arch: "amd64"},  // Should come after 1.2.0 but before 1.10.0
+			{Version: "1.10.0", OS: "darwin", Arch: "amd64"},
+			{Version: "1.9.0", OS: "darwin", Arch: "amd64"},
 			{Version: "2.0.0", OS: "darwin", Arch: "amd64"},
-			{Version: "1.0.1", OS: "darwin", Arch: "amd64"}, // Should come after 1.0.0 but before 1.2.0
+			{Version: "1.0.1", OS: "darwin", Arch: "amd64"},
 		},
 	}
 
 	addPluginToList(pluginList, newPlugin)
 
-	// Verify the plugin was merged (not added as a new one)
-	require.Equal(t, 1, len(pluginList.Plugins))
+	require.Len(t, pluginList.Plugins, 1)
+	require.Len(t, pluginList.Plugins[0].Releases, 6)
 
-	// Verify all releases are present
-	require.Equal(t, 6, len(pluginList.Plugins[0].Releases))
-
-	// Verify they are sorted by semver (not by string comparison)
 	expectedOrder := []string{"1.0.0", "1.0.1", "1.2.0", "1.9.0", "1.10.0", "2.0.0"}
 	for i, release := range pluginList.Plugins[0].Releases {
-		require.Equal(t, expectedOrder[i], release.Version,
-			"Expected release %d to be version %s, but got %s", i, expectedOrder[i], release.Version)
+		require.Equal(t, expectedOrder[i], release.Version)
 	}
-}
-
-func TestRefreshPluginManifestCreatesConfigDirectory(t *testing.T) {
-	// Create a test config that uses a non-root directory
-	testConfigPath := "/test-config-dir"
-	customConfig := &CustomTestConfig{
-		customConfigPath: testConfigPath,
-	}
-	customConfig.InitConfig()
-
-	// Create a fresh filesystem without the config directory
-	fs := afero.NewMemMapFs()
-
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-	testServers := setUpServers(t, manifestContent, nil)
-	defer func() { testServers.CloseAll() }()
-
-	// Verify the config directory doesn't exist yet
-	exists, err := afero.DirExists(fs, testConfigPath)
-	require.Nil(t, err)
-	require.False(t, exists)
-
-	// Refresh the manifest which should create the config directory
-	err = RefreshPluginManifest(context.Background(), customConfig, fs, testServers.StripeServer.URL)
-	require.Nil(t, err)
-
-	// Verify the config directory now exists
-	exists, err = afero.DirExists(fs, testConfigPath)
-	require.Nil(t, err)
-	require.True(t, exists)
-
-	// Verify the plugins.toml file was created
-	pluginManifestPath := testConfigPath + "/plugins.toml"
-	exists, err = afero.Exists(fs, pluginManifestPath)
-	require.Nil(t, err)
-	require.True(t, exists)
-}
-
-func TestRefreshPluginManifestRefusesSymlink(t *testing.T) {
-	tempDir := t.TempDir()
-	customConfig := &CustomTestConfig{
-		customConfigPath: tempDir,
-	}
-	customConfig.InitConfig()
-
-	fs := afero.NewOsFs()
-	manifestContent, err := os.ReadFile("./test_artifacts/plugins_updated.toml")
-	require.NoError(t, err)
-
-	testServers := setUpServers(t, manifestContent, nil)
-	defer func() { testServers.CloseAll() }()
-
-	victimFile := filepath.Join(tempDir, "victim.toml")
-	require.NoError(t, os.WriteFile(victimFile, []byte("original = true\n"), 0o644))
-
-	pluginManifestPath := filepath.Join(tempDir, "plugins.toml")
-	require.NoError(t, os.Symlink(victimFile, pluginManifestPath))
-
-	err = RefreshPluginManifest(context.Background(), customConfig, fs, testServers.StripeServer.URL)
-	require.ErrorContains(t, err, "symlink")
-
-	victimContents, err := os.ReadFile(victimFile)
-	require.NoError(t, err)
-	require.Equal(t, "original = true\n", string(victimContents))
-}
-
-func TestRefreshPluginManifestRefusesSymlinkedParent(t *testing.T) {
-	tempDir := t.TempDir()
-	victimDir := filepath.Join(tempDir, "victim-config")
-	require.NoError(t, os.MkdirAll(victimDir, 0o755))
-
-	configPath := filepath.Join(tempDir, "config-link")
-	require.NoError(t, os.Symlink(victimDir, configPath))
-
-	customConfig := &CustomTestConfig{
-		customConfigPath: configPath,
-	}
-	customConfig.InitConfig()
-
-	fs := afero.NewOsFs()
-	manifestContent, err := os.ReadFile("./test_artifacts/plugins_updated.toml")
-	require.NoError(t, err)
-
-	testServers := setUpServers(t, manifestContent, nil)
-	defer func() { testServers.CloseAll() }()
-
-	err = RefreshPluginManifest(context.Background(), customConfig, fs, testServers.StripeServer.URL)
-	require.ErrorContains(t, err, "symlink")
-
-	_, err = os.Stat(filepath.Join(victimDir, "plugins.toml"))
-	require.ErrorIs(t, err, os.ErrNotExist)
-}
-
-func TestResolvePluginForInstallReturnsErrPluginNotFoundWhenLoggedIn(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-	testServers := setUpServers(t, manifestContent, nil)
-	defer testServers.CloseAll()
-
-	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		switch req.URL.Path {
-		case "/v1/stripecli/get-plugin-metadata":
-			res.WriteHeader(http.StatusNotFound)
-			res.Write([]byte(`{"error":{"message":"not found"}}`))
-		case "/v1/stripecli/get-plugin-url":
-			body, _ := json.Marshal(requests.PluginData{
-				PluginBaseURL:       testServers.ArtifactoryServer.URL,
-				AdditionalManifests: nil,
-			})
-			res.Write(body)
-		default:
-			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
-		}
-	}))
-	defer failingServer.Close()
-
-	_, err := ResolvePluginForInstall(context.Background(), config, fs, "nonexistent", "1.0.0", failingServer.URL, failingServer.URL)
-	require.Error(t, err)
-
-	var pluginNotFound *ErrPluginNotFound
-	require.ErrorAs(t, err, &pluginNotFound)
-	require.Equal(t, "nonexistent", pluginNotFound.Name)
-}
-
-func TestResolvePluginForInstallReturnsErrPluginNotFoundWhenNotLoggedIn(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-	config.Profile.APIKey = ""
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-	testServers := setUpServers(t, manifestContent, nil)
-	defer testServers.CloseAll()
-
-	originalPluginData := requests.DefaultPluginData
-	requests.DefaultPluginData = requests.PluginData{
-		PluginBaseURL:       testServers.ArtifactoryServer.URL,
-		AdditionalManifests: nil,
-	}
-	defer func() {
-		requests.DefaultPluginData = originalPluginData
-	}()
-
-	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		switch req.URL.Path {
-		case "/ajax/stripecli/plugins_metadata":
-			res.WriteHeader(http.StatusNotFound)
-			res.Write([]byte(`{"error":{"message":"not found"}}`))
-		default:
-			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
-		}
-	}))
-	defer failingServer.Close()
-
-	_, err := ResolvePluginForInstall(context.Background(), config, fs, "nonexistent", "1.0.0", failingServer.URL, failingServer.URL)
-	require.Error(t, err)
-
-	var pluginNotFound *ErrPluginNotFound
-	require.ErrorAs(t, err, &pluginNotFound)
-	require.Equal(t, "nonexistent", pluginNotFound.Name)
-}
-
-func TestResolvePluginForInstallSucceedsForGAPluginWhenNotLoggedIn(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-	config.Profile.APIKey = ""
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-
-	dashboardServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		switch req.URL.Path {
-		case "/ajax/stripecli/plugins_metadata":
-			body, err := json.Marshal(requests.PluginMetadata{
-				BinaryURL:      "https://example.test/appA/2.0.1",
-				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
-			})
-			require.NoError(t, err)
-			res.Write(body)
-		default:
-			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
-		}
-	}))
-	defer dashboardServer.Close()
-
-	apiServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		t.Fatalf("anonymous resolution should not hit the API host: %s", req.URL.String())
-	}))
-	defer apiServer.Close()
-
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", apiServer.URL, dashboardServer.URL)
-	require.NoError(t, err)
-	require.NotNil(t, resolvedPlugin.Plugin)
-	require.Equal(t, "appA", resolvedPlugin.Plugin.Shortname)
-	require.Equal(t, "2.0.1", resolvedPlugin.Version)
 }
 
 func testListEndpointResponseJSON() []byte {
@@ -1460,148 +1115,11 @@ func captureStderr(t *testing.T, fn func()) string {
 
 	fn()
 
-	w.Close()
+	require.NoError(t, w.Close())
 	os.Stderr = orig
 
 	var buf bytes.Buffer
 	_, err = buf.ReadFrom(r)
 	require.NoError(t, err)
 	return buf.String()
-}
-
-func makeManifestWithPlugin(shortname, version string) string {
-	return fmt.Sprintf(`[[Plugin]]
-  Shortname = "%s"
-  Binary = "stripe-cli-%s"
-  MagicCookieValue = "TEST-COOKIE"
-
-  [[Plugin.Release]]
-    Arch = "%s"
-    OS = "%s"
-    Version = "%s"
-    Sum = "abc123"
-`, shortname, shortname, runtime.GOARCH, runtime.GOOS, version)
-}
-
-func TestCheckLatestPluginVersionPrintsWhenUpgradeAvailable(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-
-	plugin := Plugin{
-		Shortname:        "myplugin",
-		Binary:           "stripe-cli-myplugin",
-		MagicCookieValue: "MY-COOKIE",
-		Releases: []Release{
-			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.0", Sum: "abc123"},
-		},
-	}
-
-	// Simulate v1.0.0 installed on disk.
-	pluginBinaryPath := fmt.Sprintf("/plugins/myplugin/1.0.0/stripe-cli-myplugin%s", GetBinaryExtension())
-	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
-	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("binary"), 0755))
-
-	// Manifest has v1.1.0.
-	require.NoError(t, afero.WriteFile(fs, "/plugins.toml", []byte(makeManifestWithPlugin("myplugin", "1.1.0")), os.ModePerm))
-
-	output := captureStderr(t, func() {
-		CheckLatestPluginVersion(config, fs, plugin)
-	})
-
-	require.Contains(t, output, "A newer version of the myplugin plugin is available")
-	require.Contains(t, output, "v1.0.0")
-	require.Contains(t, output, "v1.1.0")
-	require.Contains(t, output, "stripe plugin upgrade myplugin")
-}
-
-func TestCheckLatestPluginVersionSilentWhenUpToDate(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-
-	plugin := Plugin{
-		Shortname:        "myplugin",
-		Binary:           "stripe-cli-myplugin",
-		MagicCookieValue: "MY-COOKIE",
-		Releases: []Release{
-			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.1.0", Sum: "abc123"},
-		},
-	}
-
-	pluginBinaryPath := fmt.Sprintf("/plugins/myplugin/1.1.0/stripe-cli-myplugin%s", GetBinaryExtension())
-	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
-	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("binary"), 0755))
-
-	require.NoError(t, afero.WriteFile(fs, "/plugins.toml", []byte(makeManifestWithPlugin("myplugin", "1.1.0")), os.ModePerm))
-
-	output := captureStderr(t, func() {
-		CheckLatestPluginVersion(config, fs, plugin)
-	})
-
-	require.Empty(t, output)
-}
-
-func TestCheckLatestPluginVersionSilentWhenNoInstalledVersion(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-
-	plugin := Plugin{
-		Shortname:        "myplugin",
-		Binary:           "stripe-cli-myplugin",
-		MagicCookieValue: "MY-COOKIE",
-	}
-
-	require.NoError(t, afero.WriteFile(fs, "/plugins.toml", []byte(makeManifestWithPlugin("myplugin", "1.1.0")), os.ModePerm))
-
-	output := captureStderr(t, func() {
-		CheckLatestPluginVersion(config, fs, plugin)
-	})
-
-	require.Empty(t, output)
-}
-
-func TestCheckLatestPluginVersionSilentWhenNoManifest(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-
-	plugin := Plugin{
-		Shortname:        "myplugin",
-		Binary:           "stripe-cli-myplugin",
-		MagicCookieValue: "MY-COOKIE",
-	}
-
-	pluginBinaryPath := fmt.Sprintf("/plugins/myplugin/1.0.0/stripe-cli-myplugin%s", GetBinaryExtension())
-	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
-	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("binary"), 0755))
-
-	output := captureStderr(t, func() {
-		CheckLatestPluginVersion(config, fs, plugin)
-	})
-
-	require.Empty(t, output)
-}
-
-func TestCheckLatestPluginVersionSilentInDevMode(t *testing.T) {
-	orig := PluginsPath
-	PluginsPath = "/some/local/dev/path"
-	defer func() { PluginsPath = orig }()
-
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-
-	plugin := Plugin{
-		Shortname:        "myplugin",
-		Binary:           "stripe-cli-myplugin",
-		MagicCookieValue: "MY-COOKIE",
-	}
-
-	pluginBinaryPath := fmt.Sprintf("/plugins/myplugin/1.0.0/stripe-cli-myplugin%s", GetBinaryExtension())
-	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
-	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("binary"), 0755))
-	require.NoError(t, afero.WriteFile(fs, "/plugins.toml", []byte(makeManifestWithPlugin("myplugin", "1.1.0")), os.ModePerm))
-
-	output := captureStderr(t, func() {
-		CheckLatestPluginVersion(config, fs, plugin)
-	})
-
-	require.Empty(t, output)
 }

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -444,6 +444,72 @@ func TestResolvePluginForInstallFallsBackToCachedLocalMetadataWhenEndpointFails(
 	require.Empty(t, resolvedPlugin.BinaryURL)
 }
 
+func TestResolvePluginForInstallPrefersFresherCachedManifestWhenEndpointFails(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	localPlugin := Plugin{
+		Shortname:        "generate",
+		Shortdesc:        "Generate things",
+		Binary:           "stripe-cli-generate",
+		MagicCookieValue: "GENERATE-COOKIE",
+		Commands: []CommandInfo{
+			{
+				Name: "create",
+				Desc: "Create generated artifacts",
+			},
+		},
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+				Runtime: map[string]string{"node": "20"},
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	manifestContent := []byte(fmt.Sprintf(`[[Plugin]]
+  Shortname = "generate"
+  Shortdesc = "Generate things"
+  Binary = "stripe-cli-generate"
+  MagicCookieValue = "GENERATE-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "1.0.0"
+    Sum = "abc123"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "1.1.0"
+    Sum = "def456"
+`, runtime.GOARCH, runtime.GOOS, runtime.GOARCH, runtime.GOOS))
+	require.NoError(t, afero.WriteFile(fs, getCachedPluginManifestPath(config), manifestContent, os.ModePerm))
+
+	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusInternalServerError)
+		_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
+	}))
+	defer failingServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", failingServer.URL, failingServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", resolvedPlugin.Version)
+	require.Equal(t, "1.1.0", resolvedPlugin.Plugin.LookUpLatestVersion())
+	require.Len(t, resolvedPlugin.Plugin.Commands, 1)
+	require.Equal(t, "create", resolvedPlugin.Plugin.Commands[0].Name)
+
+	release := resolvedPlugin.Plugin.getReleaseForVersion("1.0.0")
+	require.NotNil(t, release)
+	require.Equal(t, "20", release.Runtime["node"])
+}
+
 func TestResolvePluginForUpgradeUsesMetadataEndpointWhenAvailable(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
@@ -626,6 +692,42 @@ func TestResolvePluginForUpgradeFallsBackToCachedMetadataWhenEndpointFails(t *te
 	require.Empty(t, resolvedPlugin.BinaryURL)
 }
 
+func TestResolvePluginForUpgradePrefersFresherCachedManifestWhenEndpointFails(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	localPlugin := Plugin{
+		Shortname:        "appA",
+		Binary:           "stripe-cli-app-a",
+		MagicCookieValue: "0337A75A-C3C4-4DCF-A9EF-E7A144E5A291",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.1",
+				Sum:     "abc123",
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	manifestContent, err := os.ReadFile("./test_artifacts/plugins.toml")
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(fs, getCachedPluginManifestPath(config), manifestContent, os.ModePerm))
+
+	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusInternalServerError)
+		_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
+	}))
+	defer failingServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "appA", failingServer.URL, failingServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, "2.0.1", resolvedPlugin.Version)
+	require.Equal(t, "2.0.1", resolvedPlugin.Plugin.LookUpLatestVersion())
+}
+
 func TestResolveCachedPluginForUpgradeUsesLocalMetadataWhenPresent(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
@@ -701,6 +803,10 @@ func TestBackfillMissingInstalledPluginMetadataUsesCachedManifestBeforeNetwork(t
 	config.InitConfig()
 	config.InstalledPlugins = []string{"appA"}
 
+	pluginBinaryPath := filepath.Join(getPluginsDir(config), "appA", "2.0.1", "stripe-cli-app-a"+GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("installed"), 0755))
+
 	manifestContent, err := os.ReadFile("./test_artifacts/plugins.toml")
 	require.NoError(t, err)
 	require.NoError(t, afero.WriteFile(fs, getCachedPluginManifestPath(config), manifestContent, os.ModePerm))
@@ -719,6 +825,61 @@ func TestBackfillMissingInstalledPluginMetadataUsesCachedManifestBeforeNetwork(t
 	require.NoError(t, err)
 	require.Equal(t, "appA", plugin.Shortname)
 	require.Equal(t, []string{"appA"}, config.GetInstalledPlugins())
+}
+
+func TestBackfillMissingInstalledPluginMetadataSkipsStaleCachedManifest(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	config.InstalledPlugins = []string{"appA"}
+
+	pluginBinaryPath := filepath.Join(getPluginsDir(config), "appA", "2.0.1", "stripe-cli-app-a"+GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("installed"), 0755))
+
+	staleManifest := []byte(fmt.Sprintf(`[[Plugin]]
+  Shortname = "appA"
+  Binary = "stripe-cli-app-a"
+  MagicCookieValue = "APP-A-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "9.9.9"
+    Sum = "abc123"
+`, runtime.GOARCH, runtime.GOOS))
+	require.NoError(t, afero.WriteFile(fs, getCachedPluginManifestPath(config), staleManifest, os.ModePerm))
+
+	manifestContent, err := os.ReadFile("./test_artifacts/plugins.toml")
+	require.NoError(t, err)
+
+	var requestCount int
+	var requestedVersion string
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			requestCount++
+			requestedVersion = req.URL.Query().Get("version")
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "https://example.test/appA/2.0.1",
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			_, _ = res.Write(body)
+		default:
+			t.Fatalf("unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	require.NoError(t, BackfillMissingInstalledPluginMetadata(context.Background(), config, fs, stripeServer.URL, stripeServer.URL))
+	require.Equal(t, 1, requestCount)
+	require.Equal(t, "2.0.1", requestedVersion)
+
+	plugin, err := readLocalPluginMetadata(config, fs, "appA")
+	require.NoError(t, err)
+	require.NotNil(t, plugin.getReleaseForVersion("2.0.1"))
+	require.Nil(t, plugin.getReleaseForVersion("9.9.9"))
 }
 
 func TestResolvePluginForInstallReturnsErrPluginNotFoundWhenLoggedIn(t *testing.T) {


### PR DESCRIPTION
 ## Summary

  This changes plugin install/lookup to treat per-plugin local metadata as the primary persisted state for installed plugins.

  It:
  - backfills missing `plugin-metadata/*.toml` entries for already-installed plugins during startup
  - stops relying on a refreshed/downloaded `plugins.toml` manifest as the active source of truth
  - keeps an existing cached `plugins.toml` only as a compatibility fallback when local metadata is missing, and only if it matches the installed version
  - falls back to the live plugin metadata endpoint when the cached manifest is stale or absent
  - updates latest-version checks to resolve against metadata instead of the cached manifest
  - validates plugin shortnames before constructing install or metadata paths to block path traversal
  - simplifies uninstall to operate from a validated shortname instead of requiring a metadata lookup first


Manually played around with installing, uninstalling, and triggering the migration backfill
<img width="622" height="331" alt="Screenshot 2026-06-17 at 3 43 11 PM" src="https://github.com/user-attachments/assets/7a9eb483-e3d8-4237-a329-9c11185d1728" />

  ## Why

  We want to move installed-plugin state off the legacy global manifest and onto per-plugin local metadata without breaking older installs that predate `plugin-metadata/
  *.toml`. This keeps those installs working during the migration while tightening filesystem safety around plugin operations.

  ## Testing

  - `go test ./pkg/plugins ./pkg/cmd/plugin ./pkg/cmd`