### PR TITLE
Set cmd.Long from plugin Description for richer help text

### DIFF
--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -46,6 +46,7 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 	ptc.cmd = &cobra.Command{
 		Use:   plugin.Shortname,
 		Short: plugin.Shortdesc,
+		Long:  plugin.Description,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// "stripe [host_flags...] plugin_name [plugin_subcommands...] [plugin_flags...]" => "[plugin_subcommands...] [plugin_flags...]"
 			pluginArgs := subsliceAfter(os.Args, cmd.Name())

--- a/pkg/cmd/plugin_cmds_test.go
+++ b/pkg/cmd/plugin_cmds_test.go
@@ -54,6 +54,35 @@ func TestFlagsArePassedAsArgs(t *testing.T) {
 	require.Equal(t, "testarg --log-level=info", strings.Join(pluginCmd.ParsedArgs, " "))
 }
 
+func TestPluginCommandSetsLongFromDescription(t *testing.T) {
+	plugin := plugins.Plugin{
+		Shortname:        "tools",
+		Shortdesc:        "Manage your account from the terminal.",
+		Description:      "Manage your account from the terminal and update settings like branding, checkout color and more.",
+		Binary:           "stripe-cli-tools",
+		MagicCookieValue: "magic",
+	}
+
+	ptc := newPluginTemplateCmd(&Config, &plugin)
+
+	assert.Equal(t, "Manage your account from the terminal.", ptc.cmd.Short)
+	assert.Equal(t, "Manage your account from the terminal and update settings like branding, checkout color and more.", ptc.cmd.Long)
+}
+
+func TestPluginCommandLongEmptyWhenNoDescription(t *testing.T) {
+	plugin := plugins.Plugin{
+		Shortname:        "simple",
+		Shortdesc:        "A simple plugin",
+		Binary:           "stripe-cli-simple",
+		MagicCookieValue: "magic",
+	}
+
+	ptc := newPluginTemplateCmd(&Config, &plugin)
+
+	assert.Equal(t, "A simple plugin", ptc.cmd.Short)
+	assert.Equal(t, "", ptc.cmd.Long)
+}
+
 func TestAddPluginSubcommandStubs(t *testing.T) {
 	plugin := plugins.Plugin{
 		Shortname:        "myapp",


### PR DESCRIPTION
## Motivation

Improving plugin discoverability in `stripe --help` for AI agents and humans.
This stores the multi-line description on the cobra command so it's available
for a future "Installed plugins" template section.

## Summary

- In `newPluginTemplateCmd()`, set `cmd.Long = plugin.Description`
- Added tests verifying Long is set when Description is present, and empty when absent

## Background

The plugin's custom `SetHelpFunc` delegates to the plugin binary for
`stripe <plugin> --help`, overriding cobra's built-in Long rendering. So
setting `cmd.Long` doesn't change any current behavior — it's purely data
stored on the struct for the root help template to consume in a subsequent PR.

## Future context

The next PR adds an "Installed plugins" template section that reads `cmd.Long`
(falling back to `cmd.Short`) to render multi-line, word-wrapped descriptions.

## Testing

- Added `TestPluginCommandSetsLongFromDescription` — verifies Long is set from Description
- Added `TestPluginCommandLongEmptyWhenNoDescription` — verifies Long is empty when Description is absent
- Full test suite passes: `go test ./pkg/plugins/... ./pkg/cmd/...`
- `stripe --help` output is unchanged (field is not rendered yet)

## Rollout

No-op. Safe to merge and release in any CLI version. Zero user-visible change.