### PR TITLE
9/12 Add co-op TUI tests

### DIFF
--- a/pkg/coop/tui/commands.go
+++ b/pkg/coop/tui/commands.go
@@ -161,9 +161,9 @@ func (m Model) returnToParent() tea.Cmd {
 
 func (m Model) shouldTransitionToNewSession() bool {
 	suggestions := m.getCompletionSuggestions()
-	if m.cursor >= len(suggestions) {
+	if m.selectionCursor >= len(suggestions) {
 		return false
 	}
-	id := suggestions[m.cursor].id
+	id := suggestions[m.selectionCursor].id
 	return id == "add-integration"
 }

--- a/pkg/coop/tui/commands.go
+++ b/pkg/coop/tui/commands.go
@@ -158,3 +158,12 @@ func (m Model) returnToParent() tea.Cmd {
 		return sessionDiscoveredMsg{sessionID: parentID}
 	}
 }
+
+func (m Model) shouldTransitionToNewSession() bool {
+	suggestions := m.getCompletionSuggestions()
+	if m.cursor >= len(suggestions) {
+		return false
+	}
+	id := suggestions[m.cursor].id
+	return id == "add-integration"
+}

--- a/pkg/coop/tui/interaction_test.go
+++ b/pkg/coop/tui/interaction_test.go
@@ -1,0 +1,229 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestReviewInteractionJourney(t *testing.T) {
+	m := reviewStepLongPromptLayoutModel()
+	m = attachTestStore(t, m)
+	m = prepareInteractiveModel(m, 56, 18)
+
+	assertInteractionLayout(t, m, "initial review")
+	assert.False(t, m.expanded)
+	assert.Contains(t, m.renderFooter(), "changes")
+
+	m = updateWithKey(t, m, tea.KeyEnter)
+	assert.True(t, m.expanded)
+	assert.Empty(t, m.statusMessage)
+	assertInteractionLayout(t, m, "details opened")
+
+	m = updateWithKey(t, m, tea.KeyTab)
+	assert.Equal(t, 1, m.detailTab)
+	assertInteractionLayout(t, m, "details tabbed")
+
+	m = updateWithKey(t, m, tea.KeyEsc)
+	assert.False(t, m.expanded)
+	assertInteractionLayout(t, m, "details closed")
+
+	m = updateWithRunes(t, m, "r")
+	assert.True(t, m.rejecting)
+	assertContainsPlain(t, m.renderFooter(), "esc cancel")
+	assertInteractionLayout(t, m, "request changes input")
+
+	m = updateWithKey(t, m, tea.KeyEnter)
+	assert.True(t, m.rejecting)
+	assert.Contains(t, m.rejectionError, "short note")
+	node, err := m.session.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodeReview, node.State)
+	assertInteractionLayout(t, m, "empty request changes validation")
+
+	m = updateWithRunes(t, m, "Use the stored price ID before redirecting to Checkout")
+	m = updateWithKey(t, m, tea.KeyEnter)
+	assert.False(t, m.rejecting)
+	node, err = m.session.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodeActive, node.State)
+	assert.Contains(t, node.RejectionNote, "stored price ID")
+	assert.Contains(t, m.statusMessage, "Feedback sent")
+	assertInteractionLayout(t, m, "feedback submitted")
+}
+
+func TestFollowInteractionJourney(t *testing.T) {
+	m := manualNavigationLayoutModel()
+	m = prepareInteractiveModel(m, 69, 50)
+
+	assert.True(t, m.userMoved)
+	assert.Equal(t, 2, m.cursor)
+	assertInteractionLayout(t, m, "manual navigation")
+
+	m = updateWithRunes(t, m, "f")
+	assert.False(t, m.userMoved)
+	assert.Equal(t, 0, m.cursor)
+	assert.Contains(t, m.statusMessage, "Following")
+	assertInteractionLayout(t, m, "follow resumed")
+}
+
+func TestStepReviewInteractionJourney(t *testing.T) {
+	m := stepReviewLayoutModel()
+	m = attachTestStore(t, m)
+	m = prepareInteractiveModel(m, 69, 50)
+
+	target, ok := m.selectedReviewTarget()
+	require.True(t, ok)
+	assert.Equal(t, "step", target.kind)
+	assert.Equal(t, []int{1, 2}, target.nodeNumbers)
+	assertInteractionLayout(t, m, "step review")
+
+	m = updateWithRunes(t, m, "c")
+	node1, err := m.session.NodeByNumber(1)
+	require.NoError(t, err)
+	node2, err := m.session.NodeByNumber(2)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodeDone, node1.State)
+	assert.Equal(t, coop.NodeDone, node2.State)
+	assert.NotContains(t, m.renderFooter(), "Review step")
+	assertInteractionLayout(t, m, "step confirmed")
+}
+
+func TestCompletionInteractionJourney(t *testing.T) {
+	m := withCompletionSuggestions(completionLayoutModel())
+	m = attachTestStore(t, m)
+	m = prepareInteractiveModel(m, 56, 18)
+
+	assert.Contains(t, m.View().Content, "Next steps")
+	assertInteractionLayout(t, m, "completion initial")
+
+	m = updateWithRunes(t, m, "j")
+	assert.Equal(t, 1, m.cursor)
+	assertInteractionLayout(t, m, "completion moved")
+
+	m = updateWithRunes(t, m, "k")
+	assert.Equal(t, 0, m.cursor)
+	assertInteractionLayout(t, m, "completion moved back")
+}
+
+func TestDetailsToggleKeepsChromePinned(t *testing.T) {
+	for _, size := range []layoutSize{
+		{name: "narrow_acceptance", width: 56, height: 18},
+		{name: "coop_start_split", width: 69, height: 50},
+	} {
+		t.Run(size.name, func(t *testing.T) {
+			m := reviewStepLongPromptLayoutModel()
+			m = prepareInteractiveModel(m, size.width, size.height)
+
+			for i := 0; i < 4; i++ {
+				m = updateWithKey(t, m, tea.KeyEnter)
+				assertLayoutFits(t, m.View().Content, size)
+				assertHeaderIsPinned(t, m.View().Content)
+				assertFooterIsPinned(t, m.View().Content, "enter")
+				assert.NotContains(t, m.View().Content, "Details opened")
+				assert.NotContains(t, m.View().Content, "Details collapsed")
+			}
+		})
+	}
+}
+
+func TestExpandedReviewConfirmationKeepsChromePinned(t *testing.T) {
+	m := expandedDetailsLayoutModel()
+	m = prepareInteractiveModel(m, 69, 50)
+
+	rendered := m.View().Content
+
+	assertLayoutFits(t, rendered, layoutSize{name: "expanded_review_confirmation", width: 69, height: 50})
+	assertHeaderIsPinned(t, rendered)
+	assertFooterIsPinned(t, rendered, "enter")
+	assert.Contains(t, rendered, "Files")
+	assert.Contains(t, rendered, "confirm")
+	assert.Contains(t, rendered, "Waiting for you")
+}
+
+func TestMoveOntoReviewAfterDetailsToggleKeepsChromePinned(t *testing.T) {
+	m := testModel()
+	m.spinner = staticSpinner()
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.session.Steps[1].Nodes[0].State = coop.NodeReview
+	m.session.Steps[1].Nodes[0].Implementation = &coop.Implementation{
+		File:  "server/webhooks/checkout_completed_handler_with_long_name.js",
+		Lines: "12-96",
+	}
+	m.session.Steps[1].Nodes[0].ReviewPrompt = "Confirm the webhook handler verifies the Stripe signature, handles duplicate events, stores the Checkout Session ID, and does not expose secrets in logs."
+	m.session.Steps[1].Nodes[0].Verifications = []coop.Verification{
+		{Check: "Verified webhook signature", Passed: true},
+		{Check: "Handled duplicate events", Passed: true},
+		{Check: "Ran stripe trigger checkout.session.completed", Passed: true},
+	}
+	m.cursor = 1
+	m = prepareInteractiveModel(m, 69, 50)
+
+	m = updateWithKey(t, m, tea.KeyEnter)
+	assert.True(t, m.expanded)
+	assertInteractionLayout(t, m, "details opened before review")
+
+	m = updateWithKey(t, m, tea.KeyEsc)
+	assert.False(t, m.expanded)
+	assertInteractionLayout(t, m, "details closed before review")
+
+	m = updateWithRunes(t, m, "j")
+	assertInteractionLayout(t, m, "moved onto step")
+	m = updateWithRunes(t, m, "j")
+	assert.Equal(t, 2, m.cursor)
+	assertInteractionLayout(t, m, "moved onto review card")
+	assert.Equal(t, m.height-1, lineIndexContaining(m.View().Content, "enter"))
+	assert.Contains(t, m.View().Content, "Review")
+	assertContainsPlain(t, m.View().Content, "f follow")
+}
+
+func attachTestStore(t *testing.T, m Model) Model {
+	t.Helper()
+	store, err := coop.NewStoreAt(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, store.Write(m.session))
+	m.store = store
+	return m
+}
+
+func prepareInteractiveModel(m Model, width, height int) Model {
+	m.ready = true
+	m.width = width
+	m.height = height
+	m.viewport = viewport.New(viewport.WithWidth(width), viewport.WithHeight(10))
+	m.resizeViewport()
+	m.syncViewport()
+	return m
+}
+
+func updateWithRunes(t *testing.T, m Model, text string) Model {
+	t.Helper()
+	runes := []rune(text)
+	updated, _ := m.Update(tea.KeyPressMsg{Code: runes[0], Text: text})
+	return updated.(Model)
+}
+
+func updateWithKey(t *testing.T, m Model, key rune) Model {
+	t.Helper()
+	updated, _ := m.Update(tea.KeyPressMsg{Code: key})
+	return updated.(Model)
+}
+
+func assertInteractionLayout(t *testing.T, m Model, label string) {
+	t.Helper()
+	rendered := m.View().Content
+	size := layoutSize{name: strings.ReplaceAll(label, " ", "_"), width: m.width, height: m.height}
+	assertLayoutFits(t, rendered, size)
+	assertHeaderIsPinned(t, rendered)
+	footerToken := "enter"
+	if m.rejecting {
+		footerToken = "esc cancel"
+	}
+	assertFooterIsPinned(t, rendered, footerToken)
+}

--- a/pkg/coop/tui/interaction_test.go
+++ b/pkg/coop/tui/interaction_test.go
@@ -63,12 +63,12 @@ func TestFollowInteractionJourney(t *testing.T) {
 	m = prepareInteractiveModel(m, 69, 50)
 
 	assert.True(t, m.userMoved)
-	assert.Equal(t, 2, m.cursor)
+	assert.Equal(t, 2, m.selectionCursor)
 	assertInteractionLayout(t, m, "manual navigation")
 
 	m = updateWithRunes(t, m, "f")
 	assert.False(t, m.userMoved)
-	assert.Equal(t, 0, m.cursor)
+	assert.Equal(t, 0, m.selectionCursor)
 	assert.Contains(t, m.statusMessage, "Following")
 	assertInteractionLayout(t, m, "follow resumed")
 }
@@ -104,11 +104,11 @@ func TestCompletionInteractionJourney(t *testing.T) {
 	assertInteractionLayout(t, m, "completion initial")
 
 	m = updateWithRunes(t, m, "j")
-	assert.Equal(t, 1, m.cursor)
+	assert.Equal(t, 1, m.selectionCursor)
 	assertInteractionLayout(t, m, "completion moved")
 
 	m = updateWithRunes(t, m, "k")
-	assert.Equal(t, 0, m.cursor)
+	assert.Equal(t, 0, m.selectionCursor)
 	assertInteractionLayout(t, m, "completion moved back")
 }
 
@@ -162,7 +162,7 @@ func TestMoveOntoReviewAfterDetailsToggleKeepsChromePinned(t *testing.T) {
 		{Check: "Handled duplicate events", Passed: true},
 		{Check: "Ran stripe trigger checkout.session.completed", Passed: true},
 	}
-	m.cursor = 1
+	m.selectionCursor = 1
 	m = prepareInteractiveModel(m, 69, 50)
 
 	m = updateWithKey(t, m, tea.KeyEnter)
@@ -176,7 +176,7 @@ func TestMoveOntoReviewAfterDetailsToggleKeepsChromePinned(t *testing.T) {
 	m = updateWithRunes(t, m, "j")
 	assertInteractionLayout(t, m, "moved onto step")
 	m = updateWithRunes(t, m, "j")
-	assert.Equal(t, 2, m.cursor)
+	assert.Equal(t, 2, m.selectionCursor)
 	assertInteractionLayout(t, m, "moved onto review card")
 	assert.Equal(t, m.height-1, lineIndexContaining(m.View().Content, "enter"))
 	assert.Contains(t, m.View().Content, "Review")

--- a/pkg/coop/tui/layout_test.go
+++ b/pkg/coop/tui/layout_test.go
@@ -149,7 +149,7 @@ func TestSessionUpdateResizesAfterAutoSelectingReview(t *testing.T) {
 	m.width = 56
 	m.height = 18
 	m.viewport = viewport.New(viewport.WithWidth(m.width), viewport.WithHeight(10))
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.session.Steps[0].Nodes[0].State = coop.NodeDone
 	m.session.Steps[0].Nodes[1].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].Title = "Review Checkout Session creation, saved IDs, redirect behavior, and webhook assumptions"
@@ -283,7 +283,7 @@ func activeStepLayoutModel() Model {
 	m.session.Steps[0].Nodes[0].State = coop.NodeDone
 	m.session.Steps[0].Nodes[1].State = coop.NodeActive
 	m.session.Steps[0].Nodes[1].Activity = "Adding the Checkout endpoint and wiring the returned session URL into the app"
-	m.cursor = 1
+	m.selectionCursor = 1
 	return m
 }
 
@@ -303,7 +303,7 @@ func reviewStepLongPromptLayoutModel() Model {
 		{Check: "Saved price ID for Checkout", Passed: true},
 		{Check: "Ran local Checkout flow", Passed: true},
 	}
-	m.cursor = 0
+	m.selectionCursor = 0
 	return m
 }
 
@@ -331,7 +331,7 @@ func requestChangesLayoutModel() Model {
 
 func manualNavigationLayoutModel() Model {
 	m := reviewStepLongPromptLayoutModel()
-	m.cursor = 2
+	m.selectionCursor = 2
 	m.userMoved = true
 	return m
 }
@@ -351,7 +351,7 @@ func completionLayoutModel() Model {
 			m.session.Steps[i].Nodes[j].State = coop.NodeDone
 		}
 	}
-	m.cursor = 0
+	m.selectionCursor = 0
 	return m
 }
 

