### PR TITLE
Include credentials file path in insecure-storage warning

### DIFF
--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -40,6 +40,20 @@ func IsUsingInsecureStorage(store SecureStore) bool {
 	return ok && fb.wroteToFallback
 }
 
+// FallbackStoragePath returns the path of the plain-text fallback credentials
+// file, or an empty string if store is not a fallback-capable store.
+func FallbackStoragePath(store SecureStore) string {
+	fb, ok := store.(*fallbackStore)
+	if !ok {
+		return ""
+	}
+	fs, ok := fb.fallback.(*fileStore)
+	if !ok {
+		return ""
+	}
+	return fs.path
+}
+
 // zalandoStore wraps zalando/go-keyring with per-call timeouts so that a hung
 // or absent D-Bus daemon does not block the process indefinitely.
 type zalandoStore struct {

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -18,7 +18,8 @@ import (
 func warnIfInsecureStorage() {
 	if keyring.IsUsingInsecureStorage(config.KeyRing) {
 		color := ansi.Color(os.Stdout)
-		fmt.Println(color.Yellow("Warning: credentials stored in plaintext"))
+		path := keyring.FallbackStoragePath(config.KeyRing)
+		fmt.Println(color.Yellow(fmt.Sprintf("Warning: the system keyring is unavailable. Your credentials have been stored unencrypted in %s", path)))
 	}
 }
 


### PR DESCRIPTION
Followup to https://github.com/stripe/stripe-cli/pull/1661

Update the warning message to tell users exactly where their credentials were written: "Warning: the system keyring is unavailable. Your credentials have been stored unencrypted in <path>".

<img width="720" height="144" alt="Screenshot 2026-06-24 at 9 49 17 AM" src="https://github.com/user-attachments/assets/5b663cc5-e3dc-4cf7-ab9e-0f10d58654d1" />
