### PR TITLE
Implement KeychainFindCredentials with best-effort live key probe

### DIFF
--- a/pkg/plugins/core_cli_helper.go
+++ b/pkg/plugins/core_cli_helper.go
@@ -291,10 +291,11 @@ func (h *coreCLIHelper) KeychainDeletePassword(key string) (bool, error) {
 }
 
 // KeychainFindCredentials returns keychain keys that are present in the credential store.
-// Deprecated: full OS-level keychain enumeration is complex and platform-specific, so this takes a
-// best-effort approach: it probes for the one key plugins are most likely to need
+// It takes a best-effort approach: probing for the one key plugins are most likely to need
 // (the default profile's live mode API key), covering both the OS keychain and the
 // plain-file fallback via readKeychainPassword.
+//
+// Deprecated: full OS-level keychain enumeration is complex and platform-specific.
 func (h *coreCLIHelper) KeychainFindCredentials() ([]string, error) {
 	key := "default." + config.LiveModeAPIKeyName
 	_, exists, err := readKeychainPassword(key)

--- a/pkg/plugins/core_cli_helper.go
+++ b/pkg/plugins/core_cli_helper.go
@@ -290,9 +290,18 @@ func (h *coreCLIHelper) KeychainDeletePassword(key string) (bool, error) {
 	return true, nil
 }
 
-// KeychainFindCredentials is deprecated and always returns an empty list.
+// KeychainFindCredentials returns keychain keys that are present in the credential store.
+// Deprecated: full OS-level keychain enumeration is complex and platform-specific, so this takes a
+// best-effort approach: it probes for the one key plugins are most likely to need
+// (the default profile's live mode API key), covering both the OS keychain and the
+// plain-file fallback via readKeychainPassword.
 func (h *coreCLIHelper) KeychainFindCredentials() ([]string, error) {
-	return []string{}, nil
+	key := "default." + config.LiveModeAPIKeyName
+	_, exists, err := readKeychainPassword(key)
+	if err != nil || !exists {
+		return []string{}, err
+	}
+	return []string{key}, nil
 }
 
 // RunPeerPlugin looks up and runs the named plugin with the given arguments.

--- a/pkg/plugins/core_cli_helper.go
+++ b/pkg/plugins/core_cli_helper.go
@@ -297,7 +297,7 @@ func (h *coreCLIHelper) KeychainDeletePassword(key string) (bool, error) {
 //
 // Deprecated: full OS-level keychain enumeration is complex and platform-specific.
 func (h *coreCLIHelper) KeychainFindCredentials() ([]string, error) {
-	key := h.config.GetProfile().GetConfigField(config.LiveModeAPIKeyName)
+	key := "default." + config.LiveModeAPIKeyName
 	_, exists, err := readKeychainPassword(key)
 	if err != nil || !exists {
 		return []string{}, err

--- a/pkg/plugins/core_cli_helper.go
+++ b/pkg/plugins/core_cli_helper.go
@@ -297,7 +297,7 @@ func (h *coreCLIHelper) KeychainDeletePassword(key string) (bool, error) {
 //
 // Deprecated: full OS-level keychain enumeration is complex and platform-specific.
 func (h *coreCLIHelper) KeychainFindCredentials() ([]string, error) {
-	key := "default." + config.LiveModeAPIKeyName
+	key := h.config.GetProfile().GetConfigField(config.LiveModeAPIKeyName)
 	_, exists, err := readKeychainPassword(key)
 	if err != nil || !exists {
 		return []string{}, err

--- a/pkg/plugins/core_cli_helper.go
+++ b/pkg/plugins/core_cli_helper.go
@@ -297,6 +297,7 @@ func (h *coreCLIHelper) KeychainDeletePassword(key string) (bool, error) {
 //
 // Deprecated: full OS-level keychain enumeration is complex and platform-specific.
 func (h *coreCLIHelper) KeychainFindCredentials() ([]string, error) {
+	// "default" is hardcoded for best-effort backwards compatibility
 	key := "default." + config.LiveModeAPIKeyName
 	_, exists, err := readKeychainPassword(key)
 	if err != nil || !exists {

--- a/pkg/plugins/core_cli_helper_test.go
+++ b/pkg/plugins/core_cli_helper_test.go
@@ -412,6 +412,12 @@ func TestKeychainDeletePasswordClearsRecentWrite(t *testing.T) {
 	require.Equal(t, 1, ring.getCalls)
 }
 
+func newTestConfigWithProfile(profileName string) *TestConfig {
+	cfg := &TestConfig{}
+	cfg.Profile.ProfileName = profileName
+	return cfg
+}
+
 func TestKeychainFindCredentialsReturnsKeyWhenPresent(t *testing.T) {
 	originalKeyRing := config.KeyRing
 	ring := &fakeKeyring{
@@ -422,10 +428,11 @@ func TestKeychainFindCredentialsReturnsKeyWhenPresent(t *testing.T) {
 	config.KeyRing = ring
 	t.Cleanup(func() { config.KeyRing = originalKeyRing })
 
-	coreCLIHelper := NewCoreCLIHelper(context.Background(), nil, afero.NewMemMapFs())
+	cfg := newTestConfigWithProfile("myprofile")
+	coreCLIHelper := NewCoreCLIHelper(context.Background(), cfg, afero.NewMemMapFs())
 	keys, err := coreCLIHelper.KeychainFindCredentials()
 	require.NoError(t, err)
-	require.Equal(t, []string{"default." + config.LiveModeAPIKeyName}, keys)
+	require.Equal(t, []string{"myprofile." + config.LiveModeAPIKeyName}, keys)
 }
 
 func TestKeychainFindCredentialsReturnsEmptyWhenNotFound(t *testing.T) {
@@ -438,7 +445,8 @@ func TestKeychainFindCredentialsReturnsEmptyWhenNotFound(t *testing.T) {
 	config.KeyRing = ring
 	t.Cleanup(func() { config.KeyRing = originalKeyRing })
 
-	coreCLIHelper := NewCoreCLIHelper(context.Background(), nil, afero.NewMemMapFs())
+	cfg := newTestConfigWithProfile("myprofile")
+	coreCLIHelper := NewCoreCLIHelper(context.Background(), cfg, afero.NewMemMapFs())
 	keys, err := coreCLIHelper.KeychainFindCredentials()
 	require.NoError(t, err)
 	require.Empty(t, keys)
@@ -455,7 +463,8 @@ func TestKeychainFindCredentialsReturnsErrorOnFailure(t *testing.T) {
 	config.KeyRing = ring
 	t.Cleanup(func() { config.KeyRing = originalKeyRing })
 
-	coreCLIHelper := NewCoreCLIHelper(context.Background(), nil, afero.NewMemMapFs())
+	cfg := newTestConfigWithProfile("myprofile")
+	coreCLIHelper := NewCoreCLIHelper(context.Background(), cfg, afero.NewMemMapFs())
 	keys, err := coreCLIHelper.KeychainFindCredentials()
 	require.ErrorIs(t, err, expectedErr)
 	require.Empty(t, keys)

--- a/pkg/plugins/core_cli_helper_test.go
+++ b/pkg/plugins/core_cli_helper_test.go
@@ -412,6 +412,55 @@ func TestKeychainDeletePasswordClearsRecentWrite(t *testing.T) {
 	require.Equal(t, 1, ring.getCalls)
 }
 
+func TestKeychainFindCredentialsReturnsKeyWhenPresent(t *testing.T) {
+	originalKeyRing := config.KeyRing
+	ring := &fakeKeyring{
+		getResults: []fakeKeyringGetResult{
+			{data: []byte("sk_live_123")},
+		},
+	}
+	config.KeyRing = ring
+	t.Cleanup(func() { config.KeyRing = originalKeyRing })
+
+	coreCLIHelper := NewCoreCLIHelper(context.Background(), nil, afero.NewMemMapFs())
+	keys, err := coreCLIHelper.KeychainFindCredentials()
+	require.NoError(t, err)
+	require.Equal(t, []string{"default." + config.LiveModeAPIKeyName}, keys)
+}
+
+func TestKeychainFindCredentialsReturnsEmptyWhenNotFound(t *testing.T) {
+	originalKeyRing := config.KeyRing
+	ring := &fakeKeyring{
+		getResults: []fakeKeyringGetResult{
+			{err: keyring.ErrKeyNotFound},
+		},
+	}
+	config.KeyRing = ring
+	t.Cleanup(func() { config.KeyRing = originalKeyRing })
+
+	coreCLIHelper := NewCoreCLIHelper(context.Background(), nil, afero.NewMemMapFs())
+	keys, err := coreCLIHelper.KeychainFindCredentials()
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+func TestKeychainFindCredentialsReturnsErrorOnFailure(t *testing.T) {
+	originalKeyRing := config.KeyRing
+	expectedErr := errors.New("boom")
+	ring := &fakeKeyring{
+		getResults: []fakeKeyringGetResult{
+			{err: expectedErr},
+		},
+	}
+	config.KeyRing = ring
+	t.Cleanup(func() { config.KeyRing = originalKeyRing })
+
+	coreCLIHelper := NewCoreCLIHelper(context.Background(), nil, afero.NewMemMapFs())
+	keys, err := coreCLIHelper.KeychainFindCredentials()
+	require.ErrorIs(t, err, expectedErr)
+	require.Empty(t, keys)
+}
+
 func TestSendAnalyticsWithTelemetryClient(t *testing.T) {
 	// Test with a NoOp telemetry client
 	ctx := context.Background()

--- a/pkg/plugins/core_cli_helper_test.go
+++ b/pkg/plugins/core_cli_helper_test.go
@@ -412,12 +412,6 @@ func TestKeychainDeletePasswordClearsRecentWrite(t *testing.T) {
 	require.Equal(t, 1, ring.getCalls)
 }
 
-func newTestConfigWithProfile(profileName string) *TestConfig {
-	cfg := &TestConfig{}
-	cfg.Profile.ProfileName = profileName
-	return cfg
-}
-
 func TestKeychainFindCredentialsReturnsKeyWhenPresent(t *testing.T) {
 	originalKeyRing := config.KeyRing
 	ring := &fakeKeyring{
@@ -428,11 +422,10 @@ func TestKeychainFindCredentialsReturnsKeyWhenPresent(t *testing.T) {
 	config.KeyRing = ring
 	t.Cleanup(func() { config.KeyRing = originalKeyRing })
 
-	cfg := newTestConfigWithProfile("myprofile")
-	coreCLIHelper := NewCoreCLIHelper(context.Background(), cfg, afero.NewMemMapFs())
+	coreCLIHelper := NewCoreCLIHelper(context.Background(), nil, afero.NewMemMapFs())
 	keys, err := coreCLIHelper.KeychainFindCredentials()
 	require.NoError(t, err)
-	require.Equal(t, []string{"myprofile." + config.LiveModeAPIKeyName}, keys)
+	require.Equal(t, []string{"default." + config.LiveModeAPIKeyName}, keys)
 }
 
 func TestKeychainFindCredentialsReturnsEmptyWhenNotFound(t *testing.T) {
@@ -445,8 +438,7 @@ func TestKeychainFindCredentialsReturnsEmptyWhenNotFound(t *testing.T) {
 	config.KeyRing = ring
 	t.Cleanup(func() { config.KeyRing = originalKeyRing })
 
-	cfg := newTestConfigWithProfile("myprofile")
-	coreCLIHelper := NewCoreCLIHelper(context.Background(), cfg, afero.NewMemMapFs())
+	coreCLIHelper := NewCoreCLIHelper(context.Background(), nil, afero.NewMemMapFs())
 	keys, err := coreCLIHelper.KeychainFindCredentials()
 	require.NoError(t, err)
 	require.Empty(t, keys)
@@ -463,8 +455,7 @@ func TestKeychainFindCredentialsReturnsErrorOnFailure(t *testing.T) {
 	config.KeyRing = ring
 	t.Cleanup(func() { config.KeyRing = originalKeyRing })
 
-	cfg := newTestConfigWithProfile("myprofile")
-	coreCLIHelper := NewCoreCLIHelper(context.Background(), cfg, afero.NewMemMapFs())
+	coreCLIHelper := NewCoreCLIHelper(context.Background(), nil, afero.NewMemMapFs())
 	keys, err := coreCLIHelper.KeychainFindCredentials()
 	require.ErrorIs(t, err, expectedErr)
 	require.Empty(t, keys)


### PR DESCRIPTION
In https://github.com/stripe/stripe-cli/pull/1661, we deprecated the `KeychainFindCredentials` rpc and made it return an empty list because the new keyring library doesn't support listing keys. I mistakenly thought no plugin was using this rpc, but turns out it's used in the bootstrap which plugins do call. We've fixed it in https://github.com/stripe/stripe-cli-ts-plugin-bootstrap/pull/28 but older plugins will still expect this rpc to work.

Turns out there is only one known value we care about right now (the live key), and so this fixes `KeychainFindCredentials` to return that exact thing, while still marking rpc as deprecated.

Before:
```
stripe directory search magazine
This endpoint is not supported in testmode.
Run `stripe login` to authenticate with a live-mode account.
```

After:
```
go run cmd/stripe/main.go directory search magazine                  
╭──────────────────────────────────────────────────────────────────────────────╮
│ Fashion Pictorial Limited                                                    │
├──────────────────────────────────────────────────────────────────────────────┤
│ Web               https://stripe.com/@fashionvoo                             │
│ Stripe Apps       —                                                          │
│ Stripe Projects   —                                                          │
│ Machine Payments  —                                                          │
│ Link supported    —                                                          │
╰──────────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────────╮
│ Cherry Bombe                                                                 │
│ Cherry Bombe, Inc.                                                           │
├──────────────────────────────────────────────────────────────────────────────┤
│ Web               https://stripe.com/@cherrybombe                            │
│                   https://cherrybombe.com                                    │
│                                                                              │
│ Stripe Apps       —                                                          │
│ Stripe Projects   —                                                          │
│ Machine Payments  —                                                          │
│ Link supported    ✅                                                         │
╰──────────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────────╮
│ MangaYo!                                                                     │
│ MangaYo! è lo store online dove acquistare manga italiani e giapponesi,      │
│ artbook, figure, riviste e tante esclusive dal Giappone. I suoi punti di     │
│ forza sono le spedizioni rapide, la qualità degli imballaggi, l'affidabilità │
│ del servizio clienti e le bustine protettive su misura che… visit URL to     │
│ learn more                                                                   │
├──────────────────────────────────────────────────────────────────────────────┤
│ Web               https://stripe.com/@mangayo                                │
│                   https://mangayo.it/contattaci                              │
│                                                                              │
│ Stripe Apps       —                                                          │
│ Stripe Projects   —                                                          │
│ Machine Payments  —                                                          │
│ Link supported    —                                                          │
╰──────────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────────╮
│ Rork Media                                                                   │
├──────────────────────────────────────────────────────────────────────────────┤
│ Web               https://stripe.com/@rork_media                             │
│ Stripe Apps       —                                                          │
│ Stripe Projects   —                                                          │
│ Machine Payments  —                                                          │
│ Link supported    ✅                                                         │
╰──────────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────────╮
│ Mellow Climbing                                                              │
├──────────────────────────────────────────────────────────────────────────────┤
│ Web               https://stripe.com/@mellowclimbing                         │
│ Stripe Apps       —                                                          │
│ Stripe Projects   —                                                          │
│ Machine Payments  —                                                          │
│ Link supported    ✅                                                         │
╰──────────────────────────────────────────────────────────────────────────────╯

5 of 35 total results. Run `stripe directory search magazine --page=2 --limit=5` for the next page of results.
A newer version of the directory plugin is available (vcache → vlocal.build.dev). Run `stripe plugin upgrade directory` to update.
```
