### PR TITLE
Add dedicated plugin sections to stripe --help output

### DIFF
--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -27,16 +27,19 @@ func AddHintCommands(rootCmd *cobra.Command, cfg *config.Config, installedPlugin
 		rootCmd.AddCommand(
 			newPluginHintCmd(cfg, "apps", "This plugin lets you build and manage Stripe Apps.").Command,
 		)
+		rootCmd.Annotations["apps"] = "available_plugin"
 	}
 	if !installedPluginSet["generate"] {
 		rootCmd.AddCommand(
 			newPluginHintCmd(cfg, "generate", "This plugin creates skeleton files to get you started.", withPrivatePreview()).Command,
 		)
+		rootCmd.Annotations["generate"] = "available_plugin"
 	}
 	if !installedPluginSet["projects"] {
 		rootCmd.AddCommand(
 			newPluginHintCmd(cfg, "projects", "This plugin scaffolds and manages Stripe integration projects.").Command,
 		)
+		rootCmd.Annotations["projects"] = "available_plugin"
 	}
 	if !installedPluginSet["directory"] {
 		directoryCmd := newPluginHintCmd(cfg, "directory", "Discover businesses on Stripe. Learn more: https://stripe.directory").Command
@@ -50,11 +53,13 @@ func AddHintCommands(rootCmd *cobra.Command, cfg *config.Config, installedPlugin
 		rootCmd.AddCommand(
 			directoryCmd,
 		)
+		rootCmd.Annotations["directory"] = "available_plugin"
 	}
 	if !installedPluginSet["tools"] {
 		rootCmd.AddCommand(
 			newPluginHintCmd(cfg, "tools", "Search, inspect, and execute Stripe operations not available in the public API.").Command,
 		)
+		rootCmd.Annotations["tools"] = "available_plugin"
 	}
 }
 

--- a/pkg/cmd/pluginhints/pluginhints_test.go
+++ b/pkg/cmd/pluginhints/pluginhints_test.go
@@ -51,7 +51,7 @@ func findChildCommand(rootCmd *cobra.Command, name string) *cobra.Command {
 // --- AddHintCommands ---
 
 func TestAddHintCommands_DirectoryHintRoutesAliasesWhenPluginMissing(t *testing.T) {
-	rootCmd := &cobra.Command{Use: "stripe"}
+	rootCmd := &cobra.Command{Use: "stripe", Annotations: map[string]string{}}
 
 	AddHintCommands(rootCmd, &config.Config{}, map[string]bool{})
 
@@ -76,13 +76,40 @@ func TestAddHintCommands_DirectoryHintRoutesAliasesWhenPluginMissing(t *testing.
 }
 
 func TestAddHintCommands_DirectoryHintSkippedWhenPluginInstalled(t *testing.T) {
-	rootCmd := &cobra.Command{Use: "stripe"}
+	rootCmd := &cobra.Command{Use: "stripe", Annotations: map[string]string{}}
 
 	AddHintCommands(rootCmd, &config.Config{}, map[string]bool{
 		"directory": true,
 	})
 
 	assert.Nil(t, findChildCommand(rootCmd, "directory"))
+}
+
+func TestAddHintCommands_SetsAvailablePluginAnnotations(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "stripe", Annotations: map[string]string{}}
+
+	AddHintCommands(rootCmd, &config.Config{}, map[string]bool{})
+
+	for _, name := range []string{"apps", "generate", "projects", "directory", "tools"} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, "available_plugin", rootCmd.Annotations[name])
+		})
+	}
+}
+
+func TestAddHintCommands_NoAnnotationWhenPluginInstalled(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "stripe", Annotations: map[string]string{}}
+
+	AddHintCommands(rootCmd, &config.Config{}, map[string]bool{
+		"tools": true,
+		"apps":  true,
+	})
+
+	assert.Empty(t, rootCmd.Annotations["tools"])
+	assert.Empty(t, rootCmd.Annotations["apps"])
+	assert.Equal(t, "available_plugin", rootCmd.Annotations["generate"])
+	assert.Equal(t, "available_plugin", rootCmd.Annotations["projects"])
+	assert.Equal(t, "available_plugin", rootCmd.Annotations["directory"])
 }
 
 // --- run ---

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -306,6 +306,7 @@ func registerInstalledPlugins(root *cobra.Command, cfg *config.Config, fs afero.
 		}
 		installedPluginSet[pluginName] = true
 		root.AddCommand(newPluginTemplateCmd(cfg, &plugin).cmd)
