### PR TITLE
Add Claude agent setup POC

### DIFF
--- a/pkg/agentsetup/claude.go
+++ b/pkg/agentsetup/claude.go
@@ -1,0 +1,210 @@
+// Package agentsetup contains helpers for detecting and configuring AI coding
+// agent integrations.
+package agentsetup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	ClientClaudeCode      = "claude-code"
+	ClaudeBinaryName      = "claude"
+	TargetClaudePlugin    = "stripe@claude-plugins-official"
+	LocalClaudePlugin     = "stripe@stripe"
+	ClaudeMarketplace     = "claude-plugins-official"
+	ClaudePluginStatePath = ".claude/plugins/installed_plugins.json"
+
+	StatusNotDetected = "not_detected"
+	StatusInstalled   = "installed"
+	StatusMissing     = "missing"
+	StatusError       = "error"
+)
+
+// LookPathFunc matches exec.LookPath and exists to make detection testable.
+type LookPathFunc func(string) (string, error)
+
+// ReadFileFunc matches os.ReadFile and exists to make status parsing testable.
+type ReadFileFunc func(string) ([]byte, error)
+
+// HomeDirFunc matches os.UserHomeDir and exists to make status parsing testable.
+type HomeDirFunc func() (string, error)
+
+// WorkDirFunc matches os.Getwd and exists to make local plugin scope testable.
+type WorkDirFunc func() (string, error)
+
+// RunCommandFunc runs a command. The production implementation streams stdio.
+type RunCommandFunc func(context.Context, string, ...string) error
+
+// Scanner scans local agent installations without mutating them.
+type Scanner struct {
+	LookPath LookPathFunc
+	ReadFile ReadFileFunc
+	HomeDir  HomeDirFunc
+	WorkDir  WorkDirFunc
+}
+
+// ClaudeStatus is the read-only setup status for Claude Code.
+type ClaudeStatus struct {
+	Client          string `json:"client"`
+	Detected        bool   `json:"detected"`
+	ExecutablePath  string `json:"executable_path,omitempty"`
+	PluginInstalled bool   `json:"plugin_installed"`
+	PluginID        string `json:"plugin_id,omitempty"`
+	PluginVersion   string `json:"plugin_version,omitempty"`
+	PluginScope     string `json:"plugin_scope,omitempty"`
+	PluginProject   string `json:"plugin_project_path,omitempty"`
+	PluginStatePath string `json:"plugin_state_path,omitempty"`
+	Status          string `json:"status"`
+	Error           string `json:"error,omitempty"`
+}
+
+type installedPluginState struct {
+	Version int                             `json:"version"`
+	Plugins map[string][]installedPluginRef `json:"plugins"`
+}
+
+type installedPluginRef struct {
+	Scope       string `json:"scope"`
+	Version     string `json:"version"`
+	Installed   string `json:"installPath"`
+	ProjectPath string `json:"projectPath"`
+}
+
+// DefaultScanner returns a Scanner backed by the real OS.
+func DefaultScanner() Scanner {
+	return Scanner{
+		LookPath: exec.LookPath,
+		ReadFile: os.ReadFile,
+		HomeDir:  os.UserHomeDir,
+		WorkDir:  os.Getwd,
+	}
+}
+
+// ScanClaude returns Claude Code installation and Stripe plugin status.
+func (s Scanner) ScanClaude() ClaudeStatus {
+	s = s.withDefaults()
+
+	status := ClaudeStatus{
+		Client: ClientClaudeCode,
+		Status: StatusNotDetected,
+	}
+
+	claudePath, err := s.LookPath(ClaudeBinaryName)
+	if err != nil {
+		return status
+	}
+	status.Detected = true
+	status.ExecutablePath = claudePath
+	status.Status = StatusMissing
+
+	home, err := s.HomeDir()
+	if err != nil {
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("locating home directory: %v", err)
+		return status
+	}
+	status.PluginStatePath = filepath.Join(home, ClaudePluginStatePath)
+
+	body, err := s.ReadFile(status.PluginStatePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return status
+		}
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("reading Claude plugin state: %v", err)
+		return status
+	}
+
+	var pluginState installedPluginState
+	if err := json.Unmarshal(body, &pluginState); err != nil {
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("parsing Claude plugin state: %v", err)
+		return status
+	}
+
+	workDir, err := s.WorkDir()
+	if err != nil {
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("locating working directory: %v", err)
+		return status
+	}
+
+	if id, ref, ok := findStripePlugin(pluginState.Plugins, workDir); ok {
+		status.PluginInstalled = true
+		status.PluginID = id
+		status.PluginVersion = ref.Version
+		status.PluginScope = ref.Scope
+		status.PluginProject = ref.ProjectPath
+		status.Status = StatusInstalled
+	}
+
+	return status
+}
+
+// ClaudeInstallCommand returns the command used to install the Stripe Claude
+// Code plugin.
+func ClaudeInstallCommand() (string, []string) {
+	return ClaudeBinaryName, []string{"plugin", "install", TargetClaudePlugin}
+}
+
+// ClaudeMarketplaceUpdateCommand returns the command used to refresh Claude's
+// official plugin marketplace metadata.
+func ClaudeMarketplaceUpdateCommand() (string, []string) {
+	return ClaudeBinaryName, []string{"plugin", "marketplace", "update", ClaudeMarketplace}
+}
+
+// RunCommand streams a command through the current process stdio.
+func RunCommand(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (s Scanner) withDefaults() Scanner {
+	defaults := DefaultScanner()
+	if s.LookPath == nil {
+		s.LookPath = defaults.LookPath
+	}
+	if s.ReadFile == nil {
+		s.ReadFile = defaults.ReadFile
+	}
+	if s.HomeDir == nil {
+		s.HomeDir = defaults.HomeDir
+	}
+	if s.WorkDir == nil {
+		s.WorkDir = defaults.WorkDir
+	}
+	return s
+}
+
+func findStripePlugin(plugins map[string][]installedPluginRef, workDir string) (string, installedPluginRef, bool) {
+	for _, id := range []string{TargetClaudePlugin, LocalClaudePlugin} {
+		for _, ref := range plugins[id] {
+			if pluginVisibleInWorkDir(ref, workDir) {
+				return id, ref, true
+			}
+		}
+	}
+	return "", installedPluginRef{}, false
+}
+
+func pluginVisibleInWorkDir(ref installedPluginRef, workDir string) bool {
+	if ref.Scope != "local" || ref.ProjectPath == "" {
+		return true
+	}
+
+	rel, err := filepath.Rel(ref.ProjectPath, workDir)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && !filepath.IsAbs(rel))
+}