--- a/pkg/coop/tui/layout_test.go
+++ b/pkg/coop/tui/layout_test.go
@@ -1,0 +1,373 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/spinner"
+	"charm.land/bubbles/v2/viewport"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type layoutSize struct {
+	name   string
+	width  int
+	height int
+}
+
+type layoutScenario struct {
+	name             string
+	model            func() Model
+	footerToken      string
+	expectCursor     bool
+	expectReviewCard bool
+	expectCompletion bool
+}
+
+var layoutMatrixSizes = []layoutSize{
+	{name: "tiny", width: 40, height: 12},
+	{name: "narrow_acceptance", width: 56, height: 18},
+	{name: "coop_start_split", width: 69, height: 50},
+	{name: "normal", width: 80, height: 24},
+	{name: "wide", width: 120, height: 40},
+}
+
+func TestUILayoutMatrix(t *testing.T) {
+	scenarios := []layoutScenario{
+		{
+			name:        "waiting",
+			model:       waitingLayoutModel,
+			footerToken: "q quit",
+		},
+		{
+			name:         "active_step",
+			model:        activeStepLayoutModel,
+			footerToken:  "enter",
+			expectCursor: true,
+		},
+		{
+			name:             "review_step_long_prompt",
+			model:            reviewStepLongPromptLayoutModel,
+			footerToken:      "enter",
+			expectCursor:     true,
+			expectReviewCard: true,
+		},
+		{
+			name:             "step_review_many_changes",
+			model:            stepReviewLayoutModel,
+			footerToken:      "enter",
+			expectCursor:     true,
+			expectReviewCard: true,
+		},
+		{
+			name:             "request_changes_input",
+			model:            requestChangesLayoutModel,
+			footerToken:      "esc cancel",
+			expectCursor:     true,
+			expectReviewCard: true,
+		},
+		{
+			name:        "manual_navigation",
+			model:       manualNavigationLayoutModel,
+			footerToken: "f follow",
+		},
+		{
+			name:         "expanded_details",
+			model:        expandedDetailsLayoutModel,
+			footerToken:  "enter",
+			expectCursor: true,
+		},
+		{
+			name:             "completion",
+			model:            completionLayoutModel,
+			footerToken:      "enter",
+			expectCompletion: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		for _, size := range layoutMatrixSizes {
+			t.Run(scenario.name+"/"+size.name, func(t *testing.T) {
+				m := scenario.model()
+				rendered := renderLayoutScenario(&m, size)
+				writeLayoutCapture(t, scenario.name, size, rendered)
+
+				assertLayoutFits(t, rendered, size)
+				assertHeaderIsPinned(t, rendered)
+				assertFooterIsPinned(t, rendered, scenario.footerToken)
+				if scenario.expectCursor {
+					assert.Contains(t, rendered, strings.TrimSpace(cursorMarker), "selected row should remain visible")
+				}
+				if scenario.expectReviewCard {
+					assert.Contains(t, rendered, "Review", "review card should remain visible")
+					assert.LessOrEqual(t, lipgloss.Height(m.renderFooter()), m.footerHeightBudget(), "review footer should stay within its budget")
+				}
+				if scenario.expectCompletion {
+					assert.Contains(t, rendered, "Integration complete")
+					assert.NotContains(t, rendered, "Waiting for agent to continue")
+				}
+			})
+		}
+	}
+}
+
+func TestCompletionTransitionClearsTransientStatus(t *testing.T) {
+	m := activeStepLayoutModel()
+	m.ready = true
+	m.width = 80
+	m.height = 24
+	m.viewport = viewport.New(viewport.WithWidth(80), viewport.WithHeight(10))
+	m.statusMessage = "Waiting for agent to continue..."
+	m.statusExpiresAt = m.lastUpdateTime.Add(10)
+
+	next := completionLayoutModel().session
+	next.ID = m.session.ID
+	next.Blueprint = m.session.Blueprint
+	next.Settings = m.session.Settings
+
+	updatedModel, _ := m.Update(sessionUpdatedMsg{session: next})
+	updated := updatedModel.(Model)
+	rendered := renderLayoutScenario(&updated, layoutSize{name: "normal", width: 80, height: 24})
+
+	assert.Contains(t, rendered, "Integration complete")
+	assert.Contains(t, rendered, "Waiting for agent to publish next steps")
+	assert.NotContains(t, rendered, "Waiting for agent to continue")
+}
+
+func TestSessionUpdateResizesAfterAutoSelectingReview(t *testing.T) {
+	m := testModel()
+	m.spinner = staticSpinner()
+	m.ready = true
+	m.width = 56
+	m.height = 18
+	m.viewport = viewport.New(viewport.WithWidth(m.width), viewport.WithHeight(10))
+	m.cursor = 0
+	m.session.Steps[0].Nodes[0].State = coop.NodeDone
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].Title = "Review Checkout Session creation, saved IDs, redirect behavior, and webhook assumptions"
+	m.session.Steps[0].Nodes[1].ReviewPrompt = "Open the local app, start Checkout, inspect the server logs, confirm the saved price ID is reused instead of creating a new Price, confirm the redirect URL is correct, confirm errors are handled without exposing secrets, and confirm the success page reflects the completed payment."
+	m.session.Steps[0].Nodes[1].Implementation = &coop.Implementation{
+		File:  "server/src/payments/checkout/session/create_checkout_session_handler_with_long_name.ts",
+		Lines: "42-118",
+	}
+	m.session.Steps[0].Nodes[1].Verifications = []coop.Verification{
+		{Check: "Created product and price", Passed: true},
+		{Check: "Confirmed Checkout reuses the saved price ID", Passed: true},
+	}
+
+	updatedModel, _ := m.Update(sessionUpdatedMsg{session: m.session})
+	updated := updatedModel.(Model)
+	rendered := updated.View().Content
+
+	assert.Equal(t, navigationStep, updated.selected.kind)
+	assert.Equal(t, 0, updated.selected.stepIndex)
+	assertLayoutFits(t, rendered, layoutSize{name: "narrow_acceptance", width: 56, height: 18})
+	assertHeaderIsPinned(t, rendered)
+	assertFooterIsPinned(t, rendered, "enter")
+	assert.Contains(t, rendered, "Review")
+	assert.Contains(t, rendered, "Confirmation steps")
+}
+
+func TestFooterActionRowStaysPinnedAcrossFooterModes(t *testing.T) {
+	size := layoutSize{name: "coop_start_split", width: 69, height: 50}
+	scenarios := []struct {
+		name  string
+		model func() Model
+		token string
+	}{
+		{name: "active", model: activeStepLayoutModel, token: "enter"},
+		{name: "review", model: reviewStepLongPromptLayoutModel, token: "enter"},
+		{name: "manual", model: manualNavigationLayoutModel, token: "f follow"},
+		{name: "request_changes", model: requestChangesLayoutModel, token: "esc cancel"},
+	}
+
+	expectedRow := -1
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			m := scenario.model()
+			rendered := renderLayoutScenario(&m, size)
+			row := lineIndexContaining(rendered, scenario.token)
+			require.NotEqual(t, -1, row, "footer action row should be visible")
+			assert.Equal(t, size.height-1, row, "footer action row should sit on the final terminal row")
+			if expectedRow == -1 {
+				expectedRow = row
+			}
+			assert.Equal(t, expectedRow, row, "footer action row should not jump when card/status content changes")
+		})
+	}
+}
+
+func TestPinnedViewportCapsStaleViewportHeight(t *testing.T) {
+	size := layoutSize{name: "coop_start_split", width: 69, height: 50}
+	m := reviewStepLongPromptLayoutModel()
+	m = prepareInteractiveModel(m, size.width, size.height)
+	m.viewport.SetHeight(size.height)
+
+	rendered := m.View().Content
+
+	assertLayoutFits(t, rendered, size)
+	assertHeaderIsPinned(t, rendered)
+	assertFooterIsPinned(t, rendered, "enter")
+	assert.Equal(t, size.height-1, lineIndexContaining(rendered, "enter"))
+}
+
+func renderLayoutScenario(m *Model, size layoutSize) string {
+	m.ready = true
+	m.width = size.width
+	m.height = size.height
+	m.viewport = viewport.New(viewport.WithWidth(size.width), viewport.WithHeight(10))
+	m.resizeViewport()
+	m.syncViewport()
+	return m.View().Content
+}
+
+func assertLayoutFits(t *testing.T, rendered string, size layoutSize) {
+	t.Helper()
+	assert.LessOrEqual(t, lipgloss.Height(rendered), size.height, "layout should not exceed terminal height")
+	assertLinesWithinWidth(t, rendered, size.width)
+}
+
+func assertHeaderIsPinned(t *testing.T, rendered string) {
+	t.Helper()
+	lines := strings.Split(rendered, "\n")
+	require.NotEmpty(t, lines)
+	window := strings.Join(lines[:min(len(lines), 3)], "\n")
+	assert.Contains(t, window, "Stripe Co-op", "header should stay in the first three lines")
+}
+
+func assertFooterIsPinned(t *testing.T, rendered, token string) {
+	t.Helper()
+	lines := strings.Split(strings.TrimRight(rendered, "\n"), "\n")
+	require.NotEmpty(t, lines)
+	window := ansi.Strip(strings.Join(lines[max(len(lines)-4, 0):], "\n"))
+	assert.Contains(t, window, token, "primary footer action should stay near the bottom")
+}
+
+func lineIndexContaining(rendered, token string) int {
+	for i, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(ansi.Strip(line), token) {
+			return i
+		}
+	}
+	return -1
+}
+
+func writeLayoutCapture(t *testing.T, scenario string, size layoutSize, rendered string) {
+	t.Helper()
+	dir := os.Getenv("COOP_TUI_CAPTURE_DIR")
+	if dir == "" {
+		return
+	}
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	name := fmt.Sprintf("%s-%s-%dx%d.txt", scenario, size.name, size.width, size.height)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(rendered), 0644))
+}
+
+func waitingLayoutModel() Model {
+	m := NewWaitingModel(nil, nil)
+	m.spinner = staticSpinner()
+	return m
+}
+
+func activeStepLayoutModel() Model {
+	m := testModel()
+	m.spinner = staticSpinner()
+	m.session.Steps[0].Nodes[0].State = coop.NodeDone
+	m.session.Steps[0].Nodes[1].State = coop.NodeActive
+	m.session.Steps[0].Nodes[1].Activity = "Adding the Checkout endpoint and wiring the returned session URL into the app"
+	m.cursor = 1
+	return m
+}
+
+func reviewStepLongPromptLayoutModel() Model {
+	m := testModel()
+	m.spinner = staticSpinner()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.session.Steps[0].Nodes[0].Implementation = &coop.Implementation{
+		File:  "server/routes/payments/checkout/session_handler.js",
+		Lines: "42-118",
+		Note:  "Created product and price setup for Checkout.",
+	}
+	m.session.Steps[0].Nodes[0].ReviewPrompt = "Open the local app, complete the Checkout flow, confirm the saved price ID is reused by the Checkout Session, confirm the redirect lands on the success page, and confirm no secret keys are committed."
+	m.session.Steps[0].Nodes[0].Verifications = []coop.Verification{
+		{Check: "Created product and price", Passed: true},
+		{Check: "Saved price ID for Checkout", Passed: true},
+		{Check: "Ran local Checkout flow", Passed: true},
+	}
+	m.cursor = 0
+	return m
+}
+
+func stepReviewLayoutModel() Model {
+	m := testModel()
+	m.spinner = staticSpinner()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[0].ReviewPrompt = "Confirm the product and price are created once, persisted for later steps, and reused by the Checkout Session."
+	m.session.Steps[0].Nodes[0].Implementation = &coop.Implementation{File: "server/catalog/stripe_products.js", Lines: "10-84"}
+	m.session.Steps[0].Nodes[0].Verifications = []coop.Verification{{Check: "Created product", Passed: true}, {Check: "Created price", Passed: true}}
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].ReviewPrompt = "Open the app locally, click the Checkout button, complete payment, and confirm the redirect reaches the expected success page."
+	m.session.Steps[0].Nodes[1].Implementation = &coop.Implementation{File: "client/src/components/CheckoutButton.tsx", Lines: "9-88"}
+	m.session.Steps[0].Nodes[1].Verifications = []coop.Verification{{Check: "Rendered Checkout button", Passed: true}, {Check: "Confirmed redirect", Passed: true}}
+	m.selectStep(0)
+	return m
+}
+
+func requestChangesLayoutModel() Model {
+	m := reviewStepLongPromptLayoutModel()
+	m.rejecting = true
+	m.rejectionInput.SetValue("The Checkout Session should use the persisted price ID instead of creating a new price for every request.")
+	return m
+}
+
+func manualNavigationLayoutModel() Model {
+	m := reviewStepLongPromptLayoutModel()
+	m.cursor = 2
+	m.userMoved = true
+	return m
+}
+
+func expandedDetailsLayoutModel() Model {
+	m := reviewStepLongPromptLayoutModel()
+	m.expanded = true
+	m.detailTab = 1
+	m.session.Steps[0].Nodes[0].Implementation.Snippet = strings.Repeat("const session = await stripe.checkout.sessions.create({ mode: 'payment' })\n", 8)
+	return m
+}
+
+func completionLayoutModel() Model {
+	m := testModel()
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	m.cursor = 0
+	return m
+}
+
+func withCompletionSuggestions(m Model) Model {
+	m.session.NextSteps = &coop.NextStepsState{
+		Suggestions: []coop.NextStepSuggestion{
+			{ID: "summarize", Title: "Write a STRIPE.md summary", Description: "Ask the agent to document what changed."},
+			{ID: "add-integration", Title: "Add another Stripe feature", Description: "Ask the agent to start another co-op session."},
+			{ID: "done", Title: "Finish", Description: "Close this co-op session."},
+		},
+	}
+	return m
+}
+
+func staticSpinner() spinner.Model {
+	s := spinner.New()
+	s.Spinner = spinner.Spinner{Frames: []string{"●"}, FPS: 1}
+	return s
+}

