### PR TITLE
Allow `stripe resources help` as an alias for `stripe resources --help`

### DIFF
--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -18,7 +18,7 @@ func newResourcesCmd() *resourcesCmd {
 
 	rc.cmd = &cobra.Command{
 		Use:   "resources",
-		Args:  validators.NoArgs,
+		Args:  rc.args,
 		Short: "List resource commands",
 		RunE:  rc.run,
 	}
@@ -27,6 +27,14 @@ func newResourcesCmd() *resourcesCmd {
 	})
 
 	return rc
+}
+
+func (rc *resourcesCmd) args(cmd *cobra.Command, args []string) error {
+	if len(args) == 1 && args[0] == "help" {
+		return nil
+	}
+
+	return validators.NoArgs(cmd, args)
 }
 
 func (rc *resourcesCmd) run(cmd *cobra.Command, _ []string) error {

--- a/pkg/cmd/resources_test.go
+++ b/pkg/cmd/resources_test.go
@@ -51,6 +51,20 @@ func TestResourcesHidesDatabases(t *testing.T) {
 	require.NotContains(t, output, "databases")
 }
 
+func TestResourcesHelpAlias(t *testing.T) {
+	helpOutput, err := executeCommand(newResourcesTestRoot(t), "resources", "--help")
+	require.NoError(t, err)
+
+	aliasOutput, err := executeCommand(newResourcesTestRoot(t), "resources", "help")
+	require.NoError(t, err)
+	require.Equal(t, helpOutput, aliasOutput)
+}
+
+func TestResourcesRejectsUnexpectedPositionalArgs(t *testing.T) {
+	_, err := executeCommand(newResourcesTestRoot(t), "resources", "foo")
+	require.EqualError(t, err, "`stripe resources` does not take any positional arguments. See `stripe resources --help` for supported flags and usage")
+}
+
 func TestResourcesListAliasedName(t *testing.T) {
 	output, err := executeCommand(newResourcesTestRoot(t), "resources")
 	require.NoError(t, err)


### PR DESCRIPTION
Users naturally type `stripe resources help` expecting help output. Previously this returned a confusing "no positional arguments" error. Now it prints the same output as `--help` while still rejecting other unexpected positional args.


<img width="741" height="450" alt="image" src="https://github.com/user-attachments/assets/e7ddb051-8625-489e-912b-5eb4e562e4a8" />

Motivation:
https://stripe.slack.com/archives/CFP9HVB7D/p1782857272610849

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
