### PR TITLE
Add plugin install/uninstall/upgrade analytics

### DIFF
--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -164,8 +164,10 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if prevVersion != "" {
+		sendPluginLifecycleEvent(cmd.Context(), "Plugin Upgraded", version)
 		fmt.Println(color.Green(fmt.Sprintf("✔ %s from v%s to v%s.", versionChangeVerb(prevVersion, version), prevVersion, version)))
 	} else {
+		sendPluginLifecycleEvent(cmd.Context(), "Plugin Installed", version)
 		fmt.Println(color.Green(fmt.Sprintf("✔ installation of v%s complete.", version)))
 	}
 	postinstall.PrintTips(os.Stdout, plugin.Shortname)
@@ -187,6 +189,18 @@ func (ic *InstallCmd) setInstallTelemetryMetadata(ctx context.Context, pluginNam
 	if telemetryMetadata != nil {
 		telemetryMetadata.SetPluginName(pluginName)
 	}
+}
+
+// sendPluginLifecycleEvent sends a telemetry event for a plugin install, upgrade, or uninstall.
+func sendPluginLifecycleEvent(ctx context.Context, eventName, pluginVersion string) {
+	telemetryClient := stripe.GetTelemetryClient(ctx)
+	if telemetryClient == nil {
+		return
+	}
+	if m := stripe.GetEventMetadata(ctx); m != nil {
+		m.SetPluginVersion(pluginVersion)
+	}
+	telemetryClient.SendEvent(ctx, eventName, pluginVersion)
 }
 
 func withSIGTERMCancel(ctx context.Context, onCancel func()) context.Context {

--- a/pkg/cmd/plugin/uninstall.go
+++ b/pkg/cmd/plugin/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/plugins"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
@@ -51,9 +52,16 @@ func (uc *UninstallCmd) runUninstallCmd(cmd *cobra.Command, args []string) error
 
 	plugin := plugins.Plugin{Shortname: args[0]}
 
+	if m := stripe.GetEventMetadata(cmd.Context()); m != nil {
+		m.SetPluginName(plugin.Shortname)
+	}
+
+	installedVersion := plugin.InstalledVersion(uc.cfg, uc.fs)
+
 	err := plugin.Uninstall(ctx, uc.cfg, uc.fs)
 
 	if err == nil {
+		sendPluginLifecycleEvent(cmd.Context(), "Plugin Uninstalled", installedVersion)
 		color := ansi.Color(os.Stdout)
 		successMsg := fmt.Sprintf("✔ %s has been uninstalled.", plugin.Shortname)
 		fmt.Println(color.Green(successMsg))

--- a/pkg/cmd/plugin/upgrade.go
+++ b/pkg/cmd/plugin/upgrade.go
@@ -64,6 +64,10 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
+	if m := stripe.GetEventMetadata(cmd.Context()); m != nil {
+		m.SetPluginName(args[0])
+	}
+
 	resolvedPlugin, err := plugins.ResolvePluginForUpgrade(ctx, uc.cfg, uc.fs, args[0], uc.apiBaseURL, dashboardBaseURL)
 	if err != nil {
 		return err
@@ -86,6 +90,8 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	if err := resolvedPlugin.Install(ctx, uc.cfg, uc.fs, uc.apiBaseURL, dashboardBaseURL); err != nil {
 		return err
 	}
+
+	sendPluginLifecycleEvent(cmd.Context(), "Plugin Upgraded", version)
 
 	if prevVersion != "" {
 		fmt.Println(color.Green(fmt.Sprintf("✔ %s from v%s to v%s.", versionChangeVerb(prevVersion, version), prevVersion, version)))

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -78,6 +78,7 @@ var rootCmd = &cobra.Command{
 				telemetryMetadata.SetCommandPath(resolvePluginTelemetryCommandPath(cmd, os.Args))
 			}
 			telemetryMetadata.SetMerchant(merchant)
+			telemetryMetadata.SetMachineUUID(Config.GetMachineUUID())
 			telemetryMetadata.SetUserAgent(useragent.GetEncodedUserAgent())
 
 			flags := []string{}
@@ -206,6 +207,12 @@ var keysToReBind []string
 // ReBindKeys applies the value found in viper config to the cobra flag when viper has a value (possibly from env)
 func ReBindKeys() {
 	for _, k := range keysToReBind {
+		// If the flag was explicitly set on the command line, don't override it.
+		// viper.Reset() (called when writing config) clears the pflag binding, which
+		// would otherwise prevent viper from respecting flag > env precedence.
+		if f := rootCmd.PersistentFlags().Lookup(k); f != nil && f.Changed {
+			continue
+		}
 		if viper.IsSet(k) {
 			rootCmd.Flags().Set(k, viper.GetString(k))
 		}

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/cmd/resource"
@@ -122,6 +123,38 @@ func TestReadProjectFlagHasPrecedence(t *testing.T) {
 	executeCommand(rootCmd, "version", "--project-name", "from-flag")
 
 	require.Equal(t, "from-flag", Config.Profile.ProfileName)
+}
+
+func TestReBindKeysSkipsChangedFlags(t *testing.T) {
+	// Reproduce the CI failure: viper.Reset() (called from GetMachineUUID → WriteConfigField)
+	// clears the pflag binding. Without it, viper falls back to the env var value and
+	// ReBindKeys overwrites an explicitly-passed --project-name flag.
+	t.Setenv("STRIPE_PROJECT_NAME", "from-env")
+
+	// Simulate viper.Reset() having been called — clears the pflag binding so
+	// viper.GetString("project-name") returns the env var value, not the flag value.
+	viper.Reset()
+	viper.BindEnv("project-name", "STRIPE_PROJECT_NAME")
+	t.Cleanup(func() {
+		// Restore bindings so subsequent tests still work.
+		viper.BindPFlag("project-name", rootCmd.PersistentFlags().Lookup("project-name"))
+		viper.BindEnv("project-name", "STRIPE_PROJECT_NAME")
+	})
+
+	flag := rootCmd.PersistentFlags().Lookup("project-name")
+	origValue := flag.Value.String()
+	origChanged := flag.Changed
+	defer func() {
+		flag.Value.Set(origValue)
+		flag.Changed = origChanged
+	}()
+
+	flag.Value.Set("from-flag")
+	flag.Changed = true
+
+	ReBindKeys()
+
+	require.Equal(t, "from-flag", flag.Value.String())
 }
 
 func TestV2BillingOverrides(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/google/uuid"
 	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -49,6 +50,7 @@ type IConfig interface {
 	RemoveAllAuthFields() error
 	WriteConfigField(field string, value interface{}) error
 	GetInstalledPlugins() []string
+	GetMachineUUID() string
 }
 
 // Config handles all overall configuration for the CLI
@@ -319,6 +321,19 @@ func (c *Config) GetInstalledPlugins() []string {
 	runtimeViper := viper.GetViper()
 
 	return runtimeViper.GetStringSlice("installed_plugins")
+}
+
+// GetMachineUUID returns the persistent machine UUID from config,
+// generating and saving one if it doesn't exist.
+func (c *Config) GetMachineUUID() string {
+	runtimeViper := viper.GetViper()
+	id := runtimeViper.GetString("machine_uuid")
+	if id != "" {
+		return id
+	}
+	id = uuid.NewString()
+	_ = c.WriteConfigField("machine_uuid", id)
+	return id
 }
 
 func (c *Config) SwitchProfile(profileName string) error {

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -175,7 +175,6 @@ func (e *CLIAnalyticsEventMetadata) SetMachineUUID(machineUUID string) {
 	e.MachineUUID = machineUUID
 }
 
-
 // SendAPIRequestEvent is a special function for API requests
 func (a *AnalyticsTelemetryClient) SendAPIRequestEvent(ctx context.Context, requestID string, livemode bool) (*http.Response, error) {
 	a.wg.Add(1)

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -42,9 +42,12 @@ type CLIAnalyticsEventMetadata struct {
 	CommandPath       string `url:"command_path"`               // the command or gRPC method that initiated this request
 	CommandFlags      string `url:"command_flags"`              // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
 	PluginName        string `url:"plugin_name,omitempty"`      // the plugin being installed, when relevant
+	PluginVersion     string `url:"plugin_version,omitempty"`   // the version of the plugin being installed/uninstalled/upgraded
 	Merchant          string `url:"merchant"`                   // the merchant ID: ex. acct_xxxx
 	CLIVersion        string `url:"cli_version"`                // the version of the CLI
 	OS                string `url:"os"`                         // the OS of the system
+	Arch              string `url:"arch"`                       // the CPU architecture of the system
+	MachineUUID       string `url:"machine_uuid,omitempty"`     // the persistent machine UUID
 	GeneratedResource bool   `url:"generated_resource"`         // whether or not this was a generated resource
 	AIAgent           string `url:"ai_agent,omitempty"`         // the AI coding agent that invoked the CLI, if any
 	InstallMethod     string `url:"install_method,omitempty"`   // how the CLI was installed
@@ -80,6 +83,7 @@ func NewEventMetadata() *CLIAnalyticsEventMetadata {
 		InvocationID: uuid.NewString(),
 		CLIVersion:   version.Version,
 		OS:           runtime.GOOS,
+		Arch:         runtime.GOARCH,
 		AIAgent:      useragent.DetectAIAgent(os.Getenv),
 		InstallMethod: useragent.DetectInstallMethod(
 			os.Getenv,
@@ -160,6 +164,17 @@ func (e *CLIAnalyticsEventMetadata) SetCommandFlags(commandFlags string) {
 func (e *CLIAnalyticsEventMetadata) SetPluginName(pluginName string) {
 	e.PluginName = pluginName
 }
+
+// SetPluginVersion sets the plugin version on the CLIAnalyticsEventContext object
+func (e *CLIAnalyticsEventMetadata) SetPluginVersion(pluginVersion string) {
+	e.PluginVersion = pluginVersion
+}
+
+// SetMachineUUID sets the persistent machine UUID on the CLIAnalyticsEventContext object
+func (e *CLIAnalyticsEventMetadata) SetMachineUUID(machineUUID string) {
+	e.MachineUUID = machineUUID
+}
+
 
 // SendAPIRequestEvent is a special function for API requests
 func (a *AnalyticsTelemetryClient) SendAPIRequestEvent(ctx context.Context, requestID string, livemode bool) (*http.Response, error) {


### PR DESCRIPTION
Track plugin lifecycle events (Plugin Installed, Plugin Upgraded, Plugin Uninstalled) with name, version, CLI version, OS, CPU arch, a persistent machine UUID stored in config.toml, and merchant ID when authenticated.

Here's where the machine UUID is in the config file, we'll eventually use this in more than just analytics:
```
color = ''
installed_plugins = []
machine_uuid = '44d7bb37-055e-4aa3-9306-a39d7d2e083b'
project-name = 'default'
...
```

I verified the events in our backend logs.