### PR TITLE
10/12 Add co-op launcher and debug harness

### DIFF
--- a/pkg/cmd/coop/coop.go
+++ b/pkg/cmd/coop/coop.go
@@ -54,11 +54,14 @@ The developer confirms each step before the agent moves on.`,
 		},
 	}
 
+	cc.cmd.AddCommand(newCoopRunCmd().cmd)
 	cc.cmd.AddCommand(newCoopAgentRunCmd().cmd)
+	cc.cmd.AddCommand(newCoopJoinCmd().cmd)
 	cc.cmd.AddCommand(newCoopAgentCmd().cmd)
 	cc.cmd.AddCommand(newCoopStatusCmd().cmd)
 	cc.cmd.AddCommand(newCoopStopCmd().cmd)
 	cc.cmd.AddCommand(newCoopRecommendCmd().cmd)
+	cc.cmd.AddCommand(newCoopDebugAgentCmd().cmd)
 
 	return cc
 }
@@ -81,5 +84,11 @@ func coopSandboxClaimURL() string {
 func mustMarkFlagRequired(cmd *cobra.Command, name string) {
 	if err := cmd.MarkFlagRequired(name); err != nil {
 		panic("marking required flag " + name + ": " + err.Error())
+	}
+}
+
+func mustMarkFlagHidden(cmd *cobra.Command, name string) {
+	if err := cmd.Flags().MarkHidden(name); err != nil {
+		panic("hiding flag " + name + ": " + err.Error())
 	}
 }

--- a/pkg/cmd/coop/coop_debug_agent.go
+++ b/pkg/cmd/coop/coop_debug_agent.go
@@ -1,0 +1,322 @@
+package coopcmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/helpers"
+	"github.com/stripe/stripe-cli/pkg/coop/workflow"
+)
+
+type coopDebugAgentCmd struct {
+	cmd     *cobra.Command
+	session string
+	delay   time.Duration
+}
+
+func newCoopDebugAgentCmd() *coopDebugAgentCmd {
+	dc := &coopDebugAgentCmd{delay: 650 * time.Millisecond}
+	dc.cmd = &cobra.Command{
+		Use:    "debug-agent",
+		Short:  "Run a deterministic fake co-op agent",
+		Hidden: true,
+		RunE:   dc.runDebugAgentCmd,
+	}
+
+	dc.cmd.Flags().StringVar(&dc.session, "session", "", "Session ID to drive")
+	dc.cmd.Flags().DurationVar(&dc.delay, "delay", dc.delay, "Delay between active and review states")
+	mustMarkFlagHidden(dc.cmd, "delay")
+
+	return dc
+}
+
+func (dc *coopDebugAgentCmd) runDebugAgentCmd(cmd *cobra.Command, args []string) error {
+	if dc.session == "" {
+		return fmt.Errorf("--session is required")
+	}
+
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+
+	agent := &coopDebugAgent{
+		store:                    store,
+		sessionID:                dc.session,
+		delay:                    dc.delay,
+		pollInterval:             500 * time.Millisecond,
+		out:                      os.Stdout,
+		waitForNextStepSelection: true,
+	}
+	return agent.run(cmd.Context())
+}
+
+type coopDebugAgent struct {
+	store                    *coop.Store
+	sessionID                string
+	delay                    time.Duration
+	pollInterval             time.Duration
+	out                      io.Writer
+	waitForNextStepSelection bool
+}
+
+func (a *coopDebugAgent) run(ctx context.Context) error {
+	a.logf("debug agent attached to %s", a.sessionID)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		session, err := a.store.Read(a.sessionID)
+		if err != nil {
+			return err
+		}
+
+		if session.IsComplete() {
+			return a.completeSession(ctx, session)
+		}
+
+		if step := firstStepWithState(session, coop.NodeActive); step > 0 {
+			if err := a.completeActiveStep(ctx, step); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if step := firstStepWithState(session, coop.NodeReview); step > 0 {
+			if shouldContinueStepBeforeReview(session, step) {
+				sessionStep, stepIndex, _, err := session.StepByNodeNumber(step)
+				if err != nil {
+					return err
+				}
+				if next := helpers.NextPendingNodeInStep(session, stepIndex+1, step); next > 0 {
+					a.logf("step %q still has pending work; continuing with node %d", sessionStep.Title, next)
+					if err := a.startStep(next); err != nil {
+						return err
+					}
+					continue
+				}
+			}
+			if err := a.awaitReview(ctx, step); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if step := firstStepWithState(session, coop.NodePending); step > 0 {
+			if err := a.startStep(step); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := a.sleep(ctx, a.pollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+func (a *coopDebugAgent) startStep(step int) error {
+	session, err := a.store.Read(a.sessionID)
+	if err != nil {
+		return err
+	}
+	node, err := session.NodeByNumber(step)
+	if err != nil {
+		return err
+	}
+	if node.State != coop.NodePending {
+		return nil
+	}
+
+	resp, err := workflow.NewService(a.store).StartWork(a.sessionID, step, "Debug agent working: "+node.Title)
+	if err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	a.logf("step %d active: %s", step, node.Title)
+	return nil
+}
+
+func (a *coopDebugAgent) completeActiveStep(ctx context.Context, step int) error {
+	if err := a.sleep(ctx, a.delay); err != nil {
+		return err
+	}
+
+	session, err := a.store.Read(a.sessionID)
+	if err != nil {
+		return err
+	}
+	node, err := session.NodeByNumber(step)
+	if err != nil {
+		return err
+	}
+	if node.State != coop.NodeActive {
+		return nil
+	}
+
+	service := workflow.NewService(a.store)
+	resp, err := service.ReportCheck(a.sessionID, step, "Debug agent deterministic check", true)
+	if err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	resp, err = service.ReportWork(a.sessionID, step, workflow.ReportWorkInput{
+		File:  "debug/" + safeDebugFileName(node.Key) + ".txt",
+		Lines: "1-1",
+		Note:  "Deterministic debug agent completed " + node.Title,
+	}, false)
+	if err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	a.logf("step %d %s: %s", step, resp.State, node.Title)
+	return nil
+}
+
+func (a *coopDebugAgent) awaitReview(ctx context.Context, step int) error {
+	session, err := a.store.Read(a.sessionID)
+	if err != nil {
+		return err
+	}
+	stepDefinition, stepIndex, _, err := session.StepByNodeNumber(step)
+	if err != nil {
+		return err
+	}
+	a.logf("waiting for step review: %s", stepDefinition.Title)
+	return a.awaitStepReview(ctx, stepIndex)
+}
+
+func (a *coopDebugAgent) awaitStepReview(ctx context.Context, stepIndex int) error {
+	for {
+		if err := a.store.WriteHeartbeat(a.sessionID); err != nil {
+			return err
+		}
+		if err := a.sleep(ctx, a.pollInterval); err != nil {
+			_ = a.store.RemoveHeartbeat(a.sessionID)
+			return err
+		}
+
+		session, err := a.store.Read(a.sessionID)
+		if err != nil {
+			_ = a.store.RemoveHeartbeat(a.sessionID)
+			return err
+		}
+		if active := session.FirstActiveNodeInStep(stepIndex); active > 0 {
+			_ = a.store.RemoveHeartbeat(a.sessionID)
+			a.logf("step requested changes; rerunning from step %d", active)
+			return nil
+		}
+		if !session.StepHasReview(stepIndex) {
+			_ = a.store.RemoveHeartbeat(a.sessionID)
+			a.logf("step review released")
+			return nil
+		}
+	}
+}
+
+func (a *coopDebugAgent) completeSession(ctx context.Context, session *coop.Session) error {
+	if session.Status != coop.SessionCompleted || session.NextSteps == nil || len(session.NextSteps.Suggestions) == 0 {
+		suggestions := helpers.BuildSuggestions(session, helpers.DetectProjectEnvironment())
+		a.logf("all steps complete; showing next steps")
+		if err := helpers.ShowSuggestions(a.store, session, suggestions, ""); err != nil {
+			if isVersionConflict(err) {
+				return nil
+			}
+			return err
+		}
+	}
+
+	if !a.waitForNextStepSelection {
+		return nil
+	}
+
+	for {
+		if err := a.sleep(ctx, a.pollInterval); err != nil {
+			return err
+		}
+
+		session, err := a.store.Read(a.sessionID)
+		if err != nil {
+			return err
+		}
+		if session.NextSteps == nil || session.NextSteps.Selected == "" {
+			continue
+		}
+
+		selected := session.NextSteps.Selected
+		session.NextSteps.Selected = ""
+		if err := a.store.Write(session); err != nil && !isVersionConflict(err) {
+			return err
+		}
+		a.logf("next step selected: %s", selected)
+		return nil
+	}
+}
+
+func firstStepWithState(session *coop.Session, state coop.NodeState) int {
+	step := 0
+	for i := range session.Steps {
+		for j := range session.Steps[i].Nodes {
+			step++
+			if session.Steps[i].Nodes[j].State == state {
+				return step
+			}
+		}
+	}
+	return 0
+}
+
+func shouldContinueStepBeforeReview(session *coop.Session, step int) bool {
+	_, stepIndex, _, err := session.StepByNodeNumber(step)
+	if err != nil {
+		return false
+	}
+	return !session.StepReadyForReview(stepIndex)
+}
+
+func safeDebugFileName(key string) string {
+	if key == "" {
+		return "step"
+	}
+	return strings.NewReplacer("/", "_", "\\", "_", " ", "_").Replace(key)
+}
+
+func isVersionConflict(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "version conflict")
+}
+
+func (a *coopDebugAgent) sleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (a *coopDebugAgent) logf(format string, args ...interface{}) {
+	if a.out == nil {
+		return
+	}
+	fmt.Fprintf(a.out, "[debug-agent] "+format+"\n", args...)
+}

--- a/pkg/cmd/coop/coop_debug_agent_test.go
+++ b/pkg/cmd/coop/coop_debug_agent_test.go
@@ -1,0 +1,191 @@
+package coopcmd
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+const debugAgentTestTimeout = 10 * time.Second
+
+func TestCoopStartDebugAgentFlagIsHidden(t *testing.T) {
+	rc := newCoopRunCmd()
+	flag := rc.cmd.Flags().Lookup("debug-agent")
+	require.NotNil(t, flag)
+	assert.True(t, flag.Hidden)
+}
+
+func TestCoopStartDebugAgentRequiresBlueprint(t *testing.T) {
+	rc := &coopRunCmd{debugAgent: true}
+	err := rc.runCmd(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--debug-agent requires a blueprint ID")
+}
+
+func TestDebugAgentPaneCommandUsesStripeBinaryAndSession(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg config")
+	rc := &coopRunCmd{}
+	cmd, cleanup, err := rc.debugAgentPaneCommandBuilder("/tmp/stripe bin")(&coop.Session{ID: "coop_123"})
+	require.NoError(t, err)
+	assert.Nil(t, cleanup)
+	assert.Equal(t, "XDG_CONFIG_HOME=\"/tmp/xdg config\" \"/tmp/stripe bin\" coop debug-agent --session \"coop_123\"", cmd)
+}
+
+func TestCoopDebugAgentRerunsRequestedChanges(t *testing.T) {
+	store, session := setupDebugAgentSession(t, []coop.SessionStep{
+		{
+			StepDefinition: coop.StepDefinition{Key: "step", Title: "Step"},
+			Nodes: []coop.SessionNode{
+				{
+					NodeDefinition: coop.NodeDefinition{Key: "checkout", Title: "Build Checkout", Type: coop.NodeAPIRequest},
+					State:          coop.NodePending,
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), debugAgentTestTimeout)
+	defer cancel()
+	done := runDebugAgentForTest(ctx, store, session.ID)
+
+	waitForDebugSession(t, store, session.ID, func(s *coop.Session) bool {
+		node, _ := s.NodeByNumber(1)
+		return node.State == coop.NodeReview
+	})
+	waitForDebugHeartbeat(t, store, session.ID)
+
+	current, err := store.Read(session.ID)
+	require.NoError(t, err)
+	require.NoError(t, current.TransitionNode(1, coop.NodeActive))
+	node, _ := current.NodeByNumber(1)
+	node.RejectionNote = "Use the stored price ID"
+	node.Implementation = nil
+	node.Verifications = nil
+	require.NoError(t, store.Write(current))
+
+	waitForDebugSession(t, store, session.ID, func(s *coop.Session) bool {
+		node, _ := s.NodeByNumber(1)
+		return node.State == coop.NodeReview && len(node.Verifications) > 0 && node.Implementation != nil
+	})
+
+	current, err = store.Read(session.ID)
+	require.NoError(t, err)
+	require.NoError(t, current.TransitionNode(1, coop.NodeDone))
+	require.NoError(t, store.Write(current))
+
+	require.NoError(t, <-done)
+	finalSession, err := store.Read(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, coop.SessionCompleted, finalSession.Status)
+	assert.NotEmpty(t, finalSession.NextSteps.Suggestions)
+}
+
+func TestCoopDebugAgentWaitsForStepReviewAfterStepIsReady(t *testing.T) {
+	store, session := setupDebugAgentSession(t, []coop.SessionStep{
+		{
+			StepDefinition: coop.StepDefinition{Key: "step", Title: "Step"},
+			Nodes: []coop.SessionNode{
+				{
+					NodeDefinition: coop.NodeDefinition{Key: "product", Title: "Create product", Type: coop.NodeAPIRequest},
+					State:          coop.NodePending,
+				},
+				{
+					NodeDefinition: coop.NodeDefinition{Key: "checkout", Title: "Build Checkout", Type: coop.NodeAPIRequest},
+					State:          coop.NodePending,
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), debugAgentTestTimeout)
+	defer cancel()
+	done := runDebugAgentForTest(ctx, store, session.ID)
+
+	waitForDebugSession(t, store, session.ID, func(s *coop.Session) bool {
+		node1, _ := s.NodeByNumber(1)
+		node2, _ := s.NodeByNumber(2)
+		return node1.State == coop.NodeReview && node2.State == coop.NodeReview
+	})
+
+	current, err := store.Read(session.ID)
+	require.NoError(t, err)
+	require.NoError(t, current.TransitionNode(1, coop.NodeDone))
+	require.NoError(t, current.TransitionNode(2, coop.NodeDone))
+	require.NoError(t, store.Write(current))
+
+	require.NoError(t, <-done)
+	finalSession, err := store.Read(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, coop.SessionCompleted, finalSession.Status)
+}
+
+func setupDebugAgentSession(t *testing.T, steps []coop.SessionStep) (*coop.Store, *coop.Session) {
+	t.Helper()
+	store, err := coop.NewStoreAt(t.TempDir())
+	require.NoError(t, err)
+	session := &coop.Session{
+		ID:        "debug_agent_session",
+		Blueprint: "debug-blueprint",
+		Status:    coop.SessionActive,
+		Settings:  map[string]string{"language": "node"},
+		Steps:     steps,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, store.Write(session))
+	return store, session
+}
+
+func runDebugAgentForTest(ctx context.Context, store *coop.Store, sessionID string) <-chan error {
+	done := make(chan error, 1)
+	agent := &coopDebugAgent{
+		store:                    store,
+		sessionID:                sessionID,
+		delay:                    time.Millisecond,
+		pollInterval:             5 * time.Millisecond,
+		out:                      io.Discard,
+		waitForNextStepSelection: false,
+	}
+	go func() {
+		done <- agent.run(ctx)
+	}()
+	return done
+}
+
+func waitForDebugSession(t *testing.T, store *coop.Store, sessionID string, predicate func(*coop.Session) bool) {
+	t.Helper()
+	deadline := time.Now().Add(debugAgentTestTimeout)
+	for time.Now().Before(deadline) {
+		session, err := store.Read(sessionID)
+		require.NoError(t, err)
+		if predicate(session) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	session, err := store.Read(sessionID)
+	require.NoError(t, err)
+	require.True(t, predicate(session), "session did not reach expected state: %+v", session)
+}
+
+func waitForDebugHeartbeat(t *testing.T, store *coop.Store, sessionID string) {
+	t.Helper()
+	deadline := time.Now().Add(debugAgentTestTimeout)
+	for time.Now().Before(deadline) {
+		age, err := store.HeartbeatAge(sessionID)
+		require.NoError(t, err)
+		if age >= 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	age, err := store.HeartbeatAge(sessionID)
+	require.NoError(t, err)
+	require.True(t, age >= 0, "debug agent did not write heartbeat")
+}

--- a/pkg/cmd/coop/coop_join.go
+++ b/pkg/cmd/coop/coop_join.go
@@ -2,12 +2,12 @@ package coopcmd
 
 import (
 	"fmt"
+	"sort"
 
 	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/coop"
-	"github.com/stripe/stripe-cli/pkg/coop/helpers"
 	"github.com/stripe/stripe-cli/pkg/coop/tui"
 )
 
@@ -90,18 +90,38 @@ func (jc *coopJoinCmd) runJoinCmd(cmd *cobra.Command, args []string) error {
 	return tui.Run(store, session.ID, tui.WithSandboxClaimURL(coopSandboxClaimURL()))
 }
 
+type sessionChoice struct {
+	session *coop.Session
+	label   string
+}
+
 func (jc *coopJoinCmd) pickSession(store *coop.Store) (*coop.Session, error) {
+	entries, err := recentSessionChoices(store)
+	if err != nil {
+		return nil, err
+	}
+
+	var options []huh.Option[string]
+	for _, e := range entries {
+		options = append(options, huh.NewOption(e.label, e.session.ID))
+	}
+
+	var choice string
+	err = selectString("Pick a session to resume:", options, &choice)
+	if err != nil {
+		return nil, err
+	}
+
+	return store.Read(choice)
+}
+
+func recentSessionChoices(store *coop.Store) ([]sessionChoice, error) {
 	ids, err := store.List()
 	if err != nil || len(ids) == 0 {
 		return nil, fmt.Errorf("no sessions found. Start one with 'stripe coop start <blueprint>'")
 	}
 
-	// Load sessions and build options (most recent first)
-	type sessionEntry struct {
-		session *coop.Session
-		label   string
-	}
-	var entries []sessionEntry
+	var entries []sessionChoice
 
 	for _, id := range ids {
 		s, err := store.Read(id)
@@ -112,25 +132,19 @@ func (jc *coopJoinCmd) pickSession(store *coop.Store) (*coop.Session, error) {
 		status := string(s.Status)
 		label := fmt.Sprintf("%s  %s  %d/%d done  [%s]",
 			s.ID, s.Blueprint, summary[coop.NodeDone], s.TotalNodes(), status)
-		entries = append(entries, sessionEntry{session: s, label: label})
+		entries = append(entries, sessionChoice{session: s, label: label})
 	}
 
 	if len(entries) == 0 {
 		return nil, fmt.Errorf("no readable sessions found")
 	}
 
-	// Build huh options
-	var options []huh.Option[string]
-	for _, e := range entries {
-		options = append(options, huh.NewOption(e.label, e.session.ID))
-	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].session.UpdatedAt.Equal(entries[j].session.UpdatedAt) {
+			return entries[i].session.ID < entries[j].session.ID
+		}
+		return entries[i].session.UpdatedAt.After(entries[j].session.UpdatedAt)
+	})
 
-	var choice string
-
-	err = helpers.Select("Pick a session to resume:", options, &choice)
-	if err != nil {
-		return nil, err
-	}
-
-	return store.Read(choice)
+	return entries, nil
 }

--- a/pkg/cmd/coop/coop_join.go
+++ b/pkg/cmd/coop/coop_join.go
@@ -1,0 +1,136 @@
+package coopcmd
+
+import (
+	"fmt"
+
+	"charm.land/huh/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/helpers"
+	"github.com/stripe/stripe-cli/pkg/coop/tui"
+)
+
+type coopJoinCmd struct {
+	cmd    *cobra.Command
+	resume bool
+	wait   bool
+}
+
+func newCoopJoinCmd() *coopJoinCmd {
+	jc := &coopJoinCmd{}
+	jc.cmd = &cobra.Command{
+		Use:   "join [session-id]",
+		Short: "Join a co-op session and watch progress in the terminal UI",
+		Long: `Launches the co-op terminal UI to watch an agent work through a blueprint
+in real time. Press 'c' to confirm completed steps, 'e' to expand details.
+
+If no session ID is given, joins the most recently updated active session.
+Use --resume to pick from all recent sessions.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: jc.runJoinCmd,
+	}
+
+	jc.cmd.Flags().BoolVar(&jc.resume, "resume", false, "Pick from recent sessions")
+	jc.cmd.Flags().BoolVar(&jc.wait, "wait", false, "Wait for a new session to be created (used by coop run)")
+	jc.cmd.Flags().MarkHidden("wait")
+
+	return jc
+}
+
+func (jc *coopJoinCmd) runJoinCmd(cmd *cobra.Command, args []string) error {
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+
+	// Wait mode: launch TUI immediately and poll for a new session
+	if jc.wait {
+		existingIDs := make(map[string]bool)
+		if ids, err := store.List(); err == nil {
+			for _, id := range ids {
+				existingIDs[id] = true
+			}
+		}
+		return tui.RunWaiting(store, existingIDs, tui.WithSandboxClaimURL(coopSandboxClaimURL()))
+	}
+
+	var session *coop.Session
+
+	switch {
+	case len(args) > 0:
+		session, err = store.Read(args[0])
+		if err != nil {
+			return fmt.Errorf("session %q not found: %w", args[0], err)
+		}
+	case jc.resume:
+		session, err = jc.pickSession(store)
+		if err != nil {
+			return err
+		}
+	default:
+		// Try active first, then fall back to latest (including completed sessions with next-action suggestions).
+		session, err = store.LatestActiveSession()
+		if err != nil {
+			session, err = store.LatestSession()
+		}
+		if err != nil {
+			return fmt.Errorf("no session found. Use --resume to pick from recent sessions, or start a new one with 'stripe coop start'")
+		}
+	}
+
+	// Show reconnection notice if session is already in progress
+	summary := session.NodeSummary()
+	if summary[coop.NodeDone] > 0 || summary[coop.NodeActive] > 0 || summary[coop.NodeReview] > 0 {
+		fmt.Printf("Reconnecting to %s (%s) — %d/%d done\n",
+			session.ID, session.Blueprint, summary[coop.NodeDone], session.TotalNodes())
+		fmt.Println()
+	}
+
+	return tui.Run(store, session.ID, tui.WithSandboxClaimURL(coopSandboxClaimURL()))
+}
+
+func (jc *coopJoinCmd) pickSession(store *coop.Store) (*coop.Session, error) {
+	ids, err := store.List()
+	if err != nil || len(ids) == 0 {
+		return nil, fmt.Errorf("no sessions found. Start one with 'stripe coop start <blueprint>'")
+	}
+
+	// Load sessions and build options (most recent first)
+	type sessionEntry struct {
+		session *coop.Session
+		label   string
+	}
+	var entries []sessionEntry
+
+	for _, id := range ids {
+		s, err := store.Read(id)
+		if err != nil {
+			continue
+		}
+		summary := s.NodeSummary()
+		status := string(s.Status)
+		label := fmt.Sprintf("%s  %s  %d/%d done  [%s]",
+			s.ID, s.Blueprint, summary[coop.NodeDone], s.TotalNodes(), status)
+		entries = append(entries, sessionEntry{session: s, label: label})
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no readable sessions found")
+	}
+
+	// Build huh options
+	var options []huh.Option[string]
+	for _, e := range entries {
+		options = append(options, huh.NewOption(e.label, e.session.ID))
+	}
+
+	var choice string
+
+	err = helpers.Select("Pick a session to resume:", options, &choice)
+	if err != nil {
+		return nil, err
+	}
+
+	return store.Read(choice)
+}