+		root.Annotations[pluginName] = "installed_plugin"
 	}
 
 	return installedPluginSet

--- a/pkg/cmd/templates.go
+++ b/pkg/cmd/templates.go
@@ -376,7 +376,19 @@ func getUsageTemplate() string {
   {{rpad "delete" 29}} Make DELETE requests to the Stripe API
 
 %s{{range $index, $cmd := .Commands}}{{if (not (or (index $.Annotations $cmd.Name) $cmd.Hidden))}}
-  {{rpad $cmd.Name $cmd.NamePadding}} {{$cmd.Short}}{{end}}{{end}}{{else}}
+  {{rpad $cmd.Name $cmd.NamePadding}} {{$cmd.Short}}{{end}}{{end}}{{if HasAnnotatedCommands . "installed_plugin"}}
+
+%s
+  %s
+{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "installed_plugin")}}
+  {{$cmd.Name}}
+    {{PluginDescription $cmd}}
+{{end}}{{end}}{{end}}{{if HasAnnotatedCommands . "available_plugin"}}
+
+%s
+  %s
+{{range $index, $cmd := .Commands}}{{if (eq (index $.Annotations $cmd.Name) "available_plugin")}}
+  {{rpad $cmd.Name $cmd.NamePadding}} {{$cmd.Short}}{{end}}{{end}}{{end}}{{else}}
 
 %s{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{AIAgentHelp .}}{{if .HasAvailableLocalFlags}}
@@ -399,6 +411,10 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 		ansi.Italic("To see only v2 resource commands, run `stripe v2 help`"),
 		ansi.Bold("API commands:"),
 		ansi.Bold("Other commands:"),
+		ansi.Bold("Installed plugins:"),
+		ansi.Italic("(run 'stripe <name> --help' for full command details)"),
+		ansi.Bold("Available plugins:"),
+		ansi.Italic("(run 'stripe plugin install <name>' to add)"),
 		ansi.Bold("Available commands:"),
 		ansi.Bold("Flags:"),
 		ansi.Bold("Global flags:"),
@@ -413,6 +429,27 @@ func getTerminalWidth() int {
 	return width
 }
 
