### PR TITLE
fix(npm): remove bin declarations from platform packages to fix npm10 double-listing

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -20,9 +20,6 @@
   "cpu": [
     "arm64"
   ],
-  "bin": {
-    "stripe": "bin/stripe"
-  },
   "files": [
     "bin/stripe"
   ]

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -20,9 +20,6 @@
   "cpu": [
     "x64"
   ],
-  "bin": {
-    "stripe": "bin/stripe"
-  },
   "files": [
     "bin/stripe"
   ]

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -20,9 +20,6 @@
   "cpu": [
     "arm64"
   ],
-  "bin": {
-    "stripe": "bin/stripe"
-  },
   "files": [
     "bin/stripe"
   ]

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -20,9 +20,6 @@
   "cpu": [
     "x64"
   ],
-  "bin": {
-    "stripe": "bin/stripe"
-  },
   "files": [
     "bin/stripe"
   ]

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -20,9 +20,6 @@
   "cpu": [
     "x64"
   ],
-  "bin": {
-    "stripe": "bin/stripe.exe"
-  },
   "files": [
     "bin/stripe.exe"
   ]


### PR DESCRIPTION
## Summary

- Removes `bin` field from all five platform-specific npm packages (`darwin-arm64`, `darwin-x64`, `linux-arm64`, `linux-x64`, `win32-x64`)
- The `bin` entry belongs only in the top-level `@stripe/cli` package; having it in the optional platform packages caused npm 10 to register the `stripe` binary twice, which broke `npx @stripe/cli@latest` with `sh: stripe: command not found`

Fixes #1694

## Test plan

- [ ] Verify `npx @stripe/cli@latest login` resolves and runs without `command not found` on npm 10 + Node 22
- [ ] Confirm `stripe` binary still resolves correctly after a fresh `npm install -g @stripe/cli`
- [ ] Confirm platform packages still include the binary in `files` (just no longer register it via `bin`)