### PR TITLE
6/12 Add co-op agent command surface

### DIFF
--- a/pkg/cmd/coop/coop.go
+++ b/pkg/cmd/coop/coop.go
@@ -54,7 +54,7 @@ The developer confirms each step before the agent moves on.`,
 		},
 	}
 
-	cc.cmd.AddCommand(newCoopStartCmd().cmd)
+	cc.cmd.AddCommand(newCoopAgentRunCmd().cmd)
 	cc.cmd.AddCommand(newCoopAgentCmd().cmd)
 	cc.cmd.AddCommand(newCoopStatusCmd().cmd)
 	cc.cmd.AddCommand(newCoopStopCmd().cmd)

--- a/pkg/cmd/coop/coop.go
+++ b/pkg/cmd/coop/coop.go
@@ -1,0 +1,85 @@
+// Package coopcmd wires the co-op mode Cobra commands into the Stripe CLI.
+package coopcmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+type Options struct {
+	ConfigFolder             func() string
+	SandboxClaimURL          func() string
+	AIAgentHelpAnnotationKey string
+}
+
+const defaultAIAgentHelpAnnotationKey = "ai_agent_help"
+
+var options Options
+
+func New(opts Options) *cobra.Command {
+	options = opts
+	return newCoopCmd().cmd
+}
+
+type coopCmd struct {
+	cmd *cobra.Command
+}
+
+func newCoopCmd() *coopCmd {
+	cc := &coopCmd{}
+	annotationKey := options.AIAgentHelpAnnotationKey
+	if annotationKey == "" {
+		annotationKey = defaultAIAgentHelpAnnotationKey
+	}
+	cc.cmd = &cobra.Command{
+		Use:   "coop",
+		Short: "Collaborative integration mode (AI agent + human developer)",
+		Long: `Co-op mode enables AI agents and human developers to collaborate on Stripe
+integrations in real time. The agent writes code and reports progress via CLI
+commands; the developer watches live in a terminal UI.
+
+Start a session with a blueprint, then let the agent work through it step by step.
+The developer confirms each step before the agent moves on.`,
+		Annotations: map[string]string{
+			annotationKey: `  Workflow: start a session, then use typed agent commands to progress through it.
+  1. stripe coop run <blueprint-id> — begin a session
+  2. stripe coop agent start-work --session=<id> --step=<n> --note="..." — mark work active
+  3. stripe coop agent report-check --session=<id> --step=<n> --check="..." --passed — add verification
+  4. stripe coop agent report-work --session=<id> --step=<n> --file=... --note="..." — report work complete
+  All commands output JSON with a "next" field suggesting the next command.
+  Run "stripe coop recommend --query=..." to discover available blueprints.`,
+		},
+	}
+
+	cc.cmd.AddCommand(newCoopStartCmd().cmd)
+	cc.cmd.AddCommand(newCoopAgentCmd().cmd)
+	cc.cmd.AddCommand(newCoopStatusCmd().cmd)
+	cc.cmd.AddCommand(newCoopStopCmd().cmd)
+	cc.cmd.AddCommand(newCoopRecommendCmd().cmd)
+
+	return cc
+}
+
+func coopConfigFolder() string {
+	if options.ConfigFolder == nil {
+		var cfg config.Config
+		return cfg.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	}
+	return options.ConfigFolder()
+}
+
+func coopSandboxClaimURL() string {
+	if options.SandboxClaimURL == nil {
+		return ""
+	}
+	return options.SandboxClaimURL()
+}
+
+func mustMarkFlagRequired(cmd *cobra.Command, name string) {
+	if err := cmd.MarkFlagRequired(name); err != nil {
+		panic("marking required flag " + name + ": " + err.Error())
+	}
+}

--- a/pkg/cmd/coop/coop_agent.go
+++ b/pkg/cmd/coop/coop_agent.go
@@ -1,0 +1,208 @@
+package coopcmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/helpers"
+	"github.com/stripe/stripe-cli/pkg/coop/workflow"
+)
+
+type coopAgentCmd struct {
+	cmd *cobra.Command
+}
+
+type coopAgentActionCmd struct {
+	cmd     *cobra.Command
+	session string
+	step    int
+	note    string
+
+	file    string
+	lines   string
+	snippet string
+	check   string
+	passed  bool
+
+	completed string
+}
+
+func newCoopAgentCmd() *coopAgentCmd {
+	ac := &coopAgentCmd{}
+	ac.cmd = &cobra.Command{
+		Use:   "agent",
+		Short: "Agent-facing co-op lifecycle commands",
+		Long:  "Typed commands used by agents to report co-op progress and wait for human review.",
+	}
+	ac.cmd.AddCommand(newCoopAgentStartWorkCmd().cmd)
+	ac.cmd.AddCommand(newCoopAgentReportWorkCmd().cmd)
+	ac.cmd.AddCommand(newCoopAgentReportCheckCmd().cmd)
+	ac.cmd.AddCommand(newCoopAgentSkipCmd().cmd)
+	ac.cmd.AddCommand(newCoopAgentAwaitReviewCmd().cmd)
+	ac.cmd.AddCommand(newCoopAgentNextActionCmd().cmd)
+	return ac
+}
+
+func newCoopAgentStartWorkCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "start-work",
+		Short: "Mark a node as active",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newWorkflowService()
+			if err != nil {
+				return err
+			}
+			resp, err := service.StartWork(c.session, c.step, c.note)
+			return outputAgentResponse(resp, err)
+		},
+	}
+	c.addSessionStepFlags()
+	c.cmd.Flags().StringVar(&c.note, "note", "", "Activity note")
+	return c
+}
+
+func newCoopAgentReportWorkCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "report-work",
+		Short: "Report completed implementation work",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newWorkflowService()
+			if err != nil {
+				return err
+			}
+			resp, err := service.ReportWork(c.session, c.step, workflow.ReportWorkInput{
+				File:    c.file,
+				Lines:   c.lines,
+				Snippet: c.snippet,
+				Note:    c.note,
+			}, false)
+			return outputAgentResponse(resp, err)
+		},
+	}
+	c.addSessionStepFlags()
+	c.cmd.Flags().StringVar(&c.file, "file", "", "File path for implementation")
+	c.cmd.Flags().StringVar(&c.lines, "lines", "", "Line range, e.g. 1-15")
+	c.cmd.Flags().StringVar(&c.snippet, "snippet", "", "Code snippet")
+	c.cmd.Flags().StringVar(&c.note, "note", "", "Implementation summary")
+	return c
+}
+
+func newCoopAgentReportCheckCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "report-check",
+		Short: "Report a verification check",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newWorkflowService()
+			if err != nil {
+				return err
+			}
+			resp, err := service.ReportCheck(c.session, c.step, c.check, c.passed)
+			return outputAgentResponse(resp, err)
+		},
+	}
+	c.addSessionStepFlags()
+	c.cmd.Flags().StringVar(&c.check, "check", "", "Verification check label")
+	c.cmd.Flags().BoolVar(&c.passed, "passed", false, "Whether the verification passed")
+	return c
+}
+
+func newCoopAgentSkipCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "skip",
+		Short: "Skip a node",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newWorkflowService()
+			if err != nil {
+				return err
+			}
+			resp, err := service.Skip(c.session, c.step, c.note)
+			return outputAgentResponse(resp, err)
+		},
+	}
+	c.addSessionStepFlags()
+	c.cmd.Flags().StringVar(&c.note, "note", "", "Skip reason")
+	return c
+}
+
+func newCoopAgentAwaitReviewCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "await-review",
+		Short: "Block until the developer confirms or requests changes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newWorkflowService()
+			if err != nil {
+				return err
+			}
+			resp, err := service.AwaitReview(c.session, c.step)
+			return outputAgentResponse(resp, err)
+		},
+	}
+	c.addSessionStepFlags()
+	return c
+}
+
+func newCoopAgentNextActionCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "next-action",
+		Short: "Wait for or record the developer's next action",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCoopNextAction(c.session, c.completed)
+		},
+	}
+	c.cmd.Flags().StringVar(&c.session, "session", "", "Session ID")
+	c.cmd.Flags().StringVar(&c.completed, "completed", "", "Mark a next action as completed")
+	mustMarkFlagRequired(c.cmd, "session")
+	return c
+}
+
+func (c *coopAgentActionCmd) addSessionStepFlags() {
+	c.cmd.Flags().StringVar(&c.session, "session", "", "Session ID")
+	c.cmd.Flags().IntVar(&c.step, "step", 0, "1-based node number")
+	mustMarkFlagRequired(c.cmd, "session")
+	mustMarkFlagRequired(c.cmd, "step")
+}
+
+func newWorkflowService() (*workflow.Service, error) {
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return nil, fmt.Errorf("creating store: %w", err)
+	}
+	return workflow.NewService(store), nil
+}
+
+func runCoopNextAction(sessionID, completed string) error {
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+	resp, err := helpers.Run(store, helpers.Input{SessionID: sessionID, Completed: completed})
+	if errors.Is(err, helpers.ErrNoSession) {
+		return outputCoopError("No session found.", "stripe coop run <blueprint>")
+	}
+	if err != nil {
+		return err
+	}
+	return outputJSON(resp)
+}
+
+func outputAgentResponse(resp coop.CommandResponse, err error) error {
+	if err != nil {
+		return err
+	}
+	if outErr := outputJSON(resp); outErr != nil {
+		return outErr
+	}
+	if !resp.OK {
+		return RenderedError{}
+	}
+	return nil
+}

--- a/pkg/cmd/coop/coop_agent.go
+++ b/pkg/cmd/coop/coop_agent.go
@@ -184,14 +184,25 @@ func runCoopNextAction(sessionID, completed string) error {
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
 	}
+	return runCoopNextActionWithStore(store, sessionID, completed)
+}
+
+func runCoopNextActionWithStore(store helpers.Store, sessionID, completed string) error {
 	resp, err := helpers.Run(store, helpers.Input{SessionID: sessionID, Completed: completed})
 	if errors.Is(err, helpers.ErrNoSession) {
 		return outputCoopError("No session found.", "stripe coop run <blueprint>")
 	}
 	if err != nil {
-		return err
+		return outputCoopError(err.Error(), nextActionHint(sessionID))
 	}
 	return outputJSON(resp)
+}
+
+func nextActionHint(sessionID string) string {
+	if sessionID == "" {
+		return "stripe coop agent next-action --session=<session>"
+	}
+	return fmt.Sprintf("stripe coop agent next-action --session=%s", sessionID)
 }
 
 func outputAgentResponse(resp coop.CommandResponse, err error) error {

--- a/pkg/cmd/coop/coop_agent_test.go
+++ b/pkg/cmd/coop/coop_agent_test.go
@@ -1,0 +1,92 @@
+package coopcmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func setupAgentCommandTest(t *testing.T) (*coop.Store, *coop.Session) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	store, err := coop.NewStore(coopConfigFolder())
+	require.NoError(t, err)
+	session := &coop.Session{
+		SchemaVersion: coop.CurrentSessionSchemaVersion,
+		ID:            "agent_test_session",
+		Status:        coop.SessionActive,
+		Settings:      map[string]string{"language": "node"},
+		Steps: []coop.SessionStep{
+			{
+				StepDefinition: coop.StepDefinition{
+					Key:   "step-1",
+					Title: "Step 1",
+				},
+				Nodes: []coop.SessionNode{
+					{
+						NodeDefinition: coop.NodeDefinition{
+							Key:   "node-1",
+							Title: "Node 1",
+							Type:  coop.NodeTestHelper,
+						},
+						State: coop.NodePending,
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, store.Write(session))
+	return store, session
+}
+
+func TestCoopAgentStartWorkCommand(t *testing.T) {
+	store, session := setupAgentCommandTest(t)
+	cmd := newCoopAgentStartWorkCmd().cmd
+	cmd.SetArgs([]string{"--session", session.ID, "--step", "1", "--note", "Starting"})
+
+	output := captureStdout(t, func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &resp))
+	require.True(t, resp.OK)
+	assert.Contains(t, resp.Next, "stripe coop agent report-work")
+
+	loaded, err := store.Read(session.ID)
+	require.NoError(t, err)
+	node, err := loaded.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodeActive, node.State)
+}
+
+func TestCoopAgentReportCheckCommand(t *testing.T) {
+	store, session := setupAgentCommandTest(t)
+	_, err := store.Update(session.ID, func(session *coop.Session) error {
+		return session.TransitionNode(1, coop.NodeActive)
+	})
+	require.NoError(t, err)
+
+	cmd := newCoopAgentReportCheckCmd().cmd
+	cmd.SetArgs([]string{"--session", session.ID, "--step", "1", "--check", "Manual checkout passed", "--passed"})
+
+	output := captureStdout(t, func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &resp))
+	require.True(t, resp.OK)
+
+	loaded, err := store.Read(session.ID)
+	require.NoError(t, err)
+	node, err := loaded.NodeByNumber(1)
+	require.NoError(t, err)
+	require.Len(t, node.Verifications, 1)
+	assert.Equal(t, "Manual checkout passed", node.Verifications[0].Check)
+	assert.True(t, node.Verifications[0].Passed)
+}

--- a/pkg/cmd/coop/coop_agent_test.go
+++ b/pkg/cmd/coop/coop_agent_test.go
@@ -2,6 +2,7 @@ package coopcmd
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,4 +90,42 @@ func TestCoopAgentReportCheckCommand(t *testing.T) {
 	require.Len(t, node.Verifications, 1)
 	assert.Equal(t, "Manual checkout passed", node.Verifications[0].Check)
 	assert.True(t, node.Verifications[0].Passed)
+}
+
+func TestCoopAgentNextActionReturnsStructuredErrorForHelperFailure(t *testing.T) {
+	store := &nextActionErrorStore{
+		session: &coop.Session{
+			ID:     "agent_test_session",
+			Status: coop.SessionCompleted,
+		},
+	}
+
+	stderr := captureStderr(t, func() {
+		err := runCoopNextActionWithStore(store, "agent_test_session", "")
+		require.Error(t, err)
+		assert.IsType(t, RenderedError{}, err)
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
+	assert.False(t, resp.OK)
+	assert.Contains(t, resp.Error, "writing next-action suggestions")
+	assert.Contains(t, resp.Error, "disk full")
+	assert.Equal(t, "stripe coop agent next-action --session=agent_test_session", resp.Hint)
+}
+
+type nextActionErrorStore struct {
+	session *coop.Session
+}
+
+func (s *nextActionErrorStore) Read(id string) (*coop.Session, error) {
+	return s.session, nil
+}
+
+func (s *nextActionErrorStore) LatestSession() (*coop.Session, error) {
+	return s.session, nil
+}
+
+func (s *nextActionErrorStore) Write(session *coop.Session) error {
+	return errors.New("disk full")
 }

--- a/pkg/cmd/coop/coop_recommend.go
+++ b/pkg/cmd/coop/coop_recommend.go
@@ -1,0 +1,129 @@
+package coopcmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type coopRecommendCmd struct {
+	cmd   *cobra.Command
+	query string
+}
+
+func newCoopRecommendCmd() *coopRecommendCmd {
+	rc := &coopRecommendCmd{}
+	rc.cmd = &cobra.Command{
+		Use:   "recommend",
+		Short: "Find blueprints matching your integration needs",
+		Long: `Search available blueprints by keyword. Useful for discovering which
+blueprint to use for a given integration scenario.`,
+		Example: `  stripe coop recommend --query="accept payments"
+  stripe coop recommend --query="subscriptions"
+  stripe coop recommend --query="save card future"`,
+		RunE: rc.runRecommendCmd,
+	}
+
+	rc.cmd.Flags().StringVar(&rc.query, "query", "", "Search query to match against blueprints")
+
+	return rc
+}
+
+func (rc *coopRecommendCmd) runRecommendCmd(cmd *cobra.Command, args []string) error {
+	blueprints, err := coop.ListBlueprintsWithMetadata()
+	if err != nil {
+		return fmt.Errorf("loading blueprints: %w", err)
+	}
+
+	type bpEntry struct {
+		ID          string   `json:"id"`
+		Title       string   `json:"title"`
+		Description string   `json:"description"`
+		Products    []string `json:"products,omitempty"`
+		NodeCount   int      `json:"node_count"`
+		Command     string   `json:"command"`
+		Score       int      `json:"score,omitempty"`
+	}
+
+	var catalog []bpEntry
+	for _, bp := range blueprints {
+		nodes := 0
+		for _, step := range bp.Steps {
+			nodes += len(step.Nodes)
+		}
+		entry := bpEntry{
+			ID:          bp.ID,
+			Title:       bp.Title,
+			Description: bp.Description,
+			Products:    bp.Products,
+			NodeCount:   nodes,
+			Command:     fmt.Sprintf("stripe coop run %s", bp.ID),
+		}
+		if rc.query != "" {
+			entry.Score = blueprintMatchScore(bp, rc.query)
+			if entry.Score == 0 {
+				continue
+			}
+		}
+		catalog = append(catalog, entry)
+	}
+
+	if rc.query != "" {
+		sort.SliceStable(catalog, func(i, j int) bool {
+			return catalog[i].Score > catalog[j].Score
+		})
+	}
+
+	response := map[string]interface{}{
+		"blueprints": catalog,
+		"agent_instructions": `Pick the blueprint that best matches what the developer described.
+Consider: what they're building, whether it's one-time or recurring, if it involves platforms/marketplaces.
+If multiple could fit, ask the developer to clarify between the top 2-3 options.
+Once decided, run the "command" field for that blueprint.`,
+	}
+
+	if rc.query != "" {
+		response["query"] = rc.query
+	}
+
+	return outputJSON(response)
+}
+
+func blueprintMatchScore(bp coop.Blueprint, query string) int {
+	query = strings.ToLower(query)
+	terms := strings.FieldsFunc(query, func(r rune) bool {
+		return r == ' ' || r == '-' || r == '_' || r == ',' || r == '.' || r == '/'
+	})
+	if len(terms) == 0 {
+		return 0
+	}
+
+	id := strings.ToLower(bp.ID)
+	title := strings.ToLower(bp.Title)
+	description := strings.ToLower(bp.Description)
+	products := strings.ToLower(strings.Join(bp.Products, " "))
+
+	score := 0
+	for _, term := range terms {
+		switch {
+		case term == "":
+			continue
+		case strings.Contains(id, term):
+			score += 5
+		case strings.Contains(title, term):
+			score += 4
+		case strings.Contains(products, term):
+			score += 3
+		case strings.Contains(description, term):
+			score += 2
+		}
+	}
+	if strings.Contains(title, query) || strings.Contains(description, query) || strings.Contains(id, strings.ReplaceAll(query, " ", "-")) {
+		score += 5
+	}
+	return score
+}

--- a/pkg/cmd/coop/coop_run.go
+++ b/pkg/cmd/coop/coop_run.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/coop"
 )
 
-type coopStartCmd struct {
+type coopAgentRunCmd struct {
 	cmd           *cobra.Command
 	language      string
 	settings      []string
@@ -23,9 +23,9 @@ type coopStartCmd struct {
 	parentStep    string
 }
 
-func newCoopStartCmd() *coopStartCmd {
-	sc := &coopStartCmd{}
-	sc.cmd = &cobra.Command{
+func newCoopAgentRunCmd() *coopAgentRunCmd {
+	rc := &coopAgentRunCmd{}
+	rc.cmd = &cobra.Command{
 		Use:   "run <blueprint-id>",
 		Short: "Create a co-op session from a blueprint (agent-facing)",
 		Long: `Creates a new co-op session using the specified blueprint. The session file