+// hasAnnotatedCommands reports whether cmd has any child command whose name
+// maps to the given annotation value in cmd's own Annotations map.
+func hasAnnotatedCommands(cmd *cobra.Command, annotation string) bool {
+	for _, c := range cmd.Commands() {
+		if val, ok := cmd.Annotations[c.Name()]; ok && val == annotation {
+			return true
+		}
+	}
+	return false
+}
+
+// pluginDescription returns the plugin's Long description word-wrapped to the
+// terminal width with 4-space indentation, falling back to Short if Long is empty.
+func pluginDescription(cmd *cobra.Command) string {
+	text := cmd.Long
+	if text == "" {
+		text = cmd.Short
+	}
+	return wrapText(text, getTerminalWidth()-4, 4)
+}
+
 func init() {
 	cobra.AddTemplateFunc("WrappedInheritedFlagUsages", WrappedInheritedFlagUsages)
 	cobra.AddTemplateFunc("WrappedLocalFlagUsages", WrappedLocalFlagUsages)
@@ -421,4 +458,6 @@ func init() {
 	cobra.AddTemplateFunc("IsAIAgent", isAIAgent)
 	cobra.AddTemplateFunc("AIAgentHelp", aiAgentHelp)
 	cobra.AddTemplateFunc("AIAgentHelpTop", aiAgentHelpTop)
+	cobra.AddTemplateFunc("HasAnnotatedCommands", hasAnnotatedCommands)
+	cobra.AddTemplateFunc("PluginDescription", pluginDescription)
 }

--- a/pkg/cmd/templates_test.go
+++ b/pkg/cmd/templates_test.go
@@ -222,3 +222,205 @@ func TestUsageTemplate_RootShowsCommandGroups(t *testing.T) {
 	assert.Contains(t, output, "Webhook commands")
 	assert.Contains(t, output, "API commands")
 }
+
+func TestHasAnnotatedCommands(t *testing.T) {
+	root := &cobra.Command{
+		Use: "stripe",
+		Annotations: map[string]string{
+			"tools": "installed_plugin",
+			"apps":  "available_plugin",
+		},
+	}
+	root.AddCommand(&cobra.Command{Use: "tools", RunE: noop})
+	root.AddCommand(&cobra.Command{Use: "apps", RunE: noop})
+	root.AddCommand(&cobra.Command{Use: "login", RunE: noop})
+
+	assert.True(t, hasAnnotatedCommands(root, "installed_plugin"))
+	assert.True(t, hasAnnotatedCommands(root, "available_plugin"))
+	assert.False(t, hasAnnotatedCommands(root, "nonexistent"))
+}
+
+func TestHasAnnotatedCommands_NoMatches(t *testing.T) {
+	root := &cobra.Command{
+		Use:         "stripe",
+		Annotations: map[string]string{},
+	}
+	root.AddCommand(&cobra.Command{Use: "login", RunE: noop})
+
+	assert.False(t, hasAnnotatedCommands(root, "installed_plugin"))
+}
+
+func TestPluginDescription_UsesLongWhenPresent(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "tools",
+		Short: "Short text",
+		Long:  "A longer description of the plugin.",
+	}
+	// Attach to a parent so NamePadding() is valid.
+	parent := &cobra.Command{Use: "stripe"}
+	parent.AddCommand(cmd)
+
+	result := pluginDescription(cmd)
+	assert.Contains(t, result, "A longer description of the plugin.")
+	assert.NotContains(t, result, "Short text")
+}
+
+func TestPluginDescription_FallsBackToShort(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "tools",
+		Short: "Fallback short description",
+	}
+	parent := &cobra.Command{Use: "stripe"}
+	parent.AddCommand(cmd)
+
+	result := pluginDescription(cmd)
+	assert.Contains(t, result, "Fallback short description")
+}
+
+func TestPluginDescription_WrapsLongText(t *testing.T) {
+	longText := "Manage your account from the terminal and update settings like branding, checkout color and more. These capabilities are typically accessible only from the dashboard and not available on the public API."
+	cmd := &cobra.Command{
+		Use:   "tools",
+		Short: "Short",
+		Long:  longText,
+	}
+	parent := &cobra.Command{Use: "stripe"}
+	parent.AddCommand(cmd)
+
+	result := pluginDescription(cmd)
+	lines := strings.Split(result, "\n")
+	assert.Greater(t, len(lines), 1, "long text should wrap to multiple lines")
+	for _, line := range lines[1:] {
+		assert.True(t, strings.HasPrefix(line, "    "), "continuation lines should be indented")
+	}
+}
+
+func TestUsageTemplate_InstalledPluginsSection(t *testing.T) {
+	root := &cobra.Command{
+		Use: "stripe",
+		Annotations: map[string]string{
+			"get":   "http",
+			"tools": "installed_plugin",
+		},
+	}
+	root.SetUsageTemplate(getUsageTemplate())
+
+	get := &cobra.Command{Use: "get", Short: "Make GET requests", RunE: noop}
+	tools := &cobra.Command{Use: "tools", Short: "Manage account", Long: "Manage your account from the terminal.", RunE: noop}
+	root.AddCommand(get, tools)
+
+	output := root.UsageString()
+	assert.Contains(t, output, "Installed plugins:")
+	assert.Contains(t, output, "tools")
+	assert.Contains(t, output, "Manage your account from the terminal.")
+	assert.NotContains(t, output, "Available plugins:")
+}
+
+func TestUsageTemplate_AvailablePluginsSection(t *testing.T) {
+	root := &cobra.Command{
+		Use: "stripe",
+		Annotations: map[string]string{
+			"get":  "http",
+			"apps": "available_plugin",
+		},
+	}
+	root.SetUsageTemplate(getUsageTemplate())
+
+	get := &cobra.Command{Use: "get", Short: "Make GET requests", RunE: noop}
+	apps := &cobra.Command{Use: "apps", Short: "Build and manage Stripe Apps.", RunE: noop}
+	root.AddCommand(get, apps)
+
+	output := root.UsageString()
+	assert.Contains(t, output, "Available plugins:")
+	assert.Contains(t, output, "apps")
+	assert.Contains(t, output, "Build and manage Stripe Apps.")
+	assert.NotContains(t, output, "Installed plugins:")
+}
+
+func TestUsageTemplate_BothPluginSections(t *testing.T) {
+	root := &cobra.Command{
+		Use: "stripe",
+		Annotations: map[string]string{
+			"get":   "http",
+			"tools": "installed_plugin",
+			"apps":  "available_plugin",
+		},
+	}
+	root.SetUsageTemplate(getUsageTemplate())
+
+	get := &cobra.Command{Use: "get", Short: "Make GET requests", RunE: noop}
+	tools := &cobra.Command{Use: "tools", Short: "Manage account", Long: "Manage your account from the terminal.", RunE: noop}
+	apps := &cobra.Command{Use: "apps", Short: "Build and manage Stripe Apps.", RunE: noop}
+	root.AddCommand(get, tools, apps)
+
+	output := root.UsageString()
+	assert.Contains(t, output, "Installed plugins:")
+	assert.Contains(t, output, "Available plugins:")
+	installedIdx := strings.Index(output, "Installed plugins:")
+	availableIdx := strings.Index(output, "Available plugins:")
+	assert.Less(t, installedIdx, availableIdx, "Installed plugins should appear before Available plugins")
+}
+
+func TestUsageTemplate_PluginsExcludedFromOtherCommands(t *testing.T) {
+	root := &cobra.Command{
+		Use: "stripe",
+		Annotations: map[string]string{
+			"get":   "http",
+			"tools": "installed_plugin",
+			"apps":  "available_plugin",
+		},
+	}
+	root.SetUsageTemplate(getUsageTemplate())
+
+	get := &cobra.Command{Use: "get", Short: "Make GET requests", RunE: noop}
+	tools := &cobra.Command{Use: "tools", Short: "Manage account", RunE: noop}
+	apps := &cobra.Command{Use: "apps", Short: "Build Stripe Apps", RunE: noop}
+	login := &cobra.Command{Use: "login", Short: "Login to Stripe", RunE: noop}
+	root.AddCommand(get, tools, apps, login)
+
+	output := root.UsageString()
+	otherIdx := strings.Index(output, "Other commands:")
+	installedIdx := strings.Index(output, "Installed plugins:")
+
+	// "login" should be in Other commands, not in plugin sections
+	loginIdx := strings.Index(output, "login")
+	assert.Greater(t, loginIdx, otherIdx, "login should appear after Other commands header")
+	assert.Less(t, loginIdx, installedIdx, "login should appear before Installed plugins header")
+}
+
+func TestUsageTemplate_InstalledPluginFallsBackToShort(t *testing.T) {
+	root := &cobra.Command{
+		Use: "stripe",
+		Annotations: map[string]string{
+			"get":    "http",
+			"simple": "installed_plugin",
+		},
+	}
+	root.SetUsageTemplate(getUsageTemplate())
+
+	get := &cobra.Command{Use: "get", Short: "Make GET requests", RunE: noop}
+	simple := &cobra.Command{Use: "simple", Short: "A simple plugin with no Long", RunE: noop}
+	root.AddCommand(get, simple)
+
+	output := root.UsageString()
+	assert.Contains(t, output, "Installed plugins:")
+	assert.Contains(t, output, "A simple plugin with no Long")
+}
+
+func TestUsageTemplate_NoPluginSectionsWhenNoPlugins(t *testing.T) {
+	root := &cobra.Command{
+		Use: "stripe",
+		Annotations: map[string]string{
+			"get": "http",
+		},
+	}
+	root.SetUsageTemplate(getUsageTemplate())
+
+	get := &cobra.Command{Use: "get", Short: "Make GET requests", RunE: noop}
+	login := &cobra.Command{Use: "login", Short: "Login", RunE: noop}
+	root.AddCommand(get, login)
+
+	output := root.UsageString()
+	assert.NotContains(t, output, "Installed plugins:")
+	assert.NotContains(t, output, "Available plugins:")
+}