--- a/pkg/cmd/coop/coop_join_test.go
+++ b/pkg/cmd/coop/coop_join_test.go
@@ -1,0 +1,35 @@
+package coopcmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestRecentSessionChoicesSortsMostRecentFirst(t *testing.T) {
+	store, err := coop.NewStoreAt(t.TempDir())
+	require.NoError(t, err)
+
+	require.NoError(t, store.Write(&coop.Session{
+		ID:        "a_old",
+		Blueprint: "old-blueprint",
+		Status:    coop.SessionActive,
+	}))
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, store.Write(&coop.Session{
+		ID:        "z_new",
+		Blueprint: "new-blueprint",
+		Status:    coop.SessionActive,
+	}))
+
+	choices, err := recentSessionChoices(store)
+
+	require.NoError(t, err)
+	require.Len(t, choices, 2)
+	assert.Equal(t, "z_new", choices[0].session.ID)
+	assert.Equal(t, "a_old", choices[1].session.ID)
+}

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -1,0 +1,380 @@
+package coopcmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"charm.land/huh/v2"
+	"github.com/google/uuid"
+	"golang.org/x/term"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/helpers"
+	"github.com/stripe/stripe-cli/pkg/coop/tui"
+)
+
+type agentInfo struct {
+	name string // "claude" or "codex"
+	path string
+}
+
+type coopPaneCommandBuilder func(session *coop.Session) (string, func(), error)
+
+const (
+	defaultCoopTmuxSessionWidth  = 200
+	defaultCoopTmuxSessionHeight = 50
+)
+
+func (rc *coopRunCmd) detectAgent() (*agentInfo, error) {
+	if rc.agent != "" {
+		path, err := exec.LookPath(rc.agent)
+		if err != nil {
+			return nil, fmt.Errorf("agent %q not found in PATH", rc.agent)
+		}
+		name := rc.agent
+		if strings.Contains(path, "claude") {
+			name = "claude"
+		} else if strings.Contains(path, "codex") {
+			name = "codex"
+		}
+		return &agentInfo{name: name, path: path}, nil
+	}
+
+	claudePath, claudeErr := exec.LookPath("claude")
+	codexPath, codexErr := exec.LookPath("codex")
+
+	hasClaude := claudeErr == nil
+	hasCodex := codexErr == nil
+
+	switch {
+	case hasClaude && hasCodex:
+		var choice string
+		err := helpers.Select("Multiple agents detected. Which would you like to use?",
+			[]huh.Option[string]{
+				huh.NewOption("Claude Code", "claude"),
+				huh.NewOption("Codex", "codex"),
+			},
+			&choice,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if choice == "codex" {
+			return &agentInfo{name: "codex", path: codexPath}, nil
+		}
+		return &agentInfo{name: "claude", path: claudePath}, nil
+
+	case hasClaude:
+		return &agentInfo{name: "claude", path: claudePath}, nil
+	case hasCodex:
+		return &agentInfo{name: "codex", path: codexPath}, nil
+	default:
+		return nil, fmt.Errorf("no AI agent found in PATH.\n  Install Claude Code: https://docs.anthropic.com/en/docs/claude-code\n  Or specify a custom agent: --agent=<command>")
+	}
+}
+
+func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) bool {
+	var choice string
+
+	var title string
+	switch agent.name {
+	case "claude":
+		title = "Permission mode for Claude Code:"
+	case "codex":
+		title = "Permission mode for Codex:"
+	default:
+		return false
+	}
+
+	err := helpers.Select(title,
+		[]huh.Option[string]{
+			huh.NewOption("Normal — agent asks before running commands", "normal"),
+			huh.NewOption("Auto-approve — skip all permission prompts (faster, less safe)", "auto"),
+		},
+		&choice,
+	)
+	if err != nil {
+		return false
+	}
+	return choice == "auto"
+}
+
+func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApprove bool) (string, error) {
+	launcherPath := promptPath + ".sh"
+	var script string
+
+	switch agent.name {
+	case "claude":
+		flags := ""
+		if autoApprove {
+			flags = " --dangerously-skip-permissions"
+		}
+		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
+			strconv.Quote(promptPath), strconv.Quote(promptPath), strconv.Quote(launcherPath), strconv.Quote(agent.path), flags)
+
+	case "codex":
+		flags := ""
+		if autoApprove {
+			flags = " --dangerously-bypass-approvals-and-sandbox"
+		}
+		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
+			strconv.Quote(promptPath), strconv.Quote(promptPath), strconv.Quote(launcherPath), strconv.Quote(agent.path), flags)
+
+	default:
+		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s \"$prompt\"\n",
+			strconv.Quote(promptPath), strconv.Quote(promptPath), strconv.Quote(launcherPath), strconv.Quote(agent.path))
+	}
+
+	if err := os.WriteFile(launcherPath, []byte(script), 0700); err != nil {
+		return "", fmt.Errorf("creating agent launcher: %w", err)
+	}
+	return launcherPath, nil
+}
+
+func (rc *coopRunCmd) hasTmux() bool {
+	_, err := exec.LookPath("tmux")
+	return err == nil
+}
+
+func (rc *coopRunCmd) agentPaneCommandBuilder(agent *agentInfo, discoveryPrompt string, autoApprove bool) coopPaneCommandBuilder {
+	return func(session *coop.Session) (string, func(), error) {
+		prompt := discoveryPrompt
+		if session != nil {
+			var err error
+			prompt, err = rc.buildAgentPromptForSession(session)
+			if err != nil {
+				return "", nil, err
+			}
+		}
+		promptPath, err := writePromptFile(prompt)
+		if err != nil {
+			return "", nil, err
+		}
+
+		agentCmd, err := rc.buildAgentCmd(agent, promptPath, autoApprove)
+		if err != nil {
+			os.Remove(promptPath)
+			return "", nil, err
+		}
+		return agentCmd, func() {
+			os.Remove(promptPath)
+			os.Remove(agentCmd)
+		}, nil
+	}
+}
+
+func (rc *coopRunCmd) debugAgentPaneCommandBuilder(stripeBin string) coopPaneCommandBuilder {
+	return func(session *coop.Session) (string, func(), error) {
+		sessionID := ""
+		if session != nil {
+			sessionID = session.ID
+		}
+		cmd := fmt.Sprintf("%s coop debug-agent --session %s", strconv.Quote(stripeBin), strconv.Quote(sessionID))
+		if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+			cmd = fmt.Sprintf("XDG_CONFIG_HOME=%s %s", strconv.Quote(xdgConfigHome), cmd)
+		}
+		return cmd, nil, nil
+	}
+}
+
+func (rc *coopRunCmd) runInTmuxSplit(stripeBin string, agent *agentInfo, agentPrompt string, autoApprove bool, blueprintID string) error {
+	return rc.runInTmuxSplitWithCommand(stripeBin, blueprintID, rc.agentPaneCommandBuilder(agent, agentPrompt, autoApprove))
+}
+
+func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprintID string, buildPaneCmd coopPaneCommandBuilder) error {
+	var session *coop.Session
+	if blueprintID != "" {
+		var err error
+		session, err = rc.startSessionQuietly(blueprintID)
+		if err != nil {
+			return err
+		}
+	}
+
+	paneCmd, cleanup, err := buildPaneCmd(session)
+	if err != nil {
+		rc.abortStartedSession(session, "agent pane command failed")
+		return err
+	}
+
+	split := exec.Command("tmux", "split-window", "-h", "-p", "60", "bash", "-c", paneCmd)
+	if err := split.Run(); err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		rc.abortStartedSession(session, "tmux split failed")
+		return fmt.Errorf("tmux split failed: %w", err)
+	}
+
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return err
+	}
+
+	if blueprintID != "" {
+		return tui.Run(store, session.ID, tui.WithSandboxClaimURL(coopSandboxClaimURL()))
+	}
+
+	return runCoopTUIWait(store)
+}
+
+func (rc *coopRunCmd) runInNewTmux(stripeBin string, agent *agentInfo, agentPrompt string, autoApprove bool, blueprintID string) error {
+	return rc.runInNewTmuxWithCommand(stripeBin, blueprintID, rc.agentPaneCommandBuilder(agent, agentPrompt, autoApprove))
+}
+
+func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprintID string, buildPaneCmd coopPaneCommandBuilder) error {
+	sessionName := "stripe-coop"
+
+	// Check for existing session
+	if err := exec.Command("tmux", "has-session", "-t", sessionName).Run(); err == nil {
+		var choice string
+		if err := helpers.Select("A co-op tmux session already exists. What would you like to do?",
+			[]huh.Option[string]{
+				huh.NewOption("Reattach to existing session", "attach"),
+				huh.NewOption("Start fresh (kills existing session)", "fresh"),
+			},
+			&choice,
+		); err != nil {
+			return err
+		}
+
+		if choice == "attach" {
+			attach := exec.Command("tmux", "attach-session", "-t", sessionName)
+			attach.Stdin = os.Stdin
+			attach.Stdout = os.Stdout
+			attach.Stderr = os.Stderr
+			return attach.Run()
+		}
+		exec.Command("tmux", "kill-session", "-t", sessionName).Run()
+	}
+
+	var session *coop.Session
+	if blueprintID != "" {
+		var err error
+		session, err = rc.startSessionQuietly(blueprintID)
+		if err != nil {
+			return err
+		}
+	}
+
+	tuiCmd := fmt.Sprintf("%s coop join", strconv.Quote(stripeBin))
+	if blueprintID == "" {
+		tuiCmd += " --wait"
+	} else {
+		tuiCmd += " " + session.ID
+	}
+	paneCmd, cleanup, err := buildPaneCmd(session)
+	if err != nil {
+		rc.abortStartedSession(session, "agent pane command failed")
+		return err
+	}
+
+	width, height := coopTmuxSessionDimensions()
+	create := exec.Command("tmux", "new-session", "-d", "-s", sessionName, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height),
+		"bash", "-c", tuiCmd)
+	if err := create.Run(); err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		rc.abortStartedSession(session, "tmux new-session failed")
+		return fmt.Errorf("tmux new-session failed: %w", err)
+	}
+
+	split := exec.Command("tmux", "split-window", "-h", "-t", sessionName, "-p", "60",
+		"bash", "-c", paneCmd)
+	if err := split.Run(); err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		rc.abortStartedSession(session, "tmux split-window failed")
+		return fmt.Errorf("tmux split-window failed: %w", err)
+	}
+
+	exec.Command("tmux", "select-pane", "-t", sessionName+":0.1").Run()
+
+	attach := exec.Command("tmux", "attach-session", "-t", sessionName)
+	attach.Stdin = os.Stdin
+	attach.Stdout = os.Stdout
+	attach.Stderr = os.Stderr
+	return attach.Run()
+}
+
+func coopTmuxSessionDimensions() (int, int) {
+	width, height, err := term.GetSize(int(os.Stdout.Fd()))
+	return normalizeCoopTmuxSessionDimensions(width, height, err)
+}
+
+func normalizeCoopTmuxSessionDimensions(width, height int, err error) (int, int) {
+	if err != nil || width <= 0 || height <= 0 {
+		return defaultCoopTmuxSessionWidth, defaultCoopTmuxSessionHeight
+	}
+	return width, height
+}
+
+func (rc *coopRunCmd) runFallback(stripeBin string, agent *agentInfo, agentPrompt string, autoApprove bool, blueprintID string) error {
+	return rc.runFallbackWithCommand(stripeBin, blueprintID, rc.agentPaneCommandBuilder(agent, agentPrompt, autoApprove))
+}
+
+func (rc *coopRunCmd) runFallbackWithCommand(stripeBin string, blueprintID string, buildPaneCmd coopPaneCommandBuilder) error {
+	fmt.Println("tmux not found — running agent in this terminal.")
+
+	var session *coop.Session
+	if blueprintID != "" {
+		var err error
+		session, err = rc.startSessionQuietly(blueprintID)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Session started: %s\n", session.ID)
+		fmt.Printf("Open another terminal and run: stripe coop join %s\n", session.ID)
+	} else {
+		fmt.Println("Open another terminal and run: stripe coop join --wait")
+	}
+	fmt.Println()
+
+	paneCmd, cleanup, err := buildPaneCmd(session)
+	if err != nil {
+		rc.abortStartedSession(session, "agent pane command failed")
+		return err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	agentExec := exec.Command("bash", "-c", paneCmd)
+	agentExec.Stdin = os.Stdin
+	agentExec.Stdout = os.Stdout
+	agentExec.Stderr = os.Stderr
+	return agentExec.Run()
+}
+
+func generateShortID() string {
+	return uuid.New().String()[:8]
+}
+
+func writePromptFile(prompt string) (string, error) {
+	f, err := os.CreateTemp("", "stripe-coop-prompt-*.txt")
+	if err != nil {
+		return "", fmt.Errorf("creating prompt file: %w", err)
+	}
+	if _, err := f.WriteString(prompt); err != nil {
+		f.Close()
+		return "", fmt.Errorf("writing prompt file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("closing prompt file: %w", err)
+	}
+	return f.Name(), nil
+}
+
+func runCoopTUIWait(store *coop.Store) error {
+	existingIDs := make(map[string]bool)
+	if ids, err := store.List(); err == nil {
+		for _, id := range ids {
+			existingIDs[id] = true
+		}
+	}
+	return tui.RunWaiting(store, existingIDs, tui.WithSandboxClaimURL(coopSandboxClaimURL()))
+}

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -23,6 +23,13 @@ type agentInfo struct {
 
 type coopPaneCommandBuilder func(session *coop.Session) (string, func(), error)
 
+var (
+	selectString = helpers.Select[string]
+	runTmux      = func(args ...string) error {
+		return exec.Command("tmux", args...).Run()
+	}
+)
+
 const (
 	defaultCoopTmuxSessionWidth  = 200
 	defaultCoopTmuxSessionHeight = 50
@@ -52,7 +59,7 @@ func (rc *coopRunCmd) detectAgent() (*agentInfo, error) {
 	switch {
 	case hasClaude && hasCodex:
 		var choice string
-		err := helpers.Select("Multiple agents detected. Which would you like to use?",
+		err := selectString("Multiple agents detected. Which would you like to use?",
 			[]huh.Option[string]{
 				huh.NewOption("Claude Code", "claude"),
 				huh.NewOption("Codex", "codex"),
@@ -76,7 +83,7 @@ func (rc *coopRunCmd) detectAgent() (*agentInfo, error) {
 	}
 }
 
-func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) bool {
+func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) (bool, error) {
 	var choice string
 
 	var title string
@@ -86,10 +93,10 @@ func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) bool {
 	case "codex":
 		title = "Permission mode for Codex:"
 	default:
-		return false
+		return false, nil
 	}
 
-	err := helpers.Select(title,
+	err := selectString(title,
 		[]huh.Option[string]{
 			huh.NewOption("Normal — agent asks before running commands", "normal"),
 			huh.NewOption("Auto-approve — skip all permission prompts (faster, less safe)", "auto"),
@@ -97,9 +104,9 @@ func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) bool {
 		&choice,
 	)
 	if err != nil {
-		return false
+		return false, err
 	}
-	return choice == "auto"
+	return choice == "auto", nil
 }
 
 func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApprove bool) (string, error) {
@@ -200,8 +207,7 @@ func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprintID st
 		return err
 	}
 
-	split := exec.Command("tmux", "split-window", "-h", "-p", "60", "bash", "-c", paneCmd)
-	if err := split.Run(); err != nil {
+	if err := runTmux("split-window", "-h", "-p", "60", "bash", "-c", paneCmd); err != nil {
 		if cleanup != nil {
 			cleanup()
 		}
@@ -229,9 +235,9 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprintID stri
 	sessionName := "stripe-coop"
 
 	// Check for existing session
-	if err := exec.Command("tmux", "has-session", "-t", sessionName).Run(); err == nil {
+	if err := runTmux("has-session", "-t", sessionName); err == nil {
 		var choice string
-		if err := helpers.Select("A co-op tmux session already exists. What would you like to do?",
+		if err := selectString("A co-op tmux session already exists. What would you like to do?",
 			[]huh.Option[string]{
 				huh.NewOption("Reattach to existing session", "attach"),
 				huh.NewOption("Start fresh (kills existing session)", "fresh"),
@@ -248,7 +254,7 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprintID stri
 			attach.Stderr = os.Stderr
 			return attach.Run()
 		}
-		exec.Command("tmux", "kill-session", "-t", sessionName).Run()
+		killTmuxSession(sessionName)
 	}
 
 	var session *coop.Session
@@ -273,9 +279,8 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprintID stri
 	}
 
 	width, height := coopTmuxSessionDimensions()
-	create := exec.Command("tmux", "new-session", "-d", "-s", sessionName, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height),
-		"bash", "-c", tuiCmd)
-	if err := create.Run(); err != nil {
+	if err := runTmux("new-session", "-d", "-s", sessionName, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height),
+		"bash", "-c", tuiCmd); err != nil {
 		if cleanup != nil {
 			cleanup()
 		}
@@ -283,23 +288,27 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprintID stri
 		return fmt.Errorf("tmux new-session failed: %w", err)
 	}
 
-	split := exec.Command("tmux", "split-window", "-h", "-t", sessionName, "-p", "60",
-		"bash", "-c", paneCmd)
-	if err := split.Run(); err != nil {
+	if err := runTmux("split-window", "-h", "-t", sessionName, "-p", "60",
+		"bash", "-c", paneCmd); err != nil {
 		if cleanup != nil {
 			cleanup()
 		}
+		killTmuxSession(sessionName)
 		rc.abortStartedSession(session, "tmux split-window failed")
 		return fmt.Errorf("tmux split-window failed: %w", err)
 	}
 
-	exec.Command("tmux", "select-pane", "-t", sessionName+":0.1").Run()
+	runTmux("select-pane", "-t", sessionName+":0.1")
 
 	attach := exec.Command("tmux", "attach-session", "-t", sessionName)
 	attach.Stdin = os.Stdin
 	attach.Stdout = os.Stdout
 	attach.Stderr = os.Stderr
 	return attach.Run()
+}
+
+func killTmuxSession(sessionName string) {
+	_ = runTmux("kill-session", "-t", sessionName)
 }
 
 func coopTmuxSessionDimensions() (int, int) {

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"charm.land/huh/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -59,6 +60,22 @@ func TestExplicitBlueprintPromptIncludesSessionProtocol(t *testing.T) {
 	assert.Contains(t, prompt, "Start by running the \"next\" command exactly as written")
 }
 
+func TestPromptAutoApproveReturnsPromptErrors(t *testing.T) {
+	promptErr := errors.New("permission prompt canceled")
+	originalSelectString := selectString
+	selectString = func(title string, options []huh.Option[string], value *string) error {
+		return promptErr
+	}
+	t.Cleanup(func() {
+		selectString = originalSelectString
+	})
+
+	autoApprove, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{name: "claude"})
+
+	require.ErrorIs(t, err, promptErr)
+	assert.False(t, autoApprove)
+}
+
 func TestFallbackPaneBuildFailureAbortsStartedSession(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
@@ -82,4 +99,64 @@ func TestFallbackPaneBuildFailureAbortsStartedSession(t *testing.T) {
 
 	_, err = store.LatestActiveSession()
 	assert.Error(t, err)
+}
+
+func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	splitErr := errors.New("split failed")
+	var tmuxCalls [][]string
+	originalRunTmux := runTmux
+	runTmux = func(args ...string) error {
+		tmuxCalls = append(tmuxCalls, append([]string(nil), args...))
+		switch args[0] {
+		case "has-session":
+			return errors.New("session not found")
+		case "split-window":
+			return splitErr
+		default:
+			return nil
+		}
+	}
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+	})
+
+	cleanupCalled := false
+	rc := &coopRunCmd{language: "node"}
+	err := rc.runInNewTmuxWithCommand("/stripe", "one-time-payment", func(session *coop.Session) (string, func(), error) {
+		require.NotNil(t, session)
+		return "agent", func() { cleanupCalled = true }, nil
+	})
+	require.ErrorIs(t, err, splitErr)
+	assert.True(t, cleanupCalled)
+	assert.True(t, hasTmuxCall(tmuxCalls, "kill-session", "-t", "stripe-coop"))
+
+	store, err := coop.NewStore(coopConfigFolder())
+	require.NoError(t, err)
+	session, err := store.LatestSession()
+	require.NoError(t, err)
+	assert.Equal(t, coop.SessionAborted, session.Status)
+	node, err := session.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Contains(t, node.Activity, "tmux split-window failed")
+}
+
+func hasTmuxCall(calls [][]string, want ...string) bool {
+	for _, call := range calls {
+		if len(call) != len(want) {
+			continue
+		}
+		matches := true
+		for i := range call {
+			if call[i] != want[i] {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -1,0 +1,85 @@
+package coopcmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestNormalizeCoopTmuxSessionDimensionsUsesTerminalSize(t *testing.T) {
+	width, height := normalizeCoopTmuxSessionDimensions(260, 60, nil)
+
+	assert.Equal(t, 260, width)
+	assert.Equal(t, 60, height)
+}
+
+func TestNormalizeCoopTmuxSessionDimensionsFallsBack(t *testing.T) {
+	tests := []struct {
+		name   string
+		width  int
+		height int
+		err    error
+	}{
+		{name: "size error", width: 260, height: 60, err: errors.New("not a terminal")},
+		{name: "zero width", width: 0, height: 60},
+		{name: "zero height", width: 260, height: 0},
+		{name: "negative width", width: -1, height: 60},
+		{name: "negative height", width: 260, height: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			width, height := normalizeCoopTmuxSessionDimensions(tt.width, tt.height, tt.err)
+
+			assert.Equal(t, defaultCoopTmuxSessionWidth, width)
+			assert.Equal(t, defaultCoopTmuxSessionHeight, height)
+		})
+	}
+}
+
+func TestExplicitBlueprintPromptIncludesSessionProtocol(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	rc := &coopRunCmd{language: "node"}
+	session, err := rc.startSessionQuietly("one-time-payment")
+	require.NoError(t, err)
+
+	prompt, err := rc.buildAgentPromptForSession(session)
+	require.NoError(t, err)
+
+	assert.Contains(t, prompt, session.ID)
+	assert.Contains(t, prompt, `"agent_instructions"`)
+	assert.Contains(t, prompt, `"nodes"`)
+	assert.Contains(t, prompt, `"next": "stripe coop agent start-work --session=`+session.ID+` --step=1`)
+	assert.Contains(t, prompt, "Understand the project")
+	assert.Contains(t, prompt, "Start by running the \"next\" command exactly as written")
+}
+
+func TestFallbackPaneBuildFailureAbortsStartedSession(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	rc := &coopRunCmd{language: "node"}
+	buildErr := errors.New("pane build failed")
+
+	err := rc.runFallbackWithCommand("/stripe", "one-time-payment", func(session *coop.Session) (string, func(), error) {
+		require.NotNil(t, session)
+		return "", nil, buildErr
+	})
+	require.ErrorIs(t, err, buildErr)
+
+	store, err := coop.NewStore(coopConfigFolder())
+	require.NoError(t, err)
+	session, err := store.LatestSession()
+	require.NoError(t, err)
+	assert.Equal(t, coop.SessionAborted, session.Status)
+	node, err := session.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Contains(t, node.Activity, "agent pane command failed")
+
+	_, err = store.LatestActiveSession()
+	assert.Error(t, err)
+}

--- a/pkg/cmd/coop/coop_run.go
+++ b/pkg/cmd/coop/coop_run.go
@@ -72,7 +72,12 @@ func (rc *coopAgentRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("writing session: %w", err)
 	}
 
-	// Build node overview for the agent
+	resp := newCoopAgentRunResponse(bp, session)
+
+	return outputJSON(resp)
+}
+
+func newCoopAgentRunResponse(bp *coop.Blueprint, session *coop.Session) coopAgentRunResponse {
 	var nodes []nodeBrief
 	nodeNumber := 0
 	for _, step := range session.Steps {
@@ -93,17 +98,16 @@ func (rc *coopAgentRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 	resp := coopAgentRunResponse{
 		CommandResponse: coop.CommandResponse{
 			OK:        true,
-			SessionID: sessionID,
+			SessionID: session.ID,
 			Node:      1,
 			State:     "created",
 			Message:   fmt.Sprintf("Session started: %s (%d nodes)", bp.Title, session.TotalNodes()),
-			Next:      fmt.Sprintf("stripe coop agent start-work --session=%s --step=1 --note=%s", sessionID, quoteArg("Beginning: "+session.Steps[0].Nodes[0].Title)),
+			Next:      fmt.Sprintf("stripe coop agent start-work --session=%s --step=1 --note=%s", session.ID, quoteArg("Beginning: "+session.Steps[0].Nodes[0].Title)),
 		},
 		AgentInstructions: agentInstructions(bp, session),
 		Nodes:             nodes,
 	}
-
-	return outputJSON(resp)
+	return resp
 }
 
 func newCoopSession(bp *coop.Blueprint, sessionID, language string, rawSettings, rawParams []string, parentSession, parentStep string) (*coop.Session, error) {

--- a/pkg/cmd/coop/coop_start.go
+++ b/pkg/cmd/coop/coop_start.go
@@ -78,7 +78,10 @@ func (rc *coopRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	autoApprove := rc.promptAutoApprove(agent)
+	autoApprove, err := rc.promptAutoApprove(agent)
+	if err != nil {
+		return err
+	}
 	fmt.Println()
 
 	agentPrompt := rc.buildAgentPrompt(blueprintID)

--- a/pkg/cmd/coop/coop_start.go
+++ b/pkg/cmd/coop/coop_start.go
@@ -1,0 +1,196 @@
+package coopcmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+type coopRunCmd struct {
+	cmd        *cobra.Command
+	language   string
+	settings   []string
+	agent      string
+	debugAgent bool
+}
+
+func newCoopRunCmd() *coopRunCmd {
+	rc := &coopRunCmd{}
+	rc.cmd = &cobra.Command{
+		Use:   "start [blueprint-id]",
+		Short: "Launch a co-op session with an AI agent in split-screen",
+		Long: `Starts a co-op session and launches an AI agent (Claude Code) in a
+split terminal view. The TUI shows on one side, the agent works on the other.
+
+If no blueprint is provided, the agent will explore your codebase,
+understand your needs, and pick the right integration via the recommender.
+
+Requires tmux (detected automatically). If already in a tmux session,
+splits the current window. Otherwise creates a new tmux session.`,
+		Example: `  stripe coop start
+  stripe coop start one-time-payment --language=node
+  stripe coop start --language=python`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: rc.runCmd,
+	}
+
+	rc.cmd.Flags().StringVar(&rc.language, "language", "", "Programming language for the integration")
+	rc.cmd.Flags().StringArrayVar(&rc.settings, "setting", nil, "Blueprint settings as key=value pairs")
+	rc.cmd.Flags().StringVar(&rc.agent, "agent", "", "Agent to use (default: auto-detect claude/codex)")
+	rc.cmd.Flags().BoolVar(&rc.debugAgent, "debug-agent", false, "Use a deterministic fake agent for local TUI debugging")
+	mustMarkFlagHidden(rc.cmd, "debug-agent")
+
+	return rc
+}
+
+func (rc *coopRunCmd) runCmd(cmd *cobra.Command, args []string) error {
+	hasTmux := rc.hasTmux()
+	inTmux := os.Getenv("TMUX") != ""
+
+	var blueprintID string
+	if len(args) > 0 {
+		blueprintID = args[0]
+		if _, err := coop.LoadBlueprint(blueprintID); err != nil {
+			return fmt.Errorf("blueprint %q not found. Run 'stripe coop recommend' to see available blueprints", blueprintID)
+		}
+	}
+
+	stripeBin, _ := os.Executable()
+	if rc.debugAgent {
+		if blueprintID == "" {
+			return fmt.Errorf("--debug-agent requires a blueprint ID, e.g. stripe coop start one-time-payment --debug-agent")
+		}
+		buildDebugPane := rc.debugAgentPaneCommandBuilder(stripeBin)
+		if inTmux {
+			return rc.runInTmuxSplitWithCommand(stripeBin, blueprintID, buildDebugPane)
+		} else if hasTmux {
+			return rc.runInNewTmuxWithCommand(stripeBin, blueprintID, buildDebugPane)
+		}
+		return rc.runFallbackWithCommand(stripeBin, blueprintID, buildDebugPane)
+	}
+
+	agent, err := rc.detectAgent()
+	if err != nil {
+		return err
+	}
+
+	autoApprove := rc.promptAutoApprove(agent)
+	fmt.Println()
+
+	agentPrompt := rc.buildAgentPrompt(blueprintID)
+
+	if inTmux {
+		return rc.runInTmuxSplit(stripeBin, agent, agentPrompt, autoApprove, blueprintID)
+	} else if hasTmux {
+		return rc.runInNewTmux(stripeBin, agent, agentPrompt, autoApprove, blueprintID)
+	}
+
+	return rc.runFallback(stripeBin, agent, agentPrompt, autoApprove, blueprintID)
+}
+
+func (rc *coopRunCmd) buildAgentPrompt(blueprintID string) string {
+	if blueprintID != "" {
+		return ""
+	}
+
+	langHint := ""
+	if rc.language != "" {
+		langHint = fmt.Sprintf("\nThe developer is working in %s.", rc.language)
+	}
+
+	return fmt.Sprintf(`You are helping a developer add Stripe to their project.
+
+A developer is watching your progress in a live terminal UI (the other pane).%s
+
+Your first job is to understand what they're building and what they need from Stripe. Do NOT assume they know Stripe product names.
+
+Steps:
+1. Look at the codebase to understand the language, framework, and what the project does.
+2. Based on what you find:
+   IF code exists: Summarize what the project does in 1-2 sentences and ask the developer
+   to confirm. Then ask: "What would you like to build with Stripe?"
+   IF no code exists (empty project): Ask "What are you looking to build?"
+   WAIT for their response. Do NOT proceed until they answer.
+   Do NOT assume what they need. Let them tell you in their own words.
+3. Based on their answer, run "stripe coop recommend --query=<description of what they need>"
+4. Explain what you found in simple terms: "I'll set up X which lets you do Y" and confirm.
+5. Only after confirmation, run "stripe coop run <blueprint-id> --language=<lang>".
+6. Follow the instructions in the JSON response and work through each step.
+
+The developer will confirm each step in the TUI before you proceed.
+
+Important: Run "stripe whoami" first to check auth. If not logged in OR if it shows "Test mode key: not available", run "stripe sandbox create --from-git" to provision a sandbox. The claim URL will appear automatically in the TUI.`, langHint)
+}
+
+func (rc *coopRunCmd) buildAgentPromptForSession(session *coop.Session) (string, error) {
+	bp, err := coop.LoadBlueprint(session.Blueprint)
+	if err != nil {
+		return "", err
+	}
+	resp := newCoopAgentRunResponse(bp, session)
+	data, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(`You are running a Stripe co-op integration session.
+
+A developer is watching your progress in a live terminal UI (the other pane).
+
+The session is already created. Use this structured start response as the protocol source of truth:
+
+%s
+
+Start by running the "next" command exactly as written. Then follow agent_instructions and continue using the JSON responses from the typed co-op agent commands.
+
+Important: Run "stripe whoami" first to check auth. If not logged in OR if it shows "Test mode key: not available", run "stripe sandbox create --from-git" to provision a sandbox. The claim URL will appear automatically in the TUI.`, string(data)), nil
+}
+
+func (rc *coopRunCmd) startSessionQuietly(blueprintID string) (*coop.Session, error) {
+	bp, err := coop.LoadBlueprint(blueprintID)
+	if err != nil {
+		return nil, err
+	}
+
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return nil, err
+	}
+
+	sessionID := "coop_" + generateShortID()
+	session, err := newCoopSession(bp, sessionID, rc.language, rc.settings, nil, "", "")
+	if err != nil {
+		return nil, err
+	}
+	if err := store.Write(session); err != nil {
+		return nil, err
+	}
+	return session, nil
+}
+
+func (rc *coopRunCmd) abortStartedSession(session *coop.Session, note string) {
+	if session == nil {
+		return
+	}
+	store, err := coop.NewStore(coopConfigFolder())
+	if err != nil {
+		return
+	}
+	_, _ = store.Update(session.ID, func(session *coop.Session) error {
+		session.Status = coop.SessionAborted
+		if note != "" {
+			node, _ := session.ActiveNode()
+			if node == nil {
+				node, _ = session.NodeByNumber(1)
+			}
+			if node != nil {
+				node.Activity = note
+			}
+		}
+		return nil
+	})
+}

--- a/pkg/coop/DEBUG_AGENT.md
+++ b/pkg/coop/DEBUG_AGENT.md
@@ -1,0 +1,42 @@
+# Co-op Debug Agent
+
+The debug agent is a deterministic fake agent for local TUI debugging. It runs the normal Co-op TUI flow, but the right-hand pane is driven by scripted session updates instead of a real Claude/Codex agent.
+
+## Manual TUI debugging
+
+Build the local CLI:
+
+```bash
+go build -o bin/stripe cmd/stripe/main.go
+```
+
+Start a debug session:
+
+```bash
+bin/stripe coop start one-time-payment --language=node --debug-agent
+```
+
+This opens the same tmux split as `coop start`:
+
+- left pane: the Co-op TUI
+- right pane: deterministic debug-agent logs
+
+The fake agent advances steps quickly, pauses at review cards, handles `c` confirm, handles `r` request changes, and eventually drives the completion / next-steps view.
+
+## Automated tmux smoke test
+
+Run:
+
+```bash
+scripts/test-coop-debug-agent-tmux.sh
+```
+
+This builds a temporary CLI binary, launches a `173x50` tmux session, checks the approximate `69x50` TUI pane, requests changes once, confirms remaining reviews, and asserts the completion view appears.
+
+Use this script for regression checks. Use `bin/stripe coop start ... --debug-agent` when manually inspecting layout, copy, spacing, or interactions.
+
+## Notes
+
+- `--debug-agent` is hidden and intended only for local development.
+- The internal `stripe coop debug-agent --session <id>` command is launched automatically by `coop start --debug-agent`; you normally should not run it directly.
+- The flow uses normal Co-op session files under your configured Stripe CLI config directory, so use a local build when testing unmerged TUI changes.

--- a/scripts/test-coop-debug-agent-tmux.sh
+++ b/scripts/test-coop-debug-agent-tmux.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp_dir="${TMPDIR:-/tmp}/coop-debug-agent-tmux-$$"
+stripe_bin="$tmp_dir/stripe"
+tmux_session=""
+pass=0
+fail=0
+tui_pane=""
+agent_pane=""
+
+cleanup() {
+  if [ -n "$tmux_session" ]; then
+    tmux kill-session -t "$tmux_session" 2>/dev/null || true
+  fi
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+record_pass() {
+  pass=$((pass + 1))
+  echo "  ✓ $1"
+}
+
+record_fail() {
+  fail=$((fail + 1))
+  echo "  ✗ $1"
+  echo "  ┌─ TUI capture"
+  capture_tui | sed 's/^/  │ /'
+  echo "  ├─ agent capture"
+  capture_agent | sed 's/^/  │ /'
+  echo "  └─────────"
+}
+
+capture_tui() {
+  tmux capture-pane -t "$tui_pane" -p 2>/dev/null || true
+}
+
+capture_agent() {
+  tmux capture-pane -t "$agent_pane" -p 2>/dev/null || true
+}
+
+wait_for_tui() {
+  local pattern="$1" timeout="${2:-10}" i=0
+  while [ "$i" -lt $((timeout * 4)) ]; do
+    capture_tui | rg -q "$pattern" && return 0
+    sleep 0.25
+    i=$((i + 1))
+  done
+  return 1
+}
+
+assert_tui_visible() {
+  local pattern="$1" label="$2"
+  if capture_tui | rg -q "$pattern"; then
+    record_pass "$label"
+  else
+    record_fail "$label (missing: $pattern)"
+  fi
+}
+
+assert_agent_visible() {
+  local pattern="$1" label="$2"
+  if capture_agent | rg -q "$pattern"; then
+    record_pass "$label"
+  else
+    record_fail "$label (agent missing: $pattern)"
+  fi
+}
+
+echo "[debug-agent-tmux] building test stripe binary"
+mkdir -p "$tmp_dir"
+(cd "$repo_root" && go build -o "$stripe_bin" cmd/stripe/main.go)
+
+run_smoke() {
+  local name="$1" session_width="$2" min_tui_width="$3" max_tui_width="$4" expect_wide="$5"
+  local xdg_config_home="$tmp_dir/xdg-$name"
+
+  tmux_session="coop-debug-agent-test-$name-$$"
+  tui_pane=""
+  agent_pane=""
+  mkdir -p "$xdg_config_home"
+
+  echo "[debug-agent-tmux] launching $name coop start --debug-agent"
+  tmux new-session -d -s "$tmux_session" -x "$session_width" -y 50 \
+    "XDG_CONFIG_HOME='$xdg_config_home' '$stripe_bin' coop start one-time-payment --language=node --debug-agent; echo TUI_EXIT:\$?; sleep 60"
+  tui_pane="$(tmux display-message -p -t "$tmux_session" '#{pane_id}')"
+
+  if ! wait_for_tui "Stripe Co-op" 10; then
+    agent_pane="$tui_pane"
+    record_fail "$name TUI started"
+  else
+    record_pass "$name TUI started"
+  fi
+
+  agent_pane="$(tmux list-panes -t "$tmux_session" -F '#{pane_id} #{pane_width}' | sort -k2,2nr | sed -n '1s/ .*//p')"
+  if [ "$agent_pane" = "$tui_pane" ]; then
+    agent_pane="$(tmux list-panes -t "$tmux_session" -F '#{pane_id}' | sed -n '2p')"
+  fi
+
+  local tui_size tui_width tui_height
+  tui_size="$(tmux display-message -p -t "$tui_pane" '#{pane_width}x#{pane_height}')"
+  tui_width="${tui_size%x*}"
+  tui_height="${tui_size#*x}"
+  if [ "$tui_width" -ge "$min_tui_width" ] && [ "$tui_width" -le "$max_tui_width" ] && [ "$tui_height" = "50" ]; then
+    record_pass "$name TUI pane width is expected ($tui_size)"
+  else
+    record_fail "$name unexpected TUI pane size $tui_size"
+  fi
+
+  if [ "$expect_wide" = "true" ]; then
+    if wait_for_tui "Press enter to inspect this (step|section)" 10; then
+      record_pass "$name split workspace prompt visible"
+    else
+      record_fail "$name split workspace prompt visible"
+    fi
+  fi
+
+  if wait_for_tui "Review" 10; then
+    record_pass "$name debug agent reaches first review"
+  else
+    record_fail "$name debug agent reaches first review"
+  fi
+  assert_tui_visible "Confirmation steps" "$name review acceptance check visible"
+  assert_agent_visible "\\[debug-agent\\]" "$name debug agent logs visible"
+
+  tmux send-keys -t "$tui_pane" "r"
+  sleep 0.5
+  tmux send-keys -t "$tui_pane" "Please tighten the debug checkout path"
+  sleep 0.25
+  tmux send-keys -t "$tui_pane" Enter
+  if wait_for_tui "Review" 10; then
+    record_pass "$name debug agent reruns after request changes"
+  else
+    record_fail "$name debug agent reruns after request changes"
+  fi
+
+  for _ in $(seq 1 20); do
+    local pane
+    pane="$(capture_tui)"
+    if echo "$pane" | rg -q "Integration complete"; then
+      break
+    fi
+    if echo "$pane" | rg -q "confirm all"; then
+      tmux send-keys -t "$tui_pane" "c"
+    elif echo "$pane" | rg -q "Waiting for you: review section"; then
+      tmux send-keys -t "$tui_pane" "f"
+    elif echo "$pane" | rg -q "Review"; then
+      tmux send-keys -t "$tui_pane" "c"
+    fi
+    sleep 0.75
+  done
+
+  if wait_for_tui "Integration complete" 10; then
+    record_pass "$name debug agent reaches completion view"
+  else
+    record_fail "$name debug agent reaches completion view"
+  fi
+
+  tmux kill-session -t "$tmux_session" 2>/dev/null || true
+  tmux_session=""
+}
+
+run_smoke narrow 173 68 70 false
+run_smoke wide 260 102 106 true
+
+echo "[debug-agent-tmux] results: $pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Part 10 of the clean co-op stack targeting `coop`.

This PR adds the co-op start/join launcher path and the hidden debug-agent harness used for local/manual validation.

Changes:
- Adds start, join, launcher, and debug-agent commands.
- Adds launcher/debug-agent tests.
- Adds debug-agent documentation and the tmux validation script.

Review notes:
- The debug agent is intentionally retained as an internal/testing aid.
- This branch was adjusted to use the current step-scoped review helpers and session fixture shape.