--- a/pkg/coop/tui/model_test.go
+++ b/pkg/coop/tui/model_test.go
@@ -1,0 +1,1182 @@
+package tui
+
+import (
+	"image/color"
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func readyModel() Model {
+	m := testModel()
+	m.ready = true
+	m.viewport = viewport.New(viewport.WithWidth(80), viewport.WithHeight(20))
+	return m
+}
+
+func TestUpdateKeyDown(t *testing.T) {
+	m := readyModel()
+	m.cursor = 0
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	updated := result.(Model)
+
+	assert.Equal(t, 1, updated.cursor)
+	assert.True(t, updated.userMoved)
+}
+
+func TestUpdateKeyUp(t *testing.T) {
+	m := readyModel()
+	m.cursor = 2
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	updated := result.(Model)
+
+	assert.Equal(t, navigationStep, updated.selected.kind)
+	assert.Equal(t, 1, updated.selected.stepIndex)
+}
+
+func TestUpdateKeyUpAtTop(t *testing.T) {
+	m := readyModel()
+	m.cursor = 0
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	updated := result.(Model)
+
+	assert.Equal(t, 0, updated.cursor)
+}
+
+func TestUpdateKeyDownAtBottom(t *testing.T) {
+	m := readyModel()
+	m.cursor = m.session.TotalNodes() - 1
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	updated := result.(Model)
+
+	assert.Equal(t, m.session.TotalNodes()-1, updated.cursor)
+}
+
+func TestUpdatePageKeysMoveViewport(t *testing.T) {
+	m := readyModel()
+	m.viewport.SetContent(strings.Join([]string{
+		"one", "two", "three", "four", "five", "six", "seven", "eight",
+	}, "\n"))
+	m.viewport.SetHeight(3)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: ' '})
+	updated := result.(Model)
+
+	assert.True(t, updated.viewport.YOffset() > 0)
+	assert.True(t, updated.userMoved)
+}
+
+func TestUpdateKeyExpand(t *testing.T) {
+	m := readyModel()
+	m.expanded = false
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'e', Text: "e"})
+	updated := result.(Model)
+
+	assert.True(t, updated.expanded)
+}
+
+func TestUpdateKeyExpandToggle(t *testing.T) {
+	m := readyModel()
+	m.expanded = true
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'e', Text: "e"})
+	updated := result.(Model)
+
+	assert.False(t, updated.expanded)
+}
+
+func TestUpdateKeyTabCyclesDetailStep(t *testing.T) {
+	m := readyModel()
+	m.expanded = true
+	m.detailTab = 0
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	updated := result.(Model)
+
+	assert.Equal(t, 1, updated.detailTab)
+}
+
+func TestUpdateKeyEscClosesDetails(t *testing.T) {
+	m := readyModel()
+	m.expanded = true
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	updated := result.(Model)
+
+	assert.False(t, updated.expanded)
+}
+
+func TestUpdateKeyConfirm(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.cursor = 0
+	store.Write(m.session)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	updated := result.(Model)
+
+	node, _ := updated.session.NodeByNumber(1)
+	assert.Equal(t, coop.NodeDone, node.State)
+}
+
+func TestUpdateKeyConfirmIgnoresRepeat(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.cursor = 0
+	store.Write(m.session)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'c', Text: "c", IsRepeat: true})
+	updated := result.(Model)
+
+	node, _ := updated.session.NodeByNumber(1)
+	assert.Equal(t, coop.NodeReview, node.State)
+}
+
+func TestViewProgressBarReflectsSessionProgress(t *testing.T) {
+	m := readyModel()
+
+	view := m.View()
+
+	require.NotNil(t, view.ProgressBar)
+	assert.Equal(t, tea.ProgressBarDefault, view.ProgressBar.State)
+	assert.Equal(t, 33, view.ProgressBar.Value)
+}
+
+func TestUpdateMouseClickOpensClaimURL(t *testing.T) {
+	m := readyModel()
+	claimURL := "https://dashboard.stripe.com/sandbox/claim_abc"
+	m.session.UsedSandbox = true
+	m.sandboxClaimURL = claimURL
+	var opened string
+	oldOpen := openBrowserFn
+	openBrowserFn = func(url string) error {
+		opened = url
+		return nil
+	}
+	t.Cleanup(func() { openBrowserFn = oldOpen })
+
+	result, cmd := m.Update(tea.MouseClickMsg(tea.Mouse{Y: 1, Button: tea.MouseLeft}))
+	_ = result.(Model)
+	assert.Nil(t, cmd)
+	assert.Empty(t, opened)
+
+	view := m.View()
+	mouseCmd := view.OnMouse(tea.MouseClickMsg(tea.Mouse{Y: 1, Button: tea.MouseLeft}))
+	require.NotNil(t, mouseCmd)
+	action, ok := mouseCmd().(mouseActionMsg)
+	require.True(t, ok)
+
+	result, cmd = m.Update(action)
+	_ = result.(Model)
+	require.NotNil(t, cmd)
+	msg := cmd()
+	assert.Nil(t, msg)
+
+	assert.Equal(t, claimURL, opened)
+}
+
+func TestUpdateMouseWheelScrollsViewport(t *testing.T) {
+	m := readyModel()
+	m.viewport.SetHeight(3)
+	m.viewport.SetContent(strings.Join([]string{
+		"one", "two", "three", "four", "five", "six", "seven",
+	}, "\n"))
+
+	result, _ := m.Update(tea.MouseWheelMsg(tea.Mouse{Button: tea.MouseWheelDown}))
+	updated := result.(Model)
+
+	assert.True(t, updated.userMoved)
+	assert.Greater(t, updated.viewport.YOffset(), 0)
+}
+
+func TestSyncViewportPreservesManualScroll(t *testing.T) {
+	m := readyModel()
+	m.ready = true
+	m.width = 80
+	m.height = 12
+	m.resizeViewport()
+	m.cursor = 0
+	m.expanded = true
+	m.sdkSnippet = strings.Repeat("const product = await stripe.products.create({});\n", 20)
+	m.sdkSnippetNode = 0
+	m.syncViewport()
+	m.viewport.SetYOffset(6)
+	m.userMoved = true
+
+	m.syncViewport()
+
+	assert.Equal(t, 6, m.viewport.YOffset())
+}
+
+func TestViewInstallsMouseHandler(t *testing.T) {
+	m := readyModel()
+
+	view := m.View()
+
+	assert.NotNil(t, view.OnMouse)
+}
+
+func TestMouseActionSelectsVisibleStep(t *testing.T) {
+	m := readyModel()
+	m.ready = true
+	m.width = 80
+	m.height = 24
+	m.resizeViewport()
+	m.syncViewport()
+
+	result, _ := m.Update(mouseActionMsg{action: mouseActionSelectStep, index: 1})
+	updated := result.(Model)
+
+	assert.Equal(t, 2, updated.cursor)
+	assert.True(t, updated.userMoved)
+}
+
+func TestNavigationMovesBetweenStepAndStepRows(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.selectStep(0)
+
+	m.syncViewport()
+
+	m.moveCursorUp()
+	assert.Equal(t, navigationStep, m.selected.kind)
+	assert.Equal(t, 0, m.selected.stepIndex)
+
+	m.moveCursorDown()
+	assert.Equal(t, navigationNode, m.selected.kind)
+	assert.Equal(t, 0, m.cursor)
+}
+
+func TestMouseActionSelectsStep(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+
+	result, _ := m.Update(mouseActionMsg{action: mouseActionSelectStep, index: 0})
+	updated := result.(Model)
+
+	assert.Equal(t, navigationStep, updated.selected.kind)
+	assert.Equal(t, 0, updated.selected.stepIndex)
+	assert.True(t, updated.userMoved)
+}
+
+func TestLeftRightCollapseAndExpandSelectedStep(t *testing.T) {
+	m := readyModel()
+	m.selectStep(0)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	updated := result.(Model)
+
+	assert.True(t, updated.stepCollapsed(0))
+	assert.Equal(t, navigationStep, updated.selected.kind)
+
+	result, _ = updated.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	updated = result.(Model)
+
+	assert.False(t, updated.stepCollapsed(0))
+	assert.Equal(t, navigationStep, updated.selected.kind)
+}
+
+func TestLeftFromStepMovesToParentStep(t *testing.T) {
+	m := readyModel()
+	m.selectStep(1)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	updated := result.(Model)
+
+	assert.Equal(t, navigationStep, updated.selected.kind)
+	assert.Equal(t, 1, updated.selected.stepIndex)
+	assert.True(t, updated.stepCollapsed(1))
+}
+
+func TestUpdateKeyConfirmNotOnReviewStep(t *testing.T) {
+	m := readyModel()
+	m.cursor = 0 // step is Done, not Review
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	updated := result.(Model)
+
+	// Should not change
+	node, _ := updated.session.NodeByNumber(1)
+	assert.Equal(t, coop.NodeDone, node.State)
+}
+
+func TestUpdateKeyReject(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.session.Steps[0].Nodes[0].Implementation = &coop.Implementation{File: "a.js"}
+	m.cursor = 0
+	store.Write(m.session)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	updated := result.(Model)
+	assert.True(t, updated.rejecting)
+
+	result, _ = updated.Update(tea.KeyPressMsg{Code: 'N', Text: "Needs tests"})
+	updated = result.(Model)
+	result, _ = updated.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	updated = result.(Model)
+
+	node, _ := updated.session.NodeByNumber(1)
+	assert.Equal(t, coop.NodeActive, node.State)
+	assert.Nil(t, node.Implementation)
+	assert.Equal(t, "Needs tests", node.RejectionNote)
+	assert.False(t, updated.rejecting)
+}
+
+func TestUpdateKeyRejectRequiresNote(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.cursor = 0
+	store.Write(m.session)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	updated := result.(Model)
+	result, _ = updated.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	updated = result.(Model)
+
+	node, _ := updated.session.NodeByNumber(1)
+	assert.Equal(t, coop.NodeReview, node.State)
+	assert.True(t, updated.rejecting)
+	assert.Contains(t, updated.rejectionError, "short note")
+}
+
+func TestRejectingViewSetsRealCursor(t *testing.T) {
+	m := readyModel()
+	m.ready = true
+	m.width = 69
+	m.height = 20
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.cursor = 0
+	m.startReject()
+
+	view := m.View()
+
+	require.NotNil(t, view.Cursor)
+	assert.GreaterOrEqual(t, view.Cursor.X, 0)
+	assert.GreaterOrEqual(t, view.Cursor.Y, 0)
+	assert.Equal(t, tea.CursorBar, view.Cursor.Shape)
+}
+
+func TestBackgroundColorUpdatesTheme(t *testing.T) {
+	m := readyModel()
+	require.True(t, m.theme.IsDark)
+
+	result, _ := m.Update(tea.BackgroundColorMsg{Color: color.White})
+	updated := result.(Model)
+
+	assert.False(t, updated.theme.IsDark)
+	assert.False(t, updated.isDark)
+	assert.NotEqual(t, m.theme.HueGray300, updated.theme.HueGray300)
+}
+
+func TestUpdateKeyConfirmStepReview(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.selectStep(0)
+	m.userMoved = true
+	store.Write(m.session)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	updated := result.(Model)
+
+	node1, _ := updated.session.NodeByNumber(1)
+	node2, _ := updated.session.NodeByNumber(2)
+	assert.Equal(t, coop.NodeDone, node1.State)
+	assert.Equal(t, coop.NodeDone, node2.State)
+	assert.False(t, updated.userMoved)
+}
+
+func TestUpdateKeyConfirmStepReviewFromNodeSelection(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.selectNode(0)
+	store.Write(m.session)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	updated := result.(Model)
+
+	node1, _ := updated.session.NodeByNumber(1)
+	node2, _ := updated.session.NodeByNumber(2)
+	assert.Equal(t, coop.NodeDone, node1.State)
+	assert.Equal(t, coop.NodeDone, node2.State)
+}
+
+func TestSelectedReviewTargetStepRequiresReadyStep(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodePending
+	m.cursor = 0
+
+	_, ok := m.selectedReviewTarget()
+	assert.False(t, ok)
+	assert.False(t, m.reviewIsActionable(1))
+
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	_, ok = m.selectedReviewTarget()
+	assert.True(t, ok)
+
+	m.selectStep(0)
+	target, ok := m.selectedReviewTarget()
+
+	assert.True(t, ok)
+	assert.Equal(t, "step", target.kind)
+	assert.Equal(t, "Set up product", target.title)
+	assert.Equal(t, []int{1, 2}, target.nodeNumbers)
+	assert.True(t, m.reviewIsActionable(1))
+}
+
+func TestUpdateKeyRejectStepReview(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[0].Implementation = &coop.Implementation{File: "product.js"}
+	m.session.Steps[0].Nodes[0].Verifications = []coop.Verification{{Check: "product test", Passed: true}}
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].Implementation = &coop.Implementation{File: "checkout.js"}
+	m.session.Steps[0].Nodes[1].Verifications = []coop.Verification{{Check: "checkout test", Passed: true}}
+	m.selectStep(0)
+	m.userMoved = true
+	store.Write(m.session)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	updated := result.(Model)
+	result, _ = updated.Update(tea.KeyPressMsg{Code: 'R', Text: "Rework both steps"})
+	updated = result.(Model)
+	result, _ = updated.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	updated = result.(Model)
+
+	node1, _ := updated.session.NodeByNumber(1)
+	node2, _ := updated.session.NodeByNumber(2)
+	assert.Equal(t, coop.NodeActive, node1.State)
+	assert.Equal(t, coop.NodeActive, node2.State)
+	assert.Equal(t, "Rework both steps", node1.RejectionNote)
+	assert.Equal(t, "Rework both steps", node2.RejectionNote)
+	assert.Nil(t, node1.Implementation)
+	assert.Nil(t, node2.Implementation)
+	assert.Nil(t, node1.Verifications)
+	assert.Nil(t, node2.Verifications)
+	assert.False(t, updated.rejecting)
+	assert.False(t, updated.userMoved)
+}
+
+func TestUpdateKeyRejectCancel(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.cursor = 0
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	updated := result.(Model)
+	assert.True(t, updated.rejecting)
+
+	result, _ = updated.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	updated = result.(Model)
+
+	node, _ := updated.session.NodeByNumber(1)
+	assert.Equal(t, coop.NodeReview, node.State)
+	assert.False(t, updated.rejecting)
+	assert.Contains(t, updated.statusMessage, "canceled")
+}
+
+func TestRejectSubmissionCancelsWhenTargetChanges(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.cursor = 0
+	store.Write(m.session)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	updated := result.(Model)
+	assert.True(t, updated.rejecting)
+
+	updated.session.Steps[0].Nodes[0].State = coop.NodeDone
+	result, _ = updated.Update(tea.KeyPressMsg{Code: 'N', Text: "Needs tests"})
+	updated = result.(Model)
+	result, _ = updated.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	updated = result.(Model)
+
+	node, _ := updated.session.NodeByNumber(1)
+	assert.Equal(t, coop.NodeDone, node.State)
+	assert.Empty(t, node.RejectionNote)
+	assert.False(t, updated.rejecting)
+	assert.Contains(t, updated.statusMessage, "Review target changed")
+}
+
+func TestUpdateKeyQuit(t *testing.T) {
+	m := readyModel()
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	// tea.Quit returns a special command
+	assert.NotNil(t, cmd)
+}
+
+func TestUpdateWindowSize(t *testing.T) {
+	m := readyModel()
+
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	updated := result.(Model)
+
+	assert.Equal(t, 120, updated.width)
+	assert.Equal(t, 40, updated.height)
+	assert.Equal(t, 120, updated.viewport.Width())
+}
+
+func TestUpdateSessionUpdated(t *testing.T) {
+	m := readyModel()
+	m.lastVersion = 1
+
+	newSession := &coop.Session{
+		ID:      "test_123",
+		Version: 2,
+		Status:  coop.SessionActive,
+		Steps: []coop.SessionStep{
+			{
+				StepDefinition: coop.StepDefinition{Key: "ch1", Title: "Ch"},
+				Nodes: []coop.SessionNode{
+					{
+						NodeDefinition: coop.NodeDefinition{Key: "n1", Title: "Step"},
+						State:          coop.NodeActive,
+					},
+				},
+			},
+		},
+	}
+
+	result, _ := m.Update(sessionUpdatedMsg{session: newSession})
+	updated := result.(Model)
+
+	assert.Equal(t, 2, updated.lastVersion)
+	assert.Equal(t, "test_123", updated.session.ID)
+}
+
+func TestUpdateSessionDiscovered(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+	store.Write(&coop.Session{ID: "new_session", Status: coop.SessionActive})
+
+	m := readyModel()
+	m.store = store
+	m.waiting = true
+
+	result, cmd := m.Update(sessionDiscoveredMsg{sessionID: "new_session"})
+	updated := result.(Model)
+
+	assert.False(t, updated.waiting)
+	assert.Equal(t, "new_session", updated.sessionID)
+	assert.NotNil(t, cmd)
+}
+
+func TestCheckForUpdatesNoChangeReturnsNoUpdate(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := readyModel()
+	m.store = store
+	m.sessionID = m.session.ID
+	require.NoError(t, store.Write(m.session))
+	stored, err := store.Read(m.session.ID)
+	require.NoError(t, err)
+	m.lastVersion = stored.Version
+
+	cmd := m.checkForUpdates()
+	require.NotNil(t, cmd)
+	msg := cmd()
+
+	_, ok := msg.(noUpdateMsg)
+	require.True(t, ok)
+}
+
+func TestDiscoverNewSessionNoChangeReturnsNoUpdate(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+	require.NoError(t, store.Write(&coop.Session{ID: "old_session", Status: coop.SessionActive}))
+
+	m := NewWaitingModel(store, map[string]bool{"old_session": true})
+	cmd := m.discoverNewSession()
+	require.NotNil(t, cmd)
+	msg := cmd()
+
+	_, ok := msg.(noUpdateMsg)
+	assert.True(t, ok)
+}
+
+func TestAutoScrollToReview(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeDone
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.cursor = 0
+
+	m.autoScroll()
+
+	assert.Equal(t, navigationStep, m.selected.kind)
+	assert.Equal(t, 0, m.selected.stepIndex)
+}
+
+func TestAutoScrollToActive(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeDone
+	m.session.Steps[0].Nodes[1].State = coop.NodeActive
+	m.cursor = 0
+
+	m.autoScroll()
+
+	assert.Equal(t, 1, m.cursor)
+}
+
+func TestAutoScrollReviewPriority(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.cursor = 2
+
+	m.autoScroll()
+
+	// Should go to review (index 0), not active (index 1)
+	assert.Equal(t, 0, m.cursor)
+}
+
+func TestFollowKeyResumesAutoFollow(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeDone
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.cursor = 0
+	m.userMoved = true
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	updated := result.(Model)
+
+	assert.False(t, updated.userMoved)
+	assert.Equal(t, navigationStep, updated.selected.kind)
+	assert.Equal(t, 0, updated.selected.stepIndex)
+}
+
+func TestActionableReviewCountCollapsesStepReview(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.session.Steps[1].Nodes[0].State = coop.NodeReview
+
+	assert.Equal(t, 2, m.actionableReviewCount())
+}
+
+func TestActionableReviewCountIgnoresUnreadyStepReview(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodePending
+
+	assert.Equal(t, 0, m.actionableReviewCount())
+}
+
+func TestCompletionViewKeyDown(t *testing.T) {
+	m := withCompletionSuggestions(readyModel())
+	// Make session complete
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	m.cursor = 0
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	updated := result.(Model)
+
+	assert.Equal(t, 1, updated.cursor)
+}
+
+func TestCompletionViewWaitsForAgentSuggestions(t *testing.T) {
+	m := readyModel()
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	m.cursor = 0
+
+	result, cmd := m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	updated := result.(Model)
+
+	assert.Nil(t, cmd)
+	assert.Equal(t, 0, updated.cursor)
+	assert.Contains(t, updated.renderCompletionView(), "Waiting for agent to publish next steps")
+}
+
+func TestCompletionViewportKeepsReceiptAtTop(t *testing.T) {
+	m := readyModel()
+	m.height = 10
+	m.viewport.SetHeight(3)
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	m.session.NextSteps = &coop.NextStepsState{
+		Suggestions: []coop.NextStepSuggestion{
+			{ID: "a", Title: "First", Description: "Long first option"},
+			{ID: "b", Title: "Second", Description: "Long second option"},
+			{ID: "c", Title: "Third", Description: "Long third option"},
+			{ID: "d", Title: "Fourth", Description: "Long fourth option"},
+			{ID: "done", Title: "Finish", Description: "Close this session"},
+		},
+	}
+	m.cursor = 4
+
+	m.syncViewport()
+
+	line, ok := m.completionLineForCursor()
+	require.True(t, ok)
+	assert.GreaterOrEqual(t, line, m.viewport.YOffset())
+	assert.Less(t, line, m.viewport.YOffset()+m.viewport.Height())
+	assert.Contains(t, m.viewport.View(), "Finish")
+}
+
+func TestCompletionViewKeyDownWraps(t *testing.T) {
+	m := withCompletionSuggestions(readyModel())
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	suggestions := m.getCompletionSuggestions()
+	m.cursor = len(suggestions) - 1
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	updated := result.(Model)
+
+	assert.Equal(t, 0, updated.cursor)
+}
+
+func TestCompletionEnterSelectsDone(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := withCompletionSuggestions(readyModel())
+	m.store = store
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	m.session.ID = "done_selection"
+	store.Write(m.session)
+	// "Finish" is the last suggestion
+	suggestions := m.getCompletionSuggestions()
+	m.cursor = len(suggestions) - 1
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	// Should return tea.Quit
+	assert.NotNil(t, cmd)
+
+	session, err := store.Read("done_selection")
+	require.NoError(t, err)
+	assert.Equal(t, "done", session.NextSteps.Selected)
+}
+
+func TestCompletionEnterWritesSelection(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := withCompletionSuggestions(readyModel())
+	m.store = store
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	m.session.ID = "completion_test"
+	store.Write(m.session)
+	m.cursor = 0 // "Write a STRIPE.md summary"
+
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	// Read back from store
+	session, err := store.Read("completion_test")
+	require.NoError(t, err)
+	assert.Equal(t, "summarize", session.NextSteps.Selected)
+}
+
+func TestSyncViewportSetsContent(t *testing.T) {
+	m := readyModel()
+	m.syncViewport()
+
+	// Viewport should have content
+	view := m.viewport.View()
+	assert.NotEmpty(t, view)
+	assert.Contains(t, view, "Set up product")
+}
+
+func TestSpinnerTickDoesNotPanic(t *testing.T) {
+	m := readyModel()
+	now := time.Now()
+	// Simulate spinner tick
+	assert.NotPanics(t, func() {
+		m.Update(m.spinner.Tick())
+		_ = now
+	})
+}
+
+func TestCompletionEnterAddIntegrationWaitsForAgentSession(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := withCompletionSuggestions(readyModel())
+	m.store = store
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	m.session.ID = "parent_session"
+	store.Write(m.session)
+
+	suggestions := m.getCompletionSuggestions()
+	for i, s := range suggestions {
+		if s.id == "add-integration" {
+			m.cursor = i
+			break
+		}
+	}
+
+	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	updated := result.(Model)
+
+	session, err := store.Read("parent_session")
+	require.NoError(t, err)
+	assert.Equal(t, suggestions[m.cursor].id, session.NextSteps.Selected)
+	assert.True(t, updated.waiting)
+	require.NotNil(t, cmd)
+	msg := cmd()
+	baseline, ok := msg.(waitingBaselineMsg)
+	require.True(t, ok)
+	assert.NotNil(t, baseline.existingIDs)
+
+	assert.Equal(t, "add-integration", session.NextSteps.Selected)
+}
+
+func TestSelectCompletionOptionSummarize(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+
+	m := withCompletionSuggestions(readyModel())
+	m.store = store
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	m.session.ID = "test_summarize"
+	store.Write(m.session)
+	m.cursor = 0 // "Write a STRIPE.md summary" is first
+
+	m.selectCompletionOption()
+
+	// Should have written selection to session
+	session, _ := store.Read("test_summarize")
+	assert.Equal(t, "summarize", session.NextSteps.Selected)
+}
+
+func TestNewModel(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+	m := NewModel(store, "test_id")
+	assert.Equal(t, "test_id", m.sessionID)
+	assert.False(t, m.waiting)
+	assert.Equal(t, -1, m.sdkSnippetNode)
+}
+
+func TestNewWaitingModel(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+	ids := map[string]bool{"old_session": true}
+	m := NewWaitingModel(store, ids)
+	assert.True(t, m.waiting)
+	assert.Equal(t, ids, m.existingIDs)
+}
+
+func TestHandleKeyOpenBrowser(t *testing.T) {
+	orig := openBrowserFn
+	var opened string
+	openBrowserFn = func(url string) error {
+		opened = url
+		return nil
+	}
+	defer func() { openBrowserFn = orig }()
+
+	m := readyModel()
+	m.session.UsedSandbox = true
+	m.sandboxClaimURL = "https://example.com"
+	result, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Text: "o"})
+	updated := result.(Model)
+	assert.NotNil(t, updated)
+	require.NotNil(t, cmd)
+	msg := cmd()
+	assert.Nil(t, msg)
+	assert.Equal(t, "https://example.com", opened)
+}
+
+func TestHandleKeyCopyReviewCommand(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[1].Nodes[0].State = coop.NodeReview
+	m.cursor = 2
+
+	result, cmd := m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	updated := result.(Model)
+
+	assert.NotNil(t, cmd, "should return a clipboard command")
+	assert.Contains(t, updated.statusMessage, "Copied")
+}
+
+func TestHandleKeyQuestionMark(t *testing.T) {
+	m := readyModel()
+	m.expanded = false
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
+	updated := result.(Model)
+	assert.True(t, updated.expanded)
+}
+
+func TestAutoScrollFocusesReviewWithoutExpanding(t *testing.T) {
+	m := readyModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.expanded = false
+
+	m.autoScroll()
+
+	assert.False(t, m.expanded)
+	assert.Equal(t, 0, m.cursor)
+}
+
+func TestCompletionTransitionResetsCursor(t *testing.T) {
+	m := readyModel()
+	m.cursor = 2
+	m.viewport.SetYOffset(5)
+
+	// Simulate session becoming complete
+	newSession := &coop.Session{
+		ID:      "test_123",
+		Version: 5,
+		Status:  coop.SessionActive,
+		Steps: []coop.SessionStep{
+			{
+				StepDefinition: coop.StepDefinition{Key: "ch1", Title: "Ch"},
+				Nodes: []coop.SessionNode{
+					{
+						NodeDefinition: coop.NodeDefinition{Key: "n1", Title: "Step 1"},
+						State:          coop.NodeDone,
+					},
+					{
+						NodeDefinition: coop.NodeDefinition{Key: "n2", Title: "Step 2"},
+						State:          coop.NodeDone,
+					},
+					{
+						NodeDefinition: coop.NodeDefinition{Key: "n3", Title: "Step 3"},
+						State:          coop.NodeDone,
+					},
+				},
+			},
+		},
+	}
+
+	result, _ := m.Update(sessionUpdatedMsg{session: newSession})
+	updated := result.(Model)
+
+	assert.Equal(t, 0, updated.cursor)
+	assert.False(t, updated.expanded)
+	assert.Equal(t, 0, updated.viewport.YOffset())
+}
+
+func TestStatusExpiresOnTick(t *testing.T) {
+	m := readyModel()
+	m.setStatus("Temporary status", time.Second)
+
+	assert.Equal(t, "Temporary status", m.statusMessage)
+
+	m.clearExpiredStatus(time.Now().Add(2 * time.Second))
+
+	assert.Equal(t, "", m.statusMessage)
+	assert.True(t, m.statusExpiresAt.IsZero())
+}
+
+func TestStatusWithoutTTLDoesNotExpire(t *testing.T) {
+	m := readyModel()
+	m.setStatus("Persistent status", 0)
+
+	m.clearExpiredStatus(time.Now().Add(2 * time.Second))
+
+	assert.Equal(t, "Persistent status", m.statusMessage)
+	assert.True(t, m.statusExpiresAt.IsZero())
+}
+
+func TestShouldTransitionToNewSession(t *testing.T) {
+	m := withCompletionSuggestions(readyModel())
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+
+	suggestions := m.getCompletionSuggestions()
+
+	for i, s := range suggestions {
+		if s.id == "add-integration" {
+			m.cursor = i
+			assert.True(t, m.shouldTransitionToNewSession())
+			break
+		}
+	}
+
+	// Find "Finish" — should NOT transition
+	for i, s := range suggestions {
+		if s.id == "done" {
+			m.cursor = i
+			assert.False(t, m.shouldTransitionToNewSession())
+			break
+		}
+	}
+}
+
+func TestFetchSnippetNotAPIRequest(t *testing.T) {
+	m := readyModel()
+	m.cursor = 2 // asyncHandler node
+	cmd := m.fetchSnippetIfNeeded()
+	assert.Nil(t, cmd) // should not fetch for non-apiRequest
+}
+
+func TestFetchSnippetCached(t *testing.T) {
+	m := readyModel()
+	m.cursor = 0
+	m.sdkSnippetNode = 0 // already cached for this step
+	cmd := m.fetchSnippetIfNeeded()
+	assert.Nil(t, cmd) // should not re-fetch
+}
+
+func TestAgentIdleNoSession(t *testing.T) {
+	m := readyModel()
+	m.session = nil
+	m.updateAgentIdle(10*time.Second, true, time.Now())
+	assert.False(t, m.agentIdle())
+}
+
+func TestAgentIdleSessionComplete(t *testing.T) {
+	m := readyModel()
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	m.lastUpdateTime = time.Now().Add(-5 * time.Minute)
+	m.updateAgentIdle(10*time.Second, true, time.Now())
+	assert.False(t, m.agentIdle())
+}
+
+func TestAgentIdleNoUpdateTime(t *testing.T) {
+	m := readyModel()
+	m.updateAgentIdle(10*time.Second, true, time.Now())
+	assert.False(t, m.agentIdle())
+}
+
+func TestAgentIdleRecentUpdate(t *testing.T) {
+	m := readyModel()
+	m.lastUpdateTime = time.Now()
+	m.updateAgentIdle(10*time.Second, true, time.Now())
+	assert.False(t, m.agentIdle())
+}
+
+func TestAgentIdleStaleNoHeartbeat(t *testing.T) {
+	m := readyModel()
+	m.lastUpdateTime = time.Now().Add(-3 * time.Minute)
+	m.updateAgentIdle(0, false, time.Now())
+	assert.False(t, m.agentIdle())
+}
+
+func TestAgentIdleFreshHeartbeat(t *testing.T) {
+	m := readyModel()
+	m.lastUpdateTime = time.Now().Add(-3 * time.Minute)
+	m.updateAgentIdle(time.Second, true, time.Now())
+	assert.False(t, m.agentIdle())
+}
+
+func TestAgentIdleStaleHeartbeat(t *testing.T) {
+	m := readyModel()
+	m.lastUpdateTime = time.Now().Add(-3 * time.Minute)
+	m.updateAgentIdle(10*time.Second, true, time.Now())
+	assert.True(t, m.agentIdle())
+}
+
+func TestNoUpdateMsgRefreshesCachedAgentIdle(t *testing.T) {
+	m := readyModel()
+	m.lastUpdateTime = time.Now().Add(-3 * time.Minute)
+
+	result, _ := m.Update(noUpdateMsg{heartbeatAge: 10 * time.Second, heartbeatOK: true})
+	updated := result.(Model)
+
+	assert.True(t, updated.agentIdle())
+}
+
+func TestResizeViewportOnSessionUpdate(t *testing.T) {
+	m := readyModel()
+	m.width = 80
+	m.height = 25
+	m.resizeViewport()
+
+	initialHeight := m.viewport.Height()
+
+	// Simulate a session with a review step (footer grows by 1 line)
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.resizeViewport()
+
+	// Footer now has the review notice line — viewport should shrink
+	assert.True(t, m.viewport.Height() <= initialHeight)
+}