### PR DESCRIPTION
## Summary

- Adds "Installed plugins" and "Available plugins" sections to `stripe --help`
- Plugins are moved out of "Other commands" into their own dedicated sections
- Installed plugins show multi-line word-wrapped descriptions (falls back to short text if no description is set)
- Available plugins (uninstalled) show their short description in the standard one-liner format
- Sections are conditionally rendered — they only appear when relevant plugins exist

## Motivation

Plugins are currently mixed into "Other commands" with a single short sentence, making them hard to distinguish from built-in commands. This is especially problematic for AI agents that need to understand what plugins do. Dedicated sections with richer descriptions solve both discoverability issues.

## How it works

Uses the **same root Annotations pattern** already proven throughout the codebase:
- `rootCmd.Annotations["tools"] = "installed_plugin"` → categorizes into "Installed plugins" section
- `rootCmd.Annotations["apps"] = "available_plugin"` → categorizes into "Available plugins" section

This automatically excludes plugins from "Other commands" (the existing template filter already skips any command with a root annotation).

New template functions:
- `HasAnnotatedCommands(cmd, annotation)` — conditional rendering (skip empty sections)
- `PluginDescription(cmd)` — word-wraps `cmd.Long` to terminal width with indentation, falls back to `cmd.Short`

## How installed plugins are detected