--- a/pkg/agentsetup/claude.go
+++ b/pkg/agentsetup/claude.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,11 +21,7 @@ const (
 	LocalClaudePlugin     = "stripe@stripe"
 	ClaudeMarketplace     = "claude-plugins-official"
 	ClaudePluginStatePath = ".claude/plugins/installed_plugins.json"
-
-	StatusNotDetected = "not_detected"
-	StatusInstalled   = "installed"
-	StatusMissing     = "missing"
-	StatusError       = "error"
+	ClaudeDisplayName     = "Claude Code"
 )
 
 // LookPathFunc matches exec.LookPath and exists to make detection testable.
@@ -50,19 +47,72 @@ type Scanner struct {
 	WorkDir  WorkDirFunc
 }
 
-// ClaudeStatus is the read-only setup status for Claude Code.
-type ClaudeStatus struct {
-	Client          string `json:"client"`
-	Detected        bool   `json:"detected"`
-	ExecutablePath  string `json:"executable_path,omitempty"`
-	PluginInstalled bool   `json:"plugin_installed"`
-	PluginID        string `json:"plugin_id,omitempty"`
-	PluginVersion   string `json:"plugin_version,omitempty"`
-	PluginScope     string `json:"plugin_scope,omitempty"`
-	PluginProject   string `json:"plugin_project_path,omitempty"`
-	PluginStatePath string `json:"plugin_state_path,omitempty"`
-	Status          string `json:"status"`
-	Error           string `json:"error,omitempty"`
+// ClaudeProvider detects and configures the Stripe plugin for Claude Code.
+type ClaudeProvider struct {
+	Scanner    Scanner
+	RunCommand RunCommandFunc
+}
+
+// NewClaudeProvider returns a Claude Code setup provider.
+func NewClaudeProvider(scanner Scanner, runCommand RunCommandFunc) ClaudeProvider {
+	if runCommand == nil {
+		runCommand = RunCommand
+	}
+	return ClaudeProvider{
+		Scanner:    scanner,
+		RunCommand: runCommand,
+	}
+}
+
+func (p ClaudeProvider) ID() string {
+	return ClientClaudeCode
+}
+
+func (p ClaudeProvider) Detect() Status {
+	return p.Scanner.ScanClaude()
+}
+
+func (p ClaudeProvider) Plan(status Status, force bool) Plan {
+	name, args := ClaudeInstallCommand()
+	command := append([]string{name}, args...)
+
+	switch {
+	case status.Status == StatusError:
+		return Plan{Action: ActionNone}
+	case !status.Detected:
+		return Plan{Action: ActionNone}
+	case status.Plugin.Installed && force:
+		return Plan{Action: ActionReinstall, Command: command}
+	case status.Plugin.Installed:
+		return Plan{Action: ActionNone}
+	default:
+		return Plan{Action: ActionInstall, Command: command}
+	}
+}
+
+func (p ClaudeProvider) Apply(ctx context.Context, out io.Writer, plan Plan) error {
+	if plan.Action == ActionNone {
+		return nil
+	}
+	if len(plan.Command) == 0 {
+		return fmt.Errorf("missing command for %s action", plan.Action)
+	}
+
+	name, installArgs := plan.Command[0], plan.Command[1:]
+	if err := p.RunCommand(ctx, name, installArgs...); err == nil {
+		return nil
+	} else {
+		updateName, updateArgs := ClaudeMarketplaceUpdateCommand()
+		updateCommand := append([]string{updateName}, updateArgs...)
+		fmt.Fprintf(out, "Install failed. Updating Claude plugin marketplace and retrying: %s\n", strings.Join(updateCommand, " "))
+		if updateErr := p.RunCommand(ctx, updateName, updateArgs...); updateErr != nil {
+			return fmt.Errorf("running %q after install failed: %w", strings.Join(updateCommand, " "), updateErr)
+		}
+		if retryErr := p.RunCommand(ctx, name, installArgs...); retryErr != nil {
+			return fmt.Errorf("running %q after marketplace update: %w", strings.Join(plan.Command, " "), retryErr)
+		}
+		return nil
+	}
 }
 
 type installedPluginState struct {
@@ -88,12 +138,13 @@ func DefaultScanner() Scanner {
 }
 
 // ScanClaude returns Claude Code installation and Stripe plugin status.
-func (s Scanner) ScanClaude() ClaudeStatus {
+func (s Scanner) ScanClaude() Status {
 	s = s.withDefaults()
 
-	status := ClaudeStatus{
-		Client: ClientClaudeCode,
-		Status: StatusNotDetected,
+	status := Status{
+		Client:      ClientClaudeCode,
+		DisplayName: ClaudeDisplayName,
+		Status:      StatusNotDetected,
 	}
 
 	claudePath, err := s.LookPath(ClaudeBinaryName)
@@ -110,9 +161,9 @@ func (s Scanner) ScanClaude() ClaudeStatus {
 		status.Error = fmt.Sprintf("locating home directory: %v", err)
 		return status
 	}
-	status.PluginStatePath = filepath.Join(home, ClaudePluginStatePath)
+	status.Plugin.StatePath = filepath.Join(home, ClaudePluginStatePath)
 
-	body, err := s.ReadFile(status.PluginStatePath)
+	body, err := s.ReadFile(status.Plugin.StatePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return status
@@ -137,11 +188,11 @@ func (s Scanner) ScanClaude() ClaudeStatus {
 	}
 
 	if id, ref, ok := findStripePlugin(pluginState.Plugins, workDir); ok {
-		status.PluginInstalled = true
-		status.PluginID = id
-		status.PluginVersion = ref.Version
-		status.PluginScope = ref.Scope
-		status.PluginProject = ref.ProjectPath
+		status.Plugin.Installed = true
+		status.Plugin.ID = id
+		status.Plugin.Version = ref.Version
+		status.Plugin.Scope = ref.Scope
+		status.Plugin.Project = ref.ProjectPath
 		status.Status = StatusInstalled
 	}
 

--- a/pkg/agentsetup/claude_test.go
+++ b/pkg/agentsetup/claude_test.go
@@ -28,9 +28,9 @@ func TestScanClaude_MissingPluginState(t *testing.T) {
 	status := scanner.ScanClaude()
 
 	require.True(t, status.Detected)
-	require.False(t, status.PluginInstalled)
+	require.False(t, status.Plugin.Installed)
 	require.Equal(t, StatusMissing, status.Status)
-	require.Equal(t, filepath.Join(home, ClaudePluginStatePath), status.PluginStatePath)
+	require.Equal(t, filepath.Join(home, ClaudePluginStatePath), status.Plugin.StatePath)
 }
 
 func TestScanClaude_OfficialPluginInstalled(t *testing.T) {
@@ -47,10 +47,10 @@ func TestScanClaude_OfficialPluginInstalled(t *testing.T) {
 	status := testScanner(home).ScanClaude()
 
 	require.Equal(t, StatusInstalled, status.Status)
-	require.True(t, status.PluginInstalled)
-	require.Equal(t, TargetClaudePlugin, status.PluginID)
-	require.Equal(t, "2.4.1", status.PluginVersion)
-	require.Equal(t, "user", status.PluginScope)
+	require.True(t, status.Plugin.Installed)
+	require.Equal(t, TargetClaudePlugin, status.Plugin.ID)
+	require.Equal(t, "2.4.1", status.Plugin.Version)
+	require.Equal(t, "user", status.Plugin.Scope)
 }
 
 func TestScanClaude_LocalStripePluginInstalled(t *testing.T) {
@@ -68,11 +68,11 @@ func TestScanClaude_LocalStripePluginInstalled(t *testing.T) {
 	status := testScannerWithWorkDir(home, filepath.Join(projectPath, "subdir")).ScanClaude()
 
 	require.Equal(t, StatusInstalled, status.Status)
-	require.True(t, status.PluginInstalled)
-	require.Equal(t, LocalClaudePlugin, status.PluginID)
-	require.Equal(t, "0.1.0", status.PluginVersion)
-	require.Equal(t, "local", status.PluginScope)
-	require.Equal(t, projectPath, status.PluginProject)
+	require.True(t, status.Plugin.Installed)
+	require.Equal(t, LocalClaudePlugin, status.Plugin.ID)
+	require.Equal(t, "0.1.0", status.Plugin.Version)
+	require.Equal(t, "local", status.Plugin.Scope)
+	require.Equal(t, projectPath, status.Plugin.Project)
 }
 
 func TestScanClaude_LocalStripePluginForDifferentProjectIsMissing(t *testing.T) {
@@ -90,7 +90,7 @@ func TestScanClaude_LocalStripePluginForDifferentProjectIsMissing(t *testing.T) 
 	status := testScannerWithWorkDir(home, filepath.Join(home, "current-project")).ScanClaude()
 
 	require.Equal(t, StatusMissing, status.Status)
-	require.False(t, status.PluginInstalled)
+	require.False(t, status.Plugin.Installed)
 }
 
 func TestScanClaude_MalformedPluginState(t *testing.T) {

--- a/pkg/agentsetup/claude_test.go
+++ b/pkg/agentsetup/claude_test.go
@@ -1,0 +1,124 @@
+package agentsetup
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanClaude_NotDetected(t *testing.T) {
+	scanner := Scanner{
+		LookPath: func(string) (string, error) { return "", errors.New("missing") },
+	}
+
+	status := scanner.ScanClaude()
+
+	require.Equal(t, ClientClaudeCode, status.Client)
+	require.False(t, status.Detected)
+	require.Equal(t, StatusNotDetected, status.Status)
+}
+
+func TestScanClaude_MissingPluginState(t *testing.T) {
+	home := t.TempDir()
+	scanner := testScanner(home)
+
+	status := scanner.ScanClaude()
+
+	require.True(t, status.Detected)
+	require.False(t, status.PluginInstalled)
+	require.Equal(t, StatusMissing, status.Status)
+	require.Equal(t, filepath.Join(home, ClaudePluginStatePath), status.PluginStatePath)
+}
+
+func TestScanClaude_OfficialPluginInstalled(t *testing.T) {
+	home := t.TempDir()
+	writeClaudePluginState(t, home, `{
+		"version": 2,
+		"plugins": {
+			"stripe@claude-plugins-official": [
+				{"scope": "user", "version": "2.4.1", "installPath": "/tmp/stripe"}
+			]
+		}
+	}`)
+
+	status := testScanner(home).ScanClaude()
+
+	require.Equal(t, StatusInstalled, status.Status)
+	require.True(t, status.PluginInstalled)
+	require.Equal(t, TargetClaudePlugin, status.PluginID)
+	require.Equal(t, "2.4.1", status.PluginVersion)
+	require.Equal(t, "user", status.PluginScope)
+}
+
+func TestScanClaude_LocalStripePluginInstalled(t *testing.T) {
+	home := t.TempDir()
+	projectPath := filepath.Join(home, "project")
+	writeClaudePluginState(t, home, `{
+		"version": 2,
+		"plugins": {
+			"stripe@stripe": [
+				{"scope": "local", "version": "0.1.0", "installPath": "/tmp/stripe", "projectPath": "`+projectPath+`"}
+			]
+		}
+	}`)
+
+	status := testScannerWithWorkDir(home, filepath.Join(projectPath, "subdir")).ScanClaude()
+
+	require.Equal(t, StatusInstalled, status.Status)
+	require.True(t, status.PluginInstalled)
+	require.Equal(t, LocalClaudePlugin, status.PluginID)
+	require.Equal(t, "0.1.0", status.PluginVersion)
+	require.Equal(t, "local", status.PluginScope)
+	require.Equal(t, projectPath, status.PluginProject)
+}
+
+func TestScanClaude_LocalStripePluginForDifferentProjectIsMissing(t *testing.T) {
+	home := t.TempDir()
+	projectPath := filepath.Join(home, "other-project")
+	writeClaudePluginState(t, home, `{
+		"version": 2,
+		"plugins": {
+			"stripe@stripe": [
+				{"scope": "local", "version": "0.1.0", "installPath": "/tmp/stripe", "projectPath": "`+projectPath+`"}
+			]
+		}
+	}`)
+
+	status := testScannerWithWorkDir(home, filepath.Join(home, "current-project")).ScanClaude()
+
+	require.Equal(t, StatusMissing, status.Status)
+	require.False(t, status.PluginInstalled)
+}
+
+func TestScanClaude_MalformedPluginState(t *testing.T) {
+	home := t.TempDir()
+	writeClaudePluginState(t, home, `{nope`)
+
+	status := testScanner(home).ScanClaude()
+
+	require.Equal(t, StatusError, status.Status)
+	require.Contains(t, status.Error, "parsing Claude plugin state")
+}
+
+func testScanner(home string) Scanner {
+	return testScannerWithWorkDir(home, home)
+}
+
+func testScannerWithWorkDir(home, workDir string) Scanner {
+	return Scanner{
+		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
+		ReadFile: os.ReadFile,
+		HomeDir:  func() (string, error) { return home, nil },
+		WorkDir:  func() (string, error) { return workDir, nil },
+	}
+}
+
+func writeClaudePluginState(t *testing.T, home string, body string) {
+	t.Helper()
+	path := filepath.Join(home, ClaudePluginStatePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+}

--- a/pkg/agentsetup/provider.go
+++ b/pkg/agentsetup/provider.go
@@ -1,0 +1,71 @@
+package agentsetup
+
+import (
+	"context"
+	"io"
+	"sort"
+	"strings"
+)
+
+const (
+	StatusNotDetected = "not_detected"
+	StatusInstalled   = "installed"
+	StatusMissing     = "missing"
+	StatusError       = "error"
+
+	ActionNone      = "none"
+	ActionInstall   = "install"
+	ActionReinstall = "reinstall"
+)
+
+// Provider detects and configures Stripe tooling for one AI coding client.
+type Provider interface {
+	ID() string
+	Detect() Status
+	Plan(Status, bool) Plan
+	Apply(context.Context, io.Writer, Plan) error
+}
+
+// DefaultProviders returns production setup providers keyed by client id.
+func DefaultProviders() map[string]Provider {
+	claude := NewClaudeProvider(DefaultScanner(), RunCommand)
+	return map[string]Provider{
+		claude.ID(): claude,
+	}
+}
+
+func SupportedProviderIDs(providers map[string]Provider) string {
+	ids := make([]string, 0, len(providers))
+	for id := range providers {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ",")
+}
+
+// Status is the read-only setup status for one AI coding client.
+type Status struct {
+	Client         string       `json:"client"`
+	DisplayName    string       `json:"display_name"`
+	Detected       bool         `json:"detected"`
+	ExecutablePath string       `json:"executable_path,omitempty"`
+	Plugin         PluginStatus `json:"plugin"`
+	Status         string       `json:"status"`
+	Error          string       `json:"error,omitempty"`
+}
+
+// PluginStatus is the plugin-specific part of a client setup status.
+type PluginStatus struct {
+	Installed bool   `json:"installed"`
+	ID        string `json:"id,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Scope     string `json:"scope,omitempty"`
+	Project   string `json:"project_path,omitempty"`
+	StatePath string `json:"state_path,omitempty"`
+}
+
+// Plan describes the next setup action for a provider.
+type Plan struct {
+	Action  string   `json:"action"`
+	Command []string `json:"command,omitempty"`
+}

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bufio"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,14 +29,14 @@ type agentSetupCmd struct {
 	jsonOutput bool
 	client     string
 
-	scanner    agentsetup.Scanner
-	runInstall agentsetup.RunCommandFunc
+	providers map[string]agentsetup.Provider
 }
 
 type agentSetupJSON struct {
-	agentsetup.ClaudeStatus
-	Action  string   `json:"action"`
-	Command []string `json:"command,omitempty"`
+	Status  string              `json:"status"`
+	Clients []agentsetup.Status `json:"clients"`
+	Actions []agentsetup.Plan   `json:"actions,omitempty"`
+	Errors  []string            `json:"errors,omitempty"`
 }
 
 func newAgentCmd() *agentCmd {
@@ -54,17 +53,18 @@ func newAgentCmd() *agentCmd {
 
 func newAgentSetupCmd() *agentSetupCmd {
 	asc := &agentSetupCmd{
-		client:     agentsetup.ClientClaudeCode,
-		scanner:    agentsetup.DefaultScanner(),
-		runInstall: agentsetup.RunCommand,
+		client:    agentsetup.ClientClaudeCode,
+		providers: agentsetup.DefaultProviders(),
 	}
 
 	asc.cmd = &cobra.Command{
-		Use:   "setup",
-		Short: "Install or check Stripe agent tooling",
-		Long:  "Install or check Stripe agent tooling. This POC supports Claude Code only.",
-		Args:  validators.NoArgs,
-		RunE:  asc.runSetup,
+		Use:           "setup",
+		Short:         "Install or check Stripe agent tooling",
+		Long:          "Install or check Stripe agent tooling. This POC supports Claude Code only.",
+		Args:          validators.NoArgs,
+		RunE:          asc.runSetup,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 	asc.cmd.Flags().BoolVar(&asc.statusOnly, "status", false, "Check installed agent tooling without making changes")
 	asc.cmd.Flags().BoolVarP(&asc.yes, "yes", "y", false, "Skip confirmation prompts")
@@ -76,18 +76,25 @@ func newAgentSetupCmd() *agentSetupCmd {
 }
 
 func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, args []string) error {
-	if asc.client != agentsetup.ClientClaudeCode {
-		return fmt.Errorf("unsupported agent client %q; this POC only supports %q", asc.client, agentsetup.ClientClaudeCode)
+	provider, ok := asc.providers[asc.client]
+	if !ok {
+		return fmt.Errorf("unsupported agent client %q; supported clients: %s", asc.client, agentsetup.SupportedProviderIDs(asc.providers))
 	}
 
-	status := asc.scanner.ScanClaude()
-	action, command := setupAction(status, asc.force)
+	status := provider.Detect()
+	plan := provider.Plan(status, asc.force)
 
 	if asc.jsonOutput {
-		return asc.writeJSON(cmd.OutOrStdout(), status, action, command)
+		if err := asc.writeJSON(cmd.OutOrStdout(), status, plan); err != nil {
+			return err
+		}
+		if status.Status == agentsetup.StatusError {
+			return errors.New(status.Error)
+		}
+		return nil
 	}
 
-	printClaudeStatus(cmd.OutOrStdout(), status)
+	printAgentStatus(cmd.OutOrStdout(), status)
 
 	if status.Status == agentsetup.StatusError {
 		return errors.New(status.Error)
@@ -96,16 +103,15 @@ func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	if !status.Detected {
-		fmt.Fprintln(cmd.OutOrStdout(), "Nothing to do. Claude Code was not detected.")
+		fmt.Fprintf(cmd.OutOrStdout(), "Nothing to do. %s was not detected.\n", status.DisplayName)
 		return nil
 	}
-	if action == "none" {
+	if plan.Action == agentsetup.ActionNone {
 		fmt.Fprintln(cmd.OutOrStdout(), "Nothing to do. Stripe agent tooling is already installed.")
 		return nil
 	}
 
-	name, installArgs := agentsetup.ClaudeInstallCommand()
-	fmt.Fprintf(cmd.OutOrStdout(), "Planned command: %s %s\n", name, strings.Join(installArgs, " "))
+	fmt.Fprintf(cmd.OutOrStdout(), "Planned command: %s\n", strings.Join(plan.Command, " "))
 
 	if !asc.yes {
 		if !isInteractiveTerminal() {
@@ -121,84 +127,56 @@ func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Fprintln(cmd.OutOrStdout(), "Installing Stripe agent tooling for Claude Code...")
-	if err := asc.runClaudeInstall(commandContextOrBackground(cmd), cmd.OutOrStdout(), name, installArgs, command); err != nil {
+	fmt.Fprintf(cmd.OutOrStdout(), "Installing Stripe agent tooling for %s...\n", status.DisplayName)
+	if err := provider.Apply(commandContextOrBackground(cmd), cmd.OutOrStdout(), plan); err != nil {
 		return err
 	}
-	fmt.Fprintln(cmd.OutOrStdout(), "Installed Stripe agent tooling for Claude Code.")
+	fmt.Fprintf(cmd.OutOrStdout(), "Installed Stripe agent tooling for %s.\n", status.DisplayName)
 	return nil
 }
 
-func (asc *agentSetupCmd) runClaudeInstall(ctx context.Context, out io.Writer, name string, installArgs []string, command []string) error {
-	if err := asc.runInstall(ctx, name, installArgs...); err == nil {
-		return nil
-	} else {
-		updateName, updateArgs := agentsetup.ClaudeMarketplaceUpdateCommand()
-		updateCommand := append([]string{updateName}, updateArgs...)
-		fmt.Fprintf(out, "Install failed. Updating Claude plugin marketplace and retrying: %s\n", strings.Join(updateCommand, " "))
-		if updateErr := asc.runInstall(ctx, updateName, updateArgs...); updateErr != nil {
-			return fmt.Errorf("running %q after install failed: %w", strings.Join(updateCommand, " "), updateErr)
-		}
-		if retryErr := asc.runInstall(ctx, name, installArgs...); retryErr != nil {
-			return fmt.Errorf("running %q after marketplace update: %w", strings.Join(command, " "), retryErr)
-		}
-		return nil
+func (asc *agentSetupCmd) writeJSON(w io.Writer, status agentsetup.Status, plan agentsetup.Plan) error {
+	result := agentSetupJSON{
+		Status:  status.Status,
+		Clients: []agentsetup.Status{status},
 	}
-}
-
-func setupAction(status agentsetup.ClaudeStatus, force bool) (string, []string) {
-	name, args := agentsetup.ClaudeInstallCommand()
-	command := append([]string{name}, args...)
-
-	switch {
-	case status.Status == agentsetup.StatusError:
-		return "error", nil
-	case !status.Detected:
-		return "none", nil
-	case status.PluginInstalled && force:
-		return "reinstall", command
-	case status.PluginInstalled:
-		return "none", nil
-	default:
-		return "install", command
+	if plan.Action != agentsetup.ActionNone {
+		result.Actions = []agentsetup.Plan{plan}
 	}
-}
+	if status.Status == agentsetup.StatusError {
+		result.Errors = []string{status.Error}
+	}
 
-func (asc *agentSetupCmd) writeJSON(w io.Writer, status agentsetup.ClaudeStatus, action string, command []string) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(agentSetupJSON{
-		ClaudeStatus: status,
-		Action:       action,
-		Command:      command,
-	})
+	return enc.Encode(result)
 }
 
-func printClaudeStatus(w io.Writer, status agentsetup.ClaudeStatus) {
+func printAgentStatus(w io.Writer, status agentsetup.Status) {
 	fmt.Fprintln(w, "Scanning for AI coding clients...")
 	if !status.Detected {
-		fmt.Fprintln(w, "  Claude Code: not detected")
+		fmt.Fprintf(w, "  %s: not detected\n", status.DisplayName)
 		return
 	}
 
 	if status.ExecutablePath != "" {
-		fmt.Fprintf(w, "  Claude Code: detected (%s)\n", status.ExecutablePath)
+		fmt.Fprintf(w, "  %s: detected (%s)\n", status.DisplayName, status.ExecutablePath)
 	} else {
-		fmt.Fprintln(w, "  Claude Code: detected")
+		fmt.Fprintf(w, "  %s: detected\n", status.DisplayName)
 	}
 
 	switch status.Status {
 	case agentsetup.StatusInstalled:
-		version := status.PluginVersion
+		version := status.Plugin.Version
 		if version == "" {
 			version = "unknown version"
 		}
-		fmt.Fprintf(w, "  Stripe plugin: installed as %s (%s", status.PluginID, version)
-		if status.PluginScope != "" {
-			fmt.Fprintf(w, ", %s", status.PluginScope)
+		fmt.Fprintf(w, "  Stripe plugin: installed as %s (%s", status.Plugin.ID, version)
+		if status.Plugin.Scope != "" {
+			fmt.Fprintf(w, ", %s", status.Plugin.Scope)
 		}
-		if status.PluginScope == "local" && status.PluginProject != "" {
-			fmt.Fprintf(w, ", project %s", status.PluginProject)
+		if status.Plugin.Scope == "local" && status.Plugin.Project != "" {
+			fmt.Fprintf(w, ", project %s", status.Plugin.Project)
 		}
 		fmt.Fprintln(w, ")")
 	case agentsetup.StatusError:

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -1,0 +1,223 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/stripe/stripe-cli/pkg/agentsetup"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+type agentCmd struct {
+	cmd *cobra.Command
+}
+
+type agentSetupCmd struct {
+	cmd *cobra.Command
+
+	statusOnly bool
+	yes        bool
+	force      bool
+	jsonOutput bool
+	client     string
+
+	scanner    agentsetup.Scanner
+	runInstall agentsetup.RunCommandFunc
+}
+
+type agentSetupJSON struct {
+	agentsetup.ClaudeStatus
+	Action  string   `json:"action"`
+	Command []string `json:"command,omitempty"`
+}
+
+func newAgentCmd() *agentCmd {
+	ac := &agentCmd{}
+	ac.cmd = &cobra.Command{
+		Use:   "agent",
+		Short: "Set up AI agent tooling",
+		Long:  "Set up AI agent tooling for Stripe development.",
+		Args:  validators.NoArgs,
+	}
+	ac.cmd.AddCommand(newAgentSetupCmd().cmd)
+	return ac
+}
+
+func newAgentSetupCmd() *agentSetupCmd {
+	asc := &agentSetupCmd{
+		client:     agentsetup.ClientClaudeCode,
+		scanner:    agentsetup.DefaultScanner(),
+		runInstall: agentsetup.RunCommand,
+	}
+
+	asc.cmd = &cobra.Command{
+		Use:   "setup",
+		Short: "Install or check Stripe agent tooling",
+		Long:  "Install or check Stripe agent tooling. This POC supports Claude Code only.",
+		Args:  validators.NoArgs,
+		RunE:  asc.runSetup,
+	}
+	asc.cmd.Flags().BoolVar(&asc.statusOnly, "status", false, "Check installed agent tooling without making changes")
+	asc.cmd.Flags().BoolVarP(&asc.yes, "yes", "y", false, "Skip confirmation prompts")
+	asc.cmd.Flags().BoolVar(&asc.force, "force", false, "Reinstall even when agent tooling is already installed")
+	asc.cmd.Flags().StringVar(&asc.client, "client", agentsetup.ClientClaudeCode, "Agent client to set up")
+	asc.cmd.Flags().BoolVar(&asc.jsonOutput, "json", false, "Write machine-readable status output")
+
+	return asc
+}
+
+func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, args []string) error {
+	if asc.client != agentsetup.ClientClaudeCode {
+		return fmt.Errorf("unsupported agent client %q; this POC only supports %q", asc.client, agentsetup.ClientClaudeCode)
+	}
+
+	status := asc.scanner.ScanClaude()
+	action, command := setupAction(status, asc.force)
+
+	if asc.jsonOutput {
+		return asc.writeJSON(cmd.OutOrStdout(), status, action, command)
+	}
+
+	printClaudeStatus(cmd.OutOrStdout(), status)
+
+	if status.Status == agentsetup.StatusError {
+		return errors.New(status.Error)
+	}
+	if asc.statusOnly {
+		return nil
+	}
+	if !status.Detected {
+		fmt.Fprintln(cmd.OutOrStdout(), "Nothing to do. Claude Code was not detected.")
+		return nil
+	}
+	if action == "none" {
+		fmt.Fprintln(cmd.OutOrStdout(), "Nothing to do. Stripe agent tooling is already installed.")
+		return nil
+	}
+
+	name, installArgs := agentsetup.ClaudeInstallCommand()
+	fmt.Fprintf(cmd.OutOrStdout(), "Planned command: %s %s\n", name, strings.Join(installArgs, " "))
+
+	if !asc.yes {
+		if !isInteractiveTerminal() {
+			return fmt.Errorf("installation requires confirmation; rerun with --yes to install without prompting")
+		}
+		confirmed, err := confirmAgentSetup(cmd.InOrStdin(), cmd.OutOrStdout())
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Fprintln(cmd.OutOrStdout(), "Canceled. No changes made.")
+			return nil
+		}
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Installing Stripe agent tooling for Claude Code...")
+	if err := asc.runClaudeInstall(commandContextOrBackground(cmd), cmd.OutOrStdout(), name, installArgs, command); err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Installed Stripe agent tooling for Claude Code.")
+	return nil
+}
+
+func (asc *agentSetupCmd) runClaudeInstall(ctx context.Context, out io.Writer, name string, installArgs []string, command []string) error {
+	if err := asc.runInstall(ctx, name, installArgs...); err == nil {
+		return nil
+	} else {
+		updateName, updateArgs := agentsetup.ClaudeMarketplaceUpdateCommand()
+		updateCommand := append([]string{updateName}, updateArgs...)
+		fmt.Fprintf(out, "Install failed. Updating Claude plugin marketplace and retrying: %s\n", strings.Join(updateCommand, " "))
+		if updateErr := asc.runInstall(ctx, updateName, updateArgs...); updateErr != nil {
+			return fmt.Errorf("running %q after install failed: %w", strings.Join(updateCommand, " "), updateErr)
+		}
+		if retryErr := asc.runInstall(ctx, name, installArgs...); retryErr != nil {
+			return fmt.Errorf("running %q after marketplace update: %w", strings.Join(command, " "), retryErr)
+		}
+		return nil
+	}
+}
+
+func setupAction(status agentsetup.ClaudeStatus, force bool) (string, []string) {
+	name, args := agentsetup.ClaudeInstallCommand()
+	command := append([]string{name}, args...)
+
+	switch {
+	case status.Status == agentsetup.StatusError:
+		return "error", nil
+	case !status.Detected:
+		return "none", nil
+	case status.PluginInstalled && force:
+		return "reinstall", command
+	case status.PluginInstalled:
+		return "none", nil
+	default:
+		return "install", command
+	}
+}
+
+func (asc *agentSetupCmd) writeJSON(w io.Writer, status agentsetup.ClaudeStatus, action string, command []string) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(agentSetupJSON{
+		ClaudeStatus: status,
+		Action:       action,
+		Command:      command,
+	})
+}
+
+func printClaudeStatus(w io.Writer, status agentsetup.ClaudeStatus) {
+	fmt.Fprintln(w, "Scanning for AI coding clients...")
+	if !status.Detected {
+		fmt.Fprintln(w, "  Claude Code: not detected")
+		return
+	}
+
+	if status.ExecutablePath != "" {
+		fmt.Fprintf(w, "  Claude Code: detected (%s)\n", status.ExecutablePath)
+	} else {
+		fmt.Fprintln(w, "  Claude Code: detected")
+	}
+
+	switch status.Status {
+	case agentsetup.StatusInstalled:
+		version := status.PluginVersion
+		if version == "" {
+			version = "unknown version"
+		}
+		fmt.Fprintf(w, "  Stripe plugin: installed as %s (%s", status.PluginID, version)
+		if status.PluginScope != "" {
+			fmt.Fprintf(w, ", %s", status.PluginScope)
+		}
+		if status.PluginScope == "local" && status.PluginProject != "" {
+			fmt.Fprintf(w, ", project %s", status.PluginProject)
+		}
+		fmt.Fprintln(w, ")")
+	case agentsetup.StatusError:
+		fmt.Fprintf(w, "  Stripe plugin: error (%s)\n", status.Error)
+	default:
+		fmt.Fprintln(w, "  Stripe plugin: missing")
+	}
+}
+
+func confirmAgentSetup(r io.Reader, w io.Writer) (bool, error) {
+	fmt.Fprint(w, "Install now? [y/N] ")
+	line, err := bufio.NewReader(r).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, fmt.Errorf("reading confirmation: %w", err)
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
+}
+
+func isInteractiveTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/agentsetup"
+)
+
+func TestAgentSetupStatusDoesNotInstall(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, claudeMissingPluginScanner(t), func(context.Context, string, ...string) error {
+		t.Fatal("installer should not run in --status mode")
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd, "--status")
+
+	require.NoError(t, err)
+	require.Contains(t, output, "Claude Code: detected")
+	require.Contains(t, output, "Stripe plugin: missing")
+}
+
+func TestAgentSetupUnsupportedClient(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, claudeMissingPluginScanner(t), nil)
+
+	_, err := executeCommand(setup.cmd, "--client", "cursor")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported agent client")
+}
+
+func TestAgentSetupJSONReportsActionWithoutInstalling(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, claudeMissingPluginScanner(t), func(context.Context, string, ...string) error {
+		t.Fatal("installer should not run in --json mode")
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd, "--json")
+
+	require.NoError(t, err)
+
+	var result agentSetupJSON
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	require.True(t, result.Detected)
+	require.False(t, result.PluginInstalled)
+	require.Equal(t, "install", result.Action)
+	require.Equal(t, []string{"claude", "plugin", "install", agentsetup.TargetClaudePlugin}, result.Command)
+}
+
+func TestAgentSetupForceYesInvokesInstallerWhenInstalled(t *testing.T) {
+	var called bool
+	setup := newTestAgentSetupCmd(t, claudeInstalledPluginScanner(t), func(ctx context.Context, name string, args ...string) error {
+		called = true
+		require.Equal(t, "claude", name)
+		require.Equal(t, []string{"plugin", "install", agentsetup.TargetClaudePlugin}, args)
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd, "--force", "--yes")
+
+	require.NoError(t, err)
+	require.True(t, called)
+	require.Contains(t, output, "Installing Stripe agent tooling")
+	require.Contains(t, output, "Installed Stripe agent tooling")
+}
+
+func TestAgentSetupRetriesAfterMarketplaceUpdate(t *testing.T) {
+	var calls []string
+	setup := newTestAgentSetupCmd(t, claudeMissingPluginScanner(t), func(ctx context.Context, name string, args ...string) error {
+		call := name
+		for _, arg := range args {
+			call += " " + arg
+		}
+		calls = append(calls, call)
+		if len(calls) == 1 {
+			return fmt.Errorf("plugin not found")
+		}
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd, "--yes")
+
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"claude plugin install " + agentsetup.TargetClaudePlugin,
+		"claude plugin marketplace update " + agentsetup.ClaudeMarketplace,
+		"claude plugin install " + agentsetup.TargetClaudePlugin,
+	}, calls)
+	require.Contains(t, output, "Updating Claude plugin marketplace and retrying")
+	require.Contains(t, output, "Installed Stripe agent tooling")
+}
+
+func TestAgentSetupNoClaudeDoesNotFail(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, agentsetup.Scanner{
+		LookPath: func(string) (string, error) { return "", errors.New("not found") },
+	}, func(context.Context, string, ...string) error {
+		t.Fatal("installer should not run when Claude Code is not detected")
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd)
+
+	require.NoError(t, err)
+	require.Contains(t, output, "Claude Code: not detected")
+	require.Contains(t, output, "Nothing to do")
+}
+
+func newTestAgentSetupCmd(t *testing.T, scanner agentsetup.Scanner, runInstall agentsetup.RunCommandFunc) *agentSetupCmd {
+	t.Helper()
+	setup := newAgentSetupCmd()
+	setup.scanner = scanner
+	if runInstall != nil {
+		setup.runInstall = runInstall
+	}
+	setup.cmd.SetContext(context.Background())
+	return setup
+}
+
+func claudeMissingPluginScanner(t *testing.T) agentsetup.Scanner {
+	t.Helper()
+	home := t.TempDir()
+	return agentsetup.Scanner{
+		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
+		ReadFile: os.ReadFile,
+		HomeDir:  func() (string, error) { return home, nil },
+	}
+}
+
+func claudeInstalledPluginScanner(t *testing.T) agentsetup.Scanner {
+	t.Helper()
+	home := t.TempDir()
+	statePath := filepath.Join(home, agentsetup.ClaudePluginStatePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(statePath), 0755))
+	require.NoError(t, os.WriteFile(statePath, []byte(`{
+		"version": 2,
+		"plugins": {
+			"stripe@claude-plugins-official": [
+				{"scope": "user", "version": "2.4.1", "installPath": "/tmp/stripe"}
+			]
+		}
+	}`), 0600))
+	return agentsetup.Scanner{
+		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
+		ReadFile: os.ReadFile,
+		HomeDir:  func() (string, error) { return home, nil },
+	}
+}

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -48,10 +48,33 @@ func TestAgentSetupJSONReportsActionWithoutInstalling(t *testing.T) {
 
 	var result agentSetupJSON
 	require.NoError(t, json.Unmarshal([]byte(output), &result))
-	require.True(t, result.Detected)
-	require.False(t, result.PluginInstalled)
-	require.Equal(t, "install", result.Action)
-	require.Equal(t, []string{"claude", "plugin", "install", agentsetup.TargetClaudePlugin}, result.Command)
+	require.Equal(t, agentsetup.StatusMissing, result.Status)
+	require.Len(t, result.Clients, 1)
+	require.True(t, result.Clients[0].Detected)
+	require.False(t, result.Clients[0].Plugin.Installed)
+	require.Len(t, result.Actions, 1)
+	require.Equal(t, agentsetup.ActionInstall, result.Actions[0].Action)
+	require.Equal(t, []string{"claude", "plugin", "install", agentsetup.TargetClaudePlugin}, result.Actions[0].Command)
+}
+
+func TestAgentSetupJSONPropagatesScanError(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, agentsetup.Scanner{
+		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
+		HomeDir:  func() (string, error) { return "", errors.New("home failed") },
+	}, func(context.Context, string, ...string) error {
+		t.Fatal("installer should not run when scan fails")
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd, "--json")
+
+	require.Error(t, err)
+
+	var result agentSetupJSON
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	require.Equal(t, agentsetup.StatusError, result.Status)
+	require.Len(t, result.Errors, 1)
+	require.Contains(t, result.Errors[0], "home failed")
 }
 
 func TestAgentSetupForceYesInvokesInstallerWhenInstalled(t *testing.T) {
@@ -115,10 +138,8 @@ func TestAgentSetupNoClaudeDoesNotFail(t *testing.T) {
 func newTestAgentSetupCmd(t *testing.T, scanner agentsetup.Scanner, runInstall agentsetup.RunCommandFunc) *agentSetupCmd {
 	t.Helper()
 	setup := newAgentSetupCmd()
-	setup.scanner = scanner
-	if runInstall != nil {
-		setup.runInstall = runInstall
-	}
+	claude := agentsetup.NewClaudeProvider(scanner, runInstall)
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
 	setup.cmd.SetContext(context.Background())
 	return setup
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -242,6 +242,7 @@ func init() {
 	// also, bind flags to the environment variables
 	bindEnv("project-name", "STRIPE_PROJECT_NAME")
 
+	rootCmd.AddCommand(newAgentCmd().cmd)
 	rootCmd.AddCommand(cmddocs.New().WithOptions(cmddocs.WithConfig(&Config)).Root())
 	rootCmd.AddCommand(newCompletionCmd().cmd)
 	rootCmd.AddCommand(newConfigCmd().cmd)


### PR DESCRIPTION
### Notify
N/A

### Summary
Adds a native `stripe agent setup` POC for Claude Code. The command detects Claude Code installation, checks Claude plugin state, respects local plugin project scope, and installs the documented Stripe Claude plugin with a marketplace-update retry if Claude reports stale marketplace metadata.

### Motivation
The design doc proposes `stripe agent setup` as a plugin-first setup path. This keeps the first implementation narrowly scoped to Claude Code while making detection read local installed state rather than whether the Stripe CLI is running inside an agent.

### Test plan
- `go test ./pkg/agentsetup`
- `go test ./pkg/cmd -run 'TestAgentSetup' -count=1`

### Rollout/revert plan
- Safe to revert. This adds a new command path and does not alter existing command behavior.

### Monitoring plan
- Change has no runtime impact unless users explicitly run `stripe agent setup`.