### PR TITLE
Fix panic running plugin subcommands with nil context

### DIFF
--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -102,7 +102,15 @@ func addPluginSubcommandStubs(parent *cobra.Command, commands []plugins.CommandI
 
 // runPluginCmd hands off to the plugin itself to take over
 func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) error {
-	ctx := withSIGTERMCancel(cmd.Context(), func() {
+	// Plugin subcommand stubs can reach this path with a nil command context,
+	// which makes withSIGTERMCancel -> context.WithCancel panic ("cannot create
+	// context from nil parent"). Fall back to a background context, mirroring the
+	// guard already used on the help path above.
+	parentCtx := cmd.Context()
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	ctx := withSIGTERMCancel(parentCtx, func() {
 		log.WithFields(log.Fields{
 			"prefix": "cmd.pluginCmd.runPluginCmd",
 		}).Debug("Ctrl+C received, cleaning up...")


### PR DESCRIPTION
## Summary

Every executed plugin subcommand under `stripe projects` (`init`, `status`, `catalog`, `search`, `add`, …) panics with `cannot create context from nil parent` instead of running, making the Projects plugin unusable.

`runPluginCmd` passes `cmd.Context()` into `withSIGTERMCancel`, but `cmd.Context()` is `nil` for the dynamically-registered plugin subcommand stubs, so `context.WithCancel(nil)` panics under Go 1.15+.

The help path in the same file already guards against this with `SetContext(context.Background())`; this PR applies the same guard to the execution path.

Fixes #1707.

## Change

```go
parentCtx := cmd.Context()
if parentCtx == nil {
	parentCtx = context.Background()
}
ctx := withSIGTERMCancel(parentCtx, func() { ... })
```

## Reproduction

```
stripe plugin install projects        # v0.20.0
stripe login
stripe projects status                # panics
```

Stack trace:

```
panic: cannot create context from nil parent
context.WithCancel({0x0?, 0x0?})
github.com/stripe/stripe-cli/pkg/cmd.withSIGTERMCancel(...)   pkg/cmd/listen.go:223
github.com/stripe/stripe-cli/pkg/cmd.(*pluginTemplateCmd).runPluginCmd(...)   pkg/cmd/plugin_cmds.go:105
github.com/stripe/stripe-cli/pkg/cmd.addPluginSubcommandStubs.func1(...)   pkg/cmd/plugin_cmds.go:91
```

## Testing

- Reproduced the panic on `v1.42.15` (Homebrew) and on a clean build of the tag.
- Built from source with this change: `stripe projects status` / `init` / `catalog` now run normally instead of panicking.
- `go build ./...` and `gofmt` clean.

## Environment

- stripe-cli v1.42.15 (also reproduced on v1.40.8)
- projects plugin v0.20.0
- macOS 26.2, arm64