--- a/pkg/coop/tui/model_test.go
+++ b/pkg/coop/tui/model_test.go
@@ -401,7 +401,7 @@ func TestBackgroundColorUpdatesTheme(t *testing.T) {
 
 	assert.False(t, updated.theme.IsDark)
 	assert.False(t, updated.isDark)
-	assert.NotEqual(t, m.theme.HueGray300, updated.theme.HueGray300)
+	assert.NotEqual(t, m.theme.Gray300, updated.theme.Gray300)
 }
 
 func TestUpdateKeyConfirmStepReview(t *testing.T) {

--- a/pkg/coop/tui/model_test.go
+++ b/pkg/coop/tui/model_test.go
@@ -23,18 +23,18 @@ func readyModel() Model {
 
 func TestUpdateKeyDown(t *testing.T) {
 	m := readyModel()
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	updated := result.(Model)
 
-	assert.Equal(t, 1, updated.cursor)
+	assert.Equal(t, 1, updated.selectionCursor)
 	assert.True(t, updated.userMoved)
 }
 
 func TestUpdateKeyUp(t *testing.T) {
 	m := readyModel()
-	m.cursor = 2
+	m.selectionCursor = 2
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	updated := result.(Model)
@@ -45,22 +45,22 @@ func TestUpdateKeyUp(t *testing.T) {
 
 func TestUpdateKeyUpAtTop(t *testing.T) {
 	m := readyModel()
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	updated := result.(Model)
 
-	assert.Equal(t, 0, updated.cursor)
+	assert.Equal(t, 0, updated.selectionCursor)
 }
 
 func TestUpdateKeyDownAtBottom(t *testing.T) {
 	m := readyModel()
-	m.cursor = m.session.TotalNodes() - 1
+	m.selectionCursor = m.session.TotalNodes() - 1
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	updated := result.(Model)
 
-	assert.Equal(t, m.session.TotalNodes()-1, updated.cursor)
+	assert.Equal(t, m.session.TotalNodes()-1, updated.selectionCursor)
 }
 
 func TestUpdatePageKeysMoveViewport(t *testing.T) {
@@ -126,7 +126,7 @@ func TestUpdateKeyConfirm(t *testing.T) {
 	m.store = store
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodeDone
-	m.cursor = 0
+	m.selectionCursor = 0
 	store.Write(m.session)
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
@@ -144,7 +144,7 @@ func TestUpdateKeyConfirmIgnoresRepeat(t *testing.T) {
 	m.store = store
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodeDone
-	m.cursor = 0
+	m.selectionCursor = 0
 	store.Write(m.session)
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'c', Text: "c", IsRepeat: true})
@@ -217,7 +217,7 @@ func TestSyncViewportPreservesManualScroll(t *testing.T) {
 	m.width = 80
 	m.height = 12
 	m.resizeViewport()
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.expanded = true
 	m.sdkSnippet = strings.Repeat("const product = await stripe.products.create({});\n", 20)
 	m.sdkSnippetNode = 0
@@ -249,7 +249,7 @@ func TestMouseActionSelectsVisibleStep(t *testing.T) {
 	result, _ := m.Update(mouseActionMsg{action: mouseActionSelectStep, index: 1})
 	updated := result.(Model)
 
-	assert.Equal(t, 2, updated.cursor)
+	assert.Equal(t, 2, updated.selectionCursor)
 	assert.True(t, updated.userMoved)
 }
 
@@ -267,7 +267,7 @@ func TestNavigationMovesBetweenStepAndStepRows(t *testing.T) {
 
 	m.moveCursorDown()
 	assert.Equal(t, navigationNode, m.selected.kind)
-	assert.Equal(t, 0, m.cursor)
+	assert.Equal(t, 0, m.selectionCursor)
 }
 
 func TestMouseActionSelectsStep(t *testing.T) {
@@ -314,7 +314,7 @@ func TestLeftFromStepMovesToParentStep(t *testing.T) {
 
 func TestUpdateKeyConfirmNotOnReviewStep(t *testing.T) {
 	m := readyModel()
-	m.cursor = 0 // step is Done, not Review
+	m.selectionCursor = 0 // step is Done, not Review
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
 	updated := result.(Model)
@@ -333,7 +333,7 @@ func TestUpdateKeyReject(t *testing.T) {
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodeDone
 	m.session.Steps[0].Nodes[0].Implementation = &coop.Implementation{File: "a.js"}
-	m.cursor = 0
+	m.selectionCursor = 0
 	store.Write(m.session)
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
@@ -360,7 +360,7 @@ func TestUpdateKeyRejectRequiresNote(t *testing.T) {
 	m.store = store
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodeDone
-	m.cursor = 0
+	m.selectionCursor = 0
 	store.Write(m.session)
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
@@ -381,7 +381,7 @@ func TestRejectingViewSetsRealCursor(t *testing.T) {
 	m.height = 20
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodeDone
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.startReject()
 
 	view := m.View()
@@ -450,7 +450,7 @@ func TestSelectedReviewTargetStepRequiresReadyStep(t *testing.T) {
 	m := readyModel()
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodePending
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	_, ok := m.selectedReviewTarget()
 	assert.False(t, ok)
@@ -511,7 +511,7 @@ func TestUpdateKeyRejectCancel(t *testing.T) {
 	m := readyModel()
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodeDone
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
 	updated := result.(Model)
@@ -534,7 +534,7 @@ func TestRejectSubmissionCancelsWhenTargetChanges(t *testing.T) {
 	m.store = store
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodeDone
-	m.cursor = 0
+	m.selectionCursor = 0
 	store.Write(m.session)
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
@@ -656,7 +656,7 @@ func TestAutoScrollToReview(t *testing.T) {
 	m := readyModel()
 	m.session.Steps[0].Nodes[0].State = coop.NodeDone
 	m.session.Steps[0].Nodes[1].State = coop.NodeReview
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	m.autoScroll()
 
@@ -668,30 +668,30 @@ func TestAutoScrollToActive(t *testing.T) {
 	m := readyModel()
 	m.session.Steps[0].Nodes[0].State = coop.NodeDone
 	m.session.Steps[0].Nodes[1].State = coop.NodeActive
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	m.autoScroll()
 
-	assert.Equal(t, 1, m.cursor)
+	assert.Equal(t, 1, m.selectionCursor)
 }
 
 func TestAutoScrollReviewPriority(t *testing.T) {
 	m := readyModel()
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodeDone
-	m.cursor = 2
+	m.selectionCursor = 2
 
 	m.autoScroll()
 
 	// Should go to review (index 0), not active (index 1)
-	assert.Equal(t, 0, m.cursor)
+	assert.Equal(t, 0, m.selectionCursor)
 }
 
 func TestFollowKeyResumesAutoFollow(t *testing.T) {
 	m := readyModel()
 	m.session.Steps[0].Nodes[0].State = coop.NodeDone
 	m.session.Steps[0].Nodes[1].State = coop.NodeReview
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.userMoved = true
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
@@ -727,12 +727,12 @@ func TestCompletionViewKeyDown(t *testing.T) {
 			m.session.Steps[i].Nodes[j].State = coop.NodeDone
 		}
 	}
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	updated := result.(Model)
 
-	assert.Equal(t, 1, updated.cursor)
+	assert.Equal(t, 1, updated.selectionCursor)
 }
 
 func TestCompletionViewWaitsForAgentSuggestions(t *testing.T) {
@@ -742,13 +742,13 @@ func TestCompletionViewWaitsForAgentSuggestions(t *testing.T) {
 			m.session.Steps[i].Nodes[j].State = coop.NodeDone
 		}
 	}
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	result, cmd := m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	updated := result.(Model)
 
 	assert.Nil(t, cmd)
-	assert.Equal(t, 0, updated.cursor)
+	assert.Equal(t, 0, updated.selectionCursor)
 	assert.Contains(t, updated.renderCompletionView(), "Waiting for agent to publish next steps")
 }
 
@@ -770,7 +770,7 @@ func TestCompletionViewportKeepsReceiptAtTop(t *testing.T) {
 			{ID: "done", Title: "Finish", Description: "Close this session"},
 		},
 	}
-	m.cursor = 4
+	m.selectionCursor = 4
 
 	m.syncViewport()
 
@@ -789,12 +789,12 @@ func TestCompletionViewKeyDownWraps(t *testing.T) {
 		}
 	}
 	suggestions := m.getCompletionSuggestions()
-	m.cursor = len(suggestions) - 1
+	m.selectionCursor = len(suggestions) - 1
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	updated := result.(Model)
 
-	assert.Equal(t, 0, updated.cursor)
+	assert.Equal(t, 0, updated.selectionCursor)
 }
 
 func TestCompletionEnterSelectsDone(t *testing.T) {
@@ -812,7 +812,7 @@ func TestCompletionEnterSelectsDone(t *testing.T) {
 	store.Write(m.session)
 	// "Finish" is the last suggestion
 	suggestions := m.getCompletionSuggestions()
-	m.cursor = len(suggestions) - 1
+	m.selectionCursor = len(suggestions) - 1
 
 	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	// Should return tea.Quit
@@ -836,7 +836,7 @@ func TestCompletionEnterWritesSelection(t *testing.T) {
 	}
 	m.session.ID = "completion_test"
 	store.Write(m.session)
-	m.cursor = 0 // "Write a STRIPE.md summary"
+	m.selectionCursor = 0 // "Write a STRIPE.md summary"
 
 	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
@@ -883,7 +883,7 @@ func TestCompletionEnterAddIntegrationWaitsForAgentSession(t *testing.T) {
 	suggestions := m.getCompletionSuggestions()
 	for i, s := range suggestions {
 		if s.id == "add-integration" {
-			m.cursor = i
+			m.selectionCursor = i
 			break
 		}
 	}
@@ -893,13 +893,13 @@ func TestCompletionEnterAddIntegrationWaitsForAgentSession(t *testing.T) {
 
 	session, err := store.Read("parent_session")
 	require.NoError(t, err)
-	assert.Equal(t, suggestions[m.cursor].id, session.NextSteps.Selected)
+	assert.Equal(t, suggestions[m.selectionCursor].id, session.NextSteps.Selected)
 	assert.True(t, updated.waiting)
 	require.NotNil(t, cmd)
 	msg := cmd()
 	baseline, ok := msg.(waitingBaselineMsg)
 	require.True(t, ok)
-	assert.NotNil(t, baseline.existingIDs)
+	assert.NotNil(t, baseline.existingSessionIDs)
 
 	assert.Equal(t, "add-integration", session.NextSteps.Selected)
 }
@@ -917,7 +917,7 @@ func TestSelectCompletionOptionSummarize(t *testing.T) {
 	}
 	m.session.ID = "test_summarize"
 	store.Write(m.session)
-	m.cursor = 0 // "Write a STRIPE.md summary" is first
+	m.selectionCursor = 0 // "Write a STRIPE.md summary" is first
 
 	m.selectCompletionOption()
 
@@ -941,7 +941,7 @@ func TestNewWaitingModel(t *testing.T) {
 	ids := map[string]bool{"old_session": true}
 	m := NewWaitingModel(store, ids)
 	assert.True(t, m.waiting)
-	assert.Equal(t, ids, m.existingIDs)
+	assert.Equal(t, ids, m.existingSessionIDs)
 }
 
 func TestHandleKeyOpenBrowser(t *testing.T) {
@@ -968,7 +968,7 @@ func TestHandleKeyOpenBrowser(t *testing.T) {
 func TestHandleKeyCopyReviewCommand(t *testing.T) {
 	m := readyModel()
 	m.session.Steps[1].Nodes[0].State = coop.NodeReview
-	m.cursor = 2
+	m.selectionCursor = 2
 
 	result, cmd := m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
 	updated := result.(Model)
@@ -995,12 +995,12 @@ func TestAutoScrollFocusesReviewWithoutExpanding(t *testing.T) {
 	m.autoScroll()
 
 	assert.False(t, m.expanded)
-	assert.Equal(t, 0, m.cursor)
+	assert.Equal(t, 0, m.selectionCursor)
 }
 
 func TestCompletionTransitionResetsCursor(t *testing.T) {
 	m := readyModel()
-	m.cursor = 2
+	m.selectionCursor = 2
 	m.viewport.SetYOffset(5)
 
 	// Simulate session becoming complete
@@ -1032,7 +1032,7 @@ func TestCompletionTransitionResetsCursor(t *testing.T) {
 	result, _ := m.Update(sessionUpdatedMsg{session: newSession})
 	updated := result.(Model)
 
-	assert.Equal(t, 0, updated.cursor)
+	assert.Equal(t, 0, updated.selectionCursor)
 	assert.False(t, updated.expanded)
 	assert.Equal(t, 0, updated.viewport.YOffset())
 }
@@ -1071,7 +1071,7 @@ func TestShouldTransitionToNewSession(t *testing.T) {
 
 	for i, s := range suggestions {
 		if s.id == "add-integration" {
-			m.cursor = i
+			m.selectionCursor = i
 			assert.True(t, m.shouldTransitionToNewSession())
 			break
 		}
@@ -1080,7 +1080,7 @@ func TestShouldTransitionToNewSession(t *testing.T) {
 	// Find "Finish" — should NOT transition
 	for i, s := range suggestions {
 		if s.id == "done" {
-			m.cursor = i
+			m.selectionCursor = i
 			assert.False(t, m.shouldTransitionToNewSession())
 			break
 		}
@@ -1089,14 +1089,14 @@ func TestShouldTransitionToNewSession(t *testing.T) {
 
 func TestFetchSnippetNotAPIRequest(t *testing.T) {
 	m := readyModel()
-	m.cursor = 2 // asyncHandler node
+	m.selectionCursor = 2 // asyncHandler node
 	cmd := m.fetchSnippetIfNeeded()
 	assert.Nil(t, cmd) // should not fetch for non-apiRequest
 }
 
 func TestFetchSnippetCached(t *testing.T) {
 	m := readyModel()
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.sdkSnippetNode = 0 // already cached for this step
 	cmd := m.fetchSnippetIfNeeded()
 	assert.Nil(t, cmd) // should not re-fetch

--- a/pkg/coop/tui/review.go
+++ b/pkg/coop/tui/review.go
@@ -66,6 +66,10 @@ func (m Model) renderFooter() string {
 	return strings.Join(lines, "\n")
 }
 
+func (m Model) renderReviewCard() string {
+	return m.renderReviewCardWithMaxHeight(0)
+}
+
 func (m Model) renderReviewCardWithMaxHeight(maxHeight int) string {
 	target, ok := m.selectedReviewTarget()
 	if !ok {

--- a/pkg/coop/tui/stress_test.go
+++ b/pkg/coop/tui/stress_test.go
@@ -1,0 +1,186 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type stressScenario struct {
+	name             string
+	model            func() Model
+	expectReviewCard bool
+}
+
+func TestUILayoutStressSessions(t *testing.T) {
+	scenarios := []stressScenario{
+		{name: "long_review_content", model: stressLongReviewModel, expectReviewCard: true},
+		{name: "crowded_step_review", model: stressCrowdedStepReviewModel, expectReviewCard: true},
+		{name: "long_claim_url_active", model: stressLongClaimURLModel},
+		{name: "many_steps_manual_navigation", model: stressManyStepsManualNavigationModel},
+		{name: "long_rejection_input", model: stressLongRejectionInputModel, expectReviewCard: true},
+	}
+
+	for _, scenario := range scenarios {
+		for _, size := range layoutMatrixSizes {
+			t.Run(scenario.name+"/"+size.name, func(t *testing.T) {
+				m := scenario.model()
+				rendered := renderLayoutScenario(&m, size)
+				writeLayoutCapture(t, "stress_"+scenario.name, size, rendered)
+
+				assertLayoutFits(t, rendered, size)
+				assertHeaderIsPinned(t, rendered)
+				if m.rejecting {
+					assertFooterIsPinned(t, rendered, "esc cancel")
+				} else {
+					assertFooterIsPinned(t, rendered, "enter")
+				}
+				if scenario.expectReviewCard {
+					assert.Contains(t, rendered, "Review")
+					assert.Contains(t, rendered, "Confirmation steps")
+					assert.LessOrEqual(t, lipgloss.Height(m.renderFooter()), m.footerHeightBudget())
+				}
+			})
+		}
+	}
+}
+
+func TestUILayoutCopyAudit(t *testing.T) {
+	scenarios := []layoutScenario{
+		{name: "review", model: reviewStepLongPromptLayoutModel},
+		{name: "step_review", model: stepReviewLayoutModel},
+		{name: "request_changes", model: requestChangesLayoutModel},
+		{name: "completion", model: completionLayoutModel},
+	}
+	banned := []string{
+		"reject",
+		"looks good",
+		"verify it works",
+		"Waiting for agent to continue",
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			m := scenario.model()
+			rendered := renderLayoutScenario(&m, layoutSize{name: "audit", width: 69, height: 50})
+			lower := strings.ToLower(rendered)
+			for _, phrase := range banned {
+				assert.NotContains(t, lower, strings.ToLower(phrase))
+			}
+			if strings.Contains(rendered, "Review") {
+				assert.Contains(t, rendered, "Confirmation steps")
+			}
+		})
+	}
+}
+
+func stressLongReviewModel() Model {
+	m := reviewStepLongPromptLayoutModel()
+	m.session.Steps[0].Nodes[0].Title = "Review Checkout Session creation, saved IDs, redirect behavior, and webhook assumptions"
+	m.session.Steps[0].Nodes[0].Implementation = &coop.Implementation{
+		File:    "server/src/very/long/path/to/payments/checkout/session/create_checkout_session_handler_with_extremely_specific_name.ts",
+		Lines:   "128-276",
+		Snippet: strings.Repeat("await stripe.checkout.sessions.create({ mode: 'payment', line_items: [{ price: savedPriceID, quantity: 1 }] })\n", 6),
+		Note:    "Created the Checkout Session endpoint, persisted the returned IDs, and reused the saved price ID for later payment confirmation.",
+	}
+	m.session.Steps[0].Nodes[0].ReviewPrompt = "Open the app, start Checkout, inspect the server logs, confirm the saved price ID is reused instead of creating a new Price, confirm the redirect URL is correct, confirm errors are handled without exposing secrets, and confirm the success page reflects the completed payment."
+	m.session.Steps[0].Nodes[0].Verifications = []coop.Verification{
+		{Check: "Created product", Passed: true},
+		{Check: "Created price", Passed: true},
+		{Check: "Created Checkout Session", Passed: true},
+		{Check: "Ran redirect flow", Passed: true},
+		{Check: "Checked secrets are environment-backed", Passed: true},
+	}
+	return m
+}
+
+func stressCrowdedStepReviewModel() Model {
+	m := testModel()
+	m.spinner = staticSpinner()
+	m.session.Steps = []coop.SessionStep{
+		{
+			StepDefinition: coop.StepDefinition{
+				Key:   "crowded",
+				Title: "Build a complete Checkout and fulfillment path with intentionally long labels",
+			},
+			Nodes: make([]coop.SessionNode, 0, 8),
+		},
+	}
+	for i := 0; i < 8; i++ {
+		m.session.Steps[0].Nodes = append(m.session.Steps[0].Nodes, coop.SessionNode{
+			NodeDefinition: coop.NodeDefinition{
+				Key:          fmt.Sprintf("node-%d", i),
+				Type:         coop.NodeUIComponent,
+				Title:        fmt.Sprintf("Step %d with a detailed title that still needs to scan well in the terminal", i+1),
+				ReviewPrompt: fmt.Sprintf("Confirm item %d is observable, documented by verification evidence, and does not require hidden context from previous steps.", i+1),
+			},
+			State: coop.NodeReview,
+			Implementation: &coop.Implementation{
+				File:  fmt.Sprintf("app/src/features/payments/checkout/step_%d/component_or_handler_with_long_name.tsx", i+1),
+				Lines: fmt.Sprintf("%d-%d", 20+i*12, 31+i*12),
+			},
+			Verifications: []coop.Verification{{Check: fmt.Sprintf("Verification %d passed", i+1), Passed: true}},
+		})
+	}
+	m.selectStep(0)
+	return m
+}
+
+func stressLongClaimURLModel() Model {
+	m := activeStepLayoutModel()
+	m.session.UsedSandbox = true
+	m.sandboxClaimURL = "https://dashboard.stripe.com/sandbox/claim_test_abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789"
+	m.session.Steps[0].Nodes[1].Activity = "Running a long local verification flow with several redirects, environment checks, and Stripe object lookups"
+	return m
+}
+
+func stressManyStepsManualNavigationModel() Model {
+	m := testModel()
+	m.spinner = staticSpinner()
+	m.session.Steps = nil
+	stepCount := 0
+	for ch := 0; ch < 6; ch++ {
+		step := coop.SessionStep{
+			StepDefinition: coop.StepDefinition{
+				Key:   fmt.Sprintf("step-%d", ch),
+				Title: fmt.Sprintf("Step %d with enough steps to force scrolling", ch+1),
+			},
+		}
+		for node := 0; node < 8; node++ {
+			state := coop.NodeDone
+			if ch == 4 && node == 2 {
+				state = coop.NodeReview
+			}
+			step.Nodes = append(step.Nodes, coop.SessionNode{
+				NodeDefinition: coop.NodeDefinition{
+					Key:          fmt.Sprintf("node-%d-%d", ch, node),
+					Type:         coop.NodeAPIRequest,
+					Title:        fmt.Sprintf("Generated step %d.%d with a moderately long label", ch+1, node+1),
+					ReviewPrompt: "Confirm this generated stress step has a visible acceptance check.",
+				},
+				State: state,
+				Implementation: &coop.Implementation{
+					File:  fmt.Sprintf("generated/step_%d/step_%d/payment_flow_handler.go", ch+1, node+1),
+					Lines: "1-20",
+				},
+			})
+			stepCount++
+		}
+		m.session.Steps = append(m.session.Steps, step)
+	}
+	m.cursor = stepCount - 1
+	m.userMoved = true
+	return m
+}
+
+func stressLongRejectionInputModel() Model {
+	m := stressLongReviewModel()
+	m.rejecting = true
+	m.rejectionInput.SetValue("Please rework the endpoint so it validates the stored price ID, handles missing environment variables with a useful error, preserves webhook signature verification, and includes a manual test path I can run locally before confirming.")
+	return m
+}

--- a/pkg/coop/tui/stress_test.go
+++ b/pkg/coop/tui/stress_test.go
@@ -173,7 +173,7 @@ func stressManyStepsManualNavigationModel() Model {
 		}
 		m.session.Steps = append(m.session.Steps, step)
 	}
-	m.cursor = stepCount - 1
+	m.selectionCursor = stepCount - 1
 	m.userMoved = true
 	return m
 }

--- a/pkg/coop/tui/view_test.go
+++ b/pkg/coop/tui/view_test.go
@@ -201,7 +201,7 @@ func TestRenderStepLineActivity(t *testing.T) {
 
 func TestRenderStepLineCursor(t *testing.T) {
 	m := testModel()
-	m.cursor = 1
+	m.selectionCursor = 1
 	node := m.session.Steps[0].Nodes[1]
 	line := m.renderNodeLine(node, 1, false, true)
 
@@ -210,7 +210,7 @@ func TestRenderStepLineCursor(t *testing.T) {
 
 func TestRenderStepLineNoCursor(t *testing.T) {
 	m := testModel()
-	m.cursor = 0
+	m.selectionCursor = 0
 	node := m.session.Steps[0].Nodes[1]
 	line := m.renderNodeLine(node, 1, false, false)
 
@@ -219,7 +219,7 @@ func TestRenderStepLineNoCursor(t *testing.T) {
 
 func TestRenderDetail(t *testing.T) {
 	m := testModel()
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.expanded = true
 	m.detailTab = 1
 	detail := m.renderDetail()
@@ -232,7 +232,7 @@ func TestRenderDetail(t *testing.T) {
 
 func TestRenderSummaryDetailDoesNotRepeatLabels(t *testing.T) {
 	m := testModel()
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.expanded = true
 	m.detailTab = 0
 
@@ -249,7 +249,7 @@ func TestRenderSummaryDetailDoesNotRepeatLabels(t *testing.T) {
 
 func TestRenderSummaryDetailShowsStepSDKSnippet(t *testing.T) {
 	m := testModel()
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.expanded = true
 	m.detailTab = 0
 	m.sdkSnippet = "const product = await stripe.products.create({name: 'Gold plan'});"
@@ -278,7 +278,7 @@ func TestRenderStepDetailUsesStepOverview(t *testing.T) {
 
 func TestRenderDetailWebhook(t *testing.T) {
 	m := testModel()
-	m.cursor = 2 // asyncHandler node
+	m.selectionCursor = 2 // asyncHandler node
 	m.expanded = true
 	m.detailTab = 2
 	detail := m.renderDetail()
@@ -292,7 +292,7 @@ func TestRenderDetailWebhook(t *testing.T) {
 
 func TestRenderDetailWithSDKSnippet(t *testing.T) {
 	m := testModel()
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.expanded = true
 	m.detailTab = 3
 	m.sdkSnippet = "const product = await stripe.products.create({});"
@@ -306,7 +306,7 @@ func TestRenderDetailWithSDKSnippet(t *testing.T) {
 func TestRenderDetailFitsPaneWithIndent(t *testing.T) {
 	m := testModel()
 	m.width = 69
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.expanded = true
 	m.detailTab = 1
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
@@ -322,7 +322,7 @@ func TestRenderDetailFitsPaneWithIndent(t *testing.T) {
 func TestRenderDetailBoxMatchesOutlineWidth(t *testing.T) {
 	m := testModel()
 	m.width = 69
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.expanded = true
 
 	detail := ansi.Strip(m.renderDetail())
@@ -346,7 +346,7 @@ func TestRenderMarkdownDoesNotIndentSubsequentLines(t *testing.T) {
 
 func TestRenderFooter(t *testing.T) {
 	m := testModel()
-	m.cursor = 0
+	m.selectionCursor = 0
 	footer := m.renderFooter()
 
 	// Step 0 is done — no review actions
@@ -359,7 +359,7 @@ func TestRenderFooterReviewStep(t *testing.T) {
 	m := testModel()
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodeDone
-	m.cursor = 0
+	m.selectionCursor = 0
 	footer := m.renderFooter()
 
 	assertContainsPlain(t, footer, "confirm")
@@ -378,7 +378,7 @@ func TestRenderReviewCardEvidence(t *testing.T) {
 		{Check: "Visit http://localhost:3000/checkout, click Pay, and confirm Checkout opens with the saved price.", Passed: true},
 		{Check: "Confirm the failure banner appears for declined cards.", Passed: false},
 	}
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	card := m.renderReviewCard()
 
@@ -401,7 +401,7 @@ func TestRenderReviewCardFallsBackToBlueprintConfirmation(t *testing.T) {
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodeDone
 	m.session.Steps[0].Nodes[0].ReviewPrompt = "Confirm Checkout uses the saved price ID."
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	card := m.renderReviewCard()
 
@@ -428,7 +428,7 @@ func TestRenderStepReviewCardNamesCoveredSteps(t *testing.T) {
 func TestRenderReviewCardFallbackCheck(t *testing.T) {
 	m := testModel()
 	m.session.Steps[1].Nodes[0].State = coop.NodeReview
-	m.cursor = 2
+	m.selectionCursor = 2
 
 	card := m.renderReviewCard()
 
@@ -438,7 +438,7 @@ func TestRenderReviewCardFallbackCheck(t *testing.T) {
 func TestRenderFooterReviewCommand(t *testing.T) {
 	m := testModel()
 	m.session.Steps[1].Nodes[0].State = coop.NodeReview
-	m.cursor = 2
+	m.selectionCursor = 2
 	footer := m.renderFooter()
 
 	assertContainsPlain(t, footer, "Run:")
@@ -639,7 +639,7 @@ func TestRenderDetailSkipped(t *testing.T) {
 	m := testModel()
 	m.session.Steps[0].Nodes[0].State = coop.NodeSkipped
 	m.session.Steps[0].Nodes[0].Activity = "Already handled"
-	m.cursor = 0
+	m.selectionCursor = 0
 	detail := m.renderDetail()
 	assertContainsPlain(t, detail, "Skipped")
 }
@@ -684,7 +684,7 @@ func TestRenderFooterRejectionInput(t *testing.T) {
 	m := testModel()
 	m.session.Steps[0].Nodes[0].State = coop.NodeReview
 	m.session.Steps[0].Nodes[1].State = coop.NodeDone
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.rejecting = true
 	m.rejectionInput.SetValue("Missing webhook test")
 
@@ -698,7 +698,7 @@ func TestRenderFooterRejectionInput(t *testing.T) {
 func TestRenderFooterRejectionPlaceholder(t *testing.T) {
 	m := testModel()
 	m.session.Steps[1].Nodes[0].State = coop.NodeReview
-	m.cursor = 2
+	m.selectionCursor = 2
 	m.rejecting = true
 	target, _ := m.selectedReviewTarget()
 	m.rejectionInput.Placeholder = m.requestChangesPlaceholder(target)
@@ -723,7 +723,7 @@ func TestReviewCardFitsWithinShortViewport(t *testing.T) {
 		{Check: "Saved price ID for Checkout", Passed: true},
 		{Check: "Ran local Checkout flow", Passed: true},
 	}
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	m.resizeViewport()
 	m.syncViewport()
@@ -749,7 +749,7 @@ func TestReviewCardShowsDetailsHintWhenClipped(t *testing.T) {
 		{Check: "Created price", Passed: true},
 		{Check: "Created Checkout Session", Passed: true},
 	}
-	m.cursor = 0
+	m.selectionCursor = 0
 
 	footer := m.renderFooter()
 
@@ -809,7 +809,7 @@ func TestViewportShowsMoreBelowIndicator(t *testing.T) {
 			{NodeDefinition: coop.NodeDefinition{Title: "Six"}, State: coop.NodeDone},
 		},
 	}}
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.resizeViewport()
 	m.syncViewport()
 	m.viewport.SetHeight(4)
@@ -828,7 +828,7 @@ func TestViewportClosesClippedDetailBoxBeforeMoreBelowIndicator(t *testing.T) {
 	m.height = 12
 	m.viewport = viewport.New(viewport.WithWidth(69), viewport.WithHeight(6))
 	m.session.Steps[0].Nodes[0].ReviewPrompt = strings.Repeat("Confirm the Checkout flow uses the saved price ID and redirects correctly. ", 5)
-	m.cursor = 0
+	m.selectionCursor = 0
 	m.expanded = true
 	m.resizeViewport()
 	m.syncViewport()

--- a/pkg/coop/tui/view_test.go
+++ b/pkg/coop/tui/view_test.go
@@ -1,0 +1,894 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func assertContainsPlain(t *testing.T, s, substr string) {
+	t.Helper()
+	assert.Contains(t, ansi.Strip(s), substr)
+}
+
+func assertNotContainsPlain(t *testing.T, s, substr string) {
+	t.Helper()
+	assert.NotContains(t, ansi.Strip(s), substr)
+}
+
+func testModel() Model {
+	theme := NewTheme(true)
+	m := Model{
+		width:          80,
+		height:         30,
+		sdkSnippetNode: -1,
+		rejectionInput: newThemedRejectionInput(theme),
+		keys:           newKeyMap(),
+		help:           newThemedHelp(theme),
+		theme:          theme,
+		isDark:         true,
+		session: &coop.Session{
+			ID:        "test_123",
+			Blueprint: "one-time-payment",
+			Status:    coop.SessionActive,
+			Settings:  map[string]string{"language": "node"},
+			Steps: []coop.SessionStep{
+				{
+					StepDefinition: coop.StepDefinition{
+						Key:   "ch1",
+						Title: "Set up product",
+					},
+					Nodes: []coop.SessionNode{
+						{
+							NodeDefinition: coop.NodeDefinition{
+								Key:          "n1",
+								Title:        "Create product",
+								Type:         coop.NodeAPIRequest,
+								ReviewPrompt: "Confirm the saved price ID is reused by Checkout.",
+								Request:      &coop.APIRequest{Path: "/v1/products", Method: "post", Params: map[string]string{"name": "Gold plan"}},
+							},
+							State:          coop.NodeDone,
+							Implementation: &coop.Implementation{File: "server.js", Lines: "5-20", Note: "Created product"}},
+						{
+							NodeDefinition: coop.NodeDefinition{
+								Key:     "n2",
+								Title:   "Create checkout",
+								Type:    coop.NodeAPIRequest,
+								Request: &coop.APIRequest{Path: "/v1/checkout/sessions", Method: "post"},
+							},
+							State:    coop.NodeActive,
+							Activity: "Writing endpoint"},
+					},
+				},
+				{
+					StepDefinition: coop.StepDefinition{
+						Key:   "ch2",
+						Title: "Handle webhooks",
+					},
+					Nodes: []coop.SessionNode{
+						{
+							NodeDefinition: coop.NodeDefinition{
+								Key:    "n3",
+								Title:  "Handle event",
+								Type:   coop.NodeAsyncHandler,
+								Events: []string{"checkout.session.completed"},
+							},
+							State: coop.NodePending,
+						},
+					},
+				},
+			},
+		},
+	}
+	return m
+}
+
+func TestRenderHeader(t *testing.T) {
+	m := testModel()
+	header := m.renderHeader()
+
+	assertContainsPlain(t, header, "Co-op")
+	assertContainsPlain(t, header, "one-time-payment")
+	assertContainsPlain(t, header, "node")
+	assertContainsPlain(t, header, "1/3")
+}
+
+func TestRenderHeaderWithClaimURL(t *testing.T) {
+	m := testModel()
+	m.session.UsedSandbox = true
+	m.sandboxClaimURL = "https://dashboard.stripe.com/sandbox/claim_abc"
+	header := m.renderHeader()
+
+	assertContainsPlain(t, header, "claim_abc")
+}
+
+func TestRenderStepList(t *testing.T) {
+	m := testModel()
+	list := m.renderStepList()
+
+	assertContainsPlain(t, list, "Set up product")
+	assertContainsPlain(t, list, "Create product")
+	assertContainsPlain(t, list, "Create checkout")
+	assertContainsPlain(t, list, "Handle webhooks")
+	assertContainsPlain(t, list, "Handle event")
+}
+
+func TestRenderStepListAlignsStepTitleWithRule(t *testing.T) {
+	m := testModel()
+	lines := strings.Split(ansi.Strip(m.renderStepList()), "\n")
+
+	var titleLine, ruleLine string
+	for i, line := range lines {
+		if strings.Contains(line, "Set up product") && i+1 < len(lines) {
+			titleLine = line
+			ruleLine = lines[i+1]
+			break
+		}
+	}
+
+	require.NotEmpty(t, titleLine)
+	require.NotEmpty(t, ruleLine)
+	titleDash := strings.Index(titleLine, "-")
+	ruleDash := strings.Index(ruleLine, "─")
+	require.NotEqual(t, -1, titleDash)
+	require.NotEqual(t, -1, ruleDash)
+	titlePrefix := titleLine[:titleDash]
+	rulePrefix := ruleLine[:ruleDash]
+	assert.Equal(t, lipgloss.Width(titlePrefix), lipgloss.Width(rulePrefix))
+}
+
+func TestRenderStepListShowsStepReviewUnit(t *testing.T) {
+	m := testModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.selectStep(0)
+
+	list := m.renderStepList()
+
+	assertContainsPlain(t, list, "Awaiting review")
+	assertContainsPlain(t, list, strings.TrimSpace(cursorMarker))
+	assertContainsPlain(t, list, "Create product  Included")
+	assertContainsPlain(t, list, "Create checkout  Included")
+	assertNotContainsPlain(t, list, "Create product  Needs review")
+}
+
+func TestRenderStepListShowsSingleStepStepReviewUnit(t *testing.T) {
+	m := testModel()
+	m.session.Steps[1].Nodes[0].State = coop.NodeReview
+	m.selectStep(1)
+
+	list := m.renderStepList()
+	footer := m.renderFooter()
+
+	assertContainsPlain(t, list, "Awaiting review")
+	assertContainsPlain(t, footer, "confirm all")
+}
+
+func TestRenderCollapsedStepShowsStateSummary(t *testing.T) {
+	m := testModel()
+	m.collapseStep(0)
+
+	list := m.renderStepList()
+
+	assertContainsPlain(t, list, "+ Set up product")
+	assertContainsPlain(t, list, "✓1 ●1")
+	assertNotContainsPlain(t, list, "Create product")
+	assertNotContainsPlain(t, list, "Create checkout")
+}
+
+func TestRenderStepLineAnnotation(t *testing.T) {
+	m := testModel()
+	node := m.session.Steps[0].Nodes[0]
+	line := m.renderNodeLine(node, 0, false, false)
+
+	assertContainsPlain(t, line, "server.js:5-20")
+}
+
+func TestRenderStepLineActivity(t *testing.T) {
+	m := testModel()
+	node := m.session.Steps[0].Nodes[1]
+	line := m.renderNodeLine(node, 1, false, false)
+
+	assertContainsPlain(t, line, "Writing endpoint")
+}
+
+func TestRenderStepLineCursor(t *testing.T) {
+	m := testModel()
+	m.cursor = 1
+	node := m.session.Steps[0].Nodes[1]
+	line := m.renderNodeLine(node, 1, false, true)
+
+	assertContainsPlain(t, line, strings.TrimSpace(cursorMarker))
+}
+
+func TestRenderStepLineNoCursor(t *testing.T) {
+	m := testModel()
+	m.cursor = 0
+	node := m.session.Steps[0].Nodes[1]
+	line := m.renderNodeLine(node, 1, false, false)
+
+	assertNotContainsPlain(t, line, strings.TrimSpace(cursorMarker))
+}
+
+func TestRenderDetail(t *testing.T) {
+	m := testModel()
+	m.cursor = 0
+	m.expanded = true
+	m.detailTab = 1
+	detail := m.renderDetail()
+
+	assertContainsPlain(t, detail, "Files")
+	assertContainsPlain(t, detail, "Agent wrote")
+	assertContainsPlain(t, detail, "server.js:5-20")
+	assertContainsPlain(t, detail, "Created product")
+}
+
+func TestRenderSummaryDetailDoesNotRepeatLabels(t *testing.T) {
+	m := testModel()
+	m.cursor = 0
+	m.expanded = true
+	m.detailTab = 0
+
+	detail := m.renderDetail()
+
+	assertNotContainsPlain(t, detail, "Details:")
+	assert.NotContains(t, ansi.Strip(detail), "Summary")
+	assertNotContainsPlain(t, detail, "Files  Checks  Reference")
+	assertContainsPlain(t, detail, "Confirm the saved price ID is reused")
+	assertContainsPlain(t, detail, "Confirmation steps")
+	assertNotContainsPlain(t, detail, "POST /v1/products")
+	assertNotContainsPlain(t, detail, "You check")
+}
+
+func TestRenderSummaryDetailShowsStepSDKSnippet(t *testing.T) {
+	m := testModel()
+	m.cursor = 0
+	m.expanded = true
+	m.detailTab = 0
+	m.sdkSnippet = "const product = await stripe.products.create({name: 'Gold plan'});"
+	m.sdkSnippetNode = 0
+
+	detail := m.renderDetail()
+
+	assertContainsPlain(t, detail, "SDK example")
+	assertContainsPlain(t, detail, "stripe.products.create")
+}
+
+func TestRenderStepDetailUsesStepOverview(t *testing.T) {
+	m := testModel()
+	m.selectStep(0)
+	m.expanded = true
+	m.detailTab = 0
+
+	detail := m.renderDetail()
+
+	assertContainsPlain(t, detail, "✓ Create product")
+	assertContainsPlain(t, detail, "● Create checkout")
+	assertContainsPlain(t, detail, "Confirmation steps")
+	assertContainsPlain(t, detail, "Agent help")
+	assertNotContainsPlain(t, detail, "SDK example")
+}
+
+func TestRenderDetailWebhook(t *testing.T) {
+	m := testModel()
+	m.cursor = 2 // asyncHandler node
+	m.expanded = true
+	m.detailTab = 2
+	detail := m.renderDetail()
+
+	assertContainsPlain(t, detail, "Checks")
+	assertContainsPlain(t, detail, "Review command")
+	assertContainsPlain(t, detail, "How to verify")
+	assertContainsPlain(t, detail, "stripe listen")
+	assertContainsPlain(t, detail, "stripe trigger checkout.session.completed")
+}
+
+func TestRenderDetailWithSDKSnippet(t *testing.T) {
+	m := testModel()
+	m.cursor = 0
+	m.expanded = true
+	m.detailTab = 3
+	m.sdkSnippet = "const product = await stripe.products.create({});"
+	m.sdkSnippetNode = 0
+	detail := m.renderDetail()
+
+	assertContainsPlain(t, detail, "Reference")
+	assertContainsPlain(t, detail, "stripe.products.create")
+}
+
+func TestRenderDetailFitsPaneWithIndent(t *testing.T) {
+	m := testModel()
+	m.width = 69
+	m.cursor = 0
+	m.expanded = true
+	m.detailTab = 1
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.session.Steps[0].Nodes[0].Implementation.Snippet = strings.Repeat("const createdCheckoutSessionWithLongIdentifier = await stripe.checkout.sessions.create({ mode: 'payment' })\n", 5)
+
+	detail := m.renderDetail()
+
+	assertLinesWithinWidth(t, detail, m.width)
+	assertContainsPlain(t, detail, "Agent wrote")
+}
+
+func TestRenderDetailBoxMatchesOutlineWidth(t *testing.T) {
+	m := testModel()
+	m.width = 69
+	m.cursor = 0
+	m.expanded = true
+
+	detail := ansi.Strip(m.renderDetail())
+	lines := strings.Split(detail, "\n")
+	require.NotEmpty(t, lines)
+
+	assert.Equal(t, m.outlineRuleWidth(), lipgloss.Width(strings.TrimPrefix(lines[0], strings.Repeat(" ", detailIndent))))
+}
+
+func TestRenderMarkdownDoesNotIndentSubsequentLines(t *testing.T) {
+	m := testModel()
+	rendered := ansi.Strip(m.renderMarkdown("first line\n\nsecond line\n\nthird line", 40))
+
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		assert.NotRegexp(t, `^ {2,}`, line)
+	}
+}
+
+func TestRenderFooter(t *testing.T) {
+	m := testModel()
+	m.cursor = 0
+	footer := m.renderFooter()
+
+	// Step 0 is done — no review actions
+	assertContainsPlain(t, footer, "enter")
+	assertContainsPlain(t, footer, "quit")
+	assertNotContainsPlain(t, footer, "confirm")
+}
+
+func TestRenderFooterReviewStep(t *testing.T) {
+	m := testModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.cursor = 0
+	footer := m.renderFooter()
+
+	assertContainsPlain(t, footer, "confirm")
+	assertContainsPlain(t, footer, "changes")
+	assertContainsPlain(t, footer, "Review")
+	assertContainsPlain(t, footer, "Agent changed")
+	assertContainsPlain(t, footer, "Confirmation steps")
+}
+
+func TestRenderReviewCardEvidence(t *testing.T) {
+	m := testModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.session.Steps[0].Nodes[0].ReviewPrompt = "Confirm Checkout uses the saved price ID."
+	m.session.Steps[0].Nodes[0].Verifications = []coop.Verification{
+		{Check: "Visit http://localhost:3000/checkout, click Pay, and confirm Checkout opens with the saved price.", Passed: true},
+		{Check: "Confirm the failure banner appears for declined cards.", Passed: false},
+	}
+	m.cursor = 0
+
+	card := m.renderReviewCard()
+
+	assertContainsPlain(t, card, "Review")
+	assertNotContainsPlain(t, card, "Review: Create product")
+	assertContainsPlain(t, card, "Agent changed:")
+	assertContainsPlain(t, card, "server.js:5-20")
+	assertContainsPlain(t, card, "Agent verified:")
+	assertContainsPlain(t, card, "1/2 check(s) passed")
+	assertContainsPlain(t, card, "Confirmation steps")
+	assertContainsPlain(t, card, "Visit http://localhost:3000/checkout")
+	assertNotContainsPlain(t, card, "Confirm Checkout uses the saved price ID.")
+	assertNotContainsPlain(t, card, "declined cards")
+	plain := ansi.Strip(card)
+	assert.Less(t, strings.Index(plain, "Confirmation steps"), strings.Index(plain, "Agent changed:"))
+}
+
+func TestRenderReviewCardFallsBackToBlueprintConfirmation(t *testing.T) {
+	m := testModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.session.Steps[0].Nodes[0].ReviewPrompt = "Confirm Checkout uses the saved price ID."
+	m.cursor = 0
+
+	card := m.renderReviewCard()
+
+	assertContainsPlain(t, card, "Confirmation steps")
+	assertContainsPlain(t, card, "Confirm Checkout uses the saved price ID.")
+}
+
+func TestRenderStepReviewCardNamesCoveredSteps(t *testing.T) {
+	m := testModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.selectStep(0)
+
+	card := m.renderReviewCard()
+	footer := m.renderFooter()
+
+	assertContainsPlain(t, card, "Review step")
+	assertNotContainsPlain(t, card, "Review step (2 steps): Set up product")
+	assertContainsPlain(t, card, "Includes: Create product, Create checkout")
+	assertContainsPlain(t, footer, "confirm all")
+	assertContainsPlain(t, footer, "changes")
+}
+
+func TestRenderReviewCardFallbackCheck(t *testing.T) {
+	m := testModel()
+	m.session.Steps[1].Nodes[0].State = coop.NodeReview
+	m.cursor = 2
+
+	card := m.renderReviewCard()
+
+	assertContainsPlain(t, card, "Confirm the completed work matches this step")
+}
+
+func TestRenderFooterReviewCommand(t *testing.T) {
+	m := testModel()
+	m.session.Steps[1].Nodes[0].State = coop.NodeReview
+	m.cursor = 2
+	footer := m.renderFooter()
+
+	assertContainsPlain(t, footer, "Run:")
+	assertContainsPlain(t, footer, "stripe trigger checkout.session.completed")
+	assertContainsPlain(t, footer, "y copy")
+}
+
+func TestRenderFooterReviewNotice(t *testing.T) {
+	m := testModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	footer := m.renderFooter()
+
+	assertContainsPlain(t, footer, "Waiting for you")
+	assertContainsPlain(t, footer, "review step")
+}
+
+func TestRenderCompletionView(t *testing.T) {
+	m := withCompletionSuggestions(testModel())
+	m.session.Steps[0].Nodes[0].State = coop.NodeDone
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.session.Steps[1].Nodes[0].State = coop.NodeDone
+
+	view := m.renderCompletionView()
+
+	assertContainsPlain(t, view, "Integration complete")
+	assertContainsPlain(t, view, "Built")
+	assertContainsPlain(t, view, "Set up product")
+	assertContainsPlain(t, view, "Handle webhooks")
+	assertContainsPlain(t, view, "Important checks")
+	assertContainsPlain(t, view, "Confirm the saved price ID is reused by Checkout.")
+	assertContainsPlain(t, view, "Next steps")
+	assertContainsPlain(t, view, "STRIPE.md")
+	assertContainsPlain(t, view, "Add another Stripe feature")
+	assertContainsPlain(t, view, "Finish")
+}
+
+func TestCompletionSummaryBoxUsesSinglePaddingSpace(t *testing.T) {
+	m := completionLayoutModel()
+	body := m.renderCompletionBody()
+
+	assertContainsPlain(t, body, "│ ✓ Integration complete")
+	assertNotContainsPlain(t, body, "│  ✓ Integration complete")
+}
+
+func TestCompletionBuiltItemsFiltersContextSkippedAndIncomplete(t *testing.T) {
+	m := testModel()
+	m.session.Steps = []coop.SessionStep{
+		{
+			StepDefinition: coop.StepDefinition{Key: "context-step", Title: "Project context"},
+			Nodes: []coop.SessionNode{
+				{NodeDefinition: coop.NodeDefinition{Title: "Understand project"}, State: coop.NodeDone},
+			},
+		},
+		{
+			StepDefinition: coop.StepDefinition{Key: "built-with-skipped", Title: "Built with skipped optional work"},
+			Nodes: []coop.SessionNode{
+				{NodeDefinition: coop.NodeDefinition{Title: "Required"}, State: coop.NodeDone},
+				{NodeDefinition: coop.NodeDefinition{Title: "Optional"}, State: coop.NodeSkipped},
+			},
+		},
+		{
+			StepDefinition: coop.StepDefinition{Key: "incomplete", Title: "Incomplete step"},
+			Nodes: []coop.SessionNode{
+				{NodeDefinition: coop.NodeDefinition{Title: "Done"}, State: coop.NodeDone},
+				{NodeDefinition: coop.NodeDefinition{Title: "Still active"}, State: coop.NodeActive},
+			},
+		},
+	}
+
+	assert.Equal(t, []string{"Built with skipped optional work"}, m.completionBuiltItems())
+}
+
+func TestCompletionImportantChecksDedupesDoneOnlyAndCaps(t *testing.T) {
+	m := testModel()
+	m.session.Steps = []coop.SessionStep{
+		{
+			StepDefinition: coop.StepDefinition{Key: "checks", Title: "Checks"},
+			Nodes: []coop.SessionNode{
+				{NodeDefinition: coop.NodeDefinition{Title: "First", ReviewPrompt: "Check one"}, State: coop.NodeDone},
+				{NodeDefinition: coop.NodeDefinition{Title: "Duplicate", ReviewPrompt: "Check one"}, State: coop.NodeDone},
+				{NodeDefinition: coop.NodeDefinition{Title: "Active", ReviewPrompt: "Do not include active"}, State: coop.NodeActive},
+				{NodeDefinition: coop.NodeDefinition{Title: "Second", ReviewPrompt: "Check two"}, State: coop.NodeDone},
+				{NodeDefinition: coop.NodeDefinition{Title: "Third", ReviewPrompt: "Check three"}, State: coop.NodeDone},
+				{NodeDefinition: coop.NodeDefinition{Title: "Fourth", ReviewPrompt: "Check four"}, State: coop.NodeDone},
+				{NodeDefinition: coop.NodeDefinition{Title: "Fifth", ReviewPrompt: "Do not include after cap"}, State: coop.NodeDone},
+			},
+		},
+	}
+
+	assert.Equal(t, []string{"Check one", "Check two"}, m.completionImportantChecks())
+}
+
+func TestCompletionImportantChecksWrapOnWordBoundaries(t *testing.T) {
+	m := completionLayoutModel()
+	m.session.Steps[0].Nodes[0].ReviewPrompt = "Open the app and confirm the user-facing flow works as described."
+
+	receipt := m.renderCompletionReceipt(65)
+
+	assertNotContainsPlain(t, receipt, "a\n    s")
+	assertNotContainsPlain(t, receipt, "\n    s                                                                described.")
+	assertContainsPlain(t, receipt, "as\n    described.")
+	assertLinesWithinWidth(t, receipt, 69)
+}
+
+func TestGetCompletionSuggestionsDefaultEmpty(t *testing.T) {
+	m := testModel()
+	suggestions := m.getCompletionSuggestions()
+
+	assert.Empty(t, suggestions)
+}
+
+func TestGetCompletionSuggestionsFromSession(t *testing.T) {
+	m := testModel()
+	m.session.NextSteps = &coop.NextStepsState{
+		Suggestions: []coop.NextStepSuggestion{
+			{ID: "custom", Title: "Custom action", Description: "Do something custom"},
+		},
+	}
+	suggestions := m.getCompletionSuggestions()
+
+	assert.Len(t, suggestions, 1)
+	assert.Equal(t, "Custom action", suggestions[0].title)
+}
+
+func TestAnnotationWrapsAtNarrowWidth(t *testing.T) {
+	m := testModel()
+	m.width = 40
+	node := coop.SessionNode{
+		NodeDefinition: coop.NodeDefinition{Key: "test", Title: "Step"},
+		State:          coop.NodeActive,
+		Activity:       "This is a very long activity note that should wrap",
+	}
+	line := m.renderNodeLine(node, 0, false, false)
+
+	// Should have a newline (wrapped)
+	assert.True(t, strings.Contains(line, "\n"))
+}
+
+func TestAnnotationInlineAtWideWidth(t *testing.T) {
+	m := testModel()
+	m.width = 120
+	node := coop.SessionNode{
+		NodeDefinition: coop.NodeDefinition{Key: "test", Title: "Step"},
+		State:          coop.NodeActive,
+		Activity:       "Short note",
+	}
+	line := m.renderNodeLine(node, 0, false, false)
+
+	// Should contain the annotation inline (not wrapped to next line)
+	assertContainsPlain(t, line, "Short note")
+}
+
+func TestWordWrap(t *testing.T) {
+	result := wordWrap("hello world this is a test", 12)
+	lines := strings.Split(result, "\n")
+	assert.Equal(t, 3, len(lines))
+	for _, l := range lines {
+		assert.LessOrEqual(t, len(l), 12)
+	}
+}
+
+func TestWordWrapShort(t *testing.T) {
+	result := wordWrap("short", 80)
+	assert.Equal(t, "short", result)
+}
+
+func TestFormatDuration(t *testing.T) {
+	assert.Equal(t, "5s", formatDuration(5*1e9))
+	assert.Equal(t, "59s", formatDuration(59*1e9))
+	assert.Equal(t, "1m30s", formatDuration(90*1e9))
+}
+
+func TestRenderWaitingView(t *testing.T) {
+	m := testModel()
+	m.width = 80
+	m.height = 20
+	m.session = nil
+	view := m.renderWaitingView()
+
+	assertContainsPlain(t, view, "Co-op")
+	assertContainsPlain(t, view, "Waiting")
+	assertContainsPlain(t, view, "quit")
+}
+
+func TestRenderStepLineSkipped(t *testing.T) {
+	m := testModel()
+	node := coop.SessionNode{
+		NodeDefinition: coop.NodeDefinition{Key: "skipped", Title: "Skipped step"},
+		State:          coop.NodeSkipped,
+		Activity:       "Not needed for this project",
+	}
+	line := m.renderNodeLine(node, 0, false, false)
+	assertContainsPlain(t, line, "Not needed")
+}
+
+func TestRenderDetailSkipped(t *testing.T) {
+	m := testModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeSkipped
+	m.session.Steps[0].Nodes[0].Activity = "Already handled"
+	m.cursor = 0
+	detail := m.renderDetail()
+	assertContainsPlain(t, detail, "Skipped")
+}
+
+func TestRenderCompletionViewWithCompleted(t *testing.T) {
+	m := withCompletionSuggestions(testModel())
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	m.session.NextSteps.Completed = []string{"summarize"}
+	m.width = 80
+	m.height = 30
+
+	view := m.renderCompletionView()
+	assertContainsPlain(t, view, "✓ Write a STRIPE.md summary")
+}
+
+func TestRenderFooterComplete(t *testing.T) {
+	m := testModel()
+	for i := range m.session.Steps {
+		for j := range m.session.Steps[i].Nodes {
+			m.session.Steps[i].Nodes[j].State = coop.NodeDone
+		}
+	}
+	footer := m.renderFooter()
+	// Completion view has its own footer — step footer returns empty
+	assert.Equal(t, "", footer)
+}
+
+func TestRenderFooterShowsFollowWhenUserMoved(t *testing.T) {
+	m := testModel()
+	m.userMoved = true
+
+	footer := m.renderFooter()
+
+	assertContainsPlain(t, footer, "f follow")
+}
+
+func TestRenderFooterRejectionInput(t *testing.T) {
+	m := testModel()
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.cursor = 0
+	m.rejecting = true
+	m.rejectionInput.SetValue("Missing webhook test")
+
+	footer := m.renderFooter()
+
+	assertContainsPlain(t, footer, "enter send")
+	assertContainsPlain(t, footer, "esc cancel")
+	assertContainsPlain(t, footer, "Missing webhook test")
+}
+
+func TestRenderFooterRejectionPlaceholder(t *testing.T) {
+	m := testModel()
+	m.session.Steps[1].Nodes[0].State = coop.NodeReview
+	m.cursor = 2
+	m.rejecting = true
+	target, _ := m.selectedReviewTarget()
+	m.rejectionInput.Placeholder = m.requestChangesPlaceholder(target)
+	m.rejectionInput.Focus()
+
+	footer := m.renderFooter()
+
+	assertContainsPlain(t, footer, "Describe what should change in this step")
+}
+
+func TestReviewCardFitsWithinShortViewport(t *testing.T) {
+	m := testModel()
+	m.ready = true
+	m.width = 56
+	m.height = 18
+	m.viewport = viewport.New(viewport.WithWidth(56), viewport.WithHeight(10))
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.session.Steps[0].Nodes[0].ReviewPrompt = "Open the local application, complete the Checkout flow, confirm the redirect lands on the success page, confirm the saved price ID is reused, and confirm no secret keys or generated IDs are committed."
+	m.session.Steps[0].Nodes[0].Verifications = []coop.Verification{
+		{Check: "Created product and price", Passed: true},
+		{Check: "Saved price ID for Checkout", Passed: true},
+		{Check: "Ran local Checkout flow", Passed: true},
+	}
+	m.cursor = 0
+
+	m.resizeViewport()
+	m.syncViewport()
+	view := m.View().Content
+
+	assert.LessOrEqual(t, lipgloss.Height(view), m.height)
+	assertLinesWithinWidth(t, view, m.width)
+	assertContainsPlain(t, view, "Stripe Co-op")
+	assertContainsPlain(t, view, "q quit")
+}
+
+func TestReviewCardShowsDetailsHintWhenClipped(t *testing.T) {
+	m := testModel()
+	m.ready = true
+	m.width = 56
+	m.height = 12
+	m.viewport = viewport.New(viewport.WithWidth(56), viewport.WithHeight(10))
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.session.Steps[0].Nodes[0].ReviewPrompt = "Confirm the Checkout flow, success page, saved price ID, webhook event handling, and environment variable setup all match the intended integration."
+	m.session.Steps[0].Nodes[0].Verifications = []coop.Verification{
+		{Check: "Created product", Passed: true},
+		{Check: "Created price", Passed: true},
+		{Check: "Created Checkout Session", Passed: true},
+	}
+	m.cursor = 0
+
+	footer := m.renderFooter()
+
+	assert.LessOrEqual(t, lipgloss.Height(footer), m.footerHeightBudget())
+	assertLinesWithinWidth(t, footer, m.width)
+	assertContainsPlain(t, footer, "more checks available")
+}
+
+func TestReviewCardFitsCoopStartSplitWidth(t *testing.T) {
+	m := testModel()
+	m.ready = true
+	m.width = 69
+	m.height = 50
+	m.viewport = viewport.New(viewport.WithWidth(69), viewport.WithHeight(10))
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[0].ReviewPrompt = "Confirm the product, price, Checkout Session, redirect URL, success page, saved price ID, webhook event handling, and environment variable setup all match the intended integration."
+	m.session.Steps[0].Nodes[0].Implementation = &coop.Implementation{File: "server/routes/payments/checkout/session/handler/with/a/long/path.js", Lines: "42-118"}
+	m.session.Steps[0].Nodes[0].Verifications = []coop.Verification{
+		{Check: "Created product", Passed: true},
+		{Check: "Created price", Passed: true},
+		{Check: "Created Checkout Session", Passed: true},
+	}
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].ReviewPrompt = "Open the app locally, click the Checkout button, complete payment, and confirm the redirect lands on the expected success page without exposing secret keys."
+	m.session.Steps[0].Nodes[1].Implementation = &coop.Implementation{File: "client/src/components/payments/checkout-button-with-long-name.tsx", Lines: "9-88"}
+	m.session.Steps[0].Nodes[1].Verifications = []coop.Verification{
+		{Check: "Rendered Checkout button", Passed: true},
+		{Check: "Confirmed redirect", Passed: true},
+	}
+	m.selectStep(0)
+
+	m.resizeViewport()
+	m.syncViewport()
+	view := m.View().Content
+
+	assert.LessOrEqual(t, lipgloss.Height(view), m.height)
+	assertLinesWithinWidth(t, view, m.width)
+	assertContainsPlain(t, view, "Stripe Co-op")
+	assertContainsPlain(t, view, "Review step")
+	assertContainsPlain(t, view, "q quit")
+}
+
+func TestViewportShowsMoreBelowIndicator(t *testing.T) {
+	m := testModel()
+	m.ready = true
+	m.width = 69
+	m.height = 12
+	m.viewport = viewport.New(viewport.WithWidth(69), viewport.WithHeight(4))
+	m.session.Steps = []coop.SessionStep{{
+		StepDefinition: coop.StepDefinition{Key: "long", Title: "Long step"},
+		Nodes: []coop.SessionNode{
+			{NodeDefinition: coop.NodeDefinition{Title: "One"}, State: coop.NodeDone},
+			{NodeDefinition: coop.NodeDefinition{Title: "Two"}, State: coop.NodeDone},
+			{NodeDefinition: coop.NodeDefinition{Title: "Three"}, State: coop.NodeDone},
+			{NodeDefinition: coop.NodeDefinition{Title: "Four"}, State: coop.NodeDone},
+			{NodeDefinition: coop.NodeDefinition{Title: "Five"}, State: coop.NodeDone},
+			{NodeDefinition: coop.NodeDefinition{Title: "Six"}, State: coop.NodeDone},
+		},
+	}}
+	m.cursor = 0
+	m.resizeViewport()
+	m.syncViewport()
+	m.viewport.SetHeight(4)
+	m.viewport.SetYOffset(0)
+
+	rendered := m.renderViewportRegionWithHeight(4)
+
+	assertContainsPlain(t, rendered, "more below")
+	assertLinesWithinWidth(t, rendered, m.width)
+}
+
+func TestViewportClosesClippedDetailBoxBeforeMoreBelowIndicator(t *testing.T) {
+	m := testModel()
+	m.ready = true
+	m.width = 69
+	m.height = 12
+	m.viewport = viewport.New(viewport.WithWidth(69), viewport.WithHeight(6))
+	m.session.Steps[0].Nodes[0].ReviewPrompt = strings.Repeat("Confirm the Checkout flow uses the saved price ID and redirects correctly. ", 5)
+	m.cursor = 0
+	m.expanded = true
+	m.resizeViewport()
+	m.syncViewport()
+	m.viewport.SetHeight(6)
+	m.viewport.SetYOffset(3)
+
+	rendered := ansi.Strip(m.renderViewportRegionWithHeight(6))
+
+	assert.Contains(t, rendered, "╰")
+	assert.Contains(t, rendered, "╯")
+	assertContainsPlain(t, rendered, "more below")
+	assertLinesWithinWidth(t, rendered, m.width)
+}
+
+func TestViewportBoundaryDoesNotTurnTopBorderIntoBottomBorder(t *testing.T) {
+	rendered := closeOpenBoxAtViewportBoundary("before\n  ╭────────╮")
+
+	assert.Contains(t, rendered, "╭")
+	assert.NotContains(t, rendered, "╰")
+}
+
+func assertLinesWithinWidth(t *testing.T, rendered string, width int) {
+	t.Helper()
+	for _, line := range strings.Split(rendered, "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(line), width, "line exceeds width: %q", line)
+	}
+}
+
+func TestStepIconAllStates(t *testing.T) {
+	m := testModel()
+
+	cases := []struct {
+		state    coop.NodeState
+		contains string
+	}{
+		{coop.NodeDone, "✓"},
+		{coop.NodeReview, "◆"},
+		{coop.NodeSkipped, "–"},
+		{coop.NodePending, "○"},
+	}
+
+	for _, tc := range cases {
+		node := coop.SessionNode{State: tc.state}
+		icon := m.nodeIcon(node)
+		assert.Contains(t, ansi.Strip(icon), tc.contains, "state %s should contain %s", tc.state, tc.contains)
+	}
+}
+
+func TestClampLines(t *testing.T) {
+	long := "this is a line that is way too long for a 20 column terminal"
+	result := clampLines(long, 20)
+	// Should be truncated
+	assert.LessOrEqual(t, len(result), 30) // allow for ANSI codes
+}
+
+func TestContentWidthDefault(t *testing.T) {
+	m := testModel()
+	m.width = 0
+	assert.Equal(t, 80, m.contentWidth())
+
+	m.width = 120
+	assert.Equal(t, 120, m.contentWidth())
+}


### PR DESCRIPTION
Part 9 of the clean co-op stack targeting `coop`.

This PR adds focused test coverage for the co-op TUI introduced in the previous PR.

Changes:
- Adds model, layout, interaction, stress, and view tests.
- Adds small test-support hooks in the TUI command/review code.

Review notes:
- This PR is primarily test coverage for the previous production TUI layer.
