### PR TITLE
12/12 Register co-op command and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,4 +195,14 @@ protoc-gen-plugin:
 	@echo "Successfully compiled proto files for plugins"
 .PHONY: protoc-plugin
 
+sync-blueprints:
+	@if [ -z "$$BLUEPRINT_SOURCE" ]; then \
+		echo "Set BLUEPRINT_SOURCE to a directory of exported blueprint JSON files."; \
+		echo "Example: BLUEPRINT_SOURCE=/path/to/raw-exports make sync-blueprints"; \
+		exit 1; \
+	fi
+	@echo "Exporting blueprints from $$BLUEPRINT_SOURCE..."
+	@cd scripts/export-blueprints && npm install && npm run export -- --source "$$BLUEPRINT_SOURCE" --out ../../pkg/coop/blueprints
+.PHONY: sync-blueprints
+
 .DEFAULT_GOAL := build

--- a/pkg/cmd/logs/tail_test.go
+++ b/pkg/cmd/logs/tail_test.go
@@ -31,7 +31,7 @@ func containsZeroValueStrings(x interface{}) bool {
 	v := reflect.ValueOf(x)
 
 	// If it's a pointer, dereference it
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/term"
 
+	coopcmd "github.com/stripe/stripe-cli/pkg/cmd/coop"
 	cmddocs "github.com/stripe/stripe-cli/pkg/cmd/docs"
 	"github.com/stripe/stripe-cli/pkg/cmd/pluginhints"
 	"github.com/stripe/stripe-cli/pkg/cmd/resource"
@@ -142,11 +143,14 @@ func Execute(ctx context.Context) {
 
 	if err := rootCmd.ExecuteContext(updatedCtx); err != nil {
 		errString := err.Error()
+		var renderedCoopError coopcmd.RenderedError
 
 		isLoginRequiredError := errString == validators.ErrAPIKeyNotConfigured.Error() || errString == validators.ErrDeviceNameNotConfigured.Error()
 		projectNameFlag := rootCmd.Flag("project-name").Value.String()
 
 		switch {
+		case errors.As(err, &renderedCoopError):
+			// Co-op agent-facing commands already rendered structured JSON.
 		case errors.Is(err, errNotAuthenticated):
 			// whoami already printed output; just exit non-zero
 		case requests.IsAPIKeyExpiredError(err):
@@ -267,6 +271,15 @@ func init() {
 	rootCmd.AddCommand(newPostinstallCmd(&Config).cmd)
 	rootCmd.AddCommand(newCommunityCmd().cmd)
 	rootCmd.AddCommand(newSandboxCmd().cmd)
+	rootCmd.AddCommand(coopcmd.New(coopcmd.Options{
+		ConfigFolder: func() string {
+			return Config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+		},
+		SandboxClaimURL: func() string {
+			return viper.GetString(Config.Profile.GetConfigField("sandbox_claim_url"))
+		},
+		AIAgentHelpAnnotationKey: AIAgentHelpAnnotationKey,
+	}))
 	rootCmd.AddCommand(newPluginCmd().cmd)
 	resources.AddAllResourcesCmds(rootCmd, &Config)
 	registerHTTPCmds(rootCmd)

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -71,7 +71,7 @@ func TestSandboxVisibleInHelp(t *testing.T) {
 func TestExampleCommands(t *testing.T) {
 	{
 		_, err := executeCommand(rootCmd, "foo")
-		require.Equal(t, "unknown command \"foo\" for \"stripe\"", err.Error())
+		require.Equal(t, "unknown command \"foo\" for \"stripe\"\n\nDid you mean this?\n\tcoop\n", err.Error())
 	}
 	{
 		_, err := executeCommand(rootCmd, "listen", "foo")

--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -1,0 +1,246 @@
+# Co-op Mode
+
+Co-op mode enables an AI agent and a human developer to build Stripe integrations together in real time. The agent writes code and reports progress; the developer watches in a terminal UI, reviews work, and confirms each step.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ tmux session                                                │
+│                                                             │
+│  ┌──────────────────────┐   ┌────────────────────────────┐ │
+│  │  TUI (coop join)     │   │  Agent (Claude/Codex)      │ │
+│  │                      │   │                            │ │
+│  │  Reads session.json  │   │  Writes session.json via   │ │
+│  │  every 500ms         │   │  stripe coop agent commands│ │
+│  │                      │   │                            │ │
+│  └──────────┬───────────┘   └──────────────┬─────────────┘ │
+│             │                              │               │
+│             └──────────┬───────────────────┘               │
+│                        ▼                                   │
+│              ~/.config/stripe/coop/                         │
+│              ├── coop_abc123.json        (session file)     │
+│              └── coop_abc123.json.heartbeat (agent alive)   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+No server, no HTTP, no WebSocket. Communication is through a shared JSON session file with atomic writes (write to .tmp, rename).
+
+## Step State Machine
+
+```
+pending ──→ active ──→ review ──→ done     (normal flow)
+   │          │          │
+   │          │          └──→ active        (request changes: developer entered feedback)
+   │          │
+   │          └──→ done                     (auto_confirm nodes skip review)
+   │          └──→ skipped                  (agent decides node doesn't apply)
+   │
+   └──→ skipped                             (agent skips from pending)
+```
+
+**Terminal states:** `done`, `skipped` — no transitions out.
+
+**Transitions are validated** — `session.TransitionNode()` returns an error for invalid transitions (e.g. pending→done, done→active).
+
+## Session States
+
+```
+active ──→ completed    (all nodes done/skipped, or "stripe coop stop")
+   │
+   └──→ aborted         ("stripe coop stop --abort")
+```
+
+## Commands
+
+### User-facing (human runs these)
+| Command | Purpose |
+|---------|---------|
+| `stripe coop start [blueprint]` | Launch tmux split with agent + TUI |
+| `stripe coop join [session-id]` | Open the TUI for an existing session |
+| `stripe coop status` | Show session summary |
+| `stripe coop stop` | End the session |
+| `stripe coop recommend` | List available blueprints |
+
+### Agent-facing (AI agent runs these)
+| Command | Purpose |
+|---------|---------|
+| `stripe coop run <blueprint>` | Create a session (outputs JSON with instructions) |
+| `stripe coop agent start-work --step <n>` | Mark node as active |
+| `stripe coop agent report-work --step <n>` | Mark node as complete (→ review or → done if auto_confirm) |
+| `stripe coop agent report-check --step <n>` | Add a verification check |
+| `stripe coop agent skip --step <n>` | Skip a node |
+| `stripe coop agent await-review --step <n>` | Block until developer confirms or requests changes |
+| `stripe coop agent next-action` | Show post-completion options (blocks until selection) |
+
+All agent commands output JSON with an `ok` field and a `next` field suggesting the next command.
+
+## TUI Keybindings
+
+| Key | Action |
+|-----|--------|
+| `↑`/`k` | Move cursor up |
+| `↓`/`j` | Move cursor down |
+| `e` / `Enter` | Toggle detail panel for selected step or node |
+| `c` | Confirm the selected review item |
+| `r` | Request changes for the selected review item |
+| `f` | Resume following the active/review node after manual navigation |
+| `o` | Open claim URL in browser (when sandbox is unclaimed) |
+| `q` / `Ctrl+C` | Quit TUI |
+
+When requesting changes, `r` opens a feedback prompt. Press `Enter` to submit a note and move the reviewed node or step back to `active`; press `Esc` to cancel.
+
+In the completion view:
+| Key | Action |
+|-----|--------|
+| `↑`/`↓` | Navigate suggestions |
+| `Enter` | Select a suggestion |
+| `q` | Quit |
+
+## Example Flow
+
+```bash
+# Explicit blueprint: developer starts a pre-created session (launches tmux with agent + TUI)
+$ stripe coop start one-time-payment --language=node
+
+# What happens behind the scenes:
+# 1. CLI creates the session and gives the agent the exact session protocol
+# 2. Agent (Claude/Codex) is launched in right pane
+# 3. TUI appears in left pane showing step progress
+# 4. Agent starts from the provided next command:
+#      stripe coop agent start-work --session=coop_abc123 --step=1 --note="Beginning: Understand the project"
+# 5. Agent works through steps, calling:
+#      stripe coop agent start-work --session=coop_abc123 --step=1 --note="Scanning project"
+#      stripe coop agent report-work --session=coop_abc123 --step=1 --note="Found Next.js app"
+#      stripe coop agent start-work --session=coop_abc123 --step=2 --note="Creating product"
+#      stripe coop agent report-work --session=coop_abc123 --step=2 --file=server.js --lines=5-20 --note="Created product"
+#      stripe coop agent await-review --session=coop_abc123 --step=2   ← blocks until developer confirms
+# 6. Developer sees progress live, presses 'c' to confirm
+# 7. Agent continues to next step
+# 8. After all steps: agent runs "stripe coop agent next-action --session=coop_abc123"
+# 9. Developer picks what to do next from TUI suggestions
+```
+
+Discovery mode is different:
+
+```bash
+$ stripe coop start
+
+# The agent explores the codebase, asks what the developer wants to build,
+# runs `stripe coop recommend`, and only then runs:
+#   stripe coop run <blueprint-id> --language=<lang>
+```
+
+Post-completion choices are written into the session file for the agent. Deploy follow-ups use `stripe coop run deploy-stripe-projects --parent-session=<id> --parent-step=<selection>` so the child session can return to the completed parent and mark that next step done.
+
+## Auto-Confirm
+
+Nodes with `"auto_confirm": true` skip human review:
+- `agent report-work` transitions directly to `done` (not `review`)
+- `agent await-review` returns immediately if the step is auto-confirmed
+- The prepended "Understand the project" step is always auto-confirmed
+- Blueprint nodes can set `"auto_confirm": true` for mechanical steps
+
+## Heartbeat
+
+When the agent runs `stripe coop agent await-review`, it writes a `.heartbeat` file every 500ms. The TUI checks this file:
+- **Fresh heartbeat (< 5s old):** Agent is actively waiting for confirmation
+- **No heartbeat + no session update in 2min:** Show idle warning
+
+The heartbeat file is cleaned up when `await` exits.
+
+## Resuming
+
+`stripe coop join` is the recovery path. With no session ID, it opens the most
+recent active session, falling back to the latest session if none are active.
+Use `stripe coop join --resume` to pick from recent sessions.
+
+| Issue | What to do |
+|-------|------------|
+| Step is active | Rejoin the session and check the agent pane/TUI state |
+| Step is in review | Rejoin the session and confirm or request changes |
+| Agent appears idle | Rejoin the session; the TUI shows heartbeat/idle state |
+| Need a specific older session | Run `stripe coop join --resume` |
+
+## Blueprint Format
+
+Blueprints are embedded JSON in `pkg/coop/blueprints/`. Each has:
+- `id` — unique identifier (also the filename without .json)
+- `title`, `description` — human-readable
+- `steps` — ordered groups of nodes
+
+Each node has:
+- `type` — `apiRequest`, `asyncHandler`, `uiComponent`, `cliCommand`, `testHelper`
+- `auto_confirm` — skip human review for this node
+- `description` — what the agent should do (source of truth)
+- `review_prompt` — what the human should check before confirming
+- `request` — API request details (for `apiRequest` nodes with SDK snippet support)
+- `events` — webhook events (for `asyncHandler` nodes)
+
+### Adding a Blueprint
+
+1. Create `pkg/coop/blueprints/your-blueprint.json`
+2. Follow the schema above
+3. Test: `go run ./cmd/stripe coop run your-blueprint`
+4. Prefix matching works: short prefixes resolve to full IDs if unambiguous
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| TUI shows "Agent appears idle" | Agent crashed or stopped | Check the agent pane; restart with `stripe coop start` |
+| Agent stuck on "await" | Developer hasn't confirmed | Press `c` in TUI to confirm, or `r` to request changes |
+| "Version conflict" error | TUI and agent wrote simultaneously | Agent retries the command (safe to re-run) |
+| TUI shows wrong session | Multiple sessions exist | Use `stripe coop join <session-id>` with the correct ID |
+| Steps not updating in TUI | Agent created a duplicate session | Check `stripe coop status` for the correct session ID |
+| Agent ignores "next" hint | LLM didn't follow instructions | Copy the `next` value and run it manually, or restart |
+| Double footer / layout broken | Terminal resize not detected | Resize the terminal window (triggers recalculation) |
+| "Blueprint not found" | Typo in blueprint ID | Run `stripe coop recommend` to see available IDs |
+
+## Optimistic Locking
+
+`Store.Write()` checks the file's current version before writing. If another writer changed the file since you read it, the write fails with a version conflict error. This prevents the TUI and agent from clobbering each other's changes.
+
+## File Structure
+
+```
+pkg/coop/
+  types.go          — Session, Node, Step types and constants
+  session.go        — State machine, validation, queries
+  store.go          — Atomic file I/O, heartbeat, optimistic locking
+  blueprint.go      — Blueprint type, embed loader, prefix matching
+  snippet.go        — SDK snippet fetcher (docs.stripe.com)
+  blueprints/       — Embedded JSON blueprints
+
+pkg/coop/tui/
+  app.go            — tea.Program entry points
+  model.go          — Bubbletea model, Update, key handling
+  view.go           — All rendering (header, steps, detail, footer, completion)
+  commands.go       — Async commands (polling, snippets, session discovery)
+  helpers.go        — Word wrap, formatting, browser open
+  messages.go       — Custom message types
+  theme.go          — Sail Design System colors
+
+pkg/coop/workflow/
+  service.go        — Shared lifecycle operations for agent commands and TUI review actions
+
+pkg/coop/helpers/
+  nextaction.go     — Post-completion suggestions, environment detection, and next-action responses
+  prompt.go         — Shared Huh prompt helpers using Sail-styled prompts
+  review.go         — Shared step-review navigation rules
+
+pkg/cmd/coop/
+  coop.go           — Parent command, subcommand registration, command-package options
+  coop_start.go     — User-facing orchestrator (tmux launcher)
+  coop_launcher.go  — Agent detection and tmux/process management
+  coop_run.go       — Agent-facing session creator
+  coop_agent.go     — Typed agent lifecycle commands
+  coop_join.go      — TUI launcher
+  coop_status.go    — Session status display
+  coop_stop.go      — End session
+  coop_recommend.go — Blueprint discovery
+```
+
+## Local Harness Artifacts
+
+The repository-level `bin/` directory remains ignored. Tmux harness isolation files under `bin/` are treated as local development artifacts unless a specific script or fixture is moved into a tracked source path with tests. Do not commit the ignored `bin/` directory wholesale.

--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -26,7 +26,7 @@ Co-op mode enables an AI agent and a human developer to build Stripe integration
 
 No server, no HTTP, no WebSocket. Communication is through a shared JSON session file with atomic writes (write to .tmp, rename).
 
-## Step State Machine
+## Node State Machine
 
 ```
 pending ──→ active ──→ review ──→ done     (normal flow)
@@ -66,14 +66,15 @@ active ──→ completed    (all nodes done/skipped, or "stripe coop stop")
 | Command | Purpose |
 |---------|---------|
 | `stripe coop run <blueprint>` | Create a session (outputs JSON with instructions) |
-| `stripe coop agent start-work --step <n>` | Mark node as active |
-| `stripe coop agent report-work --step <n>` | Mark node as complete (→ review or → done if auto_confirm) |
+| `stripe coop agent start-work --step <n>` | Mark a node as active |
+| `stripe coop agent report-work --step <n>` | Mark a node complete (→ review or → done if auto_confirm) |
 | `stripe coop agent report-check --step <n>` | Add a verification check |
 | `stripe coop agent skip --step <n>` | Skip a node |
 | `stripe coop agent await-review --step <n>` | Block until developer confirms or requests changes |
 | `stripe coop agent next-action` | Show post-completion options (blocks until selection) |
+| `stripe coop agent start-followup` | Start an internal guided follow-up session selected from next actions |
 
-All agent commands output JSON with an `ok` field and a `next` field suggesting the next command.
+All agent commands output JSON with an `ok` field and a `next` field suggesting the next command. The `--step` flag name is retained for the CLI, but its value is the 1-based node number across the session.
 
 ## TUI Keybindings
 
@@ -81,9 +82,18 @@ All agent commands output JSON with an `ok` field and a `next` field suggesting 
 |-----|--------|
 | `↑`/`k` | Move cursor up |
 | `↓`/`j` | Move cursor down |
-| `e` / `Enter` | Toggle detail panel for selected step or node |
+| `PgUp`/`b` | Page up |
+| `PgDn`/`Space` | Page down |
+| `Home`/`g` | Jump to top |
+| `End`/`G` | Jump to bottom |
+| `←` | Collapse selected step |
+| `→` | Expand selected step |
+| `e` / `?` / `Enter` | Toggle detail panel for selected step or node |
+| `Tab` | Move to the next detail tab |
+| `Esc` | Close details or cancel a prompt |
 | `c` | Confirm the selected review item |
 | `r` | Request changes for the selected review item |
+| `y` | Copy the selected review command when one is available |
 | `f` | Resume following the active/review node after manual navigation |
 | `o` | Open claim URL in browser (when sandbox is unclaimed) |
 | `q` / `Ctrl+C` | Quit TUI |
@@ -131,14 +141,14 @@ $ stripe coop start
 #   stripe coop run <blueprint-id> --language=<lang>
 ```
 
-Post-completion choices are written into the session file for the agent. Deploy follow-ups use `stripe coop run deploy-stripe-projects --parent-session=<id> --parent-step=<selection>` so the child session can return to the completed parent and mark that next step done.
+Post-completion choices are written into the session file for the agent. Deploy follow-ups are internal guided sessions, not blueprints: the agent runs `stripe coop agent start-followup --session=<parent> --action=deploy` or `--action=deploy-update`. The child session returns to the completed parent by running `stripe coop agent next-action --session=<parent> --completed=<action>` when it finishes.
 
 ## Auto-Confirm
 
 Nodes with `"auto_confirm": true` skip human review:
 - `agent report-work` transitions directly to `done` (not `review`)
-- `agent await-review` returns immediately if the step is auto-confirmed
-- The prepended "Understand the project" step is always auto-confirmed
+- `agent await-review` returns immediately if the node is auto-confirmed
+- The prepended "Project context" step contains an auto-confirmed "Understand the project" node
 - Blueprint nodes can set `"auto_confirm": true` for mechanical steps
 
 ## Heartbeat
@@ -157,8 +167,8 @@ Use `stripe coop join --resume` to pick from recent sessions.
 
 | Issue | What to do |
 |-------|------------|
-| Step is active | Rejoin the session and check the agent pane/TUI state |
-| Step is in review | Rejoin the session and confirm or request changes |
+| Node is active | Rejoin the session and check the agent pane/TUI state |
+| Node or step is in review | Rejoin the session and confirm or request changes |
 | Agent appears idle | Rejoin the session; the TUI shows heartbeat/idle state |
 | Need a specific older session | Run `stripe coop join --resume` |
 
@@ -170,19 +180,27 @@ Blueprints are embedded JSON in `pkg/coop/blueprints/`. Each has:
 - `steps` — ordered groups of nodes
 
 Each node has:
-- `type` — `apiRequest`, `asyncHandler`, `uiComponent`, `cliCommand`, `testHelper`
+- `type` — `apiRequest`, `asyncHandler`, `uiComponent`, `cliCommand`, `dashboard`, `setUpWebhooks`, `testHelper`
 - `auto_confirm` — skip human review for this node
 - `description` — what the agent should do (source of truth)
 - `review_prompt` — what the human should check before confirming
+- `review_command` — optional command the TUI can show/copy for developer verification
 - `request` — API request details (for `apiRequest` nodes with SDK snippet support)
+- `request.hidden_params` — request fields that should not be shown directly in the TUI
+- `requests` — API-backed test helper requests for `testHelper` nodes
 - `events` — webhook events (for `asyncHandler` nodes)
 
-### Adding a Blueprint
+`testHelper` request metadata tells the agent which Stripe-backed test helpers can advance test state. Agents should use those helpers while verifying work, but should not encode helper-only request parameters into the user's application.
 
-1. Create `pkg/coop/blueprints/your-blueprint.json`
-2. Follow the schema above
-3. Test: `go run ./cmd/stripe coop run your-blueprint`
-4. Prefix matching works: short prefixes resolve to full IDs if unambiguous
+### Syncing Blueprints
+
+Workbench blueprint definitions are the source of truth. Do not supplement or modify `pkg/coop/blueprints/` by hand to add CLI-only product work. Update the upstream blueprint source, then export the CLI-friendly JSON:
+
+```bash
+BLUEPRINT_SOURCE=/path/to/blueprintDefinitions make sync-blueprints
+```
+
+After syncing, test with `go run ./cmd/stripe coop run <blueprint-id>`. Prefix matching works: short prefixes resolve to full IDs if unambiguous.
 
 ## Troubleshooting
 
@@ -191,15 +209,16 @@ Each node has:
 | TUI shows "Agent appears idle" | Agent crashed or stopped | Check the agent pane; restart with `stripe coop start` |
 | Agent stuck on "await" | Developer hasn't confirmed | Press `c` in TUI to confirm, or `r` to request changes |
 | "Version conflict" error | TUI and agent wrote simultaneously | Agent retries the command (safe to re-run) |
+| "timed out waiting for session lock" | A previous writer left a `.lock` file behind | If no `stripe coop` command is running, remove the named lock file and retry |
 | TUI shows wrong session | Multiple sessions exist | Use `stripe coop join <session-id>` with the correct ID |
 | Steps not updating in TUI | Agent created a duplicate session | Check `stripe coop status` for the correct session ID |
 | Agent ignores "next" hint | LLM didn't follow instructions | Copy the `next` value and run it manually, or restart |
 | Double footer / layout broken | Terminal resize not detected | Resize the terminal window (triggers recalculation) |
 | "Blueprint not found" | Typo in blueprint ID | Run `stripe coop recommend` to see available IDs |
 
-## Optimistic Locking
+## Locking
 
-`Store.Write()` checks the file's current version before writing. If another writer changed the file since you read it, the write fails with a version conflict error. This prevents the TUI and agent from clobbering each other's changes.
+Writes are serialized with a per-session `.lock` file. `Store.Write()` also checks the file's current version before writing. If another writer changed the file since you read it, the write fails with a version conflict error. This prevents the TUI and agent from clobbering each other's changes.
 
 ## File Structure
 
@@ -207,16 +226,28 @@ Each node has:
 pkg/coop/
   types.go          — Session, Node, Step types and constants
   session.go        — State machine, validation, queries
-  store.go          — Atomic file I/O, heartbeat, optimistic locking
+  store.go          — Atomic file I/O, heartbeat, lock files, optimistic locking
   blueprint.go      — Blueprint type, embed loader, prefix matching
+  guided_action.go  — In-code guided follow-up session model
   snippet.go        — SDK snippet fetcher (docs.stripe.com)
   blueprints/       — Embedded JSON blueprints
+  colors/           — Sail Design System palette helpers
+  followups/        — Built-in guided follow-up definitions
 
 pkg/coop/tui/
   app.go            — tea.Program entry points
-  model.go          — Bubbletea model, Update, key handling
-  view.go           — All rendering (header, steps, detail, footer, completion)
+  model.go          — Bubbletea model and Update loop
+  view.go           — Top-level rendering
   commands.go       — Async commands (polling, snippets, session discovery)
+  completion.go     — Post-completion suggestion view
+  detail.go         — Detail panel rendering
+  keymap.go         — Keyboard bindings
+  layout.go         — Responsive layout calculations
+  markdown.go       — Glamour rendering helpers
+  mouse.go          — Mouse interactions
+  outline.go        — Step/node outline rendering
+  review.go         — Review card rendering
+  selection.go      — Navigation and selection helpers
   helpers.go        — Word wrap, formatting, browser open
   messages.go       — Custom message types
   theme.go          — Sail Design System colors

--- a/scripts/export-blueprints/README.md
+++ b/scripts/export-blueprints/README.md
@@ -1,0 +1,56 @@
+# Blueprint Exporter
+
+Converts Workbench Blueprint TypeScript definitions into CLI-friendly JSON for co-op mode.
+
+## Pipeline
+
+```
+pay-server/blueprintDefinitions/*.tsx
+    ↓  (this script)
+pkg/coop/blueprints/*.json  (checked into stripe-cli and embedded via //go:embed)
+```
+
+## Usage
+
+### From pre-exported JSON (recommended for CI)
+
+If someone has already exported the raw blueprint objects as JSON:
+
+```bash
+cd scripts/export-blueprints
+npm install
+npm run export -- --source ./raw-exports --out ../../pkg/coop/blueprints
+```
+
+### From pay-server source (requires module context)
+
+The TypeScript blueprints use `MessageDescriptor` objects and React components
+that require pay-server's module resolution. To export from source:
+
+1. Copy this script into the pay-server tree (or symlink)
+2. Add an entry point that imports `rawBlueprintsList` from the definitions index
+3. Call `transformBlueprint` on each entry and write to the output directory
+
+### After exporting
+
+Run the Make target from the repository root to update the embedded blueprints:
+
+```bash
+BLUEPRINT_SOURCE=/path/to/raw-exports make sync-blueprints
+```
+
+## What gets stripped
+
+- `MessageDescriptor` objects → resolved to `defaultMessage` string
+- React JSX components (`display`, `messageDescriptorFormatters`) → removed
+- Dashboard-only nodes (`settingsUpdate`, `contactStripe`, etc.) → removed
+- Environment conditions (`hiddenIfEnvMatchesOne`, etc.) → removed
+
+## What gets kept
+
+- Blueprint structure: id, title, description, type, steps
+- Node types: apiRequest, asyncHandler, uiComponent, testHelper, dashboard
+- API request details: path, method, params (from first configuredDetails)
+- Interpolation strings: `${node.chapter.node:field}` preserved as-is
+- Event types for asyncHandler nodes
+- Product metadata

--- a/scripts/export-blueprints/export.ts
+++ b/scripts/export-blueprints/export.ts
@@ -1,0 +1,241 @@
+/**
+ * Blueprint Exporter for Stripe CLI Co-op Mode
+ *
+ * This script imports Blueprint definitions from pay-server's TypeScript source
+ * and exports them as CLI-friendly JSON files. It:
+ *
+ * 1. Resolves MessageDescriptor objects to their defaultMessage strings
+ * 2. Strips React/JSX components (display, messageDescriptorFormatters)
+ * 3. Retains the structural data as CLI schema fields: steps, nodes, requests, events
+ * 4. Writes one JSON file per blueprint to the output directory
+ *
+ * Usage:
+ *   cd scripts/export-blueprints
+ *   npm install
+ *   npm run export -- --source <path-to-blueprintDefinitions> --out <output-dir>
+ *
+ * Example:
+ *   npm run export -- \
+ *     --source ../../pay-server/frontend/workbench/shared/blueprints/src/blueprintDefinitions \
+ *     --out ../../api/blueprints
+ */
+
+import { writeFileSync, mkdirSync, existsSync, readdirSync, readFileSync } from 'fs';
+import { join, resolve, basename } from 'path';
+import { parseArgs } from 'util';
+
+const { values } = parseArgs({
+  options: {
+    source: { type: 'string' },
+    out: { type: 'string', default: '../../api/blueprints' },
+  },
+});
+
+if (!values.source) {
+  console.error('Usage: npm run export -- --source <path-to-blueprintDefinitions> --out <output-dir>');
+  console.error('');
+  console.error('The --source should point to the blueprintDefinitions directory in pay-server:');
+  console.error('  e.g. ../../../mint/pay-server/frontend/workbench/shared/blueprints/src/blueprintDefinitions');
+  process.exit(1);
+}
+
+const sourceDir = resolve(values.source);
+const outDir = resolve(values.out!);
+
+if (!existsSync(sourceDir)) {
+  console.error(`Source directory not found: ${sourceDir}`);
+  process.exit(1);
+}
+
+mkdirSync(outDir, { recursive: true });
+
+/**
+ * Resolve a MessageDescriptor-like object to its plain string.
+ * MessageDescriptors have shape: { id: string, defaultMessage: string, description?: string }
+ */
+function resolveMessage(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value && typeof value === 'object' && 'defaultMessage' in value) {
+    return (value as { defaultMessage: string }).defaultMessage;
+  }
+  return '';
+}
+
+/**
+ * Transform a node from the TypeScript definition to CLI-friendly JSON.
+ */
+function transformNode(node: Record<string, unknown>): Record<string, unknown> | null {
+  const type = node.type as string;
+
+  // Skip node types we can't handle in CLI
+  if (['settingsUpdate', 'contactStripe', 'enableCustomFeature', 'installApp'].includes(type)) {
+    return null;
+  }
+
+  const result: Record<string, unknown> = {
+    type,
+    key: node.key,
+    title: resolveMessage(node.title),
+  };
+
+  if (node.description) {
+    result.description = resolveMessage(node.description);
+  }
+
+  // API Request nodes
+  if (type === 'apiRequest' && node.request) {
+    const req = node.request as Record<string, unknown>;
+    const transformed: Record<string, unknown> = {
+      path: req.path,
+      method: req.method,
+    };
+
+    // Get params from configuredDetails or direct params
+    if (req.configuredDetails && Array.isArray(req.configuredDetails) && req.configuredDetails.length > 0) {
+      const first = req.configuredDetails[0] as Record<string, unknown>;
+      if (first.params) {
+        transformed.params = first.params;
+      }
+    } else if (req.params) {
+      transformed.params = req.params;
+    }
+
+    result.request = transformed;
+  }
+
+  // Async handler nodes
+  if (type === 'asyncHandler' && node.events) {
+    const events = (node.events as Array<Record<string, unknown>>)
+      .map(e => e.eventType as string)
+      .filter(Boolean);
+    result.events = events;
+  }
+
+  return result;
+}
+
+/**
+ * Transform an upstream chapter from the TypeScript definition into a CLI step.
+ */
+function transformStep(chapter: Record<string, unknown>): Record<string, unknown> | null {
+  const nodes = (chapter.nodes as Array<Record<string, unknown>> || [])
+    .map(transformNode)
+    .filter((n): n is Record<string, unknown> => n !== null);
+
+  if (nodes.length === 0) return null;
+
+  const result: Record<string, unknown> = {
+    key: chapter.key,
+    title: resolveMessage(chapter.title),
+    nodes,
+  };
+
+  if (chapter.description) {
+    result.description = resolveMessage(chapter.description);
+  }
+  if (chapter.required) {
+    result.required = true;
+  }
+
+  return result;
+}
+
+/**
+ * Transform a full blueprint definition.
+ */
+function transformBlueprint(id: string, blueprint: Record<string, unknown>): Record<string, unknown> | null {
+  const steps = (blueprint.chapters as Array<Record<string, unknown>> || [])
+    .map(transformStep)
+    .filter((c): c is Record<string, unknown> => c !== null);
+
+  if (steps.length === 0) return null;
+
+  const result: Record<string, unknown> = {
+    id,
+    title: resolveMessage(blueprint.title),
+    type: blueprint.blueprintType || 'learning',
+    steps,
+  };
+
+  if (blueprint.listViewDescription) {
+    result.description = resolveMessage(blueprint.listViewDescription);
+  }
+
+  if (blueprint.metadata && typeof blueprint.metadata === 'object') {
+    const meta = blueprint.metadata as Record<string, unknown>;
+    if (meta.products) {
+      result.products = meta.products;
+    }
+  }
+
+  return result;
+}
+
+function validateCLIBlueprint(id: string, blueprint: Record<string, unknown>): void {
+  if ('chapters' in blueprint) {
+    throw new Error(`${id}: exported blueprint must use "steps", not "chapters"`);
+  }
+  if ('prompt' in blueprint) {
+    throw new Error(`${id}: top-level "prompt" is not supported by the CLI schema`);
+  }
+  const steps = blueprint.steps as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(steps) || steps.length === 0) {
+    throw new Error(`${id}: exported blueprint must include non-empty "steps"`);
+  }
+  for (const step of steps) {
+    if ('review_granularity' in step) {
+      throw new Error(`${id}: step "review_granularity" is not supported by the CLI schema`);
+    }
+    for (const node of (step.nodes as Array<Record<string, unknown>> || [])) {
+      const request = node.request as Record<string, unknown> | undefined;
+      if (request && 'key' in request) {
+        throw new Error(`${id}: request.key is redundant and not part of the CLI schema`);
+      }
+    }
+  }
+}
+
+// Main execution
+console.log(`Exporting blueprints from: ${sourceDir}`);
+console.log(`Output directory: ${outDir}`);
+console.log('');
+
+// This script is designed to be run with the actual TypeScript source
+// For now, it provides the framework - actual import requires the pay-server
+// module resolution context.
+console.log('NOTE: This script requires running within the pay-server module context');
+console.log('to resolve TypeScript imports. For standalone use, place pre-exported');
+console.log('blueprint objects in a JSON format and use this as a transformer.');
+console.log('');
+console.log('To use with pay-server:');
+console.log('  1. Add this script to pay-server devDependencies context');
+console.log('  2. Import rawBlueprintsList from the definitions index');
+console.log('  3. Run transformBlueprint on each entry');
+console.log('');
+
+// For manual/CI usage: check if source has pre-exported JSON files
+const jsonFiles = readdirSync(sourceDir).filter(f => f.endsWith('.json'));
+if (jsonFiles.length > 0) {
+  console.log(`Found ${jsonFiles.length} JSON files in source, transforming...`);
+  for (const file of jsonFiles) {
+    try {
+      const raw = JSON.parse(readFileSync(join(sourceDir, file), 'utf-8'));
+      const id = basename(file, '.json');
+      const transformed = transformBlueprint(id, raw);
+      if (transformed) {
+        validateCLIBlueprint(id, transformed);
+        const outPath = join(outDir, `${id}.json`);
+        writeFileSync(outPath, JSON.stringify(transformed, null, 2) + '\n');
+        console.log(`  ✓ ${id}`);
+      }
+    } catch (err) {
+      console.error(`  ✗ ${file}: ${(err as Error).message}`);
+    }
+  }
+} else {
+  console.log('No JSON source files found. To export from TypeScript:');
+  console.log('  Create a wrapper that imports rawBlueprintsList and calls transformBlueprint.');
+}
+
+console.log('');
+console.log('Done.');

--- a/scripts/export-blueprints/package.json
+++ b/scripts/export-blueprints/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "stripe-cli-export-blueprints",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Exports Blueprint definitions from pay-server into CLI-friendly JSON",
+  "type": "module",
+  "scripts": {
+    "export": "tsx export.ts"
+  },
+  "dependencies": {
+    "glob": "^11.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}


### PR DESCRIPTION
Part 12 of the clean co-op stack targeting `coop`.

This PR registers the co-op command in the root command surface and adds supporting documentation/export tooling.

Changes:
- Registers the co-op command with the root CLI.
- Adds co-op README documentation.
- Adds blueprint export script documentation and package metadata.
- Updates root/log tests for the new command surface.

Review notes:
- This is the final PR in the clean stack.