The CLI determines which plugins are installed via `plugins.GetInstalledPluginNames()`, which unions two sources:

1. **`config.toml` → `installed_plugins` list** — names recorded at install time (e.g. `['tools']`)
2. **`~/.config/stripe/plugin-metadata/*.toml` files** — per-plugin metadata files written during install

A plugin having a metadata file is the primary signal that it's installed. The config list is a fallback for backward compatibility with older installs.

For each installed plugin name, `plugins.LookUpPlugin()` loads its full metadata:
1. First tries **local metadata file** (`plugin-metadata/<name>.toml`) — this is the canonical source
2. Falls back to the **global manifest** (`plugins.toml`) for backward compatibility

This is the same detection path that already decides whether to register a plugin command vs. a hint command — we're just adding an annotation alongside the existing `root.AddCommand()` call. No new detection logic was introduced.

## How the Description field flows from plugin hub to CLI

The `Description` field (multi-line, ~400 char max) is populated by plugin authors via the plugin hub admin UI and flows to users' CLIs through the existing manifest pipeline:

```
Plugin Hub DB (source of truth)
  → PluginManifest.generate() emits Description in TOML
    → Artifactory hosts the generated manifest
      → `stripe plugin install <name>` downloads manifest
        → CLI writes plugin-metadata/<name>.toml locally (includes Description)
          → At startup, LookUpPlugin() reads the TOML → Plugin.Description
            → newPluginTemplateCmd() sets cmd.Long = plugin.Description
              → Template renders cmd.Long in "Installed plugins" section
```

