### PR TITLE
Detect expired API key errors from plugin commands and show helpful message

### DIFF
--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -132,6 +132,10 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 			return errors.New("install failed due to API key not configured, please run `stripe login` or specify the `--api-key`")
 		}
 
+		if isAPIKeyExpiredError(err) {
+			fmt.Fprintln(os.Stderr, apiKeyExpiredMessage(ptc.cfg.Profile.ProfileName))
+		}
+
 		log.WithFields(log.Fields{
 			"prefix": "pluginTemplateCmd.runPluginCmd",
 		}).Debug(fmt.Sprintf("Plugin command '%s' exited with error: %s", plugin.Shortname, err))

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -148,7 +148,7 @@ func Execute(ctx context.Context) {
 		switch {
 		case errors.Is(err, errNotAuthenticated):
 			// whoami already printed output; just exit non-zero
-		case requests.IsAPIKeyExpiredError(err):
+		case isAPIKeyExpiredError(err):
 			fmt.Fprintln(os.Stderr, apiKeyExpiredMessage(projectNameFlag))
 		case isLoginRequiredError && projectNameFlag != "default":
 			fmt.Fprintf(os.Stderr, "You provided the project name \"%[1]s\" (either via the \"--project-name\" flag or the \"STRIPE_PROJECT_NAME\" environment variable), but no config for that project was found.\nPlease run `stripe login --project-name=%[1]s` to enable commands for this project.\n", projectNameFlag)
@@ -192,11 +192,25 @@ func Execute(ctx context.Context) {
 }
 
 func apiKeyExpiredMessage(profileName string) string {
-	if profileName == "default" {
+	if profileName == "" || profileName == "default" {
 		return "The API key for the default profile has expired. Run `stripe login` to re-authenticate.\n" +
 			"If you recently ran `stripe login` and still see this error, it may have authenticated a different profile — run `stripe whoami` to confirm."
 	}
 	return fmt.Sprintf("The API key for profile %q has expired. Run `stripe login --project-name=%s` to re-authenticate.", profileName, profileName)
+}
+
+func isAPIKeyExpiredError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if requests.IsAPIKeyExpiredError(err) {
+		return true
+	}
+
+	errString := strings.ToLower(err.Error())
+	return strings.Contains(errString, "api_key_expired") ||
+		strings.Contains(errString, "expired api key provided")
 }
 
 var keysToReBind []string

--- a/pkg/cmd/root_expired_key_test.go
+++ b/pkg/cmd/root_expired_key_test.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/requests"
 )
 
 func TestAPIKeyExpiredMessage_DefaultProfile(t *testing.T) {
@@ -18,4 +22,37 @@ func TestAPIKeyExpiredMessage_NamedProfile(t *testing.T) {
 	msg := apiKeyExpiredMessage("work")
 	require.Contains(t, msg, `"work"`)
 	require.Contains(t, msg, "--project-name=work")
+}
+
+func TestAPIKeyExpiredMessage_EmptyProfileDefaultsToDefault(t *testing.T) {
+	msg := apiKeyExpiredMessage("")
+	require.Contains(t, msg, "default profile")
+	require.NotContains(t, msg, `profile ""`)
+}
+
+func TestIsAPIKeyExpiredError(t *testing.T) {
+	t.Run("structured request error", func(t *testing.T) {
+		err := requests.RequestError{
+			StatusCode: 401,
+			ErrorCode:  "api_key_expired",
+		}
+		require.True(t, isAPIKeyExpiredError(err))
+	})
+
+	t.Run("wrapped request error", func(t *testing.T) {
+		err := fmt.Errorf("wrapper: %w", requests.RequestError{
+			StatusCode: 401,
+			ErrorCode:  "api_key_expired",
+		})
+		require.True(t, isAPIKeyExpiredError(err))
+	})
+
+	t.Run("plain text plugin error", func(t *testing.T) {
+		err := errors.New(`rpc error: code = Unknown desc = {"error":{"code":"api_key_expired","message":"Expired API Key provided: rk_test_***123"}}`)
+		require.True(t, isAPIKeyExpiredError(err))
+	})
+
+	t.Run("other error", func(t *testing.T) {
+		require.False(t, isAPIKeyExpiredError(errors.New("boom")))
+	})
 }


### PR DESCRIPTION
 ### Summary

Plugin commands return unstructured RPC errors that don't match the typed RequestError check. This adds a broader string-based detection for "api_key_expired" in error messages, and surfaces the re-login guidance in plugin command paths too.

Motivation: https://jira.corp.stripe.com/browse/DX-11179




 ### Reviewers
r? @
cc @stripe/developer-products