@@ -36,19 +36,19 @@ This is the agent-facing command. Developers should use "stripe coop start" inst
   stripe coop run one-time-payment --language=node
   stripe coop run setup-future-payments --setting=framework=express --param=customer_type=existing`,
 		Args: cobra.ExactArgs(1),
-		RunE: sc.runStartCmd,
+		RunE: rc.runCmd,
 	}
 
-	sc.cmd.Flags().StringVar(&sc.language, "language", "", "Programming language for the integration")
-	sc.cmd.Flags().StringArrayVar(&sc.settings, "setting", nil, "Blueprint settings as key=value pairs")
-	sc.cmd.Flags().StringArrayVar(&sc.params, "param", nil, "Blueprint params as key=value pairs")
-	sc.cmd.Flags().StringVar(&sc.parentSession, "parent-session", "", "Parent co-op session ID for follow-up work")
-	sc.cmd.Flags().StringVar(&sc.parentStep, "parent-step", "", "Parent next-step ID this session fulfills")
+	rc.cmd.Flags().StringVar(&rc.language, "language", "", "Programming language for the integration")
+	rc.cmd.Flags().StringArrayVar(&rc.settings, "setting", nil, "Blueprint settings as key=value pairs")
+	rc.cmd.Flags().StringArrayVar(&rc.params, "param", nil, "Blueprint params as key=value pairs")
+	rc.cmd.Flags().StringVar(&rc.parentSession, "parent-session", "", "Parent co-op session ID for follow-up work")
+	rc.cmd.Flags().StringVar(&rc.parentStep, "parent-step", "", "Parent next-step ID this session fulfills")
 
-	return sc
+	return rc
 }
 
-func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
+func (rc *coopAgentRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 	blueprintID := args[0]
 
 	bp, err := coop.LoadBlueprint(blueprintID)
@@ -63,7 +63,7 @@ func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
 
 	sessionID := "coop_" + uuid.New().String()[:8]
 
-	session, err := newCoopSession(bp, sessionID, sc.language, sc.settings, sc.params, sc.parentSession, sc.parentStep)
+	session, err := newCoopSession(bp, sessionID, rc.language, rc.settings, rc.params, rc.parentSession, rc.parentStep)
 	if err != nil {
 		return outputCoopError(err.Error(), "Use --setting key=value and --param key=value.")
 	}
@@ -90,7 +90,7 @@ func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	resp := coopStartResponse{
+	resp := coopAgentRunResponse{
 		CommandResponse: coop.CommandResponse{
 			OK:        true,
 			SessionID: sessionID,
@@ -143,7 +143,7 @@ func mergeKeyValues(dst map[string]string, flag string, values []string) error {
 	return nil
 }
 
-type coopStartResponse struct {
+type coopAgentRunResponse struct {
 	coop.CommandResponse
 	AgentInstructions string      `json:"agent_instructions"`
 	Nodes             []nodeBrief `json:"nodes"`

--- a/pkg/cmd/coop/coop_run.go
+++ b/pkg/cmd/coop/coop_run.go
@@ -1,0 +1,239 @@
+package coopcmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type coopStartCmd struct {
+	cmd           *cobra.Command
+	language      string
+	settings      []string
+	params        []string
+	parentSession string
+	parentStep    string
+}
+
+func newCoopStartCmd() *coopStartCmd {
+	sc := &coopStartCmd{}
+	sc.cmd = &cobra.Command{
+		Use:   "run <blueprint-id>",
+		Short: "Create a co-op session from a blueprint (agent-facing)",
+		Long: `Creates a new co-op session using the specified blueprint. The session file
+is written to disk and the agent can immediately begin working through nodes.
+
+This is the agent-facing command. Developers should use "stripe coop start" instead.`,
+		Example: `  stripe coop run one-time-payment
+  stripe coop run one-time-payment --language=node
+  stripe coop run setup-future-payments --setting=framework=express --param=customer_type=existing`,
+		Args: cobra.ExactArgs(1),
+		RunE: sc.runStartCmd,
+	}
+
+	sc.cmd.Flags().StringVar(&sc.language, "language", "", "Programming language for the integration")
+	sc.cmd.Flags().StringArrayVar(&sc.settings, "setting", nil, "Blueprint settings as key=value pairs")
+	sc.cmd.Flags().StringArrayVar(&sc.params, "param", nil, "Blueprint params as key=value pairs")
+	sc.cmd.Flags().StringVar(&sc.parentSession, "parent-session", "", "Parent co-op session ID for follow-up work")
+	sc.cmd.Flags().StringVar(&sc.parentStep, "parent-step", "", "Parent next-step ID this session fulfills")
+
+	return sc
+}
+
+func (sc *coopStartCmd) runStartCmd(cmd *cobra.Command, args []string) error {
+	blueprintID := args[0]
+
+	bp, err := coop.LoadBlueprint(blueprintID)
+	if err != nil {
+		return outputCoopError(fmt.Sprintf("Blueprint %q not found. Run 'stripe coop recommend' to see available blueprints.", blueprintID), "stripe coop recommend")
+	}
+
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+
+	sessionID := "coop_" + uuid.New().String()[:8]
+
+	session, err := newCoopSession(bp, sessionID, sc.language, sc.settings, sc.params, sc.parentSession, sc.parentStep)
+	if err != nil {
+		return outputCoopError(err.Error(), "Use --setting key=value and --param key=value.")
+	}
+
+	if err := store.Write(session); err != nil {
+		return fmt.Errorf("writing session: %w", err)
+	}
+
+	// Build node overview for the agent
+	var nodes []nodeBrief
+	nodeNumber := 0
+	for _, step := range session.Steps {
+		for _, n := range step.Nodes {
+			nodeNumber++
+			nodes = append(nodes, nodeBrief{
+				Number:        nodeNumber,
+				Title:         n.Title,
+				Type:          string(n.Type),
+				Description:   n.Description,
+				ReviewPrompt:  n.ReviewPrompt,
+				ReviewCommand: n.ReviewCommand,
+				AutoConfirm:   n.AutoConfirm,
+			})
+		}
+	}
+
+	resp := coopStartResponse{
+		CommandResponse: coop.CommandResponse{
+			OK:        true,
+			SessionID: sessionID,
+			Node:      1,
+			State:     "created",
+			Message:   fmt.Sprintf("Session started: %s (%d nodes)", bp.Title, session.TotalNodes()),
+			Next:      fmt.Sprintf("stripe coop agent start-work --session=%s --step=1 --note=%s", sessionID, quoteArg("Beginning: "+session.Steps[0].Nodes[0].Title)),
+		},
+		AgentInstructions: agentInstructions(bp, session),
+		Nodes:             nodes,
+	}
+
+	return outputJSON(resp)
+}
+
+func newCoopSession(bp *coop.Blueprint, sessionID, language string, rawSettings, rawParams []string, parentSession, parentStep string) (*coop.Session, error) {
+	settings := make(map[string]string)
+	if language != "" {
+		settings["language"] = language
+	}
+	if err := mergeKeyValues(settings, "--setting", rawSettings); err != nil {
+		return nil, err
+	}
+
+	params := make(map[string]string)
+	if err := mergeKeyValues(params, "--param", rawParams); err != nil {
+		return nil, err
+	}
+
+	session := coop.NewSessionFromBlueprint(bp, sessionID, settings, params)
+	session.CreatedAt = time.Now().UTC()
+	session.ParentSessionID = parentSession
+	session.ParentStepID = parentStep
+	session.UsedSandbox = coopSandboxClaimURL() != ""
+	return session, nil
+}
+
+func mergeKeyValues(dst map[string]string, flag string, values []string) error {
+	for _, value := range values {
+		key, val, ok := strings.Cut(value, "=")
+		if !ok {
+			return fmt.Errorf("%s must be in key=value format: %q", flag, value)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return fmt.Errorf("%s key cannot be empty: %q", flag, value)
+		}
+		dst[key] = val
+	}
+	return nil
+}
+
+type coopStartResponse struct {
+	coop.CommandResponse
+	AgentInstructions string      `json:"agent_instructions"`
+	Nodes             []nodeBrief `json:"nodes"`
+}
+
+type nodeBrief struct {
+	Number        int    `json:"number"`
+	Title         string `json:"title"`
+	Type          string `json:"type"`
+	Description   string `json:"description,omitempty"`
+	ReviewPrompt  string `json:"review_prompt,omitempty"`
+	ReviewCommand string `json:"review_command,omitempty"`
+	AutoConfirm   bool   `json:"auto_confirm,omitempty"`
+}
+
+func agentInstructions(bp *coop.Blueprint, session *coop.Session) string {
+	preamble := fmt.Sprintf("You are building a working Stripe integration: %q", bp.Title)
+
+	return fmt.Sprintf(`%s
+
+BEFORE YOU START — ensure you have API access:
+1. Run "stripe whoami" to check if you're authenticated.
+2. If not authenticated OR if the output shows "Test mode key: not available",
+   run "stripe sandbox create --from-git" to provision a sandbox.
+   This gives you a working API key without requiring browser login.
+   The claim URL will appear automatically in the TUI for the developer.
+
+Each node has a description that tells you what to do. Follow the description — it's the source of truth. The node type is a hint about the general category:
+- "apiRequest": Usually means writing code that calls a Stripe API. Run it and verify the response.
+- "asyncHandler": Set up a webhook handler. Use "stripe listen --forward-to localhost:<port>/webhook" to test.
+- "uiComponent": Build frontend code or configure something user-facing. Verify it works.
+- "cliCommand": Run a CLI command (e.g. stripe projects init, stripe projects deploy). Report the output.
+- "testHelper": Verify something works end-to-end. Run the flow and confirm the expected outcome.
+
+If a node includes review_prompt, that is the baseline acceptance check shown to the human. If it includes review_command, run that exact command when verifying or explain why it does not apply. Make your implementation note and verifications directly answer these fields. When you add verification checks, write them as useful confirmation guidance for the human too: include concrete actions and expected results, such as "Visit http://localhost:3000/checkout, click Pay, and confirm the browser redirects to Stripe Checkout" rather than vague labels like "manual test passed".
+
+Node 1 is always "Understand the project" — scan files, identify the tech stack, and summarize what you found. This helps you adapt the remaining nodes to the developer's actual setup. Don't ask the developer questions you can answer by reading the code.
+
+Agent lifecycle commands (use this session id: %s):
+1. stripe coop agent start-work --session=%s --step=<n> --note="<what you're about to do>"
+2. Write the code and run it to verify it works
+3. stripe coop agent report-check --session=%s --step=<n> --check="<what you verified>" --passed
+4. stripe coop agent report-work --session=%s --step=<n> --file=<main file> --lines=<range> --snippet="<key code>" --note="<summary>"
+5. Follow the JSON response's next command. Most nodes continue to the next node in the same step.
+6. Only run stripe coop agent await-review --session=%s --step=<n> when the response says the step is ready for review. Await blocks until the human confirms the step or requests changes.
+7. If confirmed: move to next node. If rejected: redo the affected node (check the message for feedback).
+8. When the final node is confirmed: IMMEDIATELY run "stripe coop agent next-action --session=%s". Do not stop or ask — just run it. It shows the developer their options in the TUI and blocks until they choose.
+
+Steps are the default human-review unit. Build and verify each node one at a time, but do not interrupt the developer for every node. At the end of each step, before running await, help the developer verify the step: run relevant review_command values, start any needed app/server, keep useful processes running, share the local URL or command to open it, create or identify test data, and explain exactly what observable result they should confirm. Add these concrete user-facing checks with stripe coop agent report-check --session=%s --step=<n> --check="..." --passed so the review card has useful evidence.
+
+The "await" command is critical at step boundaries — it blocks until the developer acts. Do NOT proceed to the next step without running await when the node response tells you the step is ready. Set a 5-minute timeout on the shell command (it will re-prompt you if it times out). If changes are requested, ask the developer what they'd like you to change before redoing the affected node.
+
+Some nodes are marked auto_confirm — these do not require human review. Continue following the next command returned by the CLI.
+
+Important:
+- The human is watching your progress live in a terminal UI.
+- Write working code, not stubs. Run it. Verify it actually works.
+- Report what you did concretely (file paths, line numbers, test results).
+- If a node doesn't apply to the user's setup, skip it: stripe coop agent skip --session=%s --step=<n> --note="<reason>"
+- Always install the LATEST version of the Stripe SDK for the language in use. Do not pin to old versions.
+  Examples: "npm install stripe@latest", "pip install --upgrade stripe", "gem install stripe"
+  Check https://docs.stripe.com/libraries for current versions if unsure.`, preamble, session.ID, session.ID, session.ID, session.ID, session.ID, session.ID, session.ID, session.ID)
+}
+
+func outputJSON(v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func quoteArg(value string) string {
+	return strconv.Quote(value)
+}
+
+func outputCoopError(msg, hint string) error {
+	resp := coop.CommandResponse{
+		OK:    false,
+		Error: msg,
+		Hint:  hint,
+	}
+	data, _ := json.MarshalIndent(resp, "", "  ")
+	fmt.Fprintln(os.Stderr, string(data))
+	return RenderedError{}
+}
+
+type RenderedError struct{}
+
+func (RenderedError) Error() string {
+	return "coop command failed"
+}

--- a/pkg/cmd/coop/coop_run_test.go
+++ b/pkg/cmd/coop/coop_run_test.go
@@ -1,0 +1,115 @@
+package coopcmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestNewCoopSessionAppliesSharedMetadata(t *testing.T) {
+	previousOptions := options
+	options = Options{SandboxClaimURL: func() string { return "https://dashboard.stripe.com/sandbox/claim_test" }}
+	t.Cleanup(func() { options = previousOptions })
+
+	session, err := newCoopSession(
+		&coop.Blueprint{ID: "one-time-payment"},
+		"coop_123",
+		"go",
+		[]string{"framework=gin", "framework=chi"},
+		[]string{"customer_type=existing", "customer_type=new"},
+		"parent_123",
+		"deploy",
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "coop_123", session.ID)
+	assert.Equal(t, "go", session.Settings["language"])
+	assert.Equal(t, "chi", session.Settings["framework"])
+	assert.Equal(t, "new", session.Params["customer_type"])
+	assert.Equal(t, "parent_123", session.ParentSessionID)
+	assert.Equal(t, "deploy", session.ParentStepID)
+	assert.True(t, session.UsedSandbox)
+	assert.False(t, session.CreatedAt.IsZero())
+}
+
+func TestNewCoopSessionRejectsMalformedKeyValues(t *testing.T) {
+	bp := &coop.Blueprint{ID: "one-time-payment"}
+
+	tests := []struct {
+		name     string
+		settings []string
+		params   []string
+		want     string
+	}{
+		{name: "setting missing equals", settings: []string{"framework"}, want: "--setting must be in key=value format"},
+		{name: "setting empty key", settings: []string{"=node"}, want: "--setting key cannot be empty"},
+		{name: "setting whitespace key", settings: []string{"  =node"}, want: "--setting key cannot be empty"},
+		{name: "param missing equals", params: []string{"customer_type"}, want: "--param must be in key=value format"},
+		{name: "param empty key", params: []string{"=existing"}, want: "--param key cannot be empty"},
+		{name: "param whitespace key", params: []string{"  =existing"}, want: "--param key cannot be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session, err := newCoopSession(bp, "coop_123", "go", tt.settings, tt.params, "", "")
+
+			require.Error(t, err)
+			assert.Nil(t, session)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestCoopRunReturnsStructuredErrorForMalformedSetting(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cmd := newCoopStartCmd().cmd
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"one-time-payment", "--setting", "framework"})
+
+	stderr := captureStderr(t, func() {
+		err := cmd.Execute()
+		require.Error(t, err)
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
+	assert.False(t, resp.OK)
+	assert.Contains(t, resp.Error, "--setting must be in key=value format")
+	assert.Equal(t, "Use --setting key=value and --param key=value.", resp.Hint)
+
+	store, err := coop.NewStore(coopConfigFolder())
+	require.NoError(t, err)
+	ids, err := store.List()
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
+func TestCoopRunReturnsStructuredErrorForMalformedParam(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cmd := newCoopStartCmd().cmd
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"one-time-payment", "--param", "=existing"})
+
+	stderr := captureStderr(t, func() {
+		err := cmd.Execute()
+		require.Error(t, err)
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
+	assert.False(t, resp.OK)
+	assert.Contains(t, resp.Error, "--param key cannot be empty")
+	assert.Equal(t, "Use --setting key=value and --param key=value.", resp.Hint)
+
+	store, err := coop.NewStore(coopConfigFolder())
+	require.NoError(t, err)
+	ids, err := store.List()
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}

--- a/pkg/cmd/coop/coop_run_test.go
+++ b/pkg/cmd/coop/coop_run_test.go
@@ -66,7 +66,7 @@ func TestNewCoopSessionRejectsMalformedKeyValues(t *testing.T) {
 
 func TestCoopRunReturnsStructuredErrorForMalformedSetting(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	cmd := newCoopStartCmd().cmd
+	cmd := newCoopAgentRunCmd().cmd
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{"one-time-payment", "--setting", "framework"})
@@ -91,7 +91,7 @@ func TestCoopRunReturnsStructuredErrorForMalformedSetting(t *testing.T) {
 
 func TestCoopRunReturnsStructuredErrorForMalformedParam(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	cmd := newCoopStartCmd().cmd
+	cmd := newCoopAgentRunCmd().cmd
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs([]string{"one-time-payment", "--param", "=existing"})

--- a/pkg/cmd/coop/coop_status.go
+++ b/pkg/cmd/coop/coop_status.go
@@ -1,0 +1,78 @@
+package coopcmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type coopStatusCmd struct {
+	cmd     *cobra.Command
+	session string
+	asJSON  bool
+}
+
+func newCoopStatusCmd() *coopStatusCmd {
+	sc := &coopStatusCmd{}
+	sc.cmd = &cobra.Command{
+		Use:   "status",
+		Short: "Show the current co-op session status",
+		Long:  `Displays a summary of the current co-op session including step progress.`,
+		RunE:  sc.runStatusCmd,
+	}
+
+	sc.cmd.Flags().StringVar(&sc.session, "session", "", "Session ID (defaults to latest)")
+	sc.cmd.Flags().BoolVar(&sc.asJSON, "json", false, "Output in JSON format")
+
+	return sc
+}
+
+func (sc *coopStatusCmd) runStatusCmd(cmd *cobra.Command, args []string) error {
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+
+	var session *coop.Session
+	if sc.session != "" {
+		session, err = store.Read(sc.session)
+	} else {
+		session, err = store.LatestSession()
+	}
+	if err != nil {
+		return outputCoopError("No active session found. Start one with 'stripe coop start <blueprint>'.", "stripe coop start one-time-payment")
+	}
+
+	if sc.asJSON {
+		return outputJSON(session)
+	}
+
+	summary := session.NodeSummary()
+	total := session.TotalNodes()
+
+	fmt.Printf("Session: %s\n", session.ID)
+	fmt.Printf("Blueprint: %s\n", session.Blueprint)
+	fmt.Printf("Status: %s\n", session.Status)
+	fmt.Printf("Progress: %d/%d nodes complete\n", summary[coop.NodeDone], total)
+	fmt.Println()
+
+	if summary[coop.NodeActive] > 0 {
+		fmt.Printf("  Active: %d\n", summary[coop.NodeActive])
+	}
+	if summary[coop.NodeReview] > 0 {
+		fmt.Printf("  Awaiting review: %d\n", summary[coop.NodeReview])
+	}
+	if summary[coop.NodePending] > 0 {
+		fmt.Printf("  Pending: %d\n", summary[coop.NodePending])
+	}
+	if summary[coop.NodeSkipped] > 0 {
+		fmt.Printf("  Skipped: %d\n", summary[coop.NodeSkipped])
+	}
+
+	fmt.Println()
+	fmt.Printf("Join the live view: stripe coop join %s\n", session.ID)
+
+	return nil
+}

--- a/pkg/cmd/coop/coop_stop.go
+++ b/pkg/cmd/coop/coop_stop.go
@@ -1,0 +1,69 @@
+package coopcmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type coopStopCmd struct {
+	cmd     *cobra.Command
+	session string
+	abort   bool
+}
+
+func newCoopStopCmd() *coopStopCmd {
+	sc := &coopStopCmd{}
+	sc.cmd = &cobra.Command{
+		Use:   "stop",
+		Short: "End the current co-op session",
+		Long: `Ends the current co-op session. By default marks it as "completed"
+(integration finished successfully). Use --abort to mark it as "aborted"
+(stopped early, integration incomplete).
+
+Ended sessions won't be picked up by co-op join or agent lifecycle commands.`,
+		RunE: sc.runStopCmd,
+	}
+
+	sc.cmd.Flags().StringVar(&sc.session, "session", "", "Session ID (defaults to latest active)")
+	sc.cmd.Flags().BoolVar(&sc.abort, "abort", false, "Mark session as aborted (incomplete, not finishing) instead of completed (done successfully)")
+
+	return sc
+}
+
+func (sc *coopStopCmd) runStopCmd(cmd *cobra.Command, args []string) error {
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+
+	var session *coop.Session
+	if sc.session != "" {
+		session, err = store.Read(sc.session)
+	} else {
+		session, err = store.LatestActiveSession()
+	}
+	if err != nil {
+		return outputCoopError("No active session found.", "stripe coop start <blueprint>")
+	}
+
+	if sc.abort {
+		session.Status = coop.SessionAborted
+	} else {
+		session.Status = coop.SessionCompleted
+	}
+
+	if err := store.Write(session); err != nil {
+		return fmt.Errorf("writing session: %w", err)
+	}
+
+	status := string(session.Status)
+	return outputJSON(coop.CommandResponse{
+		OK:        true,
+		SessionID: session.ID,
+		State:     status,
+		Message:   fmt.Sprintf("Session %s: %s", status, session.ID),
+	})
+}

--- a/pkg/cmd/coop/coop_test.go
+++ b/pkg/cmd/coop/coop_test.go
@@ -1,0 +1,17 @@
+package coopcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoopCommandDoesNotRegisterLegacyAgentCommands(t *testing.T) {
+	cmd := newCoopCmd().cmd
+
+	_, _, err := cmd.Find([]string{"step"})
+	require.Error(t, err)
+
+	_, _, err = cmd.Find([]string{"next-steps"})
+	require.Error(t, err)
+}

--- a/pkg/cmd/coop/coop_test_helpers_test.go
+++ b/pkg/cmd/coop/coop_test_helpers_test.go
@@ -1,0 +1,49 @@
+package coopcmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	fn()
+
+	require.NoError(t, w.Close())
+	os.Stdout = orig
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	return strings.TrimSpace(buf.String())
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	fn()
+
+	require.NoError(t, w.Close())
+	os.Stderr = orig
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	return strings.TrimSpace(buf.String())
+}

--- a/pkg/coop/workflow/service.go
+++ b/pkg/coop/workflow/service.go
@@ -75,6 +75,9 @@ type ReportWorkInput struct {
 
 func (s *Service) StartWork(sessionID string, nodeNumber int, note string) (coop.CommandResponse, error) {
 	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		if err := requireActiveSession(session); err != nil {
+			return err
+		}
 		if err := session.TransitionNode(nodeNumber, coop.NodeActive); err != nil {
 			return err
 		}
@@ -107,6 +110,9 @@ func (s *Service) StartWork(sessionID string, nodeNumber int, note string) (coop
 func (s *Service) ReportWork(sessionID string, nodeNumber int, input ReportWorkInput, autoConfirm bool) (coop.CommandResponse, error) {
 	var targetState coop.NodeState
 	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		if err := requireActiveSession(session); err != nil {
+			return err
+		}
 		node, err := session.NodeByNumber(nodeNumber)
 		if err != nil {
 			return err
@@ -145,6 +151,9 @@ func (s *Service) ReportCheck(sessionID string, nodeNumber int, check string, pa
 		return errorResponse(fmt.Errorf("--check flag is required"), fmt.Sprintf("stripe coop agent report-check --session=%s --step=%d --check=\"<label>\" --passed", sessionID, nodeNumber)), nil
 	}
 	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		if err := requireActiveSession(session); err != nil {
+			return err
+		}
 		node, err := session.NodeByNumber(nodeNumber)
 		if err != nil {
 			return err
@@ -172,6 +181,9 @@ func (s *Service) ReportCheck(sessionID string, nodeNumber int, check string, pa
 
 func (s *Service) Skip(sessionID string, nodeNumber int, note string) (coop.CommandResponse, error) {
 	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
+		if err := requireActiveSession(session); err != nil {
+			return err
+		}
 		if err := session.TransitionNode(nodeNumber, coop.NodeSkipped); err != nil {
 			return err
 		}
@@ -198,6 +210,9 @@ func (s *Service) Skip(sessionID string, nodeNumber int, note string) (coop.Comm
 
 func (s *Service) ConfirmReview(sessionID string, nodeNumbers []int) (*coop.Session, error) {
 	return s.store.Update(sessionID, func(session *coop.Session) error {
+		if err := requireActiveSession(session); err != nil {
+			return err
+		}
 		for _, nodeNumber := range nodeNumbers {
 			node, err := session.NodeByNumber(nodeNumber)
 			if err != nil {
@@ -222,6 +237,9 @@ func (s *Service) RequestChanges(sessionID string, nodeNumbers []int, note strin
 		return nil, fmt.Errorf("request changes note is required")
 	}
 	return s.store.Update(sessionID, func(session *coop.Session) error {
+		if err := requireActiveSession(session); err != nil {
+			return err
+		}
 		for _, nodeNumber := range nodeNumbers {
 			node, err := session.NodeByNumber(nodeNumber)
 			if err != nil {
@@ -244,6 +262,9 @@ func (s *Service) RequestChanges(sessionID string, nodeNumbers []int, note strin
 func (s *Service) AwaitReview(sessionID string, nodeNumber int) (coop.CommandResponse, error) {
 	session, err := s.store.Read(sessionID)
 	if err != nil {
+		return errorResponse(err, "stripe coop status"), nil
+	}
+	if err := requireActiveSession(session); err != nil {
 		return errorResponse(err, "stripe coop status"), nil
 	}
 	node, err := session.NodeByNumber(nodeNumber)
@@ -515,6 +536,13 @@ func timeoutResponse(sessionID string, nodeNumber int) coop.CommandResponse {
 
 func errorResponse(err error, hint string) coop.CommandResponse {
 	return coop.CommandResponse{OK: false, Error: err.Error(), Hint: hint}
+}
+
+func requireActiveSession(session *coop.Session) error {
+	if session.Status == coop.SessionActive {
+		return nil
+	}
+	return fmt.Errorf("session %s is %s and cannot be advanced", session.ID, session.Status)
 }
 
 func language(session *coop.Session) string {

--- a/pkg/coop/workflow/service_test.go
+++ b/pkg/coop/workflow/service_test.go
@@ -107,6 +107,109 @@ func TestRequestChangesMovesReviewNodeBackToActive(t *testing.T) {
 	assert.Nil(t, node.Implementation)
 }
 
+func TestAgentWorkflowRejectsInactiveSessions(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*Service, string) (coop.CommandResponse, error)
+	}{
+		{
+			name: "start work",
+			run: func(service *Service, sessionID string) (coop.CommandResponse, error) {
+				return service.StartWork(sessionID, 1, "Starting")
+			},
+		},
+		{
+			name: "report work",
+			run: func(service *Service, sessionID string) (coop.CommandResponse, error) {
+				return service.ReportWork(sessionID, 1, ReportWorkInput{File: "server.go"}, false)
+			},
+		},
+		{
+			name: "report check",
+			run: func(service *Service, sessionID string) (coop.CommandResponse, error) {
+				return service.ReportCheck(sessionID, 1, "Manual checkout passed", true)
+			},
+		},
+		{
+			name: "skip",
+			run: func(service *Service, sessionID string) (coop.CommandResponse, error) {
+				return service.Skip(sessionID, 1, "Not needed")
+			},
+		},
+		{
+			name: "await review",
+			run: func(service *Service, sessionID string) (coop.CommandResponse, error) {
+				return service.AwaitReview(sessionID, 1)
+			},
+		},
+	}
+
+	for _, status := range []coop.SessionStatus{coop.SessionCompleted, coop.SessionAborted} {
+		t.Run(string(status), func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					store, session := workflowTestStore(t)
+					service := NewService(store)
+					_, err := store.Update(session.ID, func(session *coop.Session) error {
+						session.Status = status
+						return nil
+					})
+					require.NoError(t, err)
+
+					resp, err := tt.run(service, session.ID)
+					require.NoError(t, err)
+					assert.False(t, resp.OK)
+					assert.Contains(t, resp.Error, "session workflow_test is "+string(status)+" and cannot be advanced")
+
+					loaded, err := store.Read(session.ID)
+					require.NoError(t, err)
+					node, err := loaded.NodeByNumber(1)
+					require.NoError(t, err)
+					assert.Equal(t, coop.NodePending, node.State)
+				})
+			}
+		})
+	}
+}
+
+func TestReviewWorkflowRejectsInactiveSessions(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*Service, string) error
+	}{
+		{
+			name: "confirm review",
+			run: func(service *Service, sessionID string) error {
+				_, err := service.ConfirmReview(sessionID, []int{1})
+				return err
+			},
+		},
+		{
+			name: "request changes",
+			run: func(service *Service, sessionID string) error {
+				_, err := service.RequestChanges(sessionID, []int{1}, "Needs tests")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, session := workflowTestStore(t)
+			service := NewService(store)
+			_, err := store.Update(session.ID, func(session *coop.Session) error {
+				session.Status = coop.SessionAborted
+				return nil
+			})
+			require.NoError(t, err)
+
+			err = tt.run(service, session.ID)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "session workflow_test is aborted and cannot be advanced")
+		})
+	}
+}
+
 func workflowTestStore(t *testing.T) (*coop.Store, *coop.Session) {
 	t.Helper()
 	store, err := coop.NewStoreAt(t.TempDir())


### PR DESCRIPTION
Part 6 of the clean co-op stack targeting `coop`.

This PR adds the Cobra command surface for co-op mode without introducing the TUI yet.

Changes:
- Adds `stripe coop` command wiring.
- Adds agent-facing commands for reporting work, checks, review state, status, stop, run, and recommendations.
- Adds command tests for the new co-op command package.

Review notes:
- This should be reviewed first in the remaining stack.
- The next PR layers in Charm dependencies and prompt helpers.