**Current state**: The plugin hub backend now has the `description` column (PRs #2307020, #2307021 merged) and the admin UI textarea is in review (PR #2307022 + validation PR #2314357). Once those merge and descriptions are filled, new installs and plugin updates will automatically pick up the richer text. Existing installs will show `Shortdesc` as a one-liner until the user updates their plugin (graceful degradation).

## Help output examples

### One installed plugin, Description not yet populated (falls back to Shortdesc)

This is what most users will see immediately after this PR merges (before plugin hub descriptions are populated):

```
  ...
  delete                        Make DELETE requests to the Stripe API

Other commands:
  community                                Chat with Stripe engineers and other developers
  completion                               Generate bash, zsh, and fish completion scripts
  config                                   Manually change the config values for the CLI
  docs                                     Browse docs.stripe.com from the terminal
  feedback                                 Provide us with feedback on the CLI
  fixtures                                 Run fixtures to populate your account with data
  help                                     Help about any command
  keys                                     Manage API keys
  login                                    Login to your Stripe account
  logout                                   Logout of your Stripe account
  open                                     Quickly open Stripe pages
  samples                                  Sample integrations built by Stripe
  sandbox                                  Manage Stripe sandbox environments
  serve                                    Serve static files locally
  version                                  Get the version of the Stripe CLI
  whoami                                   Show the current Stripe auth state

Installed plugins:
  (run 'stripe <name> --help' for full command details)

  tools
    Search, inspect, and execute Stripe operations not available in the
    public API


Available plugins:
  (run 'stripe plugin install <name>' to add)

  apps                                     This plugin lets you build and manage Stripe Apps.
  directory                                Discover businesses on Stripe. Learn more: https://stripe.directory
  generate                                 This plugin creates skeleton files to get you started.
  projects                                 This plugin scaffolds and manages Stripe integration projects.

Flags:
  ...
```

### One installed plugin, Description populated (after plugin hub descriptions are filled)

```
Installed plugins:
  (run 'stripe <name> --help' for full command details)

  tools
    Manage your account from the terminal and update settings like branding,
    checkout color and more. These capabilities are typically accessible
    only from the dashboard and not available on the public API or as Stripe
    CLI resources. Use 'stripe tools --help' to list the available
    capabilities.


Available plugins:
  (run 'stripe plugin install <name>' to add)

  apps                                     This plugin lets you build and manage Stripe Apps.
  directory                                Discover businesses on Stripe. Learn more: https://stripe.directory
  generate                                 This plugin creates skeleton files to get you started.
  projects                                 This plugin scaffolds and manages Stripe integration projects.
```

### Multiple installed plugins with descriptions

```
Installed plugins:
  (run 'stripe <name> --help' for full command details)

  atlas
    Explore and visualize your Stripe data model relationships. View object
    hierarchies, inspect linked resources, and understand how API objects
    connect to each other.

  tools
    Manage your account from the terminal and update settings like branding,
    checkout color and more. These capabilities are typically accessible
    only from the dashboard and not available on the public API or as Stripe
    CLI resources. Use 'stripe tools --help' to list the available
    capabilities.


Available plugins:
  (run 'stripe plugin install <name>' to add)

  apps                                     This plugin lets you build and manage Stripe Apps.
  directory                                Discover businesses on Stripe. Learn more: https://stripe.directory
  generate                                 This plugin creates skeleton files to get you started.
  projects                                 This plugin scaffolds and manages Stripe integration projects.
```

### No installed plugins (new user)

The "Installed plugins" section is hidden entirely. All known plugins appear as available:

```
  ...
  whoami                                   Show the current Stripe auth state

Available plugins:
  (run 'stripe plugin install <name>' to add)

  apps                                     This plugin lets you build and manage Stripe Apps.
  directory                                Discover businesses on Stripe. Learn more: https://stripe.directory
  generate                                 This plugin creates skeleton files to get you started.
  projects                                 This plugin scaffolds and manages Stripe integration projects.
  tools                                    Search, inspect, and execute Stripe operations not available in the public API.

Flags:
  ...
```

## Changes

| File | Change |
|------|--------|
| `pkg/cmd/root.go` | Set `root.Annotations[pluginName] = "installed_plugin"` in `registerInstalledPlugins()` |
| `pkg/cmd/pluginhints/pluginhints.go` | Set `rootCmd.Annotations[name] = "available_plugin"` in `AddHintCommands()` |
| `pkg/cmd/templates.go` | Add `hasAnnotatedCommands()`, `pluginDescription()` funcs + template sections |
| `pkg/cmd/templates_test.go` | 11 new tests covering section rendering, word-wrap, fallback, exclusion |
| `pkg/cmd/pluginhints/pluginhints_test.go` | 2 new tests verifying annotations are set/skipped correctly |

## Test plan

- [x] `go build ./...` passes
- [x] `make lint` — 0 issues
- [x] `make test` — all affected package tests pass (pre-existing unrelated failure in `stripeauth` due to Claude Code env var)
- [x] Race detector: `go test -race ./pkg/cmd/... ./pkg/cmd/pluginhints/...` — pass
- [x] Manual verification: built binary locally, tested all scenarios below:
  - One installed plugin with no Description (shows Shortdesc fallback, word-wrapped)
  - One installed plugin with Description populated (shows full multi-line description)
  - Multiple installed plugins (both render with blank line separation)
  - No installed plugins (section hidden entirely, all show as "Available")
- [x] Verified plugins no longer appear in "Other commands" section
- [x] Verified sections are hidden when no plugins of that type exist