### PR TITLE
Fix winget install test failing with 0x8a15000f on fresh runners

### DIFF
--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -39,6 +39,8 @@ run_install() {
     ;;
 
     winget)
+        # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
+        winget source reset --force
         winget install --id Stripe.StripeCli --accept-source-agreements --accept-package-agreements
         # winget modifies PATH but the current shell process doesn't inherit the change;
         # explicitly add the WinGet Links directory where the stripe alias was created.


### PR DESCRIPTION
Reset the winget source index before installing to avoid "data required by the source is missing" errors on GitHub Actions Windows runners. Example error: https://github.com/stripe/stripe-cli/actions/runs/28155488909/job/83382896544

Tested this change manually: https://github.com/stripe/stripe-cli/actions/runs/28201244308