### PR TITLE
Add `stripe agent setup` CLI command 

### DIFF
--- a/pkg/agentsetup/claude.go
+++ b/pkg/agentsetup/claude.go
@@ -91,7 +91,7 @@ func (p ClaudeProvider) Apply(ctx context.Context, out io.Writer, plan Plan) err
 
 	updateName, updateArgs := ClaudeMarketplaceUpdateCommand()
 	updateCommand := append([]string{updateName}, updateArgs...)
-	fmt.Fprintf(out, "Install failed. Updating Claude plugin marketplace and retrying: %s\n", strings.Join(updateCommand, " "))
+	fmt.Fprintf(out, "First install failed. Updating Claude plugin marketplace and retrying: %s\n", strings.Join(updateCommand, " "))
 	if updateErr := p.RunCommand(ctx, updateName, updateArgs...); updateErr != nil {
 		return fmt.Errorf("running %q after install failed: %w", strings.Join(updateCommand, " "), updateErr)
 	}

--- a/pkg/agentsetup/claude.go
+++ b/pkg/agentsetup/claude.go
@@ -1,0 +1,210 @@
+// Package agentsetup contains helpers for detecting and configuring AI coding
+// agent integrations.
+package agentsetup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	ClientClaudeCode      = "claude-code"
+	ClaudeBinaryName      = "claude"
+	TargetClaudePlugin    = "stripe@claude-plugins-official"
+	LocalClaudePlugin     = "stripe@stripe"
+	ClaudeMarketplace     = "claude-plugins-official"
+	ClaudePluginStatePath = ".claude/plugins/installed_plugins.json"
+
+	StatusNotDetected = "not_detected"
+	StatusInstalled   = "installed"
+	StatusMissing     = "missing"
+	StatusError       = "error"
+)
+
+// LookPathFunc matches exec.LookPath and exists to make detection testable.
+type LookPathFunc func(string) (string, error)
+
+// ReadFileFunc matches os.ReadFile and exists to make status parsing testable.
+type ReadFileFunc func(string) ([]byte, error)
+
+// HomeDirFunc matches os.UserHomeDir and exists to make status parsing testable.
+type HomeDirFunc func() (string, error)
+
+// WorkDirFunc matches os.Getwd and exists to make local plugin scope testable.
+type WorkDirFunc func() (string, error)
+
+// RunCommandFunc runs a command. The production implementation streams stdio.
+type RunCommandFunc func(context.Context, string, ...string) error
+
+// Scanner scans local agent installations without mutating them.
+type Scanner struct {
+	LookPath LookPathFunc
+	ReadFile ReadFileFunc
+	HomeDir  HomeDirFunc
+	WorkDir  WorkDirFunc
+}
+
+// ClaudeStatus is the read-only setup status for Claude Code.
+type ClaudeStatus struct {
+	Client          string `json:"client"`
+	Detected        bool   `json:"detected"`
+	ExecutablePath  string `json:"executable_path,omitempty"`
+	PluginInstalled bool   `json:"plugin_installed"`
+	PluginID        string `json:"plugin_id,omitempty"`
+	PluginVersion   string `json:"plugin_version,omitempty"`
+	PluginScope     string `json:"plugin_scope,omitempty"`
+	PluginProject   string `json:"plugin_project_path,omitempty"`
+	PluginStatePath string `json:"plugin_state_path,omitempty"`
+	Status          string `json:"status"`
+	Error           string `json:"error,omitempty"`
+}
+
+type installedPluginState struct {
+	Version int                             `json:"version"`
+	Plugins map[string][]installedPluginRef `json:"plugins"`
+}
+
+type installedPluginRef struct {
+	Scope       string `json:"scope"`
+	Version     string `json:"version"`
+	Installed   string `json:"installPath"`
+	ProjectPath string `json:"projectPath"`
+}
+
+// DefaultScanner returns a Scanner backed by the real OS.
+func DefaultScanner() Scanner {
+	return Scanner{
+		LookPath: exec.LookPath,
+		ReadFile: os.ReadFile,
+		HomeDir:  os.UserHomeDir,
+		WorkDir:  os.Getwd,
+	}
+}
+
+// ScanClaude returns Claude Code installation and Stripe plugin status.
+func (s Scanner) ScanClaude() ClaudeStatus {
+	s = s.withDefaults()
+
+	status := ClaudeStatus{
+		Client: ClientClaudeCode,
+		Status: StatusNotDetected,
+	}
+
+	claudePath, err := s.LookPath(ClaudeBinaryName)
+	if err != nil {
+		return status
+	}
+	status.Detected = true
+	status.ExecutablePath = claudePath
+	status.Status = StatusMissing
+
+	home, err := s.HomeDir()
+	if err != nil {
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("locating home directory: %v", err)
+		return status
+	}
+	status.PluginStatePath = filepath.Join(home, ClaudePluginStatePath)
+
+	body, err := s.ReadFile(status.PluginStatePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return status
+		}
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("reading Claude plugin state: %v", err)
+		return status
+	}
+
+	var pluginState installedPluginState
+	if err := json.Unmarshal(body, &pluginState); err != nil {
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("parsing Claude plugin state: %v", err)
+		return status
+	}
+
+	workDir, err := s.WorkDir()
+	if err != nil {
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("locating working directory: %v", err)
+		return status
+	}
+
+	if id, ref, ok := findStripePlugin(pluginState.Plugins, workDir); ok {
+		status.PluginInstalled = true
+		status.PluginID = id
+		status.PluginVersion = ref.Version
+		status.PluginScope = ref.Scope
+		status.PluginProject = ref.ProjectPath
+		status.Status = StatusInstalled
+	}
+
+	return status
+}
+
+// ClaudeInstallCommand returns the command used to install the Stripe Claude
+// Code plugin.
+func ClaudeInstallCommand() (string, []string) {
+	return ClaudeBinaryName, []string{"plugin", "install", TargetClaudePlugin}
+}
+
+// ClaudeMarketplaceUpdateCommand returns the command used to refresh Claude's
+// official plugin marketplace metadata.
+func ClaudeMarketplaceUpdateCommand() (string, []string) {
+	return ClaudeBinaryName, []string{"plugin", "marketplace", "update", ClaudeMarketplace}
+}
+
+// RunCommand streams a command through the current process stdio.
+func RunCommand(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (s Scanner) withDefaults() Scanner {
+	defaults := DefaultScanner()
+	if s.LookPath == nil {
+		s.LookPath = defaults.LookPath
+	}
+	if s.ReadFile == nil {
+		s.ReadFile = defaults.ReadFile
+	}
+	if s.HomeDir == nil {
+		s.HomeDir = defaults.HomeDir
+	}
+	if s.WorkDir == nil {
+		s.WorkDir = defaults.WorkDir
+	}
+	return s
+}
+
+func findStripePlugin(plugins map[string][]installedPluginRef, workDir string) (string, installedPluginRef, bool) {
+	for _, id := range []string{TargetClaudePlugin, LocalClaudePlugin} {
+		for _, ref := range plugins[id] {
+			if pluginVisibleInWorkDir(ref, workDir) {
+				return id, ref, true
+			}
+		}
+	}
+	return "", installedPluginRef{}, false
+}
+
+func pluginVisibleInWorkDir(ref installedPluginRef, workDir string) bool {
+	if ref.Scope != "local" || ref.ProjectPath == "" {
+		return true
+	}
+
+	rel, err := filepath.Rel(ref.ProjectPath, workDir)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && !filepath.IsAbs(rel))
+}

--- a/pkg/agentsetup/claude.go
+++ b/pkg/agentsetup/claude.go
@@ -4,37 +4,28 @@ package agentsetup
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
+	"time"
 )
 
 const (
-	ClientClaudeCode      = "claude-code"
-	ClaudeBinaryName      = "claude"
-	TargetClaudePlugin    = "stripe@claude-plugins-official"
-	LocalClaudePlugin     = "stripe@stripe"
-	ClaudeMarketplace     = "claude-plugins-official"
-	ClaudePluginStatePath = ".claude/plugins/installed_plugins.json"
-	ClaudeDisplayName     = "Claude Code"
-)
+	ClientClaudeCode   = "claude-code"
+	ClaudeBinaryName   = "claude"
+	TargetClaudePlugin = "stripe@claude-plugins-official"
+	ClaudeMarketplace  = "claude-plugins-official"
+	ClaudeDisplayName  = "Claude Code"
 
-func claudeClient() pluginClient {
-	return pluginClient{
-		id:           ClientClaudeCode,
-		displayName:  ClaudeDisplayName,
-		shortName:    "Claude",
-		binaryName:   ClaudeBinaryName,
-		targetPlugin: TargetClaudePlugin,
-		localPlugin:  LocalClaudePlugin,
-		pluginState:  ClaudePluginStatePath,
-	}
-}
+	claudeListTimeout = 10 * time.Second
+)
 
 // ClaudeProvider detects and configures the Stripe plugin for Claude Code.
 type ClaudeProvider struct {
 	Scanner    Scanner
 	RunCommand RunCommandFunc
+	RunOutput  RunOutputFunc
 }
 
 // NewClaudeProvider returns a Claude Code setup provider.
@@ -45,6 +36,7 @@ func NewClaudeProvider(scanner Scanner, runCommand RunCommandFunc) ClaudeProvide
 	return ClaudeProvider{
 		Scanner:    scanner,
 		RunCommand: runCommand,
+		RunOutput:  runCommandOutput,
 	}
 }
 
@@ -53,7 +45,39 @@ func (p ClaudeProvider) ID() string {
 }
 
 func (p ClaudeProvider) Detect() Status {
-	return p.Scanner.ScanClaude()
+	scanner := p.Scanner.withDefaults()
+
+	status := Status{
+		Client:      ClientClaudeCode,
+		DisplayName: ClaudeDisplayName,
+		Status:      StatusNotDetected,
+	}
+
+	binPath, err := scanner.LookPath(ClaudeBinaryName)
+	if err != nil {
+		return status
+	}
+	status.Detected = true
+	status.ExecutablePath = binPath
+	status.Status = StatusMissing
+
+	ctx, cancel := context.WithTimeout(context.Background(), claudeListTimeout)
+	defer cancel()
+
+	pluginID, version, scope, ok, supportsPlugins := p.stripePluginStatus(ctx)
+	if !supportsPlugins {
+		status.Error = "upgrade Claude Code to enable plugin support"
+		return status
+	}
+	if ok {
+		status.Plugin.Installed = true
+		status.Plugin.ID = pluginID
+		status.Plugin.Version = version
+		status.Plugin.Scope = scope
+		status.Status = StatusInstalled
+	}
+
+	return status
 }
 
 func (p ClaudeProvider) Plan(status Status, force bool) Plan {
@@ -101,9 +125,48 @@ func (p ClaudeProvider) Apply(ctx context.Context, out io.Writer, plan Plan) err
 	return nil
 }
 
-// ScanClaude returns Claude Code installation and Stripe plugin status.
-func (s Scanner) ScanClaude() Status {
-	return s.scanPlugin(claudeClient())
+// stripePluginStatus runs `claude plugin list --json` and reports whether the
+// Stripe plugin is installed. When the command fails (e.g. old Claude version
+// without plugin support), supportsPlugins is false.
+func (p ClaudeProvider) stripePluginStatus(ctx context.Context) (id, version, scope string, installed bool, supportsPlugins bool) {
+	runOutput := p.RunOutput
+	if runOutput == nil {
+		runOutput = runCommandOutput
+	}
+	out, err := runOutput(ctx, ClaudeBinaryName, "plugin", "list", "--json")
+	if err != nil {
+		return "", "", "", false, false
+	}
+	pluginID, v, s, ok := findClaudeStripePlugin(out)
+	return pluginID, v, s, ok, true
+}
+
+// claudeInstalledPlugin is an entry in `claude plugin list --json` output.
+type claudeInstalledPlugin struct {
+	ID      string `json:"id"`
+	Version string `json:"version"`
+	Scope   string `json:"scope"`
+	Enabled bool   `json:"enabled"`
+}
+
+// findClaudeStripePlugin reports whether the Stripe plugin appears in the
+// output of `claude plugin list --json`.
+func findClaudeStripePlugin(listJSON []byte) (id, version, scope string, found bool) {
+	var plugins []claudeInstalledPlugin
+	if err := json.Unmarshal(listJSON, &plugins); err != nil {
+		return "", "", "", false
+	}
+
+	for _, plugin := range plugins {
+		if claudePluginIsStripe(plugin) {
+			return plugin.ID, plugin.Version, plugin.Scope, true
+		}
+	}
+	return "", "", "", false
+}
+
+func claudePluginIsStripe(plugin claudeInstalledPlugin) bool {
+	return strings.EqualFold(plugin.ID, TargetClaudePlugin)
 }
 
 // ClaudeInstallCommand returns the command used to install the Stripe Claude

--- a/pkg/agentsetup/claude.go
+++ b/pkg/agentsetup/claude.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,11 +21,7 @@ const (
 	LocalClaudePlugin     = "stripe@stripe"
 	ClaudeMarketplace     = "claude-plugins-official"
 	ClaudePluginStatePath = ".claude/plugins/installed_plugins.json"
-
-	StatusNotDetected = "not_detected"
-	StatusInstalled   = "installed"
-	StatusMissing     = "missing"
-	StatusError       = "error"
+	ClaudeDisplayName     = "Claude Code"
 )
 
 // LookPathFunc matches exec.LookPath and exists to make detection testable.
@@ -50,19 +47,72 @@ type Scanner struct {
 	WorkDir  WorkDirFunc
 }
 
-// ClaudeStatus is the read-only setup status for Claude Code.
-type ClaudeStatus struct {
-	Client          string `json:"client"`
-	Detected        bool   `json:"detected"`
-	ExecutablePath  string `json:"executable_path,omitempty"`
-	PluginInstalled bool   `json:"plugin_installed"`
-	PluginID        string `json:"plugin_id,omitempty"`
-	PluginVersion   string `json:"plugin_version,omitempty"`
-	PluginScope     string `json:"plugin_scope,omitempty"`
-	PluginProject   string `json:"plugin_project_path,omitempty"`
-	PluginStatePath string `json:"plugin_state_path,omitempty"`
-	Status          string `json:"status"`
-	Error           string `json:"error,omitempty"`
+// ClaudeProvider detects and configures the Stripe plugin for Claude Code.
+type ClaudeProvider struct {
+	Scanner    Scanner
+	RunCommand RunCommandFunc
+}
+
+// NewClaudeProvider returns a Claude Code setup provider.
+func NewClaudeProvider(scanner Scanner, runCommand RunCommandFunc) ClaudeProvider {
+	if runCommand == nil {
+		runCommand = RunCommand
+	}
+	return ClaudeProvider{
+		Scanner:    scanner,
+		RunCommand: runCommand,
+	}
+}
+
+func (p ClaudeProvider) ID() string {
+	return ClientClaudeCode
+}
+
+func (p ClaudeProvider) Detect() Status {
+	return p.Scanner.ScanClaude()
+}
+
+func (p ClaudeProvider) Plan(status Status, force bool) Plan {
+	name, args := ClaudeInstallCommand()
+	command := append([]string{name}, args...)
+
+	switch {
+	case status.Status == StatusError:
+		return Plan{Action: ActionNone}
+	case !status.Detected:
+		return Plan{Action: ActionNone}
+	case status.Plugin.Installed && force:
+		return Plan{Action: ActionReinstall, Command: command}
+	case status.Plugin.Installed:
+		return Plan{Action: ActionNone}
+	default:
+		return Plan{Action: ActionInstall, Command: command}
+	}
+}
+
+func (p ClaudeProvider) Apply(ctx context.Context, out io.Writer, plan Plan) error {
+	if plan.Action == ActionNone {
+		return nil
+	}
+	if len(plan.Command) == 0 {
+		return fmt.Errorf("missing command for %s action", plan.Action)
+	}
+
+	name, installArgs := plan.Command[0], plan.Command[1:]
+	if err := p.RunCommand(ctx, name, installArgs...); err == nil {
+		return nil
+	} else {
+		updateName, updateArgs := ClaudeMarketplaceUpdateCommand()
+		updateCommand := append([]string{updateName}, updateArgs...)
+		fmt.Fprintf(out, "Install failed. Updating Claude plugin marketplace and retrying: %s\n", strings.Join(updateCommand, " "))
+		if updateErr := p.RunCommand(ctx, updateName, updateArgs...); updateErr != nil {
+			return fmt.Errorf("running %q after install failed: %w", strings.Join(updateCommand, " "), updateErr)
+		}
+		if retryErr := p.RunCommand(ctx, name, installArgs...); retryErr != nil {
+			return fmt.Errorf("running %q after marketplace update: %w", strings.Join(plan.Command, " "), retryErr)
+		}
+		return nil
+	}
 }
 
 type installedPluginState struct {
@@ -88,12 +138,13 @@ func DefaultScanner() Scanner {
 }
 
 // ScanClaude returns Claude Code installation and Stripe plugin status.
-func (s Scanner) ScanClaude() ClaudeStatus {
+func (s Scanner) ScanClaude() Status {
 	s = s.withDefaults()
 
-	status := ClaudeStatus{
-		Client: ClientClaudeCode,
-		Status: StatusNotDetected,
+	status := Status{
+		Client:      ClientClaudeCode,
+		DisplayName: ClaudeDisplayName,
+		Status:      StatusNotDetected,
 	}
 
 	claudePath, err := s.LookPath(ClaudeBinaryName)
@@ -110,9 +161,9 @@ func (s Scanner) ScanClaude() ClaudeStatus {
 		status.Error = fmt.Sprintf("locating home directory: %v", err)
 		return status
 	}
-	status.PluginStatePath = filepath.Join(home, ClaudePluginStatePath)
+	status.Plugin.StatePath = filepath.Join(home, ClaudePluginStatePath)
 
-	body, err := s.ReadFile(status.PluginStatePath)
+	body, err := s.ReadFile(status.Plugin.StatePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return status
@@ -137,11 +188,11 @@ func (s Scanner) ScanClaude() ClaudeStatus {
 	}
 
 	if id, ref, ok := findStripePlugin(pluginState.Plugins, workDir); ok {
-		status.PluginInstalled = true
-		status.PluginID = id
-		status.PluginVersion = ref.Version
-		status.PluginScope = ref.Scope
-		status.PluginProject = ref.ProjectPath
+		status.Plugin.Installed = true
+		status.Plugin.ID = id
+		status.Plugin.Version = ref.Version
+		status.Plugin.Scope = ref.Scope
+		status.Plugin.Project = ref.ProjectPath
 		status.Status = StatusInstalled
 	}
 

--- a/pkg/agentsetup/claude.go
+++ b/pkg/agentsetup/claude.go
@@ -4,13 +4,8 @@ package agentsetup
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 )
 
@@ -24,27 +19,16 @@ const (
 	ClaudeDisplayName     = "Claude Code"
 )
 
-// LookPathFunc matches exec.LookPath and exists to make detection testable.
-type LookPathFunc func(string) (string, error)
-
-// ReadFileFunc matches os.ReadFile and exists to make status parsing testable.
-type ReadFileFunc func(string) ([]byte, error)
-
-// HomeDirFunc matches os.UserHomeDir and exists to make status parsing testable.
-type HomeDirFunc func() (string, error)
-
-// WorkDirFunc matches os.Getwd and exists to make local plugin scope testable.
-type WorkDirFunc func() (string, error)
-
-// RunCommandFunc runs a command. The production implementation streams stdio.
-type RunCommandFunc func(context.Context, string, ...string) error
-
-// Scanner scans local agent installations without mutating them.
-type Scanner struct {
-	LookPath LookPathFunc
-	ReadFile ReadFileFunc
-	HomeDir  HomeDirFunc
-	WorkDir  WorkDirFunc
+func claudeClient() pluginClient {
+	return pluginClient{
+		id:           ClientClaudeCode,
+		displayName:  ClaudeDisplayName,
+		shortName:    "Claude",
+		binaryName:   ClaudeBinaryName,
+		targetPlugin: TargetClaudePlugin,
+		localPlugin:  LocalClaudePlugin,
+		pluginState:  ClaudePluginStatePath,
+	}
 }
 
 // ClaudeProvider detects and configures the Stripe plugin for Claude Code.
@@ -90,6 +74,8 @@ func (p ClaudeProvider) Plan(status Status, force bool) Plan {
 	}
 }
 
+// Apply installs the Stripe Claude Code plugin, refreshing the official plugin
+// marketplace and retrying once if the first attempt fails.
 func (p ClaudeProvider) Apply(ctx context.Context, out io.Writer, plan Plan) error {
 	if plan.Action == ActionNone {
 		return nil
@@ -101,102 +87,23 @@ func (p ClaudeProvider) Apply(ctx context.Context, out io.Writer, plan Plan) err
 	name, installArgs := plan.Command[0], plan.Command[1:]
 	if err := p.RunCommand(ctx, name, installArgs...); err == nil {
 		return nil
-	} else {
-		updateName, updateArgs := ClaudeMarketplaceUpdateCommand()
-		updateCommand := append([]string{updateName}, updateArgs...)
-		fmt.Fprintf(out, "Install failed. Updating Claude plugin marketplace and retrying: %s\n", strings.Join(updateCommand, " "))
-		if updateErr := p.RunCommand(ctx, updateName, updateArgs...); updateErr != nil {
-			return fmt.Errorf("running %q after install failed: %w", strings.Join(updateCommand, " "), updateErr)
-		}
-		if retryErr := p.RunCommand(ctx, name, installArgs...); retryErr != nil {
-			return fmt.Errorf("running %q after marketplace update: %w", strings.Join(plan.Command, " "), retryErr)
-		}
-		return nil
 	}
-}
 
-type installedPluginState struct {
-	Version int                             `json:"version"`
-	Plugins map[string][]installedPluginRef `json:"plugins"`
-}
-
-type installedPluginRef struct {
-	Scope       string `json:"scope"`
-	Version     string `json:"version"`
-	Installed   string `json:"installPath"`
-	ProjectPath string `json:"projectPath"`
-}
-
-// DefaultScanner returns a Scanner backed by the real OS.
-func DefaultScanner() Scanner {
-	return Scanner{
-		LookPath: exec.LookPath,
-		ReadFile: os.ReadFile,
-		HomeDir:  os.UserHomeDir,
-		WorkDir:  os.Getwd,
+	updateName, updateArgs := ClaudeMarketplaceUpdateCommand()
+	updateCommand := append([]string{updateName}, updateArgs...)
+	fmt.Fprintf(out, "Install failed. Updating Claude plugin marketplace and retrying: %s\n", strings.Join(updateCommand, " "))
+	if updateErr := p.RunCommand(ctx, updateName, updateArgs...); updateErr != nil {
+		return fmt.Errorf("running %q after install failed: %w", strings.Join(updateCommand, " "), updateErr)
 	}
+	if retryErr := p.RunCommand(ctx, name, installArgs...); retryErr != nil {
+		return fmt.Errorf("running %q after marketplace update: %w", strings.Join(plan.Command, " "), retryErr)
+	}
+	return nil
 }
 
 // ScanClaude returns Claude Code installation and Stripe plugin status.
 func (s Scanner) ScanClaude() Status {
-	s = s.withDefaults()
-
-	status := Status{
-		Client:      ClientClaudeCode,
-		DisplayName: ClaudeDisplayName,
-		Status:      StatusNotDetected,
-	}
-
-	claudePath, err := s.LookPath(ClaudeBinaryName)
-	if err != nil {
-		return status
-	}
-	status.Detected = true
-	status.ExecutablePath = claudePath
-	status.Status = StatusMissing
-
-	home, err := s.HomeDir()
-	if err != nil {
-		status.Status = StatusError
-		status.Error = fmt.Sprintf("locating home directory: %v", err)
-		return status
-	}
-	status.Plugin.StatePath = filepath.Join(home, ClaudePluginStatePath)
-
-	body, err := s.ReadFile(status.Plugin.StatePath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return status
-		}
-		status.Status = StatusError
-		status.Error = fmt.Sprintf("reading Claude plugin state: %v", err)
-		return status
-	}
-
-	var pluginState installedPluginState
-	if err := json.Unmarshal(body, &pluginState); err != nil {
-		status.Status = StatusError
-		status.Error = fmt.Sprintf("parsing Claude plugin state: %v", err)
-		return status
-	}
-
-	workDir, err := s.WorkDir()
-	if err != nil {
-		status.Status = StatusError
-		status.Error = fmt.Sprintf("locating working directory: %v", err)
-		return status
-	}
-
-	if id, ref, ok := findStripePlugin(pluginState.Plugins, workDir); ok {
-		status.Plugin.Installed = true
-		status.Plugin.ID = id
-		status.Plugin.Version = ref.Version
-		status.Plugin.Scope = ref.Scope
-		status.Plugin.Project = ref.ProjectPath
-		status.Status = StatusInstalled
-	}
-
-	return status
+	return s.scanPlugin(claudeClient())
 }
 
 // ClaudeInstallCommand returns the command used to install the Stripe Claude
@@ -209,53 +116,4 @@ func ClaudeInstallCommand() (string, []string) {
 // official plugin marketplace metadata.
 func ClaudeMarketplaceUpdateCommand() (string, []string) {
 	return ClaudeBinaryName, []string{"plugin", "marketplace", "update", ClaudeMarketplace}
-}
-
-// RunCommand streams a command through the current process stdio.
-func RunCommand(ctx context.Context, name string, args ...string) error {
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
-func (s Scanner) withDefaults() Scanner {
-	defaults := DefaultScanner()
-	if s.LookPath == nil {
-		s.LookPath = defaults.LookPath
-	}
-	if s.ReadFile == nil {
-		s.ReadFile = defaults.ReadFile
-	}
-	if s.HomeDir == nil {
-		s.HomeDir = defaults.HomeDir
-	}
-	if s.WorkDir == nil {
-		s.WorkDir = defaults.WorkDir
-	}
-	return s
-}
-
-func findStripePlugin(plugins map[string][]installedPluginRef, workDir string) (string, installedPluginRef, bool) {
-	for _, id := range []string{TargetClaudePlugin, LocalClaudePlugin} {
-		for _, ref := range plugins[id] {
-			if pluginVisibleInWorkDir(ref, workDir) {
-				return id, ref, true
-			}
-		}
-	}
-	return "", installedPluginRef{}, false
-}
-
-func pluginVisibleInWorkDir(ref installedPluginRef, workDir string) bool {
-	if ref.Scope != "local" || ref.ProjectPath == "" {
-		return true
-	}
-
-	rel, err := filepath.Rel(ref.ProjectPath, workDir)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && !filepath.IsAbs(rel))
 }

--- a/pkg/agentsetup/claude_test.go
+++ b/pkg/agentsetup/claude_test.go
@@ -1,51 +1,64 @@
 package agentsetup
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestScanClaude_NotDetected(t *testing.T) {
-	scanner := Scanner{
-		LookPath: func(string) (string, error) { return "", errors.New("missing") },
+func TestClaude_NotDetected(t *testing.T) {
+	provider := ClaudeProvider{
+		Scanner: Scanner{LookPath: func(string) (string, error) { return "", errors.New("missing") }},
 	}
 
-	status := scanner.ScanClaude()
+	status := provider.Detect()
 
 	require.Equal(t, ClientClaudeCode, status.Client)
 	require.False(t, status.Detected)
 	require.Equal(t, StatusNotDetected, status.Status)
 }
 
-func TestScanClaude_MissingPluginState(t *testing.T) {
-	home := t.TempDir()
-	scanner := testScanner(home)
+func TestClaude_DetectedNoPluginSupport(t *testing.T) {
+	provider := ClaudeProvider{
+		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil }},
+		RunOutput: func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+			return nil, errors.New("unknown command")
+		},
+	}
 
-	status := scanner.ScanClaude()
+	status := provider.Detect()
 
 	require.True(t, status.Detected)
-	require.False(t, status.Plugin.Installed)
 	require.Equal(t, StatusMissing, status.Status)
-	require.Equal(t, filepath.Join(home, ClaudePluginStatePath), status.Plugin.StatePath)
+	require.Equal(t, "upgrade Claude Code to enable plugin support", status.Error)
 }
 
-func TestScanClaude_OfficialPluginInstalled(t *testing.T) {
-	home := t.TempDir()
-	writeClaudePluginState(t, home, `{
-		"version": 2,
-		"plugins": {
-			"stripe@claude-plugins-official": [
-				{"scope": "user", "version": "2.4.1", "installPath": "/tmp/stripe"}
-			]
-		}
-	}`)
+func TestClaude_DetectedPluginMissing(t *testing.T) {
+	provider := ClaudeProvider{
+		Scanner:   Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil }},
+		RunOutput: func(_ context.Context, _ string, _ ...string) ([]byte, error) { return []byte(`[]`), nil },
+	}
 
-	status := testScanner(home).ScanClaude()
+	status := provider.Detect()
+
+	require.True(t, status.Detected)
+	require.Equal(t, StatusMissing, status.Status)
+	require.False(t, status.Plugin.Installed)
+}
+
+func TestClaude_OfficialPluginInstalled(t *testing.T) {
+	listJSON := mustJSON(t, []claudeInstalledPlugin{
+		{ID: "stripe@claude-plugins-official", Version: "2.4.1", Scope: "user", Enabled: true},
+	})
+	provider := ClaudeProvider{
+		Scanner:   Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil }},
+		RunOutput: func(_ context.Context, _ string, _ ...string) ([]byte, error) { return listJSON, nil },
+	}
+
+	status := provider.Detect()
 
 	require.Equal(t, StatusInstalled, status.Status)
 	require.True(t, status.Plugin.Installed)
@@ -54,82 +67,36 @@ func TestScanClaude_OfficialPluginInstalled(t *testing.T) {
 	require.Equal(t, "user", status.Plugin.Scope)
 }
 
-func TestScanClaude_LocalStripePluginInstalled(t *testing.T) {
-	home := t.TempDir()
-	projectPath := filepath.Join(home, "project")
-	writeClaudePluginState(t, home, `{
-		"version": 2,
-		"plugins": {
-			"stripe@stripe": [
-				{"scope": "local", "version": "0.1.0", "installPath": "/tmp/stripe", "projectPath": `+jsonString(t, projectPath)+`}
-			]
-		}
-	}`)
+func TestClaude_MalformedJSON(t *testing.T) {
+	provider := ClaudeProvider{
+		Scanner:   Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil }},
+		RunOutput: func(_ context.Context, _ string, _ ...string) ([]byte, error) { return []byte(`{nope`), nil },
+	}
 
-	status := testScannerWithWorkDir(home, filepath.Join(projectPath, "subdir")).ScanClaude()
-
-	require.Equal(t, StatusInstalled, status.Status)
-	require.True(t, status.Plugin.Installed)
-	require.Equal(t, LocalClaudePlugin, status.Plugin.ID)
-	require.Equal(t, "0.1.0", status.Plugin.Version)
-	require.Equal(t, "local", status.Plugin.Scope)
-	require.Equal(t, projectPath, status.Plugin.Project)
-}
-
-func TestScanClaude_LocalStripePluginForDifferentProjectIsMissing(t *testing.T) {
-	home := t.TempDir()
-	projectPath := filepath.Join(home, "other-project")
-	writeClaudePluginState(t, home, `{
-		"version": 2,
-		"plugins": {
-			"stripe@stripe": [
-				{"scope": "local", "version": "0.1.0", "installPath": "/tmp/stripe", "projectPath": `+jsonString(t, projectPath)+`}
-			]
-		}
-	}`)
-
-	status := testScannerWithWorkDir(home, filepath.Join(home, "current-project")).ScanClaude()
+	status := provider.Detect()
 
 	require.Equal(t, StatusMissing, status.Status)
 	require.False(t, status.Plugin.Installed)
 }
 
-func TestScanClaude_MalformedPluginState(t *testing.T) {
-	home := t.TempDir()
-	writeClaudePluginState(t, home, `{nope`)
-
-	status := testScanner(home).ScanClaude()
-
-	require.Equal(t, StatusError, status.Status)
-	require.Contains(t, status.Error, "parsing Claude plugin state")
-}
-
-func testScanner(home string) Scanner {
-	return testScannerWithWorkDir(home, home)
-}
-
-func testScannerWithWorkDir(home, workDir string) Scanner {
-	return Scanner{
-		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
-		ReadFile: os.ReadFile,
-		HomeDir:  func() (string, error) { return home, nil },
-		WorkDir:  func() (string, error) { return workDir, nil },
+func TestClaude_OtherPluginsIgnored(t *testing.T) {
+	listJSON := mustJSON(t, []claudeInstalledPlugin{
+		{ID: "other-plugin@marketplace", Version: "1.0.0", Scope: "user", Enabled: true},
+	})
+	provider := ClaudeProvider{
+		Scanner:   Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil }},
+		RunOutput: func(_ context.Context, _ string, _ ...string) ([]byte, error) { return listJSON, nil },
 	}
+
+	status := provider.Detect()
+
+	require.Equal(t, StatusMissing, status.Status)
+	require.False(t, status.Plugin.Installed)
 }
 
-// jsonString returns s as a JSON string literal (with surrounding quotes and
-// proper escaping). This matters on Windows, where filepath.Join produces paths
-// with backslashes that would otherwise be invalid JSON escapes.
-func jsonString(t *testing.T, s string) string {
+func mustJSON(t *testing.T, v interface{}) []byte {
 	t.Helper()
-	b, err := json.Marshal(s)
+	b, err := json.Marshal(v)
 	require.NoError(t, err)
-	return string(b)
-}
-
-func writeClaudePluginState(t *testing.T, home string, body string) {
-	t.Helper()
-	path := filepath.Join(home, ClaudePluginStatePath)
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
-	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+	return b
 }

--- a/pkg/agentsetup/claude_test.go
+++ b/pkg/agentsetup/claude_test.go
@@ -28,9 +28,9 @@ func TestScanClaude_MissingPluginState(t *testing.T) {
 	status := scanner.ScanClaude()
 
 	require.True(t, status.Detected)
-	require.False(t, status.PluginInstalled)
+	require.False(t, status.Plugin.Installed)
 	require.Equal(t, StatusMissing, status.Status)
-	require.Equal(t, filepath.Join(home, ClaudePluginStatePath), status.PluginStatePath)
+	require.Equal(t, filepath.Join(home, ClaudePluginStatePath), status.Plugin.StatePath)
 }
 
 func TestScanClaude_OfficialPluginInstalled(t *testing.T) {
@@ -47,10 +47,10 @@ func TestScanClaude_OfficialPluginInstalled(t *testing.T) {
 	status := testScanner(home).ScanClaude()
 
 	require.Equal(t, StatusInstalled, status.Status)
-	require.True(t, status.PluginInstalled)
-	require.Equal(t, TargetClaudePlugin, status.PluginID)
-	require.Equal(t, "2.4.1", status.PluginVersion)
-	require.Equal(t, "user", status.PluginScope)
+	require.True(t, status.Plugin.Installed)
+	require.Equal(t, TargetClaudePlugin, status.Plugin.ID)
+	require.Equal(t, "2.4.1", status.Plugin.Version)
+	require.Equal(t, "user", status.Plugin.Scope)
 }
 
 func TestScanClaude_LocalStripePluginInstalled(t *testing.T) {
@@ -68,11 +68,11 @@ func TestScanClaude_LocalStripePluginInstalled(t *testing.T) {
 	status := testScannerWithWorkDir(home, filepath.Join(projectPath, "subdir")).ScanClaude()
 
 	require.Equal(t, StatusInstalled, status.Status)
-	require.True(t, status.PluginInstalled)
-	require.Equal(t, LocalClaudePlugin, status.PluginID)
-	require.Equal(t, "0.1.0", status.PluginVersion)
-	require.Equal(t, "local", status.PluginScope)
-	require.Equal(t, projectPath, status.PluginProject)
+	require.True(t, status.Plugin.Installed)
+	require.Equal(t, LocalClaudePlugin, status.Plugin.ID)
+	require.Equal(t, "0.1.0", status.Plugin.Version)
+	require.Equal(t, "local", status.Plugin.Scope)
+	require.Equal(t, projectPath, status.Plugin.Project)
 }
 
 func TestScanClaude_LocalStripePluginForDifferentProjectIsMissing(t *testing.T) {
@@ -90,7 +90,7 @@ func TestScanClaude_LocalStripePluginForDifferentProjectIsMissing(t *testing.T) 
 	status := testScannerWithWorkDir(home, filepath.Join(home, "current-project")).ScanClaude()
 
 	require.Equal(t, StatusMissing, status.Status)
-	require.False(t, status.PluginInstalled)
+	require.False(t, status.Plugin.Installed)
 }
 
 func TestScanClaude_MalformedPluginState(t *testing.T) {

--- a/pkg/agentsetup/claude_test.go
+++ b/pkg/agentsetup/claude_test.go
@@ -1,0 +1,124 @@
+package agentsetup
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanClaude_NotDetected(t *testing.T) {
+	scanner := Scanner{
+		LookPath: func(string) (string, error) { return "", errors.New("missing") },
+	}
+
+	status := scanner.ScanClaude()
+
+	require.Equal(t, ClientClaudeCode, status.Client)
+	require.False(t, status.Detected)
+	require.Equal(t, StatusNotDetected, status.Status)
+}
+
+func TestScanClaude_MissingPluginState(t *testing.T) {
+	home := t.TempDir()
+	scanner := testScanner(home)
+
+	status := scanner.ScanClaude()
+
+	require.True(t, status.Detected)
+	require.False(t, status.PluginInstalled)
+	require.Equal(t, StatusMissing, status.Status)
+	require.Equal(t, filepath.Join(home, ClaudePluginStatePath), status.PluginStatePath)
+}
+
+func TestScanClaude_OfficialPluginInstalled(t *testing.T) {
+	home := t.TempDir()
+	writeClaudePluginState(t, home, `{
+		"version": 2,
+		"plugins": {
+			"stripe@claude-plugins-official": [
+				{"scope": "user", "version": "2.4.1", "installPath": "/tmp/stripe"}
+			]
+		}
+	}`)
+
+	status := testScanner(home).ScanClaude()
+
+	require.Equal(t, StatusInstalled, status.Status)
+	require.True(t, status.PluginInstalled)
+	require.Equal(t, TargetClaudePlugin, status.PluginID)
+	require.Equal(t, "2.4.1", status.PluginVersion)
+	require.Equal(t, "user", status.PluginScope)
+}
+
+func TestScanClaude_LocalStripePluginInstalled(t *testing.T) {
+	home := t.TempDir()
+	projectPath := filepath.Join(home, "project")
+	writeClaudePluginState(t, home, `{
+		"version": 2,
+		"plugins": {
+			"stripe@stripe": [
+				{"scope": "local", "version": "0.1.0", "installPath": "/tmp/stripe", "projectPath": "`+projectPath+`"}
+			]
+		}
+	}`)
+
+	status := testScannerWithWorkDir(home, filepath.Join(projectPath, "subdir")).ScanClaude()
+
+	require.Equal(t, StatusInstalled, status.Status)
+	require.True(t, status.PluginInstalled)
+	require.Equal(t, LocalClaudePlugin, status.PluginID)
+	require.Equal(t, "0.1.0", status.PluginVersion)
+	require.Equal(t, "local", status.PluginScope)
+	require.Equal(t, projectPath, status.PluginProject)
+}
+
+func TestScanClaude_LocalStripePluginForDifferentProjectIsMissing(t *testing.T) {
+	home := t.TempDir()
+	projectPath := filepath.Join(home, "other-project")
+	writeClaudePluginState(t, home, `{
+		"version": 2,
+		"plugins": {
+			"stripe@stripe": [
+				{"scope": "local", "version": "0.1.0", "installPath": "/tmp/stripe", "projectPath": "`+projectPath+`"}
+			]
+		}
+	}`)
+
+	status := testScannerWithWorkDir(home, filepath.Join(home, "current-project")).ScanClaude()
+
+	require.Equal(t, StatusMissing, status.Status)
+	require.False(t, status.PluginInstalled)
+}
+
+func TestScanClaude_MalformedPluginState(t *testing.T) {
+	home := t.TempDir()
+	writeClaudePluginState(t, home, `{nope`)
+
+	status := testScanner(home).ScanClaude()
+
+	require.Equal(t, StatusError, status.Status)
+	require.Contains(t, status.Error, "parsing Claude plugin state")
+}
+
+func testScanner(home string) Scanner {
+	return testScannerWithWorkDir(home, home)
+}
+
+func testScannerWithWorkDir(home, workDir string) Scanner {
+	return Scanner{
+		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
+		ReadFile: os.ReadFile,
+		HomeDir:  func() (string, error) { return home, nil },
+		WorkDir:  func() (string, error) { return workDir, nil },
+	}
+}
+
+func writeClaudePluginState(t *testing.T, home string, body string) {
+	t.Helper()
+	path := filepath.Join(home, ClaudePluginStatePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+}

--- a/pkg/agentsetup/claude_test.go
+++ b/pkg/agentsetup/claude_test.go
@@ -1,6 +1,7 @@
 package agentsetup
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -60,7 +61,7 @@ func TestScanClaude_LocalStripePluginInstalled(t *testing.T) {
 		"version": 2,
 		"plugins": {
 			"stripe@stripe": [
-				{"scope": "local", "version": "0.1.0", "installPath": "/tmp/stripe", "projectPath": "`+projectPath+`"}
+				{"scope": "local", "version": "0.1.0", "installPath": "/tmp/stripe", "projectPath": `+jsonString(t, projectPath)+`}
 			]
 		}
 	}`)
@@ -82,7 +83,7 @@ func TestScanClaude_LocalStripePluginForDifferentProjectIsMissing(t *testing.T) 
 		"version": 2,
 		"plugins": {
 			"stripe@stripe": [
-				{"scope": "local", "version": "0.1.0", "installPath": "/tmp/stripe", "projectPath": "`+projectPath+`"}
+				{"scope": "local", "version": "0.1.0", "installPath": "/tmp/stripe", "projectPath": `+jsonString(t, projectPath)+`}
 			]
 		}
 	}`)
@@ -114,6 +115,16 @@ func testScannerWithWorkDir(home, workDir string) Scanner {
 		HomeDir:  func() (string, error) { return home, nil },
 		WorkDir:  func() (string, error) { return workDir, nil },
 	}
+}
+
+// jsonString returns s as a JSON string literal (with surrounding quotes and
+// proper escaping). This matters on Windows, where filepath.Join produces paths
+// with backslashes that would otherwise be invalid JSON escapes.
+func jsonString(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	require.NoError(t, err)
+	return string(b)
 }
 
 func writeClaudePluginState(t *testing.T, home string, body string) {

--- a/pkg/agentsetup/codex.go
+++ b/pkg/agentsetup/codex.go
@@ -69,7 +69,12 @@ func (p CodexProvider) Detect() Status {
 	ctx, cancel := context.WithTimeout(context.Background(), codexListTimeout)
 	defer cancel()
 
-	if version, ok := p.stripePluginVersion(ctx); ok {
+	version, ok, supportsPlugins := p.stripePluginStatus(ctx)
+	if !supportsPlugins {
+		status.Error = "upgrade Codex to enable plugin support"
+		return status
+	}
+	if ok {
 		status.Plugin.Installed = true
 		status.Plugin.ID = TargetCodexPlugin
 		status.Plugin.Version = version
@@ -80,19 +85,21 @@ func (p CodexProvider) Detect() Status {
 	return status
 }
 
-// stripePluginVersion runs `codex plugin list --json` and reports the installed
-// Stripe plugin version, if any. A command or parse failure is treated as "not
-// installed" so a single flaky call does not fail the whole scan.
-func (p CodexProvider) stripePluginVersion(ctx context.Context) (string, bool) {
+// stripePluginStatus runs `codex plugin list --json` and reports whether (1)
+// the command is supported (supportsPlugins), and if so (2) whether the Stripe
+// plugin is installed and its version. When the command fails (e.g. old Codex
+// version without plugin support), supportsPlugins is false.
+func (p CodexProvider) stripePluginStatus(ctx context.Context) (version string, installed bool, supportsPlugins bool) {
 	runOutput := p.RunOutput
 	if runOutput == nil {
 		runOutput = runCommandOutput
 	}
 	out, err := runOutput(ctx, CodexBinaryName, "plugin", "list", "--json")
 	if err != nil {
-		return "", false
+		return "", false, false
 	}
-	return findCodexStripePlugin(out)
+	v, ok := findCodexStripePlugin(out)
+	return v, ok, true
 }
 
 func (p CodexProvider) Plan(status Status, force bool) Plan {
@@ -130,7 +137,7 @@ func (p CodexProvider) Apply(ctx context.Context, _ io.Writer, plan Plan) error 
 	// `codex plugin add` exits 0 even when it fails (e.g. the marketplace is not
 	// configured), so the exit code cannot be trusted. Confirm the plugin is
 	// actually installed before reporting success.
-	if _, ok := p.stripePluginVersion(ctx); !ok {
+	if _, installed, _ := p.stripePluginStatus(ctx); !installed {
 		return fmt.Errorf("codex reported success but %s is not installed; run `%s` to see the underlying error",
 			TargetCodexPlugin, strings.Join(plan.Command, " "))
 	}

--- a/pkg/agentsetup/codex.go
+++ b/pkg/agentsetup/codex.go
@@ -1,0 +1,185 @@
+package agentsetup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	ClientCodex       = "codex"
+	CodexBinaryName   = "codex"
+	CodexPluginName   = "stripe"
+	CodexMarketplace  = "openai-curated"
+	TargetCodexPlugin = "stripe@openai-curated"
+	CodexDisplayName  = "Codex CLI"
+
+	codexListTimeout = 10 * time.Second
+)
+
+// RunOutputFunc runs a command and returns its standard output. It exists so
+// Codex detection (which shells out to `codex plugin list --json`) is testable.
+type RunOutputFunc func(context.Context, string, ...string) ([]byte, error)
+
+// CodexProvider detects and installs the Stripe plugin for Codex CLI.
+//
+// Codex has a real plugin CLI, so detection runs `codex plugin list --json` and
+// installation runs `codex plugin add stripe@openai-curated`.
+type CodexProvider struct {
+	Scanner    Scanner
+	RunCommand RunCommandFunc
+	RunOutput  RunOutputFunc
+}
+
+// NewCodexProvider returns a Codex CLI setup provider.
+func NewCodexProvider(scanner Scanner, runCommand RunCommandFunc) Provider {
+	if runCommand == nil {
+		runCommand = RunCommand
+	}
+	return CodexProvider{
+		Scanner:    scanner,
+		RunCommand: runCommand,
+		RunOutput:  runCommandOutput,
+	}
+}
+
+func (p CodexProvider) ID() string { return ClientCodex }
+
+func (p CodexProvider) Detect() Status {
+	scanner := p.Scanner.withDefaults()
+
+	status := Status{
+		Client:      ClientCodex,
+		DisplayName: CodexDisplayName,
+		Status:      StatusNotDetected,
+	}
+
+	binPath, err := scanner.LookPath(CodexBinaryName)
+	if err != nil {
+		return status
+	}
+	status.Detected = true
+	status.ExecutablePath = binPath
+	status.Status = StatusMissing
+
+	ctx, cancel := context.WithTimeout(context.Background(), codexListTimeout)
+	defer cancel()
+
+	if version, ok := p.stripePluginVersion(ctx); ok {
+		status.Plugin.Installed = true
+		status.Plugin.ID = TargetCodexPlugin
+		status.Plugin.Version = version
+		status.Plugin.Scope = "user"
+		status.Status = StatusInstalled
+	}
+
+	return status
+}
+
+// stripePluginVersion runs `codex plugin list --json` and reports the installed
+// Stripe plugin version, if any. A command or parse failure is treated as "not
+// installed" so a single flaky call does not fail the whole scan.
+func (p CodexProvider) stripePluginVersion(ctx context.Context) (string, bool) {
+	runOutput := p.RunOutput
+	if runOutput == nil {
+		runOutput = runCommandOutput
+	}
+	out, err := runOutput(ctx, CodexBinaryName, "plugin", "list", "--json")
+	if err != nil {
+		return "", false
+	}
+	return findCodexStripePlugin(out)
+}
+
+func (p CodexProvider) Plan(status Status, force bool) Plan {
+	command := []string{CodexBinaryName, "plugin", "add", TargetCodexPlugin}
+
+	switch {
+	case status.Status == StatusError:
+		return Plan{Action: ActionNone}
+	case !status.Detected:
+		return Plan{Action: ActionNone}
+	case status.Plugin.Installed && force:
+		return Plan{Action: ActionReinstall, Command: command}
+	case status.Plugin.Installed:
+		return Plan{Action: ActionNone}
+	default:
+		return Plan{Action: ActionInstall, Command: command}
+	}
+}
+
+func (p CodexProvider) Apply(ctx context.Context, _ io.Writer, plan Plan) error {
+	if plan.Action == ActionNone {
+		return nil
+	}
+	if len(plan.Command) == 0 {
+		return fmt.Errorf("missing command for %s action", plan.Action)
+	}
+	runCommand := p.RunCommand
+	if runCommand == nil {
+		runCommand = RunCommand
+	}
+	if err := runCommand(ctx, plan.Command[0], plan.Command[1:]...); err != nil {
+		return err
+	}
+
+	// `codex plugin add` exits 0 even when it fails (e.g. the marketplace is not
+	// configured), so the exit code cannot be trusted. Confirm the plugin is
+	// actually installed before reporting success.
+	if _, ok := p.stripePluginVersion(ctx); !ok {
+		return fmt.Errorf("codex reported success but %s is not installed; run `%s` to see the underlying error",
+			TargetCodexPlugin, strings.Join(plan.Command, " "))
+	}
+	return nil
+}
+
+// codexPluginList is the shape of `codex plugin list --json` output.
+type codexPluginList struct {
+	Installed []codexInstalledPlugin `json:"installed"`
+}
+
+// codexInstalledPlugin captures the fields we might use to identify a plugin.
+// The exact schema is not fully documented, so several possible identifier
+// fields are parsed and a raw-substring fallback covers the rest.
+type codexInstalledPlugin struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	QualifiedName string `json:"qualified_name"`
+	FullName      string `json:"full_name"`
+	Marketplace   string `json:"marketplace"`
+	Version       string `json:"version"`
+}
+
+// findCodexStripePlugin reports whether the Stripe plugin appears in the
+// installed list and returns its version when available.
+func findCodexStripePlugin(listJSON []byte) (string, bool) {
+	var list codexPluginList
+	if err := json.Unmarshal(listJSON, &list); err != nil {
+		return "", false
+	}
+
+	for _, plugin := range list.Installed {
+		if codexPluginIsStripe(plugin) {
+			return plugin.Version, true
+		}
+	}
+	return "", false
+}
+
+func codexPluginIsStripe(plugin codexInstalledPlugin) bool {
+	for _, id := range []string{plugin.QualifiedName, plugin.FullName, plugin.ID} {
+		if strings.EqualFold(id, TargetCodexPlugin) {
+			return true
+		}
+	}
+	return strings.EqualFold(plugin.Name, CodexPluginName) &&
+		strings.EqualFold(plugin.Marketplace, CodexMarketplace)
+}
+
+func runCommandOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
+}

--- a/pkg/agentsetup/codex.go
+++ b/pkg/agentsetup/codex.go
@@ -142,16 +142,15 @@ type codexPluginList struct {
 	Installed []codexInstalledPlugin `json:"installed"`
 }
 
-// codexInstalledPlugin captures the fields we might use to identify a plugin.
-// The exact schema is not fully documented, so several possible identifier
-// fields are parsed and a raw-substring fallback covers the rest.
+// codexInstalledPlugin is an entry in `codex plugin list --json`'s "installed"
+// array. Field names match the real Codex CLI output (verified against
+// codex-cli 0.142.0), e.g. {"pluginId":"stripe@openai-curated","name":"stripe",
+// "marketplaceName":"openai-curated","version":"..."}.
 type codexInstalledPlugin struct {
-	ID            string `json:"id"`
-	Name          string `json:"name"`
-	QualifiedName string `json:"qualified_name"`
-	FullName      string `json:"full_name"`
-	Marketplace   string `json:"marketplace"`
-	Version       string `json:"version"`
+	PluginID    string `json:"pluginId"`
+	Name        string `json:"name"`
+	Marketplace string `json:"marketplaceName"`
+	Version     string `json:"version"`
 }
 
 // findCodexStripePlugin reports whether the Stripe plugin appears in the
@@ -171,10 +170,8 @@ func findCodexStripePlugin(listJSON []byte) (string, bool) {
 }
 
 func codexPluginIsStripe(plugin codexInstalledPlugin) bool {
-	for _, id := range []string{plugin.QualifiedName, plugin.FullName, plugin.ID} {
-		if strings.EqualFold(id, TargetCodexPlugin) {
-			return true
-		}
+	if strings.EqualFold(plugin.PluginID, TargetCodexPlugin) {
+		return true
 	}
 	return strings.EqualFold(plugin.Name, CodexPluginName) &&
 		strings.EqualFold(plugin.Marketplace, CodexMarketplace)

--- a/pkg/agentsetup/codex_test.go
+++ b/pkg/agentsetup/codex_test.go
@@ -36,19 +36,21 @@ func TestScanCodex_PluginMissing(t *testing.T) {
 }
 
 func TestScanCodex_PluginInstalled(t *testing.T) {
-	provider := codexTestProvider(`{"installed":[{"name":"stripe","marketplace":"openai-curated","version":"1.2.3"}]}`, nil, nil)
+	// Real codex-cli schema: pluginId + marketplaceName.
+	provider := codexTestProvider(`{"installed":[{"pluginId":"stripe@openai-curated","name":"stripe","marketplaceName":"openai-curated","version":"3fdeeb49"}]}`, nil, nil)
 
 	status := provider.Detect()
 
 	require.Equal(t, StatusInstalled, status.Status)
 	require.True(t, status.Plugin.Installed)
 	require.Equal(t, TargetCodexPlugin, status.Plugin.ID)
-	require.Equal(t, "1.2.3", status.Plugin.Version)
+	require.Equal(t, "3fdeeb49", status.Plugin.Version)
 	require.Equal(t, Plan{Action: ActionNone}, provider.Plan(status, false))
 }
 
-func TestScanCodex_PluginInstalledByQualifiedName(t *testing.T) {
-	provider := codexTestProvider(`{"installed":[{"qualified_name":"stripe@openai-curated","version":"2.0.0"}]}`, nil, nil)
+func TestScanCodex_PluginInstalledByNameAndMarketplace(t *testing.T) {
+	// Entry without pluginId still matches on name + marketplaceName.
+	provider := codexTestProvider(`{"installed":[{"name":"stripe","marketplaceName":"openai-curated","version":"2.0.0"}]}`, nil, nil)
 
 	status := provider.Detect()
 
@@ -81,7 +83,7 @@ func TestCodexApply_RunsAddCommandAndVerifies(t *testing.T) {
 		},
 		RunOutput: func(context.Context, string, ...string) ([]byte, error) {
 			if installed {
-				return []byte(`{"installed":[{"name":"stripe","marketplace":"openai-curated","version":"1.0.0"}]}`), nil
+				return []byte(`{"installed":[{"pluginId":"stripe@openai-curated","name":"stripe","marketplaceName":"openai-curated","version":"1.0.0"}]}`), nil
 			}
 			return []byte(`{"installed":[]}`), nil
 		},

--- a/pkg/agentsetup/codex_test.go
+++ b/pkg/agentsetup/codex_test.go
@@ -1,0 +1,126 @@
+package agentsetup
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanCodex_NotDetected(t *testing.T) {
+	provider := CodexProvider{
+		Scanner: Scanner{LookPath: func(string) (string, error) { return "", errors.New("missing") }},
+		RunOutput: func(context.Context, string, ...string) ([]byte, error) {
+			t.Fatal("plugin list should not run when Codex is not detected")
+			return nil, nil
+		},
+	}
+
+	status := provider.Detect()
+
+	require.Equal(t, ClientCodex, status.Client)
+	require.False(t, status.Detected)
+	require.Equal(t, StatusNotDetected, status.Status)
+}
+
+func TestScanCodex_PluginMissing(t *testing.T) {
+	provider := codexTestProvider(`{"installed":[],"available":[]}`, nil, nil)
+
+	status := provider.Detect()
+
+	require.True(t, status.Detected)
+	require.Equal(t, StatusMissing, status.Status)
+	require.False(t, status.Plugin.Installed)
+	require.Equal(t, Plan{Action: ActionInstall, Command: []string{"codex", "plugin", "add", TargetCodexPlugin}}, provider.Plan(status, false))
+}
+
+func TestScanCodex_PluginInstalled(t *testing.T) {
+	provider := codexTestProvider(`{"installed":[{"name":"stripe","marketplace":"openai-curated","version":"1.2.3"}]}`, nil, nil)
+
+	status := provider.Detect()
+
+	require.Equal(t, StatusInstalled, status.Status)
+	require.True(t, status.Plugin.Installed)
+	require.Equal(t, TargetCodexPlugin, status.Plugin.ID)
+	require.Equal(t, "1.2.3", status.Plugin.Version)
+	require.Equal(t, Plan{Action: ActionNone}, provider.Plan(status, false))
+}
+
+func TestScanCodex_PluginInstalledByQualifiedName(t *testing.T) {
+	provider := codexTestProvider(`{"installed":[{"qualified_name":"stripe@openai-curated","version":"2.0.0"}]}`, nil, nil)
+
+	status := provider.Detect()
+
+	require.Equal(t, StatusInstalled, status.Status)
+	require.Equal(t, "2.0.0", status.Plugin.Version)
+}
+
+func TestScanCodex_ListCommandErrorIsMissing(t *testing.T) {
+	provider := codexTestProvider("", errors.New("no marketplace configured"), nil)
+
+	status := provider.Detect()
+
+	require.True(t, status.Detected)
+	require.Equal(t, StatusMissing, status.Status)
+	require.False(t, status.Plugin.Installed)
+}
+
+func TestCodexApply_RunsAddCommandAndVerifies(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	installed := false
+
+	provider := CodexProvider{
+		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/codex", nil }},
+		RunCommand: func(_ context.Context, name string, args ...string) error {
+			gotName = name
+			gotArgs = args
+			installed = true // simulate a successful add
+			return nil
+		},
+		RunOutput: func(context.Context, string, ...string) ([]byte, error) {
+			if installed {
+				return []byte(`{"installed":[{"name":"stripe","marketplace":"openai-curated","version":"1.0.0"}]}`), nil
+			}
+			return []byte(`{"installed":[]}`), nil
+		},
+	}
+
+	status := provider.Detect()
+	plan := provider.Plan(status, false)
+	err := provider.Apply(context.Background(), nil, plan)
+
+	require.NoError(t, err)
+	require.Equal(t, "codex", gotName)
+	require.Equal(t, []string{"plugin", "add", TargetCodexPlugin}, gotArgs)
+}
+
+// TestCodexApply_FailsWhenExitZeroButNotInstalled covers the real-world case
+// where `codex plugin add` prints an error but exits 0. Apply must not report
+// success when the plugin is still not present afterward.
+func TestCodexApply_FailsWhenExitZeroButNotInstalled(t *testing.T) {
+	provider := codexTestProvider(`{"installed":[]}`, nil, func(context.Context, string, ...string) error {
+		return nil // add "succeeds" (exit 0) but installs nothing
+	})
+
+	status := provider.Detect()
+	plan := provider.Plan(status, false)
+	err := provider.Apply(context.Background(), nil, plan)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is not installed")
+}
+
+func codexTestProvider(listOutput string, listErr error, runCommand RunCommandFunc) CodexProvider {
+	return CodexProvider{
+		Scanner:    Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/codex", nil }},
+		RunCommand: runCommand,
+		RunOutput: func(context.Context, string, ...string) ([]byte, error) {
+			if listErr != nil {
+				return nil, listErr
+			}
+			return []byte(listOutput), nil
+		},
+	}
+}

--- a/pkg/agentsetup/codex_test.go
+++ b/pkg/agentsetup/codex_test.go
@@ -58,14 +58,16 @@ func TestScanCodex_PluginInstalledByNameAndMarketplace(t *testing.T) {
 	require.Equal(t, "2.0.0", status.Plugin.Version)
 }
 
-func TestScanCodex_ListCommandErrorIsMissing(t *testing.T) {
-	provider := codexTestProvider("", errors.New("no marketplace configured"), nil)
+func TestScanCodex_OldVersionWithoutPluginSupport(t *testing.T) {
+	provider := codexTestProvider("", errors.New("unrecognized subcommand 'plugin'"), nil)
 
 	status := provider.Detect()
 
+	// Old Codex shows as detected but with an error hint — the TUI renders
+	// it as disabled (visible but not selectable).
 	require.True(t, status.Detected)
 	require.Equal(t, StatusMissing, status.Status)
-	require.False(t, status.Plugin.Installed)
+	require.Contains(t, status.Error, "upgrade Codex")
 }
 
 func TestCodexApply_RunsAddCommandAndVerifies(t *testing.T) {

--- a/pkg/agentsetup/cursor.go
+++ b/pkg/agentsetup/cursor.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 )
 
@@ -109,7 +108,7 @@ func (s Scanner) ScanCursor() Status {
 // marker file indicates the install finished.
 func findCursorStripePlugin(s Scanner, pluginsRoot string) (string, cursorPluginRef, bool) {
 	cacheRoot := filepath.Join(pluginsRoot, "cache")
-	marketplaces, err := os.ReadDir(cacheRoot)
+	marketplaces, err := s.ReadDir(cacheRoot)
 	if err != nil {
 		return "", cursorPluginRef{}, false
 	}
@@ -119,7 +118,7 @@ func findCursorStripePlugin(s Scanner, pluginsRoot string) (string, cursorPlugin
 			continue
 		}
 		stripeDir := filepath.Join(cacheRoot, marketplace.Name(), CursorPluginName)
-		hashes, err := os.ReadDir(stripeDir)
+		hashes, err := s.ReadDir(stripeDir)
 		if err != nil {
 			continue
 		}
@@ -128,7 +127,7 @@ func findCursorStripePlugin(s Scanner, pluginsRoot string) (string, cursorPlugin
 				continue
 			}
 			hashPath := filepath.Join(stripeDir, hash.Name())
-			if _, err := os.Stat(filepath.Join(hashPath, ".cache-complete")); err != nil {
+			if _, err := s.Stat(filepath.Join(hashPath, ".cache-complete")); err != nil {
 				continue
 			}
 

--- a/pkg/agentsetup/cursor.go
+++ b/pkg/agentsetup/cursor.go
@@ -58,7 +58,7 @@ func (p CursorProvider) Detect() Status {
 }
 
 func (p CursorProvider) Plan(status Status, _ bool) Plan {
-	if !status.Plugin.Installed {
+	if status.Detected && !status.Plugin.Installed {
 		return Plan{
 			Action: ActionManual,
 			Manual: "run /add-plugin stripe inside Cursor",

--- a/pkg/agentsetup/cursor.go
+++ b/pkg/agentsetup/cursor.go
@@ -57,7 +57,13 @@ func (p CursorProvider) Detect() Status {
 	return status
 }
 
-func (p CursorProvider) Plan(_ Status, _ bool) Plan {
+func (p CursorProvider) Plan(status Status, _ bool) Plan {
+	if !status.Plugin.Installed {
+		return Plan{
+			Action: ActionManual,
+			Manual: "run /add-plugin stripe inside Cursor",
+		}
+	}
 	return Plan{Action: ActionNone}
 }
 

--- a/pkg/agentsetup/cursor.go
+++ b/pkg/agentsetup/cursor.go
@@ -1,0 +1,150 @@
+package agentsetup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const (
+	ClientCursor      = "cursor"
+	CursorBinaryName  = "cursor"
+	CursorPluginName  = "stripe"          // plugin directory name under a marketplace
+	CursorPluginsDir  = ".cursor/plugins" // relative to the home directory
+	CursorDisplayName = "Cursor"
+)
+
+// CursorProvider detects the Stripe plugin for Cursor.
+//
+// Unlike Claude Code, Cursor has no `cursor plugin` CLI and no JSON registry:
+// the `cursor` binary is only the editor launcher, and installed plugins are
+// recorded as a directory tree under ~/.cursor/plugins/cache/<marketplace>/
+// <plugin>/<hash>/ (a `.cache-complete` marker plus a .cursor-plugin/plugin.json
+// metadata file). Detection therefore walks the filesystem.
+//
+// Cursor plugins are installed from inside Cursor via the `/add-plugin stripe`
+// slash command; there is no shell CLI installer. This provider therefore
+// detects the plugin from disk and, when it is missing, points the user at the
+// in-app command rather than shelling out.
+type CursorProvider struct {
+	Scanner Scanner
+}
+
+// NewCursorProvider returns a Cursor setup provider. The RunCommandFunc argument
+// is accepted for signature parity with the other providers but is unused,
+// because Cursor has no CLI installer.
+func NewCursorProvider(scanner Scanner, _ RunCommandFunc) Provider {
+	return CursorProvider{Scanner: scanner}
+}
+
+func (p CursorProvider) ID() string { return ClientCursor }
+
+func (p CursorProvider) Detect() Status { return p.Scanner.ScanCursor() }
+
+func (p CursorProvider) Plan(status Status, _ bool) Plan {
+	if status.Detected && !status.Plugin.Installed && status.Status != StatusError {
+		return Plan{Action: ActionManual, Manual: "run /add-plugin stripe inside Cursor to install the Stripe plugin"}
+	}
+	return Plan{Action: ActionNone}
+}
+
+// Apply is a no-op for Cursor: the plugin is installed from inside Cursor, so the
+// setup flow surfaces the ActionManual instruction rather than calling Apply.
+func (p CursorProvider) Apply(_ context.Context, _ io.Writer, _ Plan) error {
+	return nil
+}
+
+type cursorPluginRef struct {
+	version string
+	scope   string
+	path    string
+}
+
+// ScanCursor returns Cursor installation and Stripe plugin status by walking the
+// on-disk plugin cache.
+func (s Scanner) ScanCursor() Status {
+	s = s.withDefaults()
+
+	status := Status{
+		Client:      ClientCursor,
+		DisplayName: CursorDisplayName,
+		Status:      StatusNotDetected,
+	}
+
+	binPath, err := s.LookPath(CursorBinaryName)
+	if err != nil {
+		return status
+	}
+	status.Detected = true
+	status.ExecutablePath = binPath
+	status.Status = StatusMissing
+
+	home, err := s.HomeDir()
+	if err != nil {
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("locating home directory: %v", err)
+		return status
+	}
+
+	pluginsRoot := filepath.Join(home, CursorPluginsDir)
+	status.Plugin.StatePath = pluginsRoot
+
+	if id, ref, ok := findCursorStripePlugin(s, pluginsRoot); ok {
+		status.Plugin.Installed = true
+		status.Plugin.ID = id
+		status.Plugin.Version = ref.version
+		status.Plugin.Scope = ref.scope
+		status.Plugin.StatePath = ref.path
+		status.Status = StatusInstalled
+	}
+
+	return status
+}
+
+// findCursorStripePlugin looks for a completed Stripe plugin install under
+// ~/.cursor/plugins/cache/<marketplace>/stripe/<hash>/. A `.cache-complete`
+// marker file indicates the install finished.
+func findCursorStripePlugin(s Scanner, pluginsRoot string) (string, cursorPluginRef, bool) {
+	cacheRoot := filepath.Join(pluginsRoot, "cache")
+	marketplaces, err := os.ReadDir(cacheRoot)
+	if err != nil {
+		return "", cursorPluginRef{}, false
+	}
+
+	for _, marketplace := range marketplaces {
+		if !marketplace.IsDir() {
+			continue
+		}
+		stripeDir := filepath.Join(cacheRoot, marketplace.Name(), CursorPluginName)
+		hashes, err := os.ReadDir(stripeDir)
+		if err != nil {
+			continue
+		}
+		for _, hash := range hashes {
+			if !hash.IsDir() {
+				continue
+			}
+			hashPath := filepath.Join(stripeDir, hash.Name())
+			if _, err := os.Stat(filepath.Join(hashPath, ".cache-complete")); err != nil {
+				continue
+			}
+
+			ref := cursorPluginRef{scope: "user", path: hashPath}
+			if body, err := s.ReadFile(filepath.Join(hashPath, ".cursor-plugin", "plugin.json")); err == nil {
+				var meta struct {
+					Name    string `json:"name"`
+					Version string `json:"version"`
+				}
+				if json.Unmarshal(body, &meta) == nil {
+					ref.version = meta.Version
+				}
+			}
+			return CursorPluginName + "@" + marketplace.Name(), ref, true
+		}
+	}
+
+	return "", cursorPluginRef{}, false
+}

--- a/pkg/agentsetup/cursor.go
+++ b/pkg/agentsetup/cursor.go
@@ -46,7 +46,7 @@ func (p CursorProvider) Detect() Status { return p.Scanner.ScanCursor() }
 
 func (p CursorProvider) Plan(status Status, _ bool) Plan {
 	if status.Detected && !status.Plugin.Installed && status.Status != StatusError {
-		return Plan{Action: ActionManual, Manual: "run /add-plugin stripe inside Cursor to install the Stripe plugin"}
+		return Plan{Action: ActionManual, Manual: "run /add-plugin stripe inside Cursor Agent to install the Stripe plugin"}
 	}
 	return Plan{Action: ActionNone}
 }

--- a/pkg/agentsetup/cursor.go
+++ b/pkg/agentsetup/cursor.go
@@ -2,17 +2,12 @@ package agentsetup
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
-	"path/filepath"
 )
 
 const (
 	ClientCursor      = "cursor"
 	CursorBinaryName  = "cursor"
-	CursorPluginName  = "stripe"          // plugin directory name under a marketplace
-	CursorPluginsDir  = ".cursor/plugins" // relative to the home directory
 	CursorDisplayName = "Cursor"
 )
 
@@ -41,31 +36,8 @@ func NewCursorProvider(scanner Scanner, _ RunCommandFunc) Provider {
 
 func (p CursorProvider) ID() string { return ClientCursor }
 
-func (p CursorProvider) Detect() Status { return p.Scanner.ScanCursor() }
-
-func (p CursorProvider) Plan(status Status, _ bool) Plan {
-	if status.Detected && !status.Plugin.Installed && status.Status != StatusError {
-		return Plan{Action: ActionManual, Manual: "run /add-plugin stripe inside Cursor Agent to install the Stripe plugin"}
-	}
-	return Plan{Action: ActionNone}
-}
-
-// Apply is a no-op for Cursor: the plugin is installed from inside Cursor, so the
-// setup flow surfaces the ActionManual instruction rather than calling Apply.
-func (p CursorProvider) Apply(_ context.Context, _ io.Writer, _ Plan) error {
-	return nil
-}
-
-type cursorPluginRef struct {
-	version string
-	scope   string
-	path    string
-}
-
-// ScanCursor returns Cursor installation and Stripe plugin status by walking the
-// on-disk plugin cache.
-func (s Scanner) ScanCursor() Status {
-	s = s.withDefaults()
+func (p CursorProvider) Detect() Status {
+	s := p.Scanner.withDefaults()
 
 	status := Status{
 		Client:      ClientCursor,
@@ -80,70 +52,17 @@ func (s Scanner) ScanCursor() Status {
 	status.Detected = true
 	status.ExecutablePath = binPath
 	status.Status = StatusMissing
-
-	home, err := s.HomeDir()
-	if err != nil {
-		status.Status = StatusError
-		status.Error = fmt.Sprintf("locating home directory: %v", err)
-		return status
-	}
-
-	pluginsRoot := filepath.Join(home, CursorPluginsDir)
-	status.Plugin.StatePath = pluginsRoot
-
-	if id, ref, ok := findCursorStripePlugin(s, pluginsRoot); ok {
-		status.Plugin.Installed = true
-		status.Plugin.ID = id
-		status.Plugin.Version = ref.version
-		status.Plugin.Scope = ref.scope
-		status.Plugin.StatePath = ref.path
-		status.Status = StatusInstalled
-	}
-
+	// Signal to the TUI that this row is not actionable from the CLI.
+	status.Error = "run /add-plugin stripe inside Cursor agent"
 	return status
 }
 
-// findCursorStripePlugin looks for a completed Stripe plugin install under
-// ~/.cursor/plugins/cache/<marketplace>/stripe/<hash>/. A `.cache-complete`
-// marker file indicates the install finished.
-func findCursorStripePlugin(s Scanner, pluginsRoot string) (string, cursorPluginRef, bool) {
-	cacheRoot := filepath.Join(pluginsRoot, "cache")
-	marketplaces, err := s.ReadDir(cacheRoot)
-	if err != nil {
-		return "", cursorPluginRef{}, false
-	}
+func (p CursorProvider) Plan(_ Status, _ bool) Plan {
+	return Plan{Action: ActionNone}
+}
 
-	for _, marketplace := range marketplaces {
-		if !marketplace.IsDir() {
-			continue
-		}
-		stripeDir := filepath.Join(cacheRoot, marketplace.Name(), CursorPluginName)
-		hashes, err := s.ReadDir(stripeDir)
-		if err != nil {
-			continue
-		}
-		for _, hash := range hashes {
-			if !hash.IsDir() {
-				continue
-			}
-			hashPath := filepath.Join(stripeDir, hash.Name())
-			if _, err := s.Stat(filepath.Join(hashPath, ".cache-complete")); err != nil {
-				continue
-			}
-
-			ref := cursorPluginRef{scope: "user", path: hashPath}
-			if body, err := s.ReadFile(filepath.Join(hashPath, ".cursor-plugin", "plugin.json")); err == nil {
-				var meta struct {
-					Name    string `json:"name"`
-					Version string `json:"version"`
-				}
-				if json.Unmarshal(body, &meta) == nil {
-					ref.version = meta.Version
-				}
-			}
-			return CursorPluginName + "@" + marketplace.Name(), ref, true
-		}
-	}
-
-	return "", cursorPluginRef{}, false
+// Apply is a no-op for Cursor: the plugin is installed from inside Cursor, so the
+// setup flow surfaces the ActionManual instruction rather than calling Apply.
+func (p CursorProvider) Apply(_ context.Context, _ io.Writer, _ Plan) error {
+	return nil
 }

--- a/pkg/agentsetup/cursor_test.go
+++ b/pkg/agentsetup/cursor_test.go
@@ -45,6 +45,17 @@ func TestCursor_PlanManualWhenNotInstalled(t *testing.T) {
 	require.Contains(t, plan.Manual, "/add-plugin stripe")
 }
 
+func TestCursor_PlanNoneWhenNotDetected(t *testing.T) {
+	provider := CursorProvider{
+		Scanner: Scanner{LookPath: func(string) (string, error) { return "", errors.New("missing") }},
+	}
+
+	status := provider.Detect()
+	plan := provider.Plan(status, false)
+
+	require.Equal(t, ActionNone, plan.Action)
+}
+
 func TestCursor_PlanNoneWhenInstalled(t *testing.T) {
 	provider := CursorProvider{
 		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil }},

--- a/pkg/agentsetup/cursor_test.go
+++ b/pkg/agentsetup/cursor_test.go
@@ -2,90 +2,54 @@ package agentsetup
 
 import (
 	"errors"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestScanCursor_NotDetected(t *testing.T) {
-	scanner := Scanner{
-		LookPath: func(string) (string, error) { return "", errors.New("missing") },
+func TestCursor_NotDetected(t *testing.T) {
+	provider := CursorProvider{
+		Scanner: Scanner{LookPath: func(string) (string, error) { return "", errors.New("missing") }},
 	}
 
-	status := scanner.ScanCursor()
+	status := provider.Detect()
 
 	require.Equal(t, ClientCursor, status.Client)
+	require.Equal(t, "Cursor", status.DisplayName)
 	require.False(t, status.Detected)
 	require.Equal(t, StatusNotDetected, status.Status)
 }
 
-func TestScanCursor_NoPluginsDir(t *testing.T) {
-	home := t.TempDir()
-	status := cursorTestScanner(home).ScanCursor()
+func TestCursor_DetectedAlwaysMissing(t *testing.T) {
+	provider := CursorProvider{
+		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil }},
+	}
+
+	status := provider.Detect()
 
 	require.True(t, status.Detected)
-	require.False(t, status.Plugin.Installed)
-	require.Equal(t, StatusMissing, status.Status)
-	require.Equal(t, filepath.Join(home, CursorPluginsDir), status.Plugin.StatePath)
-}
-
-func TestScanCursor_PluginInstalled(t *testing.T) {
-	home := t.TempDir()
-	hashPath := writeCursorPlugin(t, home, "cursor-public", "abc123", `{"name":"stripe","version":"0.1.0"}`, true)
-
-	status := cursorTestScanner(home).ScanCursor()
-
-	require.Equal(t, StatusInstalled, status.Status)
-	require.True(t, status.Plugin.Installed)
-	require.Equal(t, "stripe@cursor-public", status.Plugin.ID)
-	require.Equal(t, "0.1.0", status.Plugin.Version)
-	require.Equal(t, "user", status.Plugin.Scope)
-	require.Equal(t, hashPath, status.Plugin.StatePath)
-}
-
-func TestScanCursor_IncompleteInstallIsMissing(t *testing.T) {
-	home := t.TempDir()
-	// No .cache-complete marker => install did not finish.
-	writeCursorPlugin(t, home, "cursor-public", "abc123", `{"name":"stripe","version":"0.1.0"}`, false)
-
-	status := cursorTestScanner(home).ScanCursor()
-
+	require.Equal(t, "/usr/local/bin/cursor", status.ExecutablePath)
 	require.Equal(t, StatusMissing, status.Status)
 	require.False(t, status.Plugin.Installed)
 }
 
-func TestScanCursor_InstalledWithUnreadableMetadataStillDetected(t *testing.T) {
-	home := t.TempDir()
-	writeCursorPlugin(t, home, "cursor-public", "abc123", `{nope`, true)
+func TestCursor_PlanAlwaysNone(t *testing.T) {
+	provider := CursorProvider{
+		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil }},
+	}
 
-	status := cursorTestScanner(home).ScanCursor()
+	status := provider.Detect()
+	plan := provider.Plan(status, false)
 
-	require.Equal(t, StatusInstalled, status.Status)
-	require.True(t, status.Plugin.Installed)
-	require.Equal(t, "stripe@cursor-public", status.Plugin.ID)
-	require.Empty(t, status.Plugin.Version)
+	require.Equal(t, ActionNone, plan.Action)
 }
 
-func cursorTestScanner(home string) Scanner {
-	return Scanner{
-		LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil },
-		ReadFile: os.ReadFile,
-		HomeDir:  func() (string, error) { return home, nil },
+func TestCursor_ErrorHintForTUIDisable(t *testing.T) {
+	provider := CursorProvider{
+		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil }},
 	}
-}
 
-// writeCursorPlugin creates a Cursor plugin cache entry and returns the hash
-// directory path. When complete is true it also writes the .cache-complete
-// marker that ScanCursor treats as "install finished".
-func writeCursorPlugin(t *testing.T, home, marketplace, hash, pluginJSON string, complete bool) string {
-	t.Helper()
-	hashPath := filepath.Join(home, CursorPluginsDir, "cache", marketplace, CursorPluginName, hash)
-	require.NoError(t, os.MkdirAll(filepath.Join(hashPath, ".cursor-plugin"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(hashPath, ".cursor-plugin", "plugin.json"), []byte(pluginJSON), 0600))
-	if complete {
-		require.NoError(t, os.WriteFile(filepath.Join(hashPath, ".cache-complete"), nil, 0600))
-	}
-	return hashPath
+	status := provider.Detect()
+
+	require.Contains(t, status.Error, "/add-plugin stripe")
 }

--- a/pkg/agentsetup/cursor_test.go
+++ b/pkg/agentsetup/cursor_test.go
@@ -33,12 +33,25 @@ func TestCursor_DetectedAlwaysMissing(t *testing.T) {
 	require.False(t, status.Plugin.Installed)
 }
 
-func TestCursor_PlanAlwaysNone(t *testing.T) {
+func TestCursor_PlanManualWhenNotInstalled(t *testing.T) {
 	provider := CursorProvider{
 		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil }},
 	}
 
 	status := provider.Detect()
+	plan := provider.Plan(status, false)
+
+	require.Equal(t, ActionManual, plan.Action)
+	require.Contains(t, plan.Manual, "/add-plugin stripe")
+}
+
+func TestCursor_PlanNoneWhenInstalled(t *testing.T) {
+	provider := CursorProvider{
+		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil }},
+	}
+
+	status := provider.Detect()
+	status.Plugin.Installed = true
 	plan := provider.Plan(status, false)
 
 	require.Equal(t, ActionNone, plan.Action)

--- a/pkg/agentsetup/cursor_test.go
+++ b/pkg/agentsetup/cursor_test.go
@@ -1,0 +1,91 @@
+package agentsetup
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanCursor_NotDetected(t *testing.T) {
+	scanner := Scanner{
+		LookPath: func(string) (string, error) { return "", errors.New("missing") },
+	}
+
+	status := scanner.ScanCursor()
+
+	require.Equal(t, ClientCursor, status.Client)
+	require.False(t, status.Detected)
+	require.Equal(t, StatusNotDetected, status.Status)
+}
+
+func TestScanCursor_NoPluginsDir(t *testing.T) {
+	home := t.TempDir()
+	status := cursorTestScanner(home).ScanCursor()
+
+	require.True(t, status.Detected)
+	require.False(t, status.Plugin.Installed)
+	require.Equal(t, StatusMissing, status.Status)
+	require.Equal(t, filepath.Join(home, CursorPluginsDir), status.Plugin.StatePath)
+}
+
+func TestScanCursor_PluginInstalled(t *testing.T) {
+	home := t.TempDir()
+	hashPath := writeCursorPlugin(t, home, "cursor-public", "abc123", `{"name":"stripe","version":"0.1.0"}`, true)
+
+	status := cursorTestScanner(home).ScanCursor()
+
+	require.Equal(t, StatusInstalled, status.Status)
+	require.True(t, status.Plugin.Installed)
+	require.Equal(t, "stripe@cursor-public", status.Plugin.ID)
+	require.Equal(t, "0.1.0", status.Plugin.Version)
+	require.Equal(t, "user", status.Plugin.Scope)
+	require.Equal(t, hashPath, status.Plugin.StatePath)
+}
+
+func TestScanCursor_IncompleteInstallIsMissing(t *testing.T) {
+	home := t.TempDir()
+	// No .cache-complete marker => install did not finish.
+	writeCursorPlugin(t, home, "cursor-public", "abc123", `{"name":"stripe","version":"0.1.0"}`, false)
+
+	status := cursorTestScanner(home).ScanCursor()
+
+	require.Equal(t, StatusMissing, status.Status)
+	require.False(t, status.Plugin.Installed)
+}
+
+func TestScanCursor_InstalledWithUnreadableMetadataStillDetected(t *testing.T) {
+	home := t.TempDir()
+	writeCursorPlugin(t, home, "cursor-public", "abc123", `{nope`, true)
+
+	status := cursorTestScanner(home).ScanCursor()
+
+	require.Equal(t, StatusInstalled, status.Status)
+	require.True(t, status.Plugin.Installed)
+	require.Equal(t, "stripe@cursor-public", status.Plugin.ID)
+	require.Empty(t, status.Plugin.Version)
+}
+
+func cursorTestScanner(home string) Scanner {
+	return Scanner{
+		LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil },
+		ReadFile: os.ReadFile,
+		HomeDir:  func() (string, error) { return home, nil },
+	}
+}
+
+// writeCursorPlugin creates a Cursor plugin cache entry and returns the hash
+// directory path. When complete is true it also writes the .cache-complete
+// marker that ScanCursor treats as "install finished".
+func writeCursorPlugin(t *testing.T, home, marketplace, hash, pluginJSON string, complete bool) string {
+	t.Helper()
+	hashPath := filepath.Join(home, CursorPluginsDir, "cache", marketplace, CursorPluginName, hash)
+	require.NoError(t, os.MkdirAll(filepath.Join(hashPath, ".cursor-plugin"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(hashPath, ".cursor-plugin", "plugin.json"), []byte(pluginJSON), 0600))
+	if complete {
+		require.NoError(t, os.WriteFile(filepath.Join(hashPath, ".cache-complete"), nil, 0600))
+	}
+	return hashPath
+}

--- a/pkg/agentsetup/provider.go
+++ b/pkg/agentsetup/provider.go
@@ -1,0 +1,71 @@
+package agentsetup
+
+import (
+	"context"
+	"io"
+	"sort"
+	"strings"
+)
+
+const (
+	StatusNotDetected = "not_detected"
+	StatusInstalled   = "installed"
+	StatusMissing     = "missing"
+	StatusError       = "error"
+
+	ActionNone      = "none"
+	ActionInstall   = "install"
+	ActionReinstall = "reinstall"
+)
+
+// Provider detects and configures Stripe tooling for one AI coding client.
+type Provider interface {
+	ID() string
+	Detect() Status
+	Plan(Status, bool) Plan
+	Apply(context.Context, io.Writer, Plan) error
+}
+
+// DefaultProviders returns production setup providers keyed by client id.
+func DefaultProviders() map[string]Provider {
+	claude := NewClaudeProvider(DefaultScanner(), RunCommand)
+	return map[string]Provider{
+		claude.ID(): claude,
+	}
+}
+
+func SupportedProviderIDs(providers map[string]Provider) string {
+	ids := make([]string, 0, len(providers))
+	for id := range providers {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ",")
+}
+
+// Status is the read-only setup status for one AI coding client.
+type Status struct {
+	Client         string       `json:"client"`
+	DisplayName    string       `json:"display_name"`
+	Detected       bool         `json:"detected"`
+	ExecutablePath string       `json:"executable_path,omitempty"`
+	Plugin         PluginStatus `json:"plugin"`
+	Status         string       `json:"status"`
+	Error          string       `json:"error,omitempty"`
+}
+
+// PluginStatus is the plugin-specific part of a client setup status.
+type PluginStatus struct {
+	Installed bool   `json:"installed"`
+	ID        string `json:"id,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Scope     string `json:"scope,omitempty"`
+	Project   string `json:"project_path,omitempty"`
+	StatePath string `json:"state_path,omitempty"`
+}
+
+// Plan describes the next setup action for a provider.
+type Plan struct {
+	Action  string   `json:"action"`
+	Command []string `json:"command,omitempty"`
+}

--- a/pkg/agentsetup/provider.go
+++ b/pkg/agentsetup/provider.go
@@ -16,6 +16,9 @@ const (
 	ActionNone      = "none"
 	ActionInstall   = "install"
 	ActionReinstall = "reinstall"
+	// ActionManual means setup cannot be automated and the user must perform a
+	// step themselves (e.g. Cursor plugins are installed from inside Cursor).
+	ActionManual = "manual"
 )
 
 // Provider detects and configures Stripe tooling for one AI coding client.
@@ -28,9 +31,14 @@ type Provider interface {
 
 // DefaultProviders returns production setup providers keyed by client id.
 func DefaultProviders() map[string]Provider {
-	claude := NewClaudeProvider(DefaultScanner(), RunCommand)
+	scanner := DefaultScanner()
+	claude := NewClaudeProvider(scanner, RunCommand)
+	cursor := NewCursorProvider(scanner, RunCommand)
+	codex := NewCodexProvider(scanner, RunCommand)
 	return map[string]Provider{
 		claude.ID(): claude,
+		cursor.ID(): cursor,
+		codex.ID():  codex,
 	}
 }
 
@@ -68,4 +76,6 @@ type PluginStatus struct {
 type Plan struct {
 	Action  string   `json:"action"`
 	Command []string `json:"command,omitempty"`
+	// Manual holds the instruction shown for ActionManual plans.
+	Manual string `json:"manual,omitempty"`
 }

--- a/pkg/agentsetup/scanner.go
+++ b/pkg/agentsetup/scanner.go
@@ -2,13 +2,8 @@ package agentsetup
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 )
 
 // LookPathFunc matches exec.LookPath and exists to make detection testable.
@@ -84,119 +79,4 @@ func RunCommand(ctx context.Context, name string, args ...string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
-}
-
-// pluginClient describes a client whose Stripe plugin state is a Claude-style
-// installed_plugins.json registry. Claude Code uses this; Cursor and Codex
-// record installs differently and have their own scanners.
-type pluginClient struct {
-	id           string
-	displayName  string
-	shortName    string // used in error messages, e.g. "Claude"
-	binaryName   string
-	targetPlugin string
-	localPlugin  string // optional local marketplace id; "" when none
-	pluginState  string // path under the home dir to installed_plugins.json
-}
-
-type installedPluginState struct {
-	Version int                             `json:"version"`
-	Plugins map[string][]installedPluginRef `json:"plugins"`
-}
-
-type installedPluginRef struct {
-	Scope       string `json:"scope"`
-	Version     string `json:"version"`
-	Installed   string `json:"installPath"`
-	ProjectPath string `json:"projectPath"`
-}
-
-// scanPlugin returns installation and Stripe plugin status for a plugin-based
-// client without mutating anything on disk.
-func (s Scanner) scanPlugin(client pluginClient) Status {
-	s = s.withDefaults()
-
-	status := Status{
-		Client:      client.id,
-		DisplayName: client.displayName,
-		Status:      StatusNotDetected,
-	}
-
-	binPath, err := s.LookPath(client.binaryName)
-	if err != nil {
-		return status
-	}
-	status.Detected = true
-	status.ExecutablePath = binPath
-	status.Status = StatusMissing
-
-	home, err := s.HomeDir()
-	if err != nil {
-		status.Status = StatusError
-		status.Error = fmt.Sprintf("locating home directory: %v", err)
-		return status
-	}
-	status.Plugin.StatePath = filepath.Join(home, client.pluginState)
-
-	body, err := s.ReadFile(status.Plugin.StatePath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return status
-		}
-		status.Status = StatusError
-		status.Error = fmt.Sprintf("reading %s plugin state: %v", client.shortName, err)
-		return status
-	}
-
-	var pluginState installedPluginState
-	if err := json.Unmarshal(body, &pluginState); err != nil {
-		status.Status = StatusError
-		status.Error = fmt.Sprintf("parsing %s plugin state: %v", client.shortName, err)
-		return status
-	}
-
-	workDir, err := s.WorkDir()
-	if err != nil {
-		status.Status = StatusError
-		status.Error = fmt.Sprintf("locating working directory: %v", err)
-		return status
-	}
-
-	if id, ref, ok := findStripePlugin(pluginState.Plugins, client, workDir); ok {
-		status.Plugin.Installed = true
-		status.Plugin.ID = id
-		status.Plugin.Version = ref.Version
-		status.Plugin.Scope = ref.Scope
-		status.Plugin.Project = ref.ProjectPath
-		status.Status = StatusInstalled
-	}
-
-	return status
-}
-
-func findStripePlugin(plugins map[string][]installedPluginRef, client pluginClient, workDir string) (string, installedPluginRef, bool) {
-	ids := []string{client.targetPlugin}
-	if client.localPlugin != "" {
-		ids = append(ids, client.localPlugin)
-	}
-	for _, id := range ids {
-		for _, ref := range plugins[id] {
-			if pluginVisibleInWorkDir(ref, workDir) {
-				return id, ref, true
-			}
-		}
-	}
-	return "", installedPluginRef{}, false
-}
-
-func pluginVisibleInWorkDir(ref installedPluginRef, workDir string) bool {
-	if ref.Scope != "local" || ref.ProjectPath == "" {
-		return true
-	}
-
-	rel, err := filepath.Rel(ref.ProjectPath, workDir)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && !filepath.IsAbs(rel))
 }

--- a/pkg/agentsetup/scanner.go
+++ b/pkg/agentsetup/scanner.go
@@ -1,0 +1,186 @@
+package agentsetup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// LookPathFunc matches exec.LookPath and exists to make detection testable.
+type LookPathFunc func(string) (string, error)
+
+// ReadFileFunc matches os.ReadFile and exists to make status parsing testable.
+type ReadFileFunc func(string) ([]byte, error)
+
+// HomeDirFunc matches os.UserHomeDir and exists to make status parsing testable.
+type HomeDirFunc func() (string, error)
+
+// WorkDirFunc matches os.Getwd and exists to make local plugin scope testable.
+type WorkDirFunc func() (string, error)
+
+// RunCommandFunc runs a command. The production implementation streams stdio.
+type RunCommandFunc func(context.Context, string, ...string) error
+
+// Scanner scans local agent installations without mutating them.
+type Scanner struct {
+	LookPath LookPathFunc
+	ReadFile ReadFileFunc
+	HomeDir  HomeDirFunc
+	WorkDir  WorkDirFunc
+}
+
+// DefaultScanner returns a Scanner backed by the real OS.
+func DefaultScanner() Scanner {
+	return Scanner{
+		LookPath: exec.LookPath,
+		ReadFile: os.ReadFile,
+		HomeDir:  os.UserHomeDir,
+		WorkDir:  os.Getwd,
+	}
+}
+
+func (s Scanner) withDefaults() Scanner {
+	defaults := DefaultScanner()
+	if s.LookPath == nil {
+		s.LookPath = defaults.LookPath
+	}
+	if s.ReadFile == nil {
+		s.ReadFile = defaults.ReadFile
+	}
+	if s.HomeDir == nil {
+		s.HomeDir = defaults.HomeDir
+	}
+	if s.WorkDir == nil {
+		s.WorkDir = defaults.WorkDir
+	}
+	return s
+}
+
+// RunCommand streams a command through the current process stdio.
+func RunCommand(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// pluginClient describes a client whose Stripe plugin state is a Claude-style
+// installed_plugins.json registry. Claude Code uses this; Cursor and Codex
+// record installs differently and have their own scanners.
+type pluginClient struct {
+	id           string
+	displayName  string
+	shortName    string // used in error messages, e.g. "Claude"
+	binaryName   string
+	targetPlugin string
+	localPlugin  string // optional local marketplace id; "" when none
+	pluginState  string // path under the home dir to installed_plugins.json
+}
+
+type installedPluginState struct {
+	Version int                             `json:"version"`
+	Plugins map[string][]installedPluginRef `json:"plugins"`
+}
+
+type installedPluginRef struct {
+	Scope       string `json:"scope"`
+	Version     string `json:"version"`
+	Installed   string `json:"installPath"`
+	ProjectPath string `json:"projectPath"`
+}
+
+// scanPlugin returns installation and Stripe plugin status for a plugin-based
+// client without mutating anything on disk.
+func (s Scanner) scanPlugin(client pluginClient) Status {
+	s = s.withDefaults()
+
+	status := Status{
+		Client:      client.id,
+		DisplayName: client.displayName,
+		Status:      StatusNotDetected,
+	}
+
+	binPath, err := s.LookPath(client.binaryName)
+	if err != nil {
+		return status
+	}
+	status.Detected = true
+	status.ExecutablePath = binPath
+	status.Status = StatusMissing
+
+	home, err := s.HomeDir()
+	if err != nil {
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("locating home directory: %v", err)
+		return status
+	}
+	status.Plugin.StatePath = filepath.Join(home, client.pluginState)
+
+	body, err := s.ReadFile(status.Plugin.StatePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return status
+		}
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("reading %s plugin state: %v", client.shortName, err)
+		return status
+	}
+
+	var pluginState installedPluginState
+	if err := json.Unmarshal(body, &pluginState); err != nil {
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("parsing %s plugin state: %v", client.shortName, err)
+		return status
+	}
+
+	workDir, err := s.WorkDir()
+	if err != nil {
+		status.Status = StatusError
+		status.Error = fmt.Sprintf("locating working directory: %v", err)
+		return status
+	}
+
+	if id, ref, ok := findStripePlugin(pluginState.Plugins, client, workDir); ok {
+		status.Plugin.Installed = true
+		status.Plugin.ID = id
+		status.Plugin.Version = ref.Version
+		status.Plugin.Scope = ref.Scope
+		status.Plugin.Project = ref.ProjectPath
+		status.Status = StatusInstalled
+	}
+
+	return status
+}
+
+func findStripePlugin(plugins map[string][]installedPluginRef, client pluginClient, workDir string) (string, installedPluginRef, bool) {
+	ids := []string{client.targetPlugin}
+	if client.localPlugin != "" {
+		ids = append(ids, client.localPlugin)
+	}
+	for _, id := range ids {
+		for _, ref := range plugins[id] {
+			if pluginVisibleInWorkDir(ref, workDir) {
+				return id, ref, true
+			}
+		}
+	}
+	return "", installedPluginRef{}, false
+}
+
+func pluginVisibleInWorkDir(ref installedPluginRef, workDir string) bool {
+	if ref.Scope != "local" || ref.ProjectPath == "" {
+		return true
+	}
+
+	rel, err := filepath.Rel(ref.ProjectPath, workDir)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && !filepath.IsAbs(rel))
+}

--- a/pkg/agentsetup/scanner.go
+++ b/pkg/agentsetup/scanner.go
@@ -23,6 +23,12 @@ type HomeDirFunc func() (string, error)
 // WorkDirFunc matches os.Getwd and exists to make local plugin scope testable.
 type WorkDirFunc func() (string, error)
 
+// ReadDirFunc matches os.ReadDir and exists to make directory listing testable.
+type ReadDirFunc func(string) ([]os.DirEntry, error)
+
+// StatFunc matches os.Stat and exists to make file existence checks testable.
+type StatFunc func(string) (os.FileInfo, error)
+
 // RunCommandFunc runs a command. The production implementation streams stdio.
 type RunCommandFunc func(context.Context, string, ...string) error
 
@@ -32,6 +38,8 @@ type Scanner struct {
 	ReadFile ReadFileFunc
 	HomeDir  HomeDirFunc
 	WorkDir  WorkDirFunc
+	ReadDir  ReadDirFunc
+	Stat     StatFunc
 }
 
 // DefaultScanner returns a Scanner backed by the real OS.
@@ -41,6 +49,8 @@ func DefaultScanner() Scanner {
 		ReadFile: os.ReadFile,
 		HomeDir:  os.UserHomeDir,
 		WorkDir:  os.Getwd,
+		ReadDir:  os.ReadDir,
+		Stat:     os.Stat,
 	}
 }
 
@@ -57,6 +67,12 @@ func (s Scanner) withDefaults() Scanner {
 	}
 	if s.WorkDir == nil {
 		s.WorkDir = defaults.WorkDir
+	}
+	if s.ReadDir == nil {
+		s.ReadDir = defaults.ReadDir
+	}
+	if s.Stat == nil {
+		s.Stat = defaults.Stat
 	}
 	return s
 }

--- a/pkg/agentskills/agentskills.go
+++ b/pkg/agentskills/agentskills.go
@@ -1,0 +1,132 @@
+// Package agentskills installs Stripe agent skills natively, reproducing what
+// `npx skills add https://docs.stripe.com` does without any Node/npx dependency.
+// It fetches the skills index from docs.stripe.com and writes each skill's files
+// to a destination directory, preserving the skill/relative-path layout.
+package agentskills
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// IndexURL is the canonical Stripe skills index. It is a var (not a const) so
+// tests can point it at an httptest server; individual file URLs are derived
+// from it, so overriding it redirects file fetches too.
+var IndexURL = "https://docs.stripe.com/.well-known/skills/index.json"
+
+const requestTimeout = 10 * time.Second
+
+// Index is the top-level response from IndexURL.
+type Index struct {
+	Skills []Skill `json:"skills"`
+}
+
+// Skill is one entry in the index. Files lists the skill's artifacts as paths
+// relative to the skill directory (e.g. "SKILL.md", "references/billing.md").
+type Skill struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Files       []string `json:"files"`
+}
+
+func clientOrDefault(httpClient *http.Client) *http.Client {
+	if httpClient != nil {
+		return httpClient
+	}
+	return &http.Client{Timeout: requestTimeout}
+}
+
+// filesBaseURL is the directory the index lives in, e.g.
+// "https://docs.stripe.com/.well-known/skills/". Skill files are fetched from
+// filesBaseURL + "<skill>/<file>".
+func filesBaseURL() string {
+	return strings.TrimSuffix(IndexURL, "index.json")
+}
+
+// FetchIndex retrieves the skills index from docs.stripe.com.
+func FetchIndex(ctx context.Context, httpClient *http.Client) (*Index, error) {
+	body, err := get(ctx, clientOrDefault(httpClient), IndexURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching skills index: %w", err)
+	}
+
+	var index Index
+	if err := json.Unmarshal(body, &index); err != nil {
+		return nil, fmt.Errorf("parsing skills index: %w", err)
+	}
+	return &index, nil
+}
+
+// Install fetches every file of every skill in the index and writes it under
+// destDir preserving the skill/relative-path layout (destDir/<skill>/<file>).
+// Installation is best-effort: a file that fails to fetch or write is skipped.
+// It returns the names of skills that had at least one file written.
+func Install(ctx context.Context, httpClient *http.Client, destDir string) ([]string, error) {
+	client := clientOrDefault(httpClient)
+
+	index, err := FetchIndex(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	base := filesBaseURL()
+	var installed []string
+	for _, skill := range index.Skills {
+		if skill.Name == "" {
+			continue
+		}
+		wrote := false
+		for _, file := range skill.Files {
+			if file == "" {
+				continue
+			}
+			content, err := get(ctx, client, base+skill.Name+"/"+file)
+			if err != nil {
+				continue
+			}
+			target := filepath.Join(destDir, skill.Name, filepath.FromSlash(file))
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				continue
+			}
+			if err := os.WriteFile(target, content, 0600); err != nil {
+				continue
+			}
+			wrote = true
+		}
+		if wrote {
+			installed = append(installed, skill.Name)
+		}
+	}
+
+	return installed, nil
+}
+
+func get(ctx context.Context, client *http.Client, rawURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s returned %d", rawURL, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+	return body, nil
+}

--- a/pkg/agentskills/agentskills.go
+++ b/pkg/agentskills/agentskills.go
@@ -87,11 +87,14 @@ func Install(ctx context.Context, httpClient *http.Client, destDir string) ([]st
 			if file == "" {
 				continue
 			}
+			target := filepath.Join(destDir, skill.Name, filepath.FromSlash(file))
+			if !isUnderDir(target, destDir) {
+				continue
+			}
 			content, err := get(ctx, client, base+skill.Name+"/"+file)
 			if err != nil {
 				continue
 			}
-			target := filepath.Join(destDir, skill.Name, filepath.FromSlash(file))
 			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 				continue
 			}
@@ -106,6 +109,14 @@ func Install(ctx context.Context, httpClient *http.Client, destDir string) ([]st
 	}
 
 	return installed, nil
+}
+
+// isUnderDir reports whether target is strictly under dir after cleaning both
+// paths. This rejects path traversal via "../" or absolute paths in skill names.
+func isUnderDir(target, dir string) bool {
+	cleanTarget := filepath.Clean(target)
+	cleanDir := filepath.Clean(dir) + string(filepath.Separator)
+	return strings.HasPrefix(cleanTarget, cleanDir)
 }
 
 func get(ctx context.Context, client *http.Client, rawURL string) ([]byte, error) {

--- a/pkg/agentskills/agentskills_test.go
+++ b/pkg/agentskills/agentskills_test.go
@@ -104,6 +104,27 @@ func TestInstall_SkillWithNoRetrievableFilesIsOmitted(t *testing.T) {
 	require.NoDirExists(t, filepath.Join(dest, "broken"))
 }
 
+func TestInstall_RejectsPathTraversal(t *testing.T) {
+	index := Index{Skills: []Skill{
+		{Name: "../escape", Files: []string{"SKILL.md"}},
+		{Name: "legit", Files: []string{"../../etc/passwd"}},
+		{Name: "good", Files: []string{"SKILL.md"}},
+	}}
+	server := startSkillsServer(t, index, map[string]string{
+		"../escape/SKILL.md":     "# evil",
+		"legit/../../etc/passwd": "# evil",
+		"good/SKILL.md":          "# good",
+	})
+
+	dest := t.TempDir()
+	installed, err := Install(context.Background(), server.Client(), dest)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"good"}, installed)
+	require.NoFileExists(t, filepath.Join(dest, "..", "escape", "SKILL.md"))
+	require.NoFileExists(t, filepath.Join(dest, "..", "..", "etc", "passwd"))
+}
+
 func TestInstall_IndexError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/agentskills/agentskills_test.go
+++ b/pkg/agentskills/agentskills_test.go
@@ -1,0 +1,122 @@
+package agentskills
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// startSkillsServer serves the index at /index.json and each file at
+// /<skill>/<path>. content maps "<skill>/<file>" -> body. Missing routes 404.
+// It points IndexURL at the test server for the test's duration.
+func startSkillsServer(t *testing.T, index Index, content map[string]string) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(index))
+	})
+	for path, body := range content {
+		body := body
+		mux.HandleFunc("/"+path, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = fmt.Fprint(w, body)
+		})
+	}
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	original := IndexURL
+	IndexURL = server.URL + "/index.json"
+	t.Cleanup(func() { IndexURL = original })
+
+	return server
+}
+
+func TestInstall_WritesNestedFiles(t *testing.T) {
+	index := Index{Skills: []Skill{
+		{Name: "stripe-best-practices", Files: []string{"SKILL.md", "references/billing.md"}},
+		{Name: "upgrade-stripe", Files: []string{"SKILL.md"}},
+	}}
+	server := startSkillsServer(t, index, map[string]string{
+		"stripe-best-practices/SKILL.md":              "# best practices",
+		"stripe-best-practices/references/billing.md": "# billing",
+		"upgrade-stripe/SKILL.md":                     "# upgrade",
+	})
+
+	dest := t.TempDir()
+	installed, err := Install(context.Background(), server.Client(), dest)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"stripe-best-practices", "upgrade-stripe"}, installed)
+
+	body, err := os.ReadFile(filepath.Join(dest, "stripe-best-practices", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, "# best practices", string(body))
+
+	body, err = os.ReadFile(filepath.Join(dest, "stripe-best-practices", "references", "billing.md"))
+	require.NoError(t, err)
+	require.Equal(t, "# billing", string(body))
+
+	body, err = os.ReadFile(filepath.Join(dest, "upgrade-stripe", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, "# upgrade", string(body))
+}
+
+func TestInstall_SkipsMissingFilesButKeepsSkill(t *testing.T) {
+	index := Index{Skills: []Skill{
+		{Name: "stripe-best-practices", Files: []string{"SKILL.md", "references/missing.md"}},
+	}}
+	server := startSkillsServer(t, index, map[string]string{
+		"stripe-best-practices/SKILL.md": "# best practices",
+		// references/missing.md has no route -> 404
+	})
+
+	dest := t.TempDir()
+	installed, err := Install(context.Background(), server.Client(), dest)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"stripe-best-practices"}, installed)
+	require.FileExists(t, filepath.Join(dest, "stripe-best-practices", "SKILL.md"))
+	require.NoFileExists(t, filepath.Join(dest, "stripe-best-practices", "references", "missing.md"))
+}
+
+func TestInstall_SkillWithNoRetrievableFilesIsOmitted(t *testing.T) {
+	index := Index{Skills: []Skill{
+		{Name: "ok", Files: []string{"SKILL.md"}},
+		{Name: "broken", Files: []string{"SKILL.md"}}, // no route
+	}}
+	server := startSkillsServer(t, index, map[string]string{
+		"ok/SKILL.md": "# ok",
+	})
+
+	dest := t.TempDir()
+	installed, err := Install(context.Background(), server.Client(), dest)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"ok"}, installed)
+	require.NoDirExists(t, filepath.Join(dest, "broken"))
+}
+
+func TestInstall_IndexError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	original := IndexURL
+	IndexURL = server.URL + "/index.json"
+	t.Cleanup(func() { IndexURL = original })
+
+	installed, err := Install(context.Background(), server.Client(), t.TempDir())
+
+	require.Error(t, err)
+	require.Nil(t, installed)
+	require.Contains(t, err.Error(), "fetching skills index")
+}

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -1,20 +1,32 @@
 package cmd
 
 import (
-	"bufio"
+	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
 	"github.com/stripe/stripe-cli/pkg/agentsetup"
+	"github.com/stripe/stripe-cli/pkg/agentskills"
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/docs/spinner"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
+
+// providerOrder is the canonical display order for known clients. Providers not
+// listed here are appended afterward in alphabetical order.
+var providerOrder = []string{
+	agentsetup.ClientClaudeCode,
+	agentsetup.ClientCursor,
+	agentsetup.ClientCodex,
+}
 
 type agentCmd struct {
 	cmd *cobra.Command
@@ -23,13 +35,21 @@ type agentCmd struct {
 type agentSetupCmd struct {
 	cmd *cobra.Command
 
-	statusOnly bool
-	yes        bool
-	force      bool
-	jsonOutput bool
-	client     string
+	statusOnly  bool
+	yes         bool
+	force       bool
+	jsonOutput  bool
+	client      string
+	skills      bool
+	skillsScope string
 
 	providers map[string]agentsetup.Provider
+
+	// Skills installation is injectable so tests can avoid the network and
+	// point installs at temp directories.
+	skillsInstall   func(ctx context.Context, destDir string) ([]string, error)
+	skillsLocalDir  func() (string, error)
+	skillsGlobalDir func() (string, error)
 }
 
 type agentSetupJSON struct {
@@ -53,147 +73,406 @@ func newAgentCmd() *agentCmd {
 
 func newAgentSetupCmd() *agentSetupCmd {
 	asc := &agentSetupCmd{
-		client:    agentsetup.ClientClaudeCode,
 		providers: agentsetup.DefaultProviders(),
+		skillsInstall: func(ctx context.Context, destDir string) ([]string, error) {
+			return agentskills.Install(ctx, nil, destDir)
+		},
+		skillsLocalDir:  func() (string, error) { return skillsDirUnder(os.Getwd) },
+		skillsGlobalDir: func() (string, error) { return skillsDirUnder(os.UserHomeDir) },
 	}
 
 	asc.cmd = &cobra.Command{
 		Use:           "setup",
 		Short:         "Install or check Stripe agent tooling",
-		Long:          "Install or check Stripe agent tooling. This POC supports Claude Code only.",
+		Long:          "Detect installed AI coding clients and install Stripe agent tooling for them.",
 		Args:          validators.NoArgs,
 		RunE:          asc.runSetup,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	asc.cmd.Flags().BoolVar(&asc.statusOnly, "status", false, "Check installed agent tooling without making changes")
-	asc.cmd.Flags().BoolVarP(&asc.yes, "yes", "y", false, "Skip confirmation prompts")
+	asc.cmd.Flags().BoolVarP(&asc.yes, "yes", "y", false, "Set up every detected client without prompting")
 	asc.cmd.Flags().BoolVar(&asc.force, "force", false, "Reinstall even when agent tooling is already installed")
-	asc.cmd.Flags().StringVar(&asc.client, "client", agentsetup.ClientClaudeCode, "Agent client to set up")
+	asc.cmd.Flags().StringVar(&asc.client, "client", "", "Limit setup to a single client (default: all detected clients)")
 	asc.cmd.Flags().BoolVar(&asc.jsonOutput, "json", false, "Write machine-readable status output")
+	asc.cmd.Flags().BoolVar(&asc.skills, "skills", false, "Install Stripe skills directly, without the interactive prompt")
+	asc.cmd.Flags().StringVar(&asc.skillsScope, "skills-scope", skillsScopeLocal, "Where to install skills: local (current directory) or global (home directory)")
 
 	return asc
 }
 
-func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, args []string) error {
-	provider, ok := asc.providers[asc.client]
-	if !ok {
-		return fmt.Errorf("unsupported agent client %q; supported clients: %s", asc.client, agentsetup.SupportedProviderIDs(asc.providers))
+// skillsDirUnder returns the .agents/skills directory beneath the base returned
+// by baseDir (the current working directory for local, the home directory for
+// global), matching the layout `npx skills add` produces.
+func skillsDirUnder(baseDir func() (string, error)) (string, error) {
+	base, err := baseDir()
+	if err != nil {
+		return "", err
 	}
+	return filepath.Join(base, ".agents", "skills"), nil
+}
 
-	status := provider.Detect()
-	plan := provider.Plan(status, asc.force)
-
-	if asc.jsonOutput {
-		if err := asc.writeJSON(cmd.OutOrStdout(), status, plan); err != nil {
-			return err
-		}
-		if status.Status == agentsetup.StatusError {
-			return errors.New(status.Error)
-		}
-		return nil
-	}
-
-	printAgentStatus(cmd.OutOrStdout(), status)
-
-	if status.Status == agentsetup.StatusError {
-		return errors.New(status.Error)
-	}
-	if asc.statusOnly {
-		return nil
-	}
-	if !status.Detected {
-		fmt.Fprintf(cmd.OutOrStdout(), "Nothing to do. %s was not detected.\n", status.DisplayName)
-		return nil
-	}
-	if plan.Action == agentsetup.ActionNone {
-		fmt.Fprintln(cmd.OutOrStdout(), "Nothing to do. Stripe agent tooling is already installed.")
-		return nil
-	}
-
-	fmt.Fprintf(cmd.OutOrStdout(), "Planned command: %s\n", strings.Join(plan.Command, " "))
-
-	if !asc.yes {
-		if !isInteractiveTerminal() {
-			return fmt.Errorf("installation requires confirmation; rerun with --yes to install without prompting")
-		}
-		confirmed, err := confirmAgentSetup(cmd.InOrStdin(), cmd.OutOrStdout())
-		if err != nil {
-			return err
-		}
-		if !confirmed {
-			fmt.Fprintln(cmd.OutOrStdout(), "Canceled. No changes made.")
-			return nil
-		}
-	}
-
-	fmt.Fprintf(cmd.OutOrStdout(), "Installing Stripe agent tooling for %s...\n", status.DisplayName)
-	if err := provider.Apply(commandContextOrBackground(cmd), cmd.OutOrStdout(), plan); err != nil {
+func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, _ []string) error {
+	providers, err := asc.selectedProviders()
+	if err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Installed Stripe agent tooling for %s.\n", status.DisplayName)
+
+	if asc.skillsScope != skillsScopeLocal && asc.skillsScope != skillsScopeGlobal {
+		return fmt.Errorf("invalid --skills-scope %q; use %q or %q", asc.skillsScope, skillsScopeLocal, skillsScopeGlobal)
+	}
+
+	ctx := commandContextOrBackground(cmd)
+	out := cmd.OutOrStdout()
+
+	statuses := detectAll(providers)
+
+	if asc.jsonOutput {
+		return asc.writeJSON(out, providers, statuses)
+	}
+
+	detected := detectedStatuses(statuses)
+
+	if asc.statusOnly {
+		if len(detected) == 0 {
+			printNothingDetected(out)
+			return nil
+		}
+		printStatusTable(out, statuses)
+		return nil
+	}
+
+	sel, scope, err := asc.resolveSelection(cmd, out, detected)
+	if err != nil {
+		return err
+	}
+	if sel == nil {
+		return nil // nothing to do; a message was already printed
+	}
+
+	return asc.install(ctx, out, providers, *sel, scope)
+}
+
+// resolveSelection decides which agents and/or skills to install. It uses the
+// interactive TUI when attached to a terminal (and neither --yes nor --skills
+// forced a non-interactive run), otherwise it derives the selection from flags.
+// A nil Selection means there is nothing to do and a message has been printed.
+func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, detected []agentsetup.Status) (*Selection, string, error) {
+	scope := asc.skillsScope
+
+	useTUI := isInteractiveTerminal() && !asc.yes && !asc.skills
+	if !useTUI {
+		// --skills on its own means "install skills only" (the alternative to
+		// configuring agents). Agents are installed when --yes is given, or via
+		// the interactive picker.
+		agents := detected
+		if asc.skills && !asc.yes {
+			agents = nil
+		}
+		if len(agents) == 0 && !asc.skills {
+			printNothingDetected(out)
+			return nil, scope, nil
+		}
+		return &Selection{Agents: agents, InstallSkills: asc.skills}, scope, nil
+	}
+
+	sel, err := RunSelectionTUI(detected)
+	if err != nil {
+		return nil, scope, err
+	}
+	if sel == nil {
+		fmt.Fprintln(out, "Canceled. No changes made.")
+		return nil, scope, nil
+	}
+	if len(sel.Agents) == 0 && !sel.InstallSkills {
+		fmt.Fprintln(out, "Nothing selected. No changes made.")
+		return nil, scope, nil
+	}
+
+	// Mirror `npx skills add` by asking where to install skills, unless the
+	// scope was already pinned with --skills-scope.
+	if sel.InstallSkills && !cmd.Flags().Changed("skills-scope") {
+		chosen, ok, err := RunSkillsScopeTUI()
+		if err != nil {
+			return nil, scope, err
+		}
+		if !ok {
+			fmt.Fprintln(out, "Canceled. No changes made.")
+			return nil, scope, nil
+		}
+		scope = chosen
+	}
+
+	return sel, scope, nil
+}
+
+// selectedProviders returns the providers to operate on, honoring the --client
+// filter when set.
+func (asc *agentSetupCmd) selectedProviders() (map[string]agentsetup.Provider, error) {
+	if asc.client == "" {
+		return asc.providers, nil
+	}
+	provider, ok := asc.providers[asc.client]
+	if !ok {
+		return nil, fmt.Errorf("unsupported agent client %q; supported clients: %s", asc.client, agentsetup.SupportedProviderIDs(asc.providers))
+	}
+	return map[string]agentsetup.Provider{asc.client: provider}, nil
+}
+
+// install applies the selection (agent plugins and/or Stripe skills), showing a
+// spinner per item and printing a summary. It returns an error only when at
+// least one install fails.
+func (asc *agentSetupCmd) install(ctx context.Context, out io.Writer, providers map[string]agentsetup.Provider, sel Selection, scope string) error {
+	fmt.Fprintln(out, "\nSetting up Stripe agent tooling:")
+
+	color := ansi.Color(out)
+	check := color.Green("✔").String()
+	cross := color.Red("✗").String()
+	warn := color.Yellow("⚠").String()
+
+	var successCount, skipCount, errCount int
+	for _, status := range sel.Agents {
+		provider := providers[status.Client]
+		plan := provider.Plan(status, asc.force)
+
+		fmt.Fprintf(out, "\n  %s\n", status.DisplayName)
+		switch plan.Action {
+		case agentsetup.ActionNone:
+			fmt.Fprintln(out, "  already set up")
+			skipCount++
+			continue
+		case agentsetup.ActionManual:
+			// Setup can't be automated (e.g. Cursor). Surface the instruction and
+			// treat it as skipped, not a failure.
+			fmt.Fprintf(out, "  %s manual step: %s\n", warn, plan.Manual)
+			skipCount++
+			continue
+		}
+
+		err := spinner.New().
+			WithLabel("Installing...").
+			WithOutput(os.Stderr).
+			Run(func() error { return provider.Apply(ctx, out, plan) })
+		if err != nil {
+			fmt.Fprintf(out, "  %s error: %v\n", cross, err)
+			errCount++
+			continue
+		}
+		fmt.Fprintf(out, "  %s done\n", check)
+		successCount++
+	}
+
+	if sel.InstallSkills {
+		if asc.installSkills(ctx, out, scope, check, cross) {
+			successCount++
+		} else {
+			errCount++
+		}
+	}
+
+	fmt.Fprintf(out, "\n%d installed, %d skipped, %d errors\n", successCount, skipCount, errCount)
+	if errCount > 0 {
+		return fmt.Errorf("%d item(s) failed to set up", errCount)
+	}
 	return nil
 }
 
-func (asc *agentSetupCmd) writeJSON(w io.Writer, status agentsetup.Status, plan agentsetup.Plan) error {
+// installSkills fetches and writes Stripe skills to the local or global
+// .agents/skills directory. It returns true on success.
+func (asc *agentSetupCmd) installSkills(ctx context.Context, out io.Writer, scope, check, cross string) bool {
+	fmt.Fprintf(out, "\n  Stripe skills (%s)\n", scope)
+
+	dirFn := asc.skillsLocalDir
+	if scope == skillsScopeGlobal {
+		dirFn = asc.skillsGlobalDir
+	}
+	dir, err := dirFn()
+	if err != nil {
+		fmt.Fprintf(out, "  %s error: resolving skills directory: %v\n", cross, err)
+		return false
+	}
+
+	var installed []string
+	runErr := spinner.New().
+		WithLabel("Installing skills...").
+		WithOutput(os.Stderr).
+		Run(func() error {
+			var e error
+			installed, e = asc.skillsInstall(ctx, dir)
+			return e
+		})
+	if runErr != nil {
+		fmt.Fprintf(out, "  %s error: %v\n", cross, runErr)
+		return false
+	}
+
+	fmt.Fprintf(out, "  %s installed %d skill(s) to %s: %s\n", check, len(installed), dir, strings.Join(installed, ", "))
+	return true
+}
+
+func (asc *agentSetupCmd) writeJSON(w io.Writer, providers map[string]agentsetup.Provider, statuses []agentsetup.Status) error {
 	result := agentSetupJSON{
-		Status:  status.Status,
-		Clients: []agentsetup.Status{status},
+		Status:  aggregateStatus(statuses),
+		Clients: statuses,
 	}
-	if plan.Action != agentsetup.ActionNone {
-		result.Actions = []agentsetup.Plan{plan}
-	}
-	if status.Status == agentsetup.StatusError {
-		result.Errors = []string{status.Error}
+	for _, status := range statuses {
+		if plan := providers[status.Client].Plan(status, asc.force); plan.Action != agentsetup.ActionNone {
+			result.Actions = append(result.Actions, plan)
+		}
+		if status.Status == agentsetup.StatusError {
+			result.Errors = append(result.Errors, status.Error)
+		}
 	}
 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(result)
+	if err := enc.Encode(result); err != nil {
+		return err
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("%s", result.Errors[0])
+	}
+	return nil
 }
 
-func printAgentStatus(w io.Writer, status agentsetup.Status) {
-	fmt.Fprintln(w, "Scanning for AI coding clients...")
-	if !status.Detected {
-		fmt.Fprintf(w, "  %s: not detected\n", status.DisplayName)
-		return
+// detectAll runs Detect for every provider and returns statuses in canonical
+// display order.
+func detectAll(providers map[string]agentsetup.Provider) []agentsetup.Status {
+	ids := orderedProviderIDs(providers)
+	statuses := make([]agentsetup.Status, 0, len(ids))
+	for _, id := range ids {
+		statuses = append(statuses, providers[id].Detect())
 	}
+	return statuses
+}
 
-	if status.ExecutablePath != "" {
-		fmt.Fprintf(w, "  %s: detected (%s)\n", status.DisplayName, status.ExecutablePath)
-	} else {
-		fmt.Fprintf(w, "  %s: detected\n", status.DisplayName)
+func orderedProviderIDs(providers map[string]agentsetup.Provider) []string {
+	seen := make(map[string]bool, len(providers))
+	ids := make([]string, 0, len(providers))
+	for _, id := range providerOrder {
+		if _, ok := providers[id]; ok {
+			ids = append(ids, id)
+			seen[id] = true
+		}
 	}
+	var rest []string
+	for id := range providers {
+		if !seen[id] {
+			rest = append(rest, id)
+		}
+	}
+	sort.Strings(rest)
+	return append(ids, rest...)
+}
 
-	switch status.Status {
-	case agentsetup.StatusInstalled:
-		version := status.Plugin.Version
-		if version == "" {
-			version = "unknown version"
+func detectedStatuses(statuses []agentsetup.Status) []agentsetup.Status {
+	var detected []agentsetup.Status
+	for _, s := range statuses {
+		if s.Detected {
+			detected = append(detected, s)
 		}
-		fmt.Fprintf(w, "  Stripe plugin: installed as %s (%s", status.Plugin.ID, version)
-		if status.Plugin.Scope != "" {
-			fmt.Fprintf(w, ", %s", status.Plugin.Scope)
+	}
+	return detected
+}
+
+// aggregateStatus collapses per-client statuses into a single headline status,
+// surfacing the most actionable state first.
+func aggregateStatus(statuses []agentsetup.Status) string {
+	var missing, installed bool
+	for _, s := range statuses {
+		switch s.Status {
+		case agentsetup.StatusError:
+			return agentsetup.StatusError
+		case agentsetup.StatusMissing:
+			missing = true
+		case agentsetup.StatusInstalled:
+			installed = true
 		}
-		if status.Plugin.Scope == "local" && status.Plugin.Project != "" {
-			fmt.Fprintf(w, ", project %s", status.Plugin.Project)
-		}
-		fmt.Fprintln(w, ")")
-	case agentsetup.StatusError:
-		fmt.Fprintf(w, "  Stripe plugin: error (%s)\n", status.Error)
+	}
+	switch {
+	case missing:
+		return agentsetup.StatusMissing
+	case installed:
+		return agentsetup.StatusInstalled
 	default:
-		fmt.Fprintln(w, "  Stripe plugin: missing")
+		return agentsetup.StatusNotDetected
 	}
 }
 
-func confirmAgentSetup(r io.Reader, w io.Writer) (bool, error) {
-	fmt.Fprint(w, "Install now? [y/N] ")
-	line, err := bufio.NewReader(r).ReadString('\n')
-	if err != nil && err != io.EOF {
-		return false, fmt.Errorf("reading confirmation: %w", err)
+// printStatusTable renders a compact, aligned, color-coded view of each client
+// and its Stripe plugin state. Colors are disabled automatically when the writer
+// is not a TTY (via ansi.Color).
+func printStatusTable(w io.Writer, statuses []agentsetup.Status) {
+	color := ansi.Color(w)
+
+	fmt.Fprintln(w, color.Bold("AI coding clients").String())
+	fmt.Fprintln(w)
+
+	nameWidth := 0
+	for _, s := range statuses {
+		if n := len(s.DisplayName); n > nameWidth {
+			nameWidth = n
+		}
 	}
-	answer := strings.ToLower(strings.TrimSpace(line))
-	return answer == "y" || answer == "yes", nil
+
+	needsSetup := false
+	for _, s := range statuses {
+		var icon, state string
+		switch {
+		case !s.Detected:
+			icon = color.Faint("–").String()
+			state = color.Faint("not detected").String()
+		case s.Status == agentsetup.StatusError:
+			icon = color.Red("✗").String()
+			state = color.Red("error: " + s.Error).String()
+		case s.Status == agentsetup.StatusInstalled:
+			icon = color.Green("✔").String()
+			state = "Stripe plugin installed"
+			if detail := pluginDetail(s.Plugin); detail != "" {
+				state += "  " + color.Faint(detail).String()
+			}
+		default:
+			icon = color.Yellow("•").String()
+			state = "Stripe plugin not installed"
+			needsSetup = true
+		}
+		fmt.Fprintf(w, "  %s  %-*s  %s\n", icon, nameWidth, s.DisplayName, state)
+	}
+
+	if needsSetup {
+		fmt.Fprintf(w, "\nRun %s to install the Stripe plugin where it's missing.\n", color.Bold("stripe agent setup").String())
+	}
+}
+
+// pluginDetail summarizes an installed plugin, e.g. "stripe@cursor-public 0.1.0, user".
+func pluginDetail(p agentsetup.PluginStatus) string {
+	detail := p.ID
+	if p.Version != "" {
+		if detail != "" {
+			detail += " "
+		}
+		detail += p.Version
+	}
+	if p.Scope != "" {
+		detail += ", " + p.Scope
+	}
+	return detail
+}
+
+func printNothingDetected(w io.Writer) {
+	fmt.Fprint(w, `No AI coding clients detected on this machine.
+
+Supported clients for automatic setup:
+  • Claude Code   https://claude.ai/code
+  • Cursor        https://cursor.com
+  • Codex CLI     https://github.com/openai/codex
+
+Once a client is installed, re-run: stripe agent setup
+
+Or install Stripe skills directly (no agent required):
+  stripe agent setup --skills               # into ./.agents/skills
+  stripe agent setup --skills --skills-scope global   # into ~/.agents/skills
+`)
 }
 
 func isInteractiveTerminal() bool {

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -17,8 +17,18 @@ import (
 	"github.com/stripe/stripe-cli/pkg/agentskills"
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/docs/spinner"
+	"github.com/stripe/stripe-cli/pkg/useragent"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
+
+// agentClientID maps the AI agent identifiers returned by
+// useragent.DetectAIAgent to this command's provider ids. Agents not backed by
+// a provider (e.g. gemini_cli) map to "".
+var agentClientID = map[string]string{
+	"claude_code": agentsetup.ClientClaudeCode,
+	"codex_cli":   agentsetup.ClientCodex,
+	"cursor":      agentsetup.ClientCursor,
+}
 
 // providerOrder is the canonical display order for known clients. Providers not
 // listed here are appended afterward in alphabetical order.
@@ -50,6 +60,10 @@ type agentSetupCmd struct {
 	skillsInstall   func(ctx context.Context, destDir string) ([]string, error)
 	skillsLocalDir  func() (string, error)
 	skillsGlobalDir func() (string, error)
+
+	// callingAgent returns the AI agent invoking this command (e.g.
+	// "claude_code"), or "" for a human shell. Injectable for tests.
+	callingAgent func() string
 }
 
 type agentSetupJSON struct {
@@ -79,6 +93,7 @@ func newAgentSetupCmd() *agentSetupCmd {
 		},
 		skillsLocalDir:  func() (string, error) { return skillsDirUnder(os.Getwd) },
 		skillsGlobalDir: func() (string, error) { return skillsDirUnder(os.UserHomeDir) },
+		callingAgent:    func() string { return useragent.DetectAIAgent(os.Getenv) },
 	}
 
 	asc.cmd = &cobra.Command{
@@ -166,6 +181,25 @@ func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, de
 		// configuring agents). Agents are installed when --yes is given, or via
 		// the interactive picker.
 		agents := detected
+
+		// When an AI agent invokes this non-interactively (it can't use the
+		// picker), install just that agent's plugin rather than every detected
+		// client. --client and --yes are explicit overrides and win.
+		if asc.client == "" && !asc.yes && !asc.skills {
+			agent := asc.callingAgent()
+			if id := agentClientID[agent]; id != "" {
+				if scoped := statusesForClient(detected, id); len(scoped) > 0 {
+					fmt.Fprintf(out, "Detected %s — setting up its Stripe plugin.\n", scoped[0].DisplayName)
+					agents = scoped
+				}
+			} else if agent != "" {
+				// Known agent with no Stripe plugin (e.g. Gemini CLI): install
+				// client-agnostic skills instead of every detected client's plugin.
+				fmt.Fprintf(out, "Detected %s, which has no Stripe plugin — installing Stripe skills instead.\n", agent)
+				return &Selection{InstallSkills: true}, scope, nil
+			}
+		}
+
 		if asc.skills && !asc.yes {
 			agents = nil
 		}
@@ -363,6 +397,16 @@ func orderedProviderIDs(providers map[string]agentsetup.Provider) []string {
 	}
 	sort.Strings(rest)
 	return append(ids, rest...)
+}
+
+func statusesForClient(statuses []agentsetup.Status, client string) []agentsetup.Status {
+	var out []agentsetup.Status
+	for _, s := range statuses {
+		if s.Client == client {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func detectedStatuses(statuses []agentsetup.Status) []agentsetup.Status {

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bufio"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,14 +29,14 @@ type agentSetupCmd struct {
 	jsonOutput bool
 	client     string
 
-	scanner    agentsetup.Scanner
-	runInstall agentsetup.RunCommandFunc
+	providers map[string]agentsetup.Provider
 }
 
 type agentSetupJSON struct {
-	agentsetup.ClaudeStatus
-	Action  string   `json:"action"`
-	Command []string `json:"command,omitempty"`
+	Status  string              `json:"status"`
+	Clients []agentsetup.Status `json:"clients"`
+	Actions []agentsetup.Plan   `json:"actions,omitempty"`
+	Errors  []string            `json:"errors,omitempty"`
 }
 
 func newAgentCmd() *agentCmd {
@@ -54,17 +53,18 @@ func newAgentCmd() *agentCmd {
 
 func newAgentSetupCmd() *agentSetupCmd {
 	asc := &agentSetupCmd{
-		client:     agentsetup.ClientClaudeCode,
-		scanner:    agentsetup.DefaultScanner(),
-		runInstall: agentsetup.RunCommand,
+		client:    agentsetup.ClientClaudeCode,
+		providers: agentsetup.DefaultProviders(),
 	}
 
 	asc.cmd = &cobra.Command{
-		Use:   "setup",
-		Short: "Install or check Stripe agent tooling",
-		Long:  "Install or check Stripe agent tooling. This POC supports Claude Code only.",
-		Args:  validators.NoArgs,
-		RunE:  asc.runSetup,
+		Use:           "setup",
+		Short:         "Install or check Stripe agent tooling",
+		Long:          "Install or check Stripe agent tooling. This POC supports Claude Code only.",
+		Args:          validators.NoArgs,
+		RunE:          asc.runSetup,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 	asc.cmd.Flags().BoolVar(&asc.statusOnly, "status", false, "Check installed agent tooling without making changes")
 	asc.cmd.Flags().BoolVarP(&asc.yes, "yes", "y", false, "Skip confirmation prompts")
@@ -76,18 +76,25 @@ func newAgentSetupCmd() *agentSetupCmd {
 }
 
 func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, args []string) error {
-	if asc.client != agentsetup.ClientClaudeCode {
-		return fmt.Errorf("unsupported agent client %q; this POC only supports %q", asc.client, agentsetup.ClientClaudeCode)
+	provider, ok := asc.providers[asc.client]
+	if !ok {
+		return fmt.Errorf("unsupported agent client %q; supported clients: %s", asc.client, agentsetup.SupportedProviderIDs(asc.providers))
 	}
 
-	status := asc.scanner.ScanClaude()
-	action, command := setupAction(status, asc.force)
+	status := provider.Detect()
+	plan := provider.Plan(status, asc.force)
 
 	if asc.jsonOutput {
-		return asc.writeJSON(cmd.OutOrStdout(), status, action, command)
+		if err := asc.writeJSON(cmd.OutOrStdout(), status, plan); err != nil {
+			return err
+		}
+		if status.Status == agentsetup.StatusError {
+			return errors.New(status.Error)
+		}
+		return nil
 	}
 
-	printClaudeStatus(cmd.OutOrStdout(), status)
+	printAgentStatus(cmd.OutOrStdout(), status)
 
 	if status.Status == agentsetup.StatusError {
 		return errors.New(status.Error)
@@ -96,16 +103,15 @@ func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	if !status.Detected {
-		fmt.Fprintln(cmd.OutOrStdout(), "Nothing to do. Claude Code was not detected.")
+		fmt.Fprintf(cmd.OutOrStdout(), "Nothing to do. %s was not detected.\n", status.DisplayName)
 		return nil
 	}
-	if action == "none" {
+	if plan.Action == agentsetup.ActionNone {
 		fmt.Fprintln(cmd.OutOrStdout(), "Nothing to do. Stripe agent tooling is already installed.")
 		return nil
 	}
 
-	name, installArgs := agentsetup.ClaudeInstallCommand()
-	fmt.Fprintf(cmd.OutOrStdout(), "Planned command: %s %s\n", name, strings.Join(installArgs, " "))
+	fmt.Fprintf(cmd.OutOrStdout(), "Planned command: %s\n", strings.Join(plan.Command, " "))
 
 	if !asc.yes {
 		if !isInteractiveTerminal() {
@@ -121,84 +127,56 @@ func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Fprintln(cmd.OutOrStdout(), "Installing Stripe agent tooling for Claude Code...")
-	if err := asc.runClaudeInstall(commandContextOrBackground(cmd), cmd.OutOrStdout(), name, installArgs, command); err != nil {
+	fmt.Fprintf(cmd.OutOrStdout(), "Installing Stripe agent tooling for %s...\n", status.DisplayName)
+	if err := provider.Apply(commandContextOrBackground(cmd), cmd.OutOrStdout(), plan); err != nil {
 		return err
 	}
-	fmt.Fprintln(cmd.OutOrStdout(), "Installed Stripe agent tooling for Claude Code.")
+	fmt.Fprintf(cmd.OutOrStdout(), "Installed Stripe agent tooling for %s.\n", status.DisplayName)
 	return nil
 }
 
-func (asc *agentSetupCmd) runClaudeInstall(ctx context.Context, out io.Writer, name string, installArgs []string, command []string) error {
-	if err := asc.runInstall(ctx, name, installArgs...); err == nil {
-		return nil
-	} else {
-		updateName, updateArgs := agentsetup.ClaudeMarketplaceUpdateCommand()
-		updateCommand := append([]string{updateName}, updateArgs...)
-		fmt.Fprintf(out, "Install failed. Updating Claude plugin marketplace and retrying: %s\n", strings.Join(updateCommand, " "))
-		if updateErr := asc.runInstall(ctx, updateName, updateArgs...); updateErr != nil {
-			return fmt.Errorf("running %q after install failed: %w", strings.Join(updateCommand, " "), updateErr)
-		}
-		if retryErr := asc.runInstall(ctx, name, installArgs...); retryErr != nil {
-			return fmt.Errorf("running %q after marketplace update: %w", strings.Join(command, " "), retryErr)
-		}
-		return nil
+func (asc *agentSetupCmd) writeJSON(w io.Writer, status agentsetup.Status, plan agentsetup.Plan) error {
+	result := agentSetupJSON{
+		Status:  status.Status,
+		Clients: []agentsetup.Status{status},
 	}
-}
-
-func setupAction(status agentsetup.ClaudeStatus, force bool) (string, []string) {
-	name, args := agentsetup.ClaudeInstallCommand()
-	command := append([]string{name}, args...)
-
-	switch {
-	case status.Status == agentsetup.StatusError:
-		return "error", nil
-	case !status.Detected:
-		return "none", nil
-	case status.PluginInstalled && force:
-		return "reinstall", command
-	case status.PluginInstalled:
-		return "none", nil
-	default:
-		return "install", command
+	if plan.Action != agentsetup.ActionNone {
+		result.Actions = []agentsetup.Plan{plan}
 	}
-}
+	if status.Status == agentsetup.StatusError {
+		result.Errors = []string{status.Error}
+	}
 
-func (asc *agentSetupCmd) writeJSON(w io.Writer, status agentsetup.ClaudeStatus, action string, command []string) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(agentSetupJSON{
-		ClaudeStatus: status,
-		Action:       action,
-		Command:      command,
-	})
+	return enc.Encode(result)
 }
 
-func printClaudeStatus(w io.Writer, status agentsetup.ClaudeStatus) {
+func printAgentStatus(w io.Writer, status agentsetup.Status) {
 	fmt.Fprintln(w, "Scanning for AI coding clients...")
 	if !status.Detected {
-		fmt.Fprintln(w, "  Claude Code: not detected")
+		fmt.Fprintf(w, "  %s: not detected\n", status.DisplayName)
 		return
 	}
 
 	if status.ExecutablePath != "" {
-		fmt.Fprintf(w, "  Claude Code: detected (%s)\n", status.ExecutablePath)
+		fmt.Fprintf(w, "  %s: detected (%s)\n", status.DisplayName, status.ExecutablePath)
 	} else {
-		fmt.Fprintln(w, "  Claude Code: detected")
+		fmt.Fprintf(w, "  %s: detected\n", status.DisplayName)
 	}
 
 	switch status.Status {
 	case agentsetup.StatusInstalled:
-		version := status.PluginVersion
+		version := status.Plugin.Version
 		if version == "" {
 			version = "unknown version"
 		}
-		fmt.Fprintf(w, "  Stripe plugin: installed as %s (%s", status.PluginID, version)
-		if status.PluginScope != "" {
-			fmt.Fprintf(w, ", %s", status.PluginScope)
+		fmt.Fprintf(w, "  Stripe plugin: installed as %s (%s", status.Plugin.ID, version)
+		if status.Plugin.Scope != "" {
+			fmt.Fprintf(w, ", %s", status.Plugin.Scope)
 		}
-		if status.PluginScope == "local" && status.PluginProject != "" {
-			fmt.Fprintf(w, ", project %s", status.PluginProject)
+		if status.Plugin.Scope == "local" && status.Plugin.Project != "" {
+			fmt.Fprintf(w, ", project %s", status.Plugin.Project)
 		}
 		fmt.Fprintln(w, ")")
 	case agentsetup.StatusError:

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -187,36 +187,36 @@ func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, de
 
 	useTUI := asc.isInteractive() && !asc.yes && !asc.skills && agent == ""
 	if !useTUI {
-		// --skills on its own means "install skills only" (the alternative to
-		// configuring agents). Agents are installed when --yes is given, or via
-		// the interactive picker.
-		agents := detected
+		// Explicit "skills only" request (--skills without --yes) wins everywhere.
+		if asc.skills && !asc.yes {
+			return &Selection{InstallSkills: true}, scope, nil
+		}
 
-		// When an AI agent invokes this non-interactively (it can't use the
-		// picker), install just that agent's plugin rather than every detected
-		// client. --client and --yes are explicit overrides and win.
-		if asc.client == "" && !asc.yes && !asc.skills {
+		// Inside a coding agent (and no explicit --client), only ever set up that
+		// agent — never other clients, even with --yes, since the agent can't act
+		// on another client's plugin. --client is the explicit escape hatch.
+		if agent != "" && asc.client == "" {
 			if id := agentClientID[agent]; id != "" {
 				if scoped := statusesForClient(detected, id); len(scoped) > 0 {
 					fmt.Fprintf(out, "Detected %s — setting up its Stripe plugin.\n", scoped[0].DisplayName)
-					agents = scoped
+					return &Selection{Agents: scoped, InstallSkills: asc.skills}, scope, nil
 				}
-			} else if agent != "" {
+				// The agent's binary isn't among the detected clients; fall
+				// through to the generic path rather than claim nothing to do.
+			} else {
 				// Known agent with no Stripe plugin (e.g. Gemini CLI): install
-				// client-agnostic skills instead of every detected client's plugin.
+				// client-agnostic skills instead of another client's plugin.
 				fmt.Fprintf(out, "Detected %s, which has no Stripe plugin — installing Stripe skills instead.\n", agent)
 				return &Selection{InstallSkills: true}, scope, nil
 			}
 		}
 
-		if asc.skills && !asc.yes {
-			agents = nil
-		}
-		if len(agents) == 0 && !asc.skills {
+		// Human CLI (or explicit --client): --yes installs every detected client.
+		if len(detected) == 0 && !asc.skills {
 			printNothingDetected(out)
 			return nil, scope, nil
 		}
-		return &Selection{Agents: agents, InstallSkills: asc.skills}, scope, nil
+		return &Selection{Agents: detected, InstallSkills: asc.skills}, scope, nil
 	}
 
 	sel, err := RunSelectionTUI(detected)

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -34,8 +34,8 @@ var agentClientID = map[string]string{
 // listed here are appended afterward in alphabetical order.
 var providerOrder = []string{
 	agentsetup.ClientClaudeCode,
-	agentsetup.ClientCursor,
 	agentsetup.ClientCodex,
+	agentsetup.ClientCursor,
 }
 
 type agentCmd struct {
@@ -499,6 +499,9 @@ func printStatusTable(w io.Writer, statuses []agentsetup.Status) {
 			if detail := pluginDetail(s.Plugin); detail != "" {
 				state += "  " + color.Faint(detail).String()
 			}
+		case s.Error != "":
+			icon = color.Yellow("•").String()
+			state = color.Faint(s.Error).String()
 		default:
 			icon = color.Yellow("•").String()
 			state = "Stripe plugin not installed"

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -179,43 +179,46 @@ func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, _ []string) error {
 func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, detected []agentsetup.Status) (*Selection, string, error) {
 	scope := asc.skillsScope
 
-	// Detect the calling agent up front. When an agent invoked us we must never
-	// show the interactive picker — some agent runtimes (e.g. Gemini CLI)
-	// allocate a PTY, so a TTY check alone would wrongly think a human is present
-	// and the picker would hang/fail.
+	// Detect the calling agent up front.
 	agent := asc.callingAgent()
 
-	useTUI := asc.isInteractive() && !asc.yes && !asc.skills && agent == ""
-	if !useTUI {
-		// Explicit "skills only" request (--skills without --yes) wins everywhere.
-		if asc.skills && !asc.yes {
+	// Explicit "skills only" request (--skills without --yes) wins everywhere.
+	if asc.skills && !asc.yes {
+		return &Selection{InstallSkills: true}, scope, nil
+	}
+
+	// Inside a coding agent (and no explicit --client), only ever set up that
+	// agent — never other clients, even with --yes, since the agent can't act on
+	// another client's plugin. --client is the explicit escape hatch.
+	if agent != "" && asc.client == "" {
+		if id := agentClientID[agent]; id != "" {
+			if scoped := statusesForClient(detected, id); len(scoped) > 0 {
+				fmt.Fprintf(out, "Detected %s — setting up its Stripe plugin.\n", scoped[0].DisplayName)
+				return &Selection{Agents: scoped, InstallSkills: asc.skills}, scope, nil
+			}
+			// The agent's binary isn't among the detected clients; fall through.
+		} else {
+			// Known agent with no Stripe plugin (e.g. Gemini CLI): install
+			// client-agnostic skills instead of another client's plugin.
+			fmt.Fprintf(out, "Detected %s, which has no Stripe plugin — installing Stripe skills instead.\n", agent)
 			return &Selection{InstallSkills: true}, scope, nil
 		}
+	}
 
-		// Inside a coding agent (and no explicit --client), only ever set up that
-		// agent — never other clients, even with --yes, since the agent can't act
-		// on another client's plugin. --client is the explicit escape hatch.
-		if agent != "" && asc.client == "" {
-			if id := agentClientID[agent]; id != "" {
-				if scoped := statusesForClient(detected, id); len(scoped) > 0 {
-					fmt.Fprintf(out, "Detected %s — setting up its Stripe plugin.\n", scoped[0].DisplayName)
-					return &Selection{Agents: scoped, InstallSkills: asc.skills}, scope, nil
-				}
-				// The agent's binary isn't among the detected clients; fall
-				// through to the generic path rather than claim nothing to do.
-			} else {
-				// Known agent with no Stripe plugin (e.g. Gemini CLI): install
-				// client-agnostic skills instead of another client's plugin.
-				fmt.Fprintf(out, "Detected %s, which has no Stripe plugin — installing Stripe skills instead.\n", agent)
-				return &Selection{InstallSkills: true}, scope, nil
-			}
-		}
+	// Nothing detected: always show the informative message (supported clients +
+	// how to install skills), rather than a context-free picker. This is the same
+	// whether or not we're on an interactive terminal.
+	if len(detected) == 0 {
+		printNothingDetected(out)
+		return nil, scope, nil
+	}
 
+	// A human at a terminal picks interactively. Agent runtimes can allocate a
+	// PTY, so we also require no calling agent (checked above via the early
+	// returns) before trusting the TTY.
+	useTUI := asc.isInteractive() && !asc.yes && !asc.skills && agent == ""
+	if !useTUI {
 		// Human CLI (or explicit --client): --yes installs every detected client.
-		if len(detected) == 0 && !asc.skills {
-			printNothingDetected(out)
-			return nil, scope, nil
-		}
 		return &Selection{Agents: detected, InstallSkills: asc.skills}, scope, nil
 	}
 

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -64,6 +64,9 @@ type agentSetupCmd struct {
 	// callingAgent returns the AI agent invoking this command (e.g.
 	// "claude_code"), or "" for a human shell. Injectable for tests.
 	callingAgent func() string
+	// isInteractive reports whether an interactive picker can be shown.
+	// Injectable for tests.
+	isInteractive func() bool
 }
 
 type agentSetupJSON struct {
@@ -94,6 +97,7 @@ func newAgentSetupCmd() *agentSetupCmd {
 		skillsLocalDir:  func() (string, error) { return skillsDirUnder(os.Getwd) },
 		skillsGlobalDir: func() (string, error) { return skillsDirUnder(os.UserHomeDir) },
 		callingAgent:    func() string { return useragent.DetectAIAgent(os.Getenv) },
+		isInteractive:   isInteractiveTerminal,
 	}
 
 	asc.cmd = &cobra.Command{
@@ -175,7 +179,13 @@ func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, _ []string) error {
 func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, detected []agentsetup.Status) (*Selection, string, error) {
 	scope := asc.skillsScope
 
-	useTUI := isInteractiveTerminal() && !asc.yes && !asc.skills
+	// Detect the calling agent up front. When an agent invoked us we must never
+	// show the interactive picker — some agent runtimes (e.g. Gemini CLI)
+	// allocate a PTY, so a TTY check alone would wrongly think a human is present
+	// and the picker would hang/fail.
+	agent := asc.callingAgent()
+
+	useTUI := asc.isInteractive() && !asc.yes && !asc.skills && agent == ""
 	if !useTUI {
 		// --skills on its own means "install skills only" (the alternative to
 		// configuring agents). Agents are installed when --yes is given, or via
@@ -186,7 +196,6 @@ func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, de
 		// picker), install just that agent's plugin rather than every detected
 		// client. --client and --yes are explicit overrides and win.
 		if asc.client == "" && !asc.yes && !asc.skills {
-			agent := asc.callingAgent()
 			if id := agentClientID[agent]; id != "" {
 				if scoped := statusesForClient(detected, id); len(scoped) > 0 {
 					fmt.Fprintf(out, "Detected %s — setting up its Stripe plugin.\n", scoped[0].DisplayName)

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -114,7 +114,7 @@ func newAgentSetupCmd() *agentSetupCmd {
 	asc.cmd.Flags().BoolVar(&asc.force, "force", false, "Reinstall even when agent tooling is already installed")
 	asc.cmd.Flags().StringVar(&asc.client, "client", "", "Limit setup to a single client (default: all detected clients)")
 	asc.cmd.Flags().BoolVar(&asc.jsonOutput, "json", false, "Write machine-readable status output")
-	asc.cmd.Flags().BoolVar(&asc.skills, "skills", false, "Install Stripe skills directly, without the interactive prompt")
+	asc.cmd.Flags().BoolVar(&asc.skills, "skills", false, "Install Stripe skills without the interactive prompt")
 	asc.cmd.Flags().StringVar(&asc.skillsScope, "skills-scope", skillsScopeLocal, "Where to install skills: local (current directory) or global (home directory)")
 
 	return asc
@@ -211,6 +211,7 @@ func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, de
 	if len(detected) == 0 {
 		if asc.isInteractive() && agent == "" {
 			printNothingDetectedInteractive(out)
+			fmt.Fprintln(out)
 			chosen, ok, err := RunSkillsScopeTUI()
 			if err != nil {
 				return nil, scope, err
@@ -250,6 +251,7 @@ func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, de
 	// Mirror `npx skills add` by asking where to install skills, unless the
 	// scope was already pinned with --skills-scope.
 	if sel.InstallSkills && !cmd.Flags().Changed("skills-scope") {
+		fmt.Fprintln(out)
 		chosen, ok, err := RunSkillsScopeTUI()
 		if err != nil {
 			return nil, scope, err
@@ -473,7 +475,7 @@ func aggregateStatus(statuses []agentsetup.Status) string {
 func printStatusTable(w io.Writer, statuses []agentsetup.Status) {
 	color := ansi.Color(w)
 
-	fmt.Fprintln(w, color.Bold("AI coding clients").String())
+	fmt.Fprintln(w, color.Bold("Detected agents with supported Stripe plugins:").String())
 	fmt.Fprintln(w)
 
 	nameWidth := 0
@@ -538,7 +540,7 @@ Supported clients for automatic setup:
   • Cursor        https://cursor.com
   • Codex CLI     https://openai.com/codex/
 
-You can still install Stripe skills directly.
+You can still install Stripe skills.
 `)
 }
 
@@ -552,7 +554,7 @@ Supported clients for automatic setup:
 
 Once a client is installed, re-run: stripe agent setup
 
-Or install Stripe skills directly (no agent required):
+Or install Stripe skills:
   stripe agent setup --skills               # into ./.agents/skills
   stripe agent setup --skills --skills-scope global   # into ~/.agents/skills
 `)

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -45,13 +45,11 @@ type agentCmd struct {
 type agentSetupCmd struct {
 	cmd *cobra.Command
 
-	statusOnly  bool
-	yes         bool
-	force       bool
-	jsonOutput  bool
-	client      string
-	skills      bool
-	skillsScope string
+	statusOnly bool
+	yes        bool
+	force      bool
+	jsonOutput bool
+	client     string
 
 	providers map[string]agentsetup.Provider
 
@@ -114,8 +112,6 @@ func newAgentSetupCmd() *agentSetupCmd {
 	asc.cmd.Flags().BoolVar(&asc.force, "force", false, "Reinstall even when agent tooling is already installed")
 	asc.cmd.Flags().StringVar(&asc.client, "client", "", fmt.Sprintf("Limit setup to a single client; supported values: %s", agentsetup.SupportedProviderIDs(asc.providers)))
 	asc.cmd.Flags().BoolVar(&asc.jsonOutput, "json", false, "Write machine-readable status output")
-	asc.cmd.Flags().BoolVar(&asc.skills, "skills", false, "Install Stripe skills without the interactive prompt")
-	asc.cmd.Flags().StringVar(&asc.skillsScope, "skills-scope", skillsScopeLocal, "Where to install skills: local (current directory) or global (home directory)")
 
 	return asc
 }
@@ -135,10 +131,6 @@ func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, _ []string) error {
 	providers, err := asc.selectedProviders()
 	if err != nil {
 		return err
-	}
-
-	if asc.skillsScope != skillsScopeLocal && asc.skillsScope != skillsScopeGlobal {
-		return fmt.Errorf("invalid --skills-scope %q; use %q or %q", asc.skillsScope, skillsScopeLocal, skillsScopeGlobal)
 	}
 
 	ctx := commandContextOrBackground(cmd)
@@ -175,19 +167,12 @@ func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, _ []string) error {
 }
 
 // resolveSelection decides which agents and/or skills to install. It uses the
-// interactive TUI when attached to a terminal (and neither --yes nor --skills
-// forced a non-interactive run), otherwise it derives the selection from flags.
+// interactive TUI when attached to a terminal (and --yes was not passed),
+// otherwise it derives the selection from flags.
 // A nil Selection means there is nothing to do and a message has been printed.
 func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, detected []agentsetup.Status) (*Selection, string, error) {
-	scope := asc.skillsScope
-
 	// Detect the calling agent up front.
 	agent := asc.callingAgent()
-
-	// Explicit "skills only" request (--skills without --yes) wins everywhere.
-	if asc.skills && !asc.yes {
-		return &Selection{InstallSkills: true}, scope, nil
-	}
 
 	// Inside a coding agent (and no explicit --client), only ever set up that
 	// agent — never other clients, even with --yes, since the agent can't act on
@@ -196,14 +181,14 @@ func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, de
 		if id := agentClientID[agent]; id != "" {
 			if scoped := statusesForClient(detected, id); len(scoped) > 0 {
 				fmt.Fprintf(out, "Detected %s — setting up its Stripe plugin.\n", scoped[0].DisplayName)
-				return &Selection{Agents: scoped, InstallSkills: asc.skills}, scope, nil
+				return &Selection{Agents: scoped}, "", nil
 			}
 			// The agent's binary isn't among the detected clients; fall through.
 		} else {
 			// Known agent with no Stripe plugin (e.g. Gemini CLI): install
 			// client-agnostic skills instead of another client's plugin.
 			fmt.Fprintf(out, "Detected %s, which has no Stripe plugin — installing Stripe skills instead.\n", agent)
-			return &Selection{InstallSkills: true}, scope, nil
+			return &Selection{InstallSkills: true}, skillsScopeLocal, nil
 		}
 	}
 
@@ -214,56 +199,55 @@ func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, de
 			fmt.Fprintln(out)
 			chosen, ok, err := RunSkillsScopeTUI()
 			if err != nil {
-				return nil, scope, err
+				return nil, "", err
 			}
 			if !ok {
 				fmt.Fprintln(out, "Canceled. No changes made.")
-				return nil, scope, nil
+				return nil, "", nil
 			}
 			return &Selection{InstallSkills: true}, chosen, nil
 		}
 		printNothingDetected(out)
-		return nil, scope, nil
+		return nil, "", nil
 	}
 
 	// A human at a terminal picks interactively. Agent runtimes can allocate a
 	// PTY, so we also require no calling agent (checked above via the early
 	// returns) before trusting the TTY.
-	useTUI := asc.isInteractive() && !asc.yes && !asc.skills && agent == ""
+	useTUI := asc.isInteractive() && !asc.yes && agent == ""
 	if !useTUI {
-		// Human CLI (or explicit --client): --yes installs every detected client.
-		return &Selection{Agents: detected, InstallSkills: asc.skills}, scope, nil
+		// --yes installs every detected client (no skills).
+		return &Selection{Agents: detected}, "", nil
 	}
 
 	sel, err := RunSelectionTUI(detected)
 	if err != nil {
-		return nil, scope, err
+		return nil, "", err
 	}
 	if sel == nil {
 		fmt.Fprintln(out, "Canceled. No changes made.")
-		return nil, scope, nil
+		return nil, "", nil
 	}
 	if len(sel.Agents) == 0 && !sel.InstallSkills {
 		fmt.Fprintln(out, "Nothing selected. No changes made.")
-		return nil, scope, nil
+		return nil, "", nil
 	}
 
-	// Mirror `npx skills add` by asking where to install skills, unless the
-	// scope was already pinned with --skills-scope.
-	if sel.InstallSkills && !cmd.Flags().Changed("skills-scope") {
+	// If skills were selected in the TUI, ask where to install them.
+	if sel.InstallSkills {
 		fmt.Fprintln(out)
 		chosen, ok, err := RunSkillsScopeTUI()
 		if err != nil {
-			return nil, scope, err
+			return nil, "", err
 		}
 		if !ok {
 			fmt.Fprintln(out, "Canceled. No changes made.")
-			return nil, scope, nil
+			return nil, "", nil
 		}
-		scope = chosen
+		return sel, chosen, nil
 	}
 
-	return sel, scope, nil
+	return sel, "", nil
 }
 
 // selectedProviders returns the providers to operate on, honoring the --client
@@ -553,10 +537,6 @@ Supported clients for automatic setup:
   • Codex CLI     https://openai.com/codex/
 
 Once a client is installed, re-run: stripe agent setup
-
-Or install Stripe skills:
-  stripe agent setup --skills               # into ./.agents/skills
-  stripe agent setup --skills --skills-scope global   # into ~/.agents/skills
 `)
 }
 

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -112,7 +112,7 @@ func newAgentSetupCmd() *agentSetupCmd {
 	asc.cmd.Flags().BoolVar(&asc.statusOnly, "status", false, "Check installed agent tooling without making changes")
 	asc.cmd.Flags().BoolVarP(&asc.yes, "yes", "y", false, "Set up every detected client without prompting")
 	asc.cmd.Flags().BoolVar(&asc.force, "force", false, "Reinstall even when agent tooling is already installed")
-	asc.cmd.Flags().StringVar(&asc.client, "client", "", "Limit setup to a single client (default: all detected clients)")
+	asc.cmd.Flags().StringVar(&asc.client, "client", "", fmt.Sprintf("Limit setup to a single client; supported values: %s", agentsetup.SupportedProviderIDs(asc.providers)))
 	asc.cmd.Flags().BoolVar(&asc.jsonOutput, "json", false, "Write machine-readable status output")
 	asc.cmd.Flags().BoolVar(&asc.skills, "skills", false, "Install Stripe skills without the interactive prompt")
 	asc.cmd.Flags().StringVar(&asc.skillsScope, "skills-scope", skillsScopeLocal, "Where to install skills: local (current directory) or global (home directory)")

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -207,10 +207,20 @@ func (asc *agentSetupCmd) resolveSelection(cmd *cobra.Command, out io.Writer, de
 		}
 	}
 
-	// Nothing detected: always show the informative message (supported clients +
-	// how to install skills), rather than a context-free picker. This is the same
-	// whether or not we're on an interactive terminal.
+	// Nothing detected: show guidance, and if interactive, offer to install skills.
 	if len(detected) == 0 {
+		if asc.isInteractive() && agent == "" {
+			printNothingDetectedInteractive(out)
+			chosen, ok, err := RunSkillsScopeTUI()
+			if err != nil {
+				return nil, scope, err
+			}
+			if !ok {
+				fmt.Fprintln(out, "Canceled. No changes made.")
+				return nil, scope, nil
+			}
+			return &Selection{InstallSkills: true}, chosen, nil
+		}
 		printNothingDetected(out)
 		return nil, scope, nil
 	}
@@ -515,6 +525,18 @@ func pluginDetail(p agentsetup.PluginStatus) string {
 		detail += ", " + p.Scope
 	}
 	return detail
+}
+
+func printNothingDetectedInteractive(w io.Writer) {
+	fmt.Fprint(w, `No AI coding clients detected on this machine.
+
+Supported clients for automatic setup:
+  • Claude Code   https://claude.ai/code
+  • Cursor        https://cursor.com
+  • Codex CLI     https://github.com/openai/codex
+
+You can still install Stripe skills directly.
+`)
 }
 
 func printNothingDetected(w io.Writer) {

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -157,7 +157,9 @@ func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, _ []string) error {
 			printNothingDetected(out)
 			return nil
 		}
-		printStatusTable(out, statuses)
+		// Only show clients that are actually installed on this machine; there's
+		// no value in listing clients the user doesn't have.
+		printStatusTable(out, detected)
 		return nil
 	}
 

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -528,24 +528,24 @@ func pluginDetail(p agentsetup.PluginStatus) string {
 }
 
 func printNothingDetectedInteractive(w io.Writer) {
-	fmt.Fprint(w, `No AI coding clients detected on this machine.
+	fmt.Fprint(w, `No supported AI coding clients detected on this machine.
 
 Supported clients for automatic setup:
   • Claude Code   https://claude.ai/code
   • Cursor        https://cursor.com
-  • Codex CLI     https://github.com/openai/codex
+  • Codex CLI     https://openai.com/codex/
 
 You can still install Stripe skills directly.
 `)
 }
 
 func printNothingDetected(w io.Writer) {
-	fmt.Fprint(w, `No AI coding clients detected on this machine.
+	fmt.Fprint(w, `No supported AI coding clients detected on this machine.
 
 Supported clients for automatic setup:
   • Claude Code   https://claude.ai/code
   • Cursor        https://cursor.com
-  • Codex CLI     https://github.com/openai/codex
+  • Codex CLI     https://openai.com/codex/
 
 Once a client is installed, re-run: stripe agent setup
 

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -388,7 +388,7 @@ func (asc *agentSetupCmd) writeJSON(w io.Writer, providers map[string]agentsetup
 		return err
 	}
 	if len(result.Errors) > 0 {
-		return fmt.Errorf("%s", result.Errors[0])
+		return fmt.Errorf("%s", strings.Join(result.Errors, "; "))
 	}
 	return nil
 }

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -1,0 +1,223 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/stripe/stripe-cli/pkg/agentsetup"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+type agentCmd struct {
+	cmd *cobra.Command
+}
+
+type agentSetupCmd struct {
+	cmd *cobra.Command
+
+	statusOnly bool
+	yes        bool
+	force      bool
+	jsonOutput bool
+	client     string
+
+	scanner    agentsetup.Scanner
+	runInstall agentsetup.RunCommandFunc
+}
+
+type agentSetupJSON struct {
+	agentsetup.ClaudeStatus
+	Action  string   `json:"action"`
+	Command []string `json:"command,omitempty"`
+}
+
+func newAgentCmd() *agentCmd {
+	ac := &agentCmd{}
+	ac.cmd = &cobra.Command{
+		Use:   "agent",
+		Short: "Set up AI agent tooling",
+		Long:  "Set up AI agent tooling for Stripe development.",
+		Args:  validators.NoArgs,
+	}
+	ac.cmd.AddCommand(newAgentSetupCmd().cmd)
+	return ac
+}
+
+func newAgentSetupCmd() *agentSetupCmd {
+	asc := &agentSetupCmd{
+		client:     agentsetup.ClientClaudeCode,
+		scanner:    agentsetup.DefaultScanner(),
+		runInstall: agentsetup.RunCommand,
+	}
+
+	asc.cmd = &cobra.Command{
+		Use:   "setup",
+		Short: "Install or check Stripe agent tooling",
+		Long:  "Install or check Stripe agent tooling. This POC supports Claude Code only.",
+		Args:  validators.NoArgs,
+		RunE:  asc.runSetup,
+	}
+	asc.cmd.Flags().BoolVar(&asc.statusOnly, "status", false, "Check installed agent tooling without making changes")
+	asc.cmd.Flags().BoolVarP(&asc.yes, "yes", "y", false, "Skip confirmation prompts")
+	asc.cmd.Flags().BoolVar(&asc.force, "force", false, "Reinstall even when agent tooling is already installed")
+	asc.cmd.Flags().StringVar(&asc.client, "client", agentsetup.ClientClaudeCode, "Agent client to set up")
+	asc.cmd.Flags().BoolVar(&asc.jsonOutput, "json", false, "Write machine-readable status output")
+
+	return asc
+}
+
+func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, args []string) error {
+	if asc.client != agentsetup.ClientClaudeCode {
+		return fmt.Errorf("unsupported agent client %q; this POC only supports %q", asc.client, agentsetup.ClientClaudeCode)
+	}
+
+	status := asc.scanner.ScanClaude()
+	action, command := setupAction(status, asc.force)
+
+	if asc.jsonOutput {
+		return asc.writeJSON(cmd.OutOrStdout(), status, action, command)
+	}
+
+	printClaudeStatus(cmd.OutOrStdout(), status)
+
+	if status.Status == agentsetup.StatusError {
+		return errors.New(status.Error)
+	}
+	if asc.statusOnly {
+		return nil
+	}
+	if !status.Detected {
+		fmt.Fprintln(cmd.OutOrStdout(), "Nothing to do. Claude Code was not detected.")
+		return nil
+	}
+	if action == "none" {
+		fmt.Fprintln(cmd.OutOrStdout(), "Nothing to do. Stripe agent tooling is already installed.")
+		return nil
+	}
+
+	name, installArgs := agentsetup.ClaudeInstallCommand()
+	fmt.Fprintf(cmd.OutOrStdout(), "Planned command: %s %s\n", name, strings.Join(installArgs, " "))
+
+	if !asc.yes {
+		if !isInteractiveTerminal() {
+			return fmt.Errorf("installation requires confirmation; rerun with --yes to install without prompting")
+		}
+		confirmed, err := confirmAgentSetup(cmd.InOrStdin(), cmd.OutOrStdout())
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Fprintln(cmd.OutOrStdout(), "Canceled. No changes made.")
+			return nil
+		}
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Installing Stripe agent tooling for Claude Code...")
+	if err := asc.runClaudeInstall(commandContextOrBackground(cmd), cmd.OutOrStdout(), name, installArgs, command); err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Installed Stripe agent tooling for Claude Code.")
+	return nil
+}
+
+func (asc *agentSetupCmd) runClaudeInstall(ctx context.Context, out io.Writer, name string, installArgs []string, command []string) error {
+	if err := asc.runInstall(ctx, name, installArgs...); err == nil {
+		return nil
+	} else {
+		updateName, updateArgs := agentsetup.ClaudeMarketplaceUpdateCommand()
+		updateCommand := append([]string{updateName}, updateArgs...)
+		fmt.Fprintf(out, "Install failed. Updating Claude plugin marketplace and retrying: %s\n", strings.Join(updateCommand, " "))
+		if updateErr := asc.runInstall(ctx, updateName, updateArgs...); updateErr != nil {
+			return fmt.Errorf("running %q after install failed: %w", strings.Join(updateCommand, " "), updateErr)
+		}
+		if retryErr := asc.runInstall(ctx, name, installArgs...); retryErr != nil {
+			return fmt.Errorf("running %q after marketplace update: %w", strings.Join(command, " "), retryErr)
+		}
+		return nil
+	}
+}
+
+func setupAction(status agentsetup.ClaudeStatus, force bool) (string, []string) {
+	name, args := agentsetup.ClaudeInstallCommand()
+	command := append([]string{name}, args...)
+
+	switch {
+	case status.Status == agentsetup.StatusError:
+		return "error", nil
+	case !status.Detected:
+		return "none", nil
+	case status.PluginInstalled && force:
+		return "reinstall", command
+	case status.PluginInstalled:
+		return "none", nil
+	default:
+		return "install", command
+	}
+}
+
+func (asc *agentSetupCmd) writeJSON(w io.Writer, status agentsetup.ClaudeStatus, action string, command []string) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(agentSetupJSON{
+		ClaudeStatus: status,
+		Action:       action,
+		Command:      command,
+	})
+}
+
+func printClaudeStatus(w io.Writer, status agentsetup.ClaudeStatus) {
+	fmt.Fprintln(w, "Scanning for AI coding clients...")
+	if !status.Detected {
+		fmt.Fprintln(w, "  Claude Code: not detected")
+		return
+	}
+
+	if status.ExecutablePath != "" {
+		fmt.Fprintf(w, "  Claude Code: detected (%s)\n", status.ExecutablePath)
+	} else {
+		fmt.Fprintln(w, "  Claude Code: detected")
+	}
+
+	switch status.Status {
+	case agentsetup.StatusInstalled:
+		version := status.PluginVersion
+		if version == "" {
+			version = "unknown version"
+		}
+		fmt.Fprintf(w, "  Stripe plugin: installed as %s (%s", status.PluginID, version)
+		if status.PluginScope != "" {
+			fmt.Fprintf(w, ", %s", status.PluginScope)
+		}
+		if status.PluginScope == "local" && status.PluginProject != "" {
+			fmt.Fprintf(w, ", project %s", status.PluginProject)
+		}
+		fmt.Fprintln(w, ")")
+	case agentsetup.StatusError:
+		fmt.Fprintf(w, "  Stripe plugin: error (%s)\n", status.Error)
+	default:
+		fmt.Fprintln(w, "  Stripe plugin: missing")
+	}
+}
+
+func confirmAgentSetup(r io.Reader, w io.Writer) (bool, error) {
+	fmt.Fprint(w, "Install now? [y/N] ")
+	line, err := bufio.NewReader(r).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, fmt.Errorf("reading confirmation: %w", err)
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
+}
+
+func isInteractiveTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}

--- a/pkg/cmd/agent_setup_tui.go
+++ b/pkg/cmd/agent_setup_tui.go
@@ -65,8 +65,8 @@ func newSelectModel(statuses []agentsetup.Status) selectModel {
 	}
 	rows = append(rows, selectRow{
 		kind:     rowSkills,
-		label:    "Install Stripe skills directly",
-		detail:   "no agent required",
+		label:    "Install Stripe skills",
+		detail:   "",
 		selected: len(statuses) == 0, // pre-selected only when it's the sole option
 	})
 
@@ -149,12 +149,12 @@ var (
 )
 
 func (m selectModel) View() tea.View {
-	body := "Select agents to configure with Stripe:\n\n"
+	body := "Select agents to install the Stripe plugin:\n\n"
 
 	skillsDividerShown := false
 	for i, r := range m.rows {
 		if r.kind == rowSkills && !skillsDividerShown {
-			body += "\n" + dividerStyle.Render("── or install Stripe skills directly ──") + "\n"
+			body += "\n" + dividerStyle.Render("──────────────────── OR ────────────────────") + "\n"
 			skillsDividerShown = true
 		}
 

--- a/pkg/cmd/agent_setup_tui.go
+++ b/pkg/cmd/agent_setup_tui.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -187,13 +188,25 @@ func RunSelectionTUI(statuses []agentsetup.Status) (*Selection, error) {
 // scopeModel is a small radio prompt for choosing where to install skills.
 type scopeModel struct {
 	options []string
+	labels  []string
 	cursor  int
 	done    bool
 	quit    bool
 }
 
 func newScopeModel() scopeModel {
-	return scopeModel{options: []string{skillsScopeLocal, skillsScopeGlobal}}
+	localLabel := "This project (current directory only)"
+	if cwd, err := os.Getwd(); err == nil {
+		localLabel = fmt.Sprintf("This project   %s/.agents/skills", cwd)
+	}
+	globalLabel := "Global (available everywhere)"
+	if home, err := os.UserHomeDir(); err == nil {
+		globalLabel = fmt.Sprintf("Global         %s/.agents/skills", home)
+	}
+	return scopeModel{
+		options: []string{skillsScopeLocal, skillsScopeGlobal},
+		labels:  []string{localLabel, globalLabel},
+	}
 }
 
 func (m scopeModel) Init() tea.Cmd { return nil }
@@ -224,16 +237,12 @@ func (m scopeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m scopeModel) View() tea.View {
 	body := "Install Stripe skills where?\n\n"
-	labels := map[string]string{
-		skillsScopeLocal:  "This project   ./.agents/skills",
-		skillsScopeGlobal: "Global         ~/.agents/skills",
-	}
-	for i, opt := range m.options {
+	for i := range m.options {
 		marker := "( )"
 		if i == m.cursor {
 			marker = "(•)"
 		}
-		line := fmt.Sprintf("  %s %s", marker, labels[opt])
+		line := fmt.Sprintf("  %s %s", marker, m.labels[i])
 		if i == m.cursor {
 			line = cursorRowStyle.Render(line)
 		}

--- a/pkg/cmd/agent_setup_tui.go
+++ b/pkg/cmd/agent_setup_tui.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/stripe/stripe-cli/pkg/agentsetup"
+)
+
+const (
+	skillsScopeLocal  = "local"
+	skillsScopeGlobal = "global"
+)
+
+type rowKind int
+
+const (
+	rowAgent rowKind = iota
+	rowSkills
+)
+
+type selectRow struct {
+	kind     rowKind
+	status   agentsetup.Status // set when kind == rowAgent
+	label    string
+	detail   string
+	selected bool
+}
+
+type selectModel struct {
+	rows   []selectRow
+	cursor int
+	done   bool
+	quit   bool
+}
+
+// Selection is the outcome of the agent-setup checklist.
+type Selection struct {
+	Agents        []agentsetup.Status
+	InstallSkills bool
+}
+
+func newSelectModel(statuses []agentsetup.Status) selectModel {
+	rows := make([]selectRow, 0, len(statuses)+1)
+	for _, s := range statuses {
+		rows = append(rows, selectRow{
+			kind:     rowAgent,
+			status:   s,
+			label:    s.DisplayName,
+			detail:   s.ExecutablePath,
+			selected: true, // agents are the recommended default
+		})
+	}
+	rows = append(rows, selectRow{
+		kind:     rowSkills,
+		label:    "Install Stripe skills directly",
+		detail:   "no agent required",
+		selected: len(statuses) == 0, // pre-selected only when it's the sole option
+	})
+
+	return selectModel{rows: rows}
+}
+
+func (m selectModel) Init() tea.Cmd { return nil }
+
+func (m selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch {
+	case key.Code == tea.KeyUp || key.Code == 'k':
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case key.Code == tea.KeyDown || key.Code == 'j':
+		if m.cursor < len(m.rows)-1 {
+			m.cursor++
+		}
+	case key.Code == tea.KeySpace:
+		if len(m.rows) > 0 {
+			m.rows[m.cursor].selected = !m.rows[m.cursor].selected
+		}
+	case key.Code == 'a':
+		m.toggleAll()
+	case key.Code == tea.KeyEnter:
+		m.done = true
+		return m, tea.Quit
+	case key.Code == 'q' || key.Code == tea.KeyEscape || (key.Code == 'c' && key.Mod == tea.ModCtrl):
+		m.quit = true
+		return m, tea.Quit
+	}
+
+	return m, nil
+}
+
+// toggleAll selects every row when any is unselected, otherwise deselects all.
+func (m *selectModel) toggleAll() {
+	anyUnselected := false
+	for _, r := range m.rows {
+		if !r.selected {
+			anyUnselected = true
+			break
+		}
+	}
+	for i := range m.rows {
+		m.rows[i].selected = anyUnselected
+	}
+}
+
+func (m selectModel) selection() Selection {
+	sel := Selection{}
+	for _, r := range m.rows {
+		if !r.selected {
+			continue
+		}
+		switch r.kind {
+		case rowAgent:
+			sel.Agents = append(sel.Agents, r.status)
+		case rowSkills:
+			sel.InstallSkills = true
+		}
+	}
+	return sel
+}
+
+var (
+	checkedStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	uncheckedStyle = lipgloss.NewStyle().Faint(true)
+	cursorRowStyle = lipgloss.NewStyle().Bold(true)
+	dividerStyle   = lipgloss.NewStyle().Faint(true)
+	containerStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(1, 2)
+)
+
+func (m selectModel) View() tea.View {
+	body := "Select agents to configure with Stripe:\n\n"
+
+	skillsDividerShown := false
+	for i, r := range m.rows {
+		if r.kind == rowSkills && !skillsDividerShown {
+			body += "\n" + dividerStyle.Render("── or install Stripe skills directly ──") + "\n"
+			skillsDividerShown = true
+		}
+
+		box := uncheckedStyle.Render("·")
+		if r.selected {
+			box = checkedStyle.Render("✔")
+		}
+
+		pointer := "  "
+		if i == m.cursor {
+			pointer = "▶ "
+		}
+
+		line := fmt.Sprintf("%s[%s] %-22s %s", pointer, box, r.label, r.detail)
+		if i == m.cursor {
+			line = cursorRowStyle.Render(line)
+		}
+		body += line + "\n"
+	}
+
+	body += "\nspace toggle · a select all · enter confirm · q quit"
+
+	return tea.NewView(containerStyle.Render(body))
+}
+
+// RunSelectionTUI shows the checklist and returns the user's selection. It
+// returns nil (not an error) when the user quits without confirming.
+func RunSelectionTUI(statuses []agentsetup.Status) (*Selection, error) {
+	m := newSelectModel(statuses)
+	final, err := tea.NewProgram(m).Run()
+	if err != nil {
+		return nil, fmt.Errorf("agent selection: %w", err)
+	}
+
+	result, ok := final.(selectModel)
+	if !ok || result.quit || !result.done {
+		return nil, nil
+	}
+	sel := result.selection()
+	return &sel, nil
+}
+
+// scopeModel is a small radio prompt for choosing where to install skills.
+type scopeModel struct {
+	options []string
+	cursor  int
+	done    bool
+	quit    bool
+}
+
+func newScopeModel() scopeModel {
+	return scopeModel{options: []string{skillsScopeLocal, skillsScopeGlobal}}
+}
+
+func (m scopeModel) Init() tea.Cmd { return nil }
+
+func (m scopeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return m, nil
+	}
+	switch {
+	case key.Code == tea.KeyUp || key.Code == 'k':
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case key.Code == tea.KeyDown || key.Code == 'j':
+		if m.cursor < len(m.options)-1 {
+			m.cursor++
+		}
+	case key.Code == tea.KeyEnter:
+		m.done = true
+		return m, tea.Quit
+	case key.Code == 'q' || key.Code == tea.KeyEscape || (key.Code == 'c' && key.Mod == tea.ModCtrl):
+		m.quit = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m scopeModel) View() tea.View {
+	body := "Install Stripe skills where?\n\n"
+	labels := map[string]string{
+		skillsScopeLocal:  "This project   ./.agents/skills",
+		skillsScopeGlobal: "Global         ~/.agents/skills",
+	}
+	for i, opt := range m.options {
+		marker := "( )"
+		if i == m.cursor {
+			marker = "(•)"
+		}
+		line := fmt.Sprintf("  %s %s", marker, labels[opt])
+		if i == m.cursor {
+			line = cursorRowStyle.Render(line)
+		}
+		body += line + "\n"
+	}
+	body += "\n↑/↓ move · enter confirm · q cancel"
+	return tea.NewView(containerStyle.Render(body))
+}
+
+// RunSkillsScopeTUI prompts for the skills install scope, returning "local" or
+// "global". ok is false when the user cancels.
+func RunSkillsScopeTUI() (scope string, ok bool, err error) {
+	final, runErr := tea.NewProgram(newScopeModel()).Run()
+	if runErr != nil {
+		return "", false, fmt.Errorf("skills scope selection: %w", runErr)
+	}
+	result, isModel := final.(scopeModel)
+	if !isModel || result.quit || !result.done {
+		return "", false, nil
+	}
+	return result.options[result.cursor], true, nil
+}

--- a/pkg/cmd/agent_setup_tui.go
+++ b/pkg/cmd/agent_setup_tui.go
@@ -28,6 +28,8 @@ type selectRow struct {
 	label    string
 	detail   string
 	selected bool
+	disabled bool   // shown but not selectable (e.g. unsupported version)
+	hint     string // explanation shown when disabled
 }
 
 type selectModel struct {
@@ -46,13 +48,20 @@ type Selection struct {
 func newSelectModel(statuses []agentsetup.Status) selectModel {
 	rows := make([]selectRow, 0, len(statuses)+1)
 	for _, s := range statuses {
-		rows = append(rows, selectRow{
-			kind:     rowAgent,
-			status:   s,
-			label:    s.DisplayName,
-			detail:   s.ExecutablePath,
-			selected: true, // agents are the recommended default
-		})
+		row := selectRow{
+			kind:   rowAgent,
+			status: s,
+			label:  s.DisplayName,
+			detail: s.ExecutablePath,
+		}
+		// Disable rows where a capability issue prevents installation (e.g. old
+		// Codex without plugin support). These show but are grayed out.
+		if s.Error != "" && s.Status != agentsetup.StatusError {
+			row.disabled = true
+			row.hint = s.Error
+		}
+		row.selected = !row.disabled
+		rows = append(rows, row)
 	}
 	rows = append(rows, selectRow{
 		kind:     rowSkills,
@@ -82,7 +91,7 @@ func (m selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.cursor++
 		}
 	case key.Code == tea.KeySpace:
-		if len(m.rows) > 0 {
+		if len(m.rows) > 0 && !m.rows[m.cursor].disabled {
 			m.rows[m.cursor].selected = !m.rows[m.cursor].selected
 		}
 	case key.Code == 'a':
@@ -98,17 +107,20 @@ func (m selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// toggleAll selects every row when any is unselected, otherwise deselects all.
+// toggleAll selects every non-disabled row when any is unselected, otherwise
+// deselects all non-disabled rows.
 func (m *selectModel) toggleAll() {
 	anyUnselected := false
 	for _, r := range m.rows {
-		if !r.selected {
+		if !r.selected && !r.disabled {
 			anyUnselected = true
 			break
 		}
 	}
 	for i := range m.rows {
-		m.rows[i].selected = anyUnselected
+		if !m.rows[i].disabled {
+			m.rows[i].selected = anyUnselected
+		}
 	}
 }
 
@@ -146,14 +158,20 @@ func (m selectModel) View() tea.View {
 			skillsDividerShown = true
 		}
 
-		box := uncheckedStyle.Render("·")
-		if r.selected {
-			box = checkedStyle.Render("✔")
-		}
-
 		pointer := "  "
 		if i == m.cursor {
 			pointer = "▶ "
+		}
+
+		if r.disabled {
+			line := fmt.Sprintf("%s[-] %-22s %s", pointer, r.label, dividerStyle.Render(r.hint))
+			body += line + "\n"
+			continue
+		}
+
+		box := uncheckedStyle.Render("·")
+		if r.selected {
+			box = checkedStyle.Render("✔")
 		}
 
 		line := fmt.Sprintf("%s[%s] %-22s %s", pointer, box, r.label, r.detail)

--- a/pkg/cmd/agent_setup_tui_test.go
+++ b/pkg/cmd/agent_setup_tui_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/agentsetup"
+)
+
+func testStatuses() []agentsetup.Status {
+	return []agentsetup.Status{
+		{Client: "claude-code", DisplayName: "Claude Code", ExecutablePath: "/usr/local/bin/claude"},
+		{Client: "cursor", DisplayName: "Cursor", ExecutablePath: "/usr/local/bin/cursor"},
+		{Client: "codex", DisplayName: "Codex CLI", ExecutablePath: "/usr/local/bin/codex"},
+	}
+}
+
+func pressSelect(m selectModel, code rune) selectModel {
+	next, _ := m.Update(tea.KeyPressMsg{Code: code})
+	return next.(selectModel)
+}
+
+func TestSelectModel_AgentsSelectedSkillsRowNot(t *testing.T) {
+	m := newSelectModel(testStatuses())
+
+	// 3 agent rows + 1 skills row.
+	require.Len(t, m.rows, 4)
+	for i := 0; i < 3; i++ {
+		require.Equal(t, rowAgent, m.rows[i].kind)
+		require.True(t, m.rows[i].selected)
+	}
+	require.Equal(t, rowSkills, m.rows[3].kind)
+	require.False(t, m.rows[3].selected)
+}
+
+func TestSelectModel_NoAgentsPreselectsSkills(t *testing.T) {
+	m := newSelectModel(nil)
+
+	require.Len(t, m.rows, 1)
+	require.Equal(t, rowSkills, m.rows[0].kind)
+	require.True(t, m.rows[0].selected)
+}
+
+func TestSelectModel_SelectionSeparatesAgentsAndSkills(t *testing.T) {
+	m := newSelectModel(testStatuses())
+
+	// Toggle the skills row (index 3) on.
+	m.cursor = 3
+	m = pressSelect(m, tea.KeySpace)
+	// Toggle Cursor (index 1) off.
+	m.cursor = 1
+	m = pressSelect(m, tea.KeySpace)
+
+	sel := m.selection()
+	require.True(t, sel.InstallSkills)
+	require.Len(t, sel.Agents, 2)
+	require.Equal(t, "claude-code", sel.Agents[0].Client)
+	require.Equal(t, "codex", sel.Agents[1].Client)
+}
+
+func TestSelectModel_SelectAllTogglesEveryRow(t *testing.T) {
+	m := newSelectModel(testStatuses())
+
+	// Skills row starts unselected, so 'a' selects all.
+	m = pressSelect(m, 'a')
+	for _, r := range m.rows {
+		require.True(t, r.selected)
+	}
+	// All selected -> 'a' deselects all.
+	m = pressSelect(m, 'a')
+	for _, r := range m.rows {
+		require.False(t, r.selected)
+	}
+}
+
+func TestSelectModel_CursorClampedAcrossAllRows(t *testing.T) {
+	m := newSelectModel(testStatuses())
+
+	m = pressSelect(m, tea.KeyUp)
+	require.Equal(t, 0, m.cursor)
+
+	for i := 0; i < 10; i++ {
+		m = pressSelect(m, tea.KeyDown)
+	}
+	require.Equal(t, len(m.rows)-1, m.cursor) // clamped at the skills row
+}
+
+func TestSelectModel_EnterConfirmsQuitCancels(t *testing.T) {
+	m := newSelectModel(testStatuses())
+	next, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = next.(selectModel)
+	require.True(t, m.done)
+	require.False(t, m.quit)
+	require.NotNil(t, cmd)
+
+	m2 := newSelectModel(testStatuses())
+	next2, cmd2 := m2.Update(tea.KeyPressMsg{Code: 'q'})
+	m2 = next2.(selectModel)
+	require.True(t, m2.quit)
+	require.False(t, m2.done)
+	require.NotNil(t, cmd2)
+}
+
+func TestScopeModel_DefaultsToLocalAndConfirms(t *testing.T) {
+	m := newScopeModel()
+	require.Equal(t, skillsScopeLocal, m.options[m.cursor])
+
+	next, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = next.(scopeModel)
+	require.Equal(t, skillsScopeGlobal, m.options[m.cursor])
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = next.(scopeModel)
+	require.True(t, m.done)
+	require.NotNil(t, cmd)
+}
+
+func TestScopeModel_QuitCancels(t *testing.T) {
+	m := newScopeModel()
+	next, _ := m.Update(tea.KeyPressMsg{Code: 'q'})
+	m = next.(scopeModel)
+	require.True(t, m.quit)
+	require.False(t, m.done)
+}

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -385,6 +385,54 @@ func TestAgentSetupUnsupportedAgentInstallsSkills(t *testing.T) {
 	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
 }
 
+func TestAgentSetupAgentScopingWinsOverYes(t *testing.T) {
+	// Inside a coding agent, --yes must NOT broaden to all clients — it still
+	// only sets up the calling agent.
+	var installed []string
+	record := func(_ context.Context, name string, args ...string) error {
+		installed = append(installed, name)
+		return nil
+	}
+	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), func(context.Context, string, ...string) error {
+		t.Fatal("Claude must not be installed when the calling agent is Codex")
+		return nil
+	})
+	codex := codexMissingProvider(record)
+
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude, codex.ID(): codex}
+	setup.callingAgent = func() string { return "codex_cli" }
+	setup.cmd.SetContext(context.Background())
+
+	output, err := executeCommand(setup.cmd, "--yes")
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"codex"}, installed) // only codex, despite --yes and Claude detected
+	require.Contains(t, output, "Detected Codex CLI — setting up its Stripe plugin.")
+	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
+}
+
+func TestAgentSetupYesInstallsAllWhenNoAgent(t *testing.T) {
+	// In a plain CLI (no calling agent), --yes still installs every detected client.
+	var installed []string
+	record := func(_ context.Context, name string, args ...string) error {
+		installed = append(installed, name)
+		return nil
+	}
+	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), record)
+	codex := codexMissingProvider(record)
+
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude, codex.ID(): codex}
+	setup.callingAgent = func() string { return "" }
+	setup.cmd.SetContext(context.Background())
+
+	_, err := executeCommand(setup.cmd, "--yes")
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"claude", "codex"}, installed)
+}
+
 func TestAgentSetupAgentNeverUsesInteractivePicker(t *testing.T) {
 	// Gemini CLI allocates a PTY, so isInteractive() reports true even though no
 	// human is present. When an agent is detected we must skip the picker and

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -23,7 +23,7 @@ func TestAgentSetupStatusDoesNotInstall(t *testing.T) {
 	output, err := executeCommand(setup.cmd, "--status")
 
 	require.NoError(t, err)
-	require.Contains(t, output, "AI coding clients")
+	require.Contains(t, output, "Detected agents with supported Stripe plugins:")
 	require.Contains(t, output, "Claude Code")
 	require.Contains(t, output, "Stripe plugin not installed")
 }

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestAgentSetupStatusDoesNotInstall(t *testing.T) {
 }
 
 func TestAgentSetupStatusShowsInstalledDetail(t *testing.T) {
-	setup := newTestAgentSetupCmd(t, claudeInstalledPluginScanner(t), nil)
+	setup := newTestAgentSetupCmdInstalled(t, nil)
 
 	output, err := executeCommand(setup.cmd, "--status")
 
@@ -70,29 +69,32 @@ func TestAgentSetupJSONReportsActionWithoutInstalling(t *testing.T) {
 	require.Equal(t, []string{"claude", "plugin", "install", agentsetup.TargetClaudePlugin}, result.Actions[0].Command)
 }
 
-func TestAgentSetupJSONPropagatesScanError(t *testing.T) {
-	setup := newTestAgentSetupCmd(t, agentsetup.Scanner{
+func TestAgentSetupJSONShowsUpgradeHintWhenPluginCommandFails(t *testing.T) {
+	setup := newAgentSetupCmd()
+	claude := agentsetup.NewClaudeProvider(agentsetup.Scanner{
 		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
-		HomeDir:  func() (string, error) { return "", errors.New("home failed") },
-	}, func(context.Context, string, ...string) error {
-		t.Fatal("installer should not run when scan fails")
-		return nil
-	})
+	}, nil)
+	claude.RunOutput = func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return nil, errors.New("unknown command")
+	}
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
+	setup.callingAgent = func() string { return "" }
+	setup.cmd.SetContext(context.Background())
 
 	output, err := executeCommand(setup.cmd, "--json")
 
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	var result agentSetupJSON
 	require.NoError(t, json.Unmarshal([]byte(output), &result))
-	require.Equal(t, agentsetup.StatusError, result.Status)
-	require.Len(t, result.Errors, 1)
-	require.Contains(t, result.Errors[0], "home failed")
+	require.Len(t, result.Clients, 1)
+	require.True(t, result.Clients[0].Detected)
+	require.Contains(t, result.Clients[0].Error, "upgrade Claude Code")
 }
 
 func TestAgentSetupForceYesInvokesInstallerWhenInstalled(t *testing.T) {
 	var called bool
-	setup := newTestAgentSetupCmd(t, claudeInstalledPluginScanner(t), func(ctx context.Context, name string, args ...string) error {
+	setup := newTestAgentSetupCmdInstalled(t, func(ctx context.Context, name string, args ...string) error {
 		called = true
 		require.Equal(t, "claude", name)
 		require.Equal(t, []string{"plugin", "install", agentsetup.TargetClaudePlugin}, args)
@@ -504,6 +506,20 @@ func newTestAgentSetupCmd(t *testing.T, scanner agentsetup.Scanner, runInstall a
 	t.Helper()
 	setup := newAgentSetupCmd()
 	claude := agentsetup.NewClaudeProvider(scanner, runInstall)
+	claude.RunOutput = claudeListEmpty
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
+	setup.callingAgent = func() string { return "" }
+	setup.cmd.SetContext(context.Background())
+	return setup
+}
+
+func newTestAgentSetupCmdInstalled(t *testing.T, runInstall agentsetup.RunCommandFunc) *agentSetupCmd {
+	t.Helper()
+	setup := newAgentSetupCmd()
+	claude := agentsetup.NewClaudeProvider(agentsetup.Scanner{
+		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
+	}, runInstall)
+	claude.RunOutput = claudeListInstalled
 	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
 	setup.callingAgent = func() string { return "" }
 	setup.cmd.SetContext(context.Background())
@@ -512,30 +528,15 @@ func newTestAgentSetupCmd(t *testing.T, scanner agentsetup.Scanner, runInstall a
 
 func claudeMissingPluginScanner(t *testing.T) agentsetup.Scanner {
 	t.Helper()
-	home := t.TempDir()
 	return agentsetup.Scanner{
 		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
-		ReadFile: os.ReadFile,
-		HomeDir:  func() (string, error) { return home, nil },
 	}
 }
 
-func claudeInstalledPluginScanner(t *testing.T) agentsetup.Scanner {
-	t.Helper()
-	home := t.TempDir()
-	statePath := filepath.Join(home, agentsetup.ClaudePluginStatePath)
-	require.NoError(t, os.MkdirAll(filepath.Dir(statePath), 0755))
-	require.NoError(t, os.WriteFile(statePath, []byte(`{
-		"version": 2,
-		"plugins": {
-			"stripe@claude-plugins-official": [
-				{"scope": "user", "version": "2.4.1", "installPath": "/tmp/stripe"}
-			]
-		}
-	}`), 0600))
-	return agentsetup.Scanner{
-		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
-		ReadFile: os.ReadFile,
-		HomeDir:  func() (string, error) { return home, nil },
-	}
+func claudeListEmpty(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return []byte(`[]`), nil
+}
+
+func claudeListInstalled(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return []byte(`[{"id":"stripe@claude-plugins-official","version":"2.4.1","scope":"user","enabled":true}]`), nil
 }

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/agentsetup"
+)
+
+func TestAgentSetupStatusDoesNotInstall(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, claudeMissingPluginScanner(t), func(context.Context, string, ...string) error {
+		t.Fatal("installer should not run in --status mode")
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd, "--status")
+
+	require.NoError(t, err)
+	require.Contains(t, output, "Claude Code: detected")
+	require.Contains(t, output, "Stripe plugin: missing")
+}
+
+func TestAgentSetupUnsupportedClient(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, claudeMissingPluginScanner(t), nil)
+
+	_, err := executeCommand(setup.cmd, "--client", "cursor")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported agent client")
+}
+
+func TestAgentSetupJSONReportsActionWithoutInstalling(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, claudeMissingPluginScanner(t), func(context.Context, string, ...string) error {
+		t.Fatal("installer should not run in --json mode")
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd, "--json")
+
+	require.NoError(t, err)
+
+	var result agentSetupJSON
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	require.True(t, result.Detected)
+	require.False(t, result.PluginInstalled)
+	require.Equal(t, "install", result.Action)
+	require.Equal(t, []string{"claude", "plugin", "install", agentsetup.TargetClaudePlugin}, result.Command)
+}
+
+func TestAgentSetupForceYesInvokesInstallerWhenInstalled(t *testing.T) {
+	var called bool
+	setup := newTestAgentSetupCmd(t, claudeInstalledPluginScanner(t), func(ctx context.Context, name string, args ...string) error {
+		called = true
+		require.Equal(t, "claude", name)
+		require.Equal(t, []string{"plugin", "install", agentsetup.TargetClaudePlugin}, args)
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd, "--force", "--yes")
+
+	require.NoError(t, err)
+	require.True(t, called)
+	require.Contains(t, output, "Installing Stripe agent tooling")
+	require.Contains(t, output, "Installed Stripe agent tooling")
+}
+
+func TestAgentSetupRetriesAfterMarketplaceUpdate(t *testing.T) {
+	var calls []string
+	setup := newTestAgentSetupCmd(t, claudeMissingPluginScanner(t), func(ctx context.Context, name string, args ...string) error {
+		call := name
+		for _, arg := range args {
+			call += " " + arg
+		}
+		calls = append(calls, call)
+		if len(calls) == 1 {
+			return fmt.Errorf("plugin not found")
+		}
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd, "--yes")
+
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"claude plugin install " + agentsetup.TargetClaudePlugin,
+		"claude plugin marketplace update " + agentsetup.ClaudeMarketplace,
+		"claude plugin install " + agentsetup.TargetClaudePlugin,
+	}, calls)
+	require.Contains(t, output, "Updating Claude plugin marketplace and retrying")
+	require.Contains(t, output, "Installed Stripe agent tooling")
+}
+
+func TestAgentSetupNoClaudeDoesNotFail(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, agentsetup.Scanner{
+		LookPath: func(string) (string, error) { return "", errors.New("not found") },
+	}, func(context.Context, string, ...string) error {
+		t.Fatal("installer should not run when Claude Code is not detected")
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd)
+
+	require.NoError(t, err)
+	require.Contains(t, output, "Claude Code: not detected")
+	require.Contains(t, output, "Nothing to do")
+}
+
+func newTestAgentSetupCmd(t *testing.T, scanner agentsetup.Scanner, runInstall agentsetup.RunCommandFunc) *agentSetupCmd {
+	t.Helper()
+	setup := newAgentSetupCmd()
+	setup.scanner = scanner
+	if runInstall != nil {
+		setup.runInstall = runInstall
+	}
+	setup.cmd.SetContext(context.Background())
+	return setup
+}
+
+func claudeMissingPluginScanner(t *testing.T) agentsetup.Scanner {
+	t.Helper()
+	home := t.TempDir()
+	return agentsetup.Scanner{
+		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
+		ReadFile: os.ReadFile,
+		HomeDir:  func() (string, error) { return home, nil },
+	}
+}
+
+func claudeInstalledPluginScanner(t *testing.T) agentsetup.Scanner {
+	t.Helper()
+	home := t.TempDir()
+	statePath := filepath.Join(home, agentsetup.ClaudePluginStatePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(statePath), 0755))
+	require.NoError(t, os.WriteFile(statePath, []byte(`{
+		"version": 2,
+		"plugins": {
+			"stripe@claude-plugins-official": [
+				{"scope": "user", "version": "2.4.1", "installPath": "/tmp/stripe"}
+			]
+		}
+	}`), 0600))
+	return agentsetup.Scanner{
+		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
+		ReadFile: os.ReadFile,
+		HomeDir:  func() (string, error) { return home, nil },
+	}
+}

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -339,22 +339,21 @@ func TestAgentSetupSkillsAlongsideAgent(t *testing.T) {
 	require.Contains(t, output, "2 installed, 0 skipped, 0 errors")
 }
 
-func TestAgentSetupCursorIsManualStepNotError(t *testing.T) {
-	// Cursor detected, plugin not installed (empty temp home) -> manual step.
+func TestAgentSetupCursorIsSkippedNotInstalled(t *testing.T) {
+	// Cursor detected but always skipped (Plan returns ActionNone).
 	cursor := agentsetup.NewCursorProvider(agentsetup.Scanner{
 		LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil },
-		ReadFile: os.ReadFile,
-		HomeDir:  func() (string, error) { return t.TempDir(), nil },
 	}, nil)
 
 	setup := newAgentSetupCmd()
 	setup.providers = map[string]agentsetup.Provider{cursor.ID(): cursor}
+	setup.callingAgent = func() string { return "" }
 	setup.cmd.SetContext(context.Background())
 
 	output, err := executeCommand(setup.cmd, "--client", "cursor", "--yes")
 
-	require.NoError(t, err) // manual step must not fail the command
-	require.Contains(t, output, "manual step: run /add-plugin stripe inside Cursor")
+	require.NoError(t, err)
+	require.Contains(t, output, "already set up")
 	require.Contains(t, output, "0 installed, 1 skipped, 0 errors")
 }
 

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -405,13 +405,13 @@ func TestAgentSetupStatusHidesUndetectedClients(t *testing.T) {
 	require.NotContains(t, output, "not detected")
 }
 
-func TestAgentSetupNoClientsShowsMessageNotPicker(t *testing.T) {
-	// No clients detected. Even on an interactive terminal we must show the
-	// informative "nothing detected" message, not a context-free skills picker.
+func TestAgentSetupNoClientsNonInteractiveShowsHint(t *testing.T) {
+	// No clients detected, non-interactive: show the full info message with the
+	// --skills hint so scripts/CI know what to do.
 	setup := newAgentSetupCmd()
 	setup.providers = map[string]agentsetup.Provider{} // nothing detected
 	setup.callingAgent = func() string { return "" }
-	setup.isInteractive = func() bool { return true } // pretend TTY
+	setup.isInteractive = func() bool { return false }
 	setup.cmd.SetContext(context.Background())
 
 	output, err := executeCommand(setup.cmd)

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -340,7 +340,7 @@ func TestAgentSetupSkillsAlongsideAgent(t *testing.T) {
 }
 
 func TestAgentSetupCursorIsSkippedNotInstalled(t *testing.T) {
-	// Cursor detected but always skipped (Plan returns ActionNone).
+	// Cursor detected but plugin not installed — shows manual step hint.
 	cursor := agentsetup.NewCursorProvider(agentsetup.Scanner{
 		LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil },
 	}, nil)
@@ -353,7 +353,8 @@ func TestAgentSetupCursorIsSkippedNotInstalled(t *testing.T) {
 	output, err := executeCommand(setup.cmd, "--client", "cursor", "--yes")
 
 	require.NoError(t, err)
-	require.Contains(t, output, "already set up")
+	require.Contains(t, output, "manual step")
+	require.Contains(t, output, "/add-plugin stripe")
 	require.Contains(t, output, "0 installed, 1 skipped, 0 errors")
 }
 

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -385,6 +385,35 @@ func TestAgentSetupUnsupportedAgentInstallsSkills(t *testing.T) {
 	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
 }
 
+func TestAgentSetupAgentNeverUsesInteractivePicker(t *testing.T) {
+	// Gemini CLI allocates a PTY, so isInteractive() reports true even though no
+	// human is present. When an agent is detected we must skip the picker and
+	// fall back to non-interactive behavior (skills for an unsupported agent).
+	var skillsCalled bool
+	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), func(context.Context, string, ...string) error {
+		t.Fatal("no plugin should install; and the picker must not run")
+		return nil
+	})
+
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
+	setup.callingAgent = func() string { return "gemini_cli" }
+	setup.isInteractive = func() bool { return true } // simulate a PTY
+	setup.skillsInstall = func(context.Context, string) ([]string, error) {
+		skillsCalled = true
+		return []string{"stripe-best-practices"}, nil
+	}
+	setup.skillsLocalDir = func() (string, error) { return filepath.Join(t.TempDir(), ".agents", "skills"), nil }
+	setup.cmd.SetContext(context.Background())
+
+	output, err := executeCommand(setup.cmd)
+
+	require.NoError(t, err)
+	require.True(t, skillsCalled)
+	require.Contains(t, output, "installing Stripe skills instead")
+	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
+}
+
 func newTestAgentSetupCmd(t *testing.T, scanner agentsetup.Scanner, runInstall agentsetup.RunCommandFunc) *agentSetupCmd {
 	t.Helper()
 	setup := newAgentSetupCmd()

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -48,10 +48,33 @@ func TestAgentSetupJSONReportsActionWithoutInstalling(t *testing.T) {
 
 	var result agentSetupJSON
 	require.NoError(t, json.Unmarshal([]byte(output), &result))
-	require.True(t, result.Detected)
-	require.False(t, result.PluginInstalled)
-	require.Equal(t, "install", result.Action)
-	require.Equal(t, []string{"claude", "plugin", "install", agentsetup.TargetClaudePlugin}, result.Command)
+	require.Equal(t, agentsetup.StatusMissing, result.Status)
+	require.Len(t, result.Clients, 1)
+	require.True(t, result.Clients[0].Detected)
+	require.False(t, result.Clients[0].Plugin.Installed)
+	require.Len(t, result.Actions, 1)
+	require.Equal(t, agentsetup.ActionInstall, result.Actions[0].Action)
+	require.Equal(t, []string{"claude", "plugin", "install", agentsetup.TargetClaudePlugin}, result.Actions[0].Command)
+}
+
+func TestAgentSetupJSONPropagatesScanError(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, agentsetup.Scanner{
+		LookPath: func(string) (string, error) { return "/usr/local/bin/claude", nil },
+		HomeDir:  func() (string, error) { return "", errors.New("home failed") },
+	}, func(context.Context, string, ...string) error {
+		t.Fatal("installer should not run when scan fails")
+		return nil
+	})
+
+	output, err := executeCommand(setup.cmd, "--json")
+
+	require.Error(t, err)
+
+	var result agentSetupJSON
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	require.Equal(t, agentsetup.StatusError, result.Status)
+	require.Len(t, result.Errors, 1)
+	require.Contains(t, result.Errors[0], "home failed")
 }
 
 func TestAgentSetupForceYesInvokesInstallerWhenInstalled(t *testing.T) {
@@ -115,10 +138,8 @@ func TestAgentSetupNoClaudeDoesNotFail(t *testing.T) {
 func newTestAgentSetupCmd(t *testing.T, scanner agentsetup.Scanner, runInstall agentsetup.RunCommandFunc) *agentSetupCmd {
 	t.Helper()
 	setup := newAgentSetupCmd()
-	setup.scanner = scanner
-	if runInstall != nil {
-		setup.runInstall = runInstall
-	}
+	claude := agentsetup.NewClaudeProvider(scanner, runInstall)
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
 	setup.cmd.SetContext(context.Background())
 	return setup
 }

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -163,6 +163,7 @@ func TestAgentSetupInstallsAllDetectedClients(t *testing.T) {
 
 	setup := newAgentSetupCmd()
 	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude, codex.ID(): codex}
+	setup.callingAgent = func() string { return "" } // no agent -> install all detected
 	setup.cmd.SetContext(context.Background())
 
 	// executeCommand is non-interactive, so all detected clients install without a TUI.
@@ -187,12 +188,38 @@ func TestAgentSetupClientFlagLimitsToOne(t *testing.T) {
 
 	setup := newAgentSetupCmd()
 	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude, codex.ID(): codex}
+	setup.callingAgent = func() string { return "" }
 	setup.cmd.SetContext(context.Background())
 
 	output, err := executeCommand(setup.cmd, "--client", "codex")
 
 	require.NoError(t, err)
 	require.Equal(t, []string{"codex"}, installed)
+	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
+}
+
+func TestAgentSetupAutoInstallsForCallingAgent(t *testing.T) {
+	var installed []string
+	record := func(_ context.Context, name string, args ...string) error {
+		installed = append(installed, name)
+		return nil
+	}
+
+	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), record)
+	codex := codexMissingProvider(record)
+
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude, codex.ID(): codex}
+	// Simulate being invoked by Codex CLI — only its plugin should install,
+	// even though Claude is also detected, and with no --client flag.
+	setup.callingAgent = func() string { return "codex_cli" }
+	setup.cmd.SetContext(context.Background())
+
+	output, err := executeCommand(setup.cmd)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"codex"}, installed) // Claude NOT installed
+	require.Contains(t, output, "Detected Codex CLI — setting up its Stripe plugin.")
 	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
 }
 
@@ -331,11 +358,39 @@ func TestAgentSetupCursorIsManualStepNotError(t *testing.T) {
 	require.Contains(t, output, "0 installed, 1 skipped, 0 errors")
 }
 
+func TestAgentSetupUnsupportedAgentInstallsSkills(t *testing.T) {
+	var skillsCalled bool
+	// Claude is detected, but we're invoked by an agent with no Stripe plugin.
+	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), func(context.Context, string, ...string) error {
+		t.Fatal("no plugin should be installed for an unsupported agent")
+		return nil
+	})
+
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
+	setup.callingAgent = func() string { return "gemini_cli" }
+	setup.skillsInstall = func(context.Context, string) ([]string, error) {
+		skillsCalled = true
+		return []string{"stripe-best-practices"}, nil
+	}
+	setup.skillsLocalDir = func() (string, error) { return filepath.Join(t.TempDir(), ".agents", "skills"), nil }
+	setup.cmd.SetContext(context.Background())
+
+	output, err := executeCommand(setup.cmd)
+
+	require.NoError(t, err)
+	require.True(t, skillsCalled)
+	require.Contains(t, output, "Detected gemini_cli, which has no Stripe plugin — installing Stripe skills instead.")
+	require.Contains(t, output, "Stripe skills (local)")
+	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
+}
+
 func newTestAgentSetupCmd(t *testing.T, scanner agentsetup.Scanner, runInstall agentsetup.RunCommandFunc) *agentSetupCmd {
 	t.Helper()
 	setup := newAgentSetupCmd()
 	claude := agentsetup.NewClaudeProvider(scanner, runInstall)
 	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
+	setup.callingAgent = func() string { return "" }
 	setup.cmd.SetContext(context.Background())
 	return setup
 }

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -23,8 +23,21 @@ func TestAgentSetupStatusDoesNotInstall(t *testing.T) {
 	output, err := executeCommand(setup.cmd, "--status")
 
 	require.NoError(t, err)
-	require.Contains(t, output, "Claude Code: detected")
-	require.Contains(t, output, "Stripe plugin: missing")
+	require.Contains(t, output, "AI coding clients")
+	require.Contains(t, output, "Claude Code")
+	require.Contains(t, output, "Stripe plugin not installed")
+}
+
+func TestAgentSetupStatusShowsInstalledDetail(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, claudeInstalledPluginScanner(t), nil)
+
+	output, err := executeCommand(setup.cmd, "--status")
+
+	require.NoError(t, err)
+	require.Contains(t, output, "Claude Code")
+	require.Contains(t, output, "Stripe plugin installed")
+	require.Contains(t, output, agentsetup.TargetClaudePlugin) // plugin id in the dimmed detail
+	require.Contains(t, output, "2.4.1")
 }
 
 func TestAgentSetupUnsupportedClient(t *testing.T) {
@@ -90,8 +103,10 @@ func TestAgentSetupForceYesInvokesInstallerWhenInstalled(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, called)
-	require.Contains(t, output, "Installing Stripe agent tooling")
-	require.Contains(t, output, "Installed Stripe agent tooling")
+	require.Contains(t, output, "Setting up Stripe agent tooling")
+	require.Contains(t, output, "Claude Code")
+	require.Contains(t, output, "done")
+	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
 }
 
 func TestAgentSetupRetriesAfterMarketplaceUpdate(t *testing.T) {
@@ -117,7 +132,8 @@ func TestAgentSetupRetriesAfterMarketplaceUpdate(t *testing.T) {
 		"claude plugin install " + agentsetup.TargetClaudePlugin,
 	}, calls)
 	require.Contains(t, output, "Updating Claude plugin marketplace and retrying")
-	require.Contains(t, output, "Installed Stripe agent tooling")
+	require.Contains(t, output, "done")
+	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
 }
 
 func TestAgentSetupNoClaudeDoesNotFail(t *testing.T) {
@@ -131,8 +147,188 @@ func TestAgentSetupNoClaudeDoesNotFail(t *testing.T) {
 	output, err := executeCommand(setup.cmd)
 
 	require.NoError(t, err)
-	require.Contains(t, output, "Claude Code: not detected")
-	require.Contains(t, output, "Nothing to do")
+	require.Contains(t, output, "No AI coding clients detected on this machine.")
+	require.Contains(t, output, "re-run: stripe agent setup")
+}
+
+func TestAgentSetupInstallsAllDetectedClients(t *testing.T) {
+	var installed []string
+	record := func(_ context.Context, name string, args ...string) error {
+		installed = append(installed, name)
+		return nil
+	}
+
+	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), record)
+	codex := codexMissingProvider(record)
+
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude, codex.ID(): codex}
+	setup.cmd.SetContext(context.Background())
+
+	// executeCommand is non-interactive, so all detected clients install without a TUI.
+	output, err := executeCommand(setup.cmd)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"claude", "codex"}, installed)
+	require.Contains(t, output, "Claude Code")
+	require.Contains(t, output, "Codex CLI")
+	require.Contains(t, output, "2 installed, 0 skipped, 0 errors")
+}
+
+func TestAgentSetupClientFlagLimitsToOne(t *testing.T) {
+	var installed []string
+	record := func(_ context.Context, name string, args ...string) error {
+		installed = append(installed, name)
+		return nil
+	}
+
+	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), record)
+	codex := codexMissingProvider(record)
+
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude, codex.ID(): codex}
+	setup.cmd.SetContext(context.Background())
+
+	output, err := executeCommand(setup.cmd, "--client", "codex")
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"codex"}, installed)
+	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
+}
+
+// codexMissingProvider returns a Codex provider that detects the binary, starts
+// with the Stripe plugin not installed, records install commands via record, and
+// reports the plugin as installed once the add command has run (mirroring the
+// post-install verification the provider performs).
+func codexMissingProvider(record agentsetup.RunCommandFunc) agentsetup.CodexProvider {
+	installed := false
+	return agentsetup.CodexProvider{
+		Scanner: agentsetup.Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/codex", nil }},
+		RunCommand: func(ctx context.Context, name string, args ...string) error {
+			installed = true
+			if record != nil {
+				return record(ctx, name, args...)
+			}
+			return nil
+		},
+		RunOutput: func(context.Context, string, ...string) ([]byte, error) {
+			if installed {
+				return []byte(`{"installed":[{"name":"stripe","marketplace":"openai-curated","version":"1.0.0"}]}`), nil
+			}
+			return []byte(`{"installed":[]}`), nil
+		},
+	}
+}
+
+func TestAgentSetupSkillsFlagInstallsToLocalDir(t *testing.T) {
+	var gotDir string
+	setup := newAgentSetupCmd()
+	// No agents registered, so only the skills path runs.
+	setup.providers = map[string]agentsetup.Provider{}
+	setup.cmd.SetContext(context.Background())
+	setup.skillsInstall = func(_ context.Context, destDir string) ([]string, error) {
+		gotDir = destDir
+		return []string{"stripe-best-practices", "upgrade-stripe"}, nil
+	}
+	localDir := filepath.Join(t.TempDir(), ".agents", "skills")
+	setup.skillsLocalDir = func() (string, error) { return localDir, nil }
+
+	output, err := executeCommand(setup.cmd, "--skills")
+
+	require.NoError(t, err)
+	require.Equal(t, localDir, gotDir)
+	require.Contains(t, output, "Stripe skills (local)")
+	require.Contains(t, output, "installed 2 skill(s)")
+	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
+}
+
+func TestAgentSetupSkillsGlobalScope(t *testing.T) {
+	var gotDir string
+	globalDir := filepath.Join(t.TempDir(), ".agents", "skills")
+
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{}
+	setup.cmd.SetContext(context.Background())
+	setup.skillsInstall = func(_ context.Context, destDir string) ([]string, error) {
+		gotDir = destDir
+		return []string{"stripe-best-practices"}, nil
+	}
+	setup.skillsGlobalDir = func() (string, error) { return globalDir, nil }
+
+	output, err := executeCommand(setup.cmd, "--skills", "--skills-scope", "global")
+
+	require.NoError(t, err)
+	require.Equal(t, globalDir, gotDir)
+	require.Contains(t, output, "Stripe skills (global)")
+	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
+}
+
+func TestAgentSetupSkillsInstallFailureReportsError(t *testing.T) {
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{}
+	setup.cmd.SetContext(context.Background())
+	setup.skillsInstall = func(context.Context, string) ([]string, error) {
+		return nil, errors.New("index unreachable")
+	}
+	setup.skillsLocalDir = func() (string, error) { return t.TempDir(), nil }
+
+	output, err := executeCommand(setup.cmd, "--skills")
+
+	require.Error(t, err)
+	require.Contains(t, output, "error: index unreachable")
+	require.Contains(t, output, "0 installed, 0 skipped, 1 errors")
+}
+
+func TestAgentSetupInvalidSkillsScope(t *testing.T) {
+	setup := newAgentSetupCmd()
+	setup.cmd.SetContext(context.Background())
+
+	_, err := executeCommand(setup.cmd, "--skills", "--skills-scope", "sideways")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid --skills-scope")
+}
+
+func TestAgentSetupSkillsAlongsideAgent(t *testing.T) {
+	var skillsCalled bool
+	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), func(context.Context, string, ...string) error { return nil })
+
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
+	setup.cmd.SetContext(context.Background())
+	setup.skillsInstall = func(context.Context, string) ([]string, error) {
+		skillsCalled = true
+		return []string{"stripe-best-practices"}, nil
+	}
+	setup.skillsLocalDir = func() (string, error) { return filepath.Join(t.TempDir(), ".agents", "skills"), nil }
+
+	// --yes installs the detected agent; --skills adds skills in the same run.
+	output, err := executeCommand(setup.cmd, "--yes", "--skills")
+
+	require.NoError(t, err)
+	require.True(t, skillsCalled)
+	require.Contains(t, output, "Claude Code")
+	require.Contains(t, output, "Stripe skills (local)")
+	require.Contains(t, output, "2 installed, 0 skipped, 0 errors")
+}
+
+func TestAgentSetupCursorIsManualStepNotError(t *testing.T) {
+	// Cursor detected, plugin not installed (empty temp home) -> manual step.
+	cursor := agentsetup.NewCursorProvider(agentsetup.Scanner{
+		LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil },
+		ReadFile: os.ReadFile,
+		HomeDir:  func() (string, error) { return t.TempDir(), nil },
+	}, nil)
+
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{cursor.ID(): cursor}
+	setup.cmd.SetContext(context.Background())
+
+	output, err := executeCommand(setup.cmd, "--client", "cursor", "--yes")
+
+	require.NoError(t, err) // manual step must not fail the command
+	require.Contains(t, output, "manual step: run /add-plugin stripe inside Cursor")
+	require.Contains(t, output, "0 installed, 1 skipped, 0 errors")
 }
 
 func newTestAgentSetupCmd(t *testing.T, scanner agentsetup.Scanner, runInstall agentsetup.RunCommandFunc) *agentSetupCmd {

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -385,6 +385,26 @@ func TestAgentSetupUnsupportedAgentInstallsSkills(t *testing.T) {
 	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
 }
 
+func TestAgentSetupStatusHidesUndetectedClients(t *testing.T) {
+	// Claude detected, Cursor not — --status should list only Claude.
+	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), nil)
+	cursor := agentsetup.NewCursorProvider(agentsetup.Scanner{
+		LookPath: func(string) (string, error) { return "", errors.New("not found") },
+	}, nil)
+
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude, cursor.ID(): cursor}
+	setup.callingAgent = func() string { return "" }
+	setup.cmd.SetContext(context.Background())
+
+	output, err := executeCommand(setup.cmd, "--status")
+
+	require.NoError(t, err)
+	require.Contains(t, output, "Claude Code")
+	require.NotContains(t, output, "Cursor")
+	require.NotContains(t, output, "not detected")
+}
+
 func TestAgentSetupNoClientsShowsMessageNotPicker(t *testing.T) {
 	// No clients detected. Even on an interactive terminal we must show the
 	// informative "nothing detected" message, not a context-free skills picker.

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -240,7 +240,7 @@ func codexMissingProvider(record agentsetup.RunCommandFunc) agentsetup.CodexProv
 		},
 		RunOutput: func(context.Context, string, ...string) ([]byte, error) {
 			if installed {
-				return []byte(`{"installed":[{"name":"stripe","marketplace":"openai-curated","version":"1.0.0"}]}`), nil
+				return []byte(`{"installed":[{"pluginId":"stripe@openai-curated","name":"stripe","marketplaceName":"openai-curated","version":"1.0.0"}]}`), nil
 			}
 			return []byte(`{"installed":[]}`), nil
 		},

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -294,7 +294,6 @@ func TestAgentSetupCursorIsSkippedNotInstalled(t *testing.T) {
 	require.Contains(t, output, "0 installed, 1 skipped, 0 errors")
 }
 
-
 func TestAgentSetupStatusHidesUndetectedClients(t *testing.T) {
 	// Claude detected, Cursor not — --status should list only Claude.
 	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), nil)

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -249,96 +249,30 @@ func codexMissingProvider(record agentsetup.RunCommandFunc) agentsetup.CodexProv
 	}
 }
 
-func TestAgentSetupSkillsFlagInstallsToLocalDir(t *testing.T) {
+func TestAgentSetupUnsupportedAgentInstallsSkillsToLocal(t *testing.T) {
 	var gotDir string
+	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), func(context.Context, string, ...string) error {
+		t.Fatal("no plugin should be installed for an unsupported agent")
+		return nil
+	})
+
 	setup := newAgentSetupCmd()
-	// No agents registered, so only the skills path runs.
-	setup.providers = map[string]agentsetup.Provider{}
-	setup.cmd.SetContext(context.Background())
+	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
+	setup.callingAgent = func() string { return "gemini_cli" }
+	localDir := filepath.Join(t.TempDir(), ".agents", "skills")
 	setup.skillsInstall = func(_ context.Context, destDir string) ([]string, error) {
 		gotDir = destDir
-		return []string{"stripe-best-practices", "upgrade-stripe"}, nil
+		return []string{"stripe-best-practices"}, nil
 	}
-	localDir := filepath.Join(t.TempDir(), ".agents", "skills")
 	setup.skillsLocalDir = func() (string, error) { return localDir, nil }
+	setup.cmd.SetContext(context.Background())
 
-	output, err := executeCommand(setup.cmd, "--skills")
+	output, err := executeCommand(setup.cmd)
 
 	require.NoError(t, err)
 	require.Equal(t, localDir, gotDir)
 	require.Contains(t, output, "Stripe skills (local)")
-	require.Contains(t, output, "installed 2 skill(s)")
 	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
-}
-
-func TestAgentSetupSkillsGlobalScope(t *testing.T) {
-	var gotDir string
-	globalDir := filepath.Join(t.TempDir(), ".agents", "skills")
-
-	setup := newAgentSetupCmd()
-	setup.providers = map[string]agentsetup.Provider{}
-	setup.cmd.SetContext(context.Background())
-	setup.skillsInstall = func(_ context.Context, destDir string) ([]string, error) {
-		gotDir = destDir
-		return []string{"stripe-best-practices"}, nil
-	}
-	setup.skillsGlobalDir = func() (string, error) { return globalDir, nil }
-
-	output, err := executeCommand(setup.cmd, "--skills", "--skills-scope", "global")
-
-	require.NoError(t, err)
-	require.Equal(t, globalDir, gotDir)
-	require.Contains(t, output, "Stripe skills (global)")
-	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
-}
-
-func TestAgentSetupSkillsInstallFailureReportsError(t *testing.T) {
-	setup := newAgentSetupCmd()
-	setup.providers = map[string]agentsetup.Provider{}
-	setup.cmd.SetContext(context.Background())
-	setup.skillsInstall = func(context.Context, string) ([]string, error) {
-		return nil, errors.New("index unreachable")
-	}
-	setup.skillsLocalDir = func() (string, error) { return t.TempDir(), nil }
-
-	output, err := executeCommand(setup.cmd, "--skills")
-
-	require.Error(t, err)
-	require.Contains(t, output, "error: index unreachable")
-	require.Contains(t, output, "0 installed, 0 skipped, 1 errors")
-}
-
-func TestAgentSetupInvalidSkillsScope(t *testing.T) {
-	setup := newAgentSetupCmd()
-	setup.cmd.SetContext(context.Background())
-
-	_, err := executeCommand(setup.cmd, "--skills", "--skills-scope", "sideways")
-
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid --skills-scope")
-}
-
-func TestAgentSetupSkillsAlongsideAgent(t *testing.T) {
-	var skillsCalled bool
-	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), func(context.Context, string, ...string) error { return nil })
-
-	setup := newAgentSetupCmd()
-	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
-	setup.cmd.SetContext(context.Background())
-	setup.skillsInstall = func(context.Context, string) ([]string, error) {
-		skillsCalled = true
-		return []string{"stripe-best-practices"}, nil
-	}
-	setup.skillsLocalDir = func() (string, error) { return filepath.Join(t.TempDir(), ".agents", "skills"), nil }
-
-	// --yes installs the detected agent; --skills adds skills in the same run.
-	output, err := executeCommand(setup.cmd, "--yes", "--skills")
-
-	require.NoError(t, err)
-	require.True(t, skillsCalled)
-	require.Contains(t, output, "Claude Code")
-	require.Contains(t, output, "Stripe skills (local)")
-	require.Contains(t, output, "2 installed, 0 skipped, 0 errors")
 }
 
 func TestAgentSetupCursorIsSkippedNotInstalled(t *testing.T) {
@@ -360,32 +294,6 @@ func TestAgentSetupCursorIsSkippedNotInstalled(t *testing.T) {
 	require.Contains(t, output, "0 installed, 1 skipped, 0 errors")
 }
 
-func TestAgentSetupUnsupportedAgentInstallsSkills(t *testing.T) {
-	var skillsCalled bool
-	// Claude is detected, but we're invoked by an agent with no Stripe plugin.
-	claude := agentsetup.NewClaudeProvider(claudeMissingPluginScanner(t), func(context.Context, string, ...string) error {
-		t.Fatal("no plugin should be installed for an unsupported agent")
-		return nil
-	})
-
-	setup := newAgentSetupCmd()
-	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
-	setup.callingAgent = func() string { return "gemini_cli" }
-	setup.skillsInstall = func(context.Context, string) ([]string, error) {
-		skillsCalled = true
-		return []string{"stripe-best-practices"}, nil
-	}
-	setup.skillsLocalDir = func() (string, error) { return filepath.Join(t.TempDir(), ".agents", "skills"), nil }
-	setup.cmd.SetContext(context.Background())
-
-	output, err := executeCommand(setup.cmd)
-
-	require.NoError(t, err)
-	require.True(t, skillsCalled)
-	require.Contains(t, output, "Detected gemini_cli, which has no Stripe plugin — installing Stripe skills instead.")
-	require.Contains(t, output, "Stripe skills (local)")
-	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
-}
 
 func TestAgentSetupStatusHidesUndetectedClients(t *testing.T) {
 	// Claude detected, Cursor not — --status should list only Claude.
@@ -408,8 +316,7 @@ func TestAgentSetupStatusHidesUndetectedClients(t *testing.T) {
 }
 
 func TestAgentSetupNoClientsNonInteractiveShowsHint(t *testing.T) {
-	// No clients detected, non-interactive: show the full info message with the
-	// --skills hint so scripts/CI know what to do.
+	// No clients detected, non-interactive: show info message.
 	setup := newAgentSetupCmd()
 	setup.providers = map[string]agentsetup.Provider{} // nothing detected
 	setup.callingAgent = func() string { return "" }
@@ -422,7 +329,6 @@ func TestAgentSetupNoClientsNonInteractiveShowsHint(t *testing.T) {
 	require.Contains(t, output, "No supported AI coding clients detected on this machine.")
 	require.Contains(t, output, "Supported clients for automatic setup:")
 	require.Contains(t, output, "Once a client is installed, re-run: stripe agent setup")
-	require.Contains(t, output, "stripe agent setup --skills")
 }
 
 func TestAgentSetupAgentScopingWinsOverYes(t *testing.T) {

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -147,7 +147,7 @@ func TestAgentSetupNoClaudeDoesNotFail(t *testing.T) {
 	output, err := executeCommand(setup.cmd)
 
 	require.NoError(t, err)
-	require.Contains(t, output, "No AI coding clients detected on this machine.")
+	require.Contains(t, output, "No supported AI coding clients detected on this machine.")
 	require.Contains(t, output, "re-run: stripe agent setup")
 }
 
@@ -417,7 +417,7 @@ func TestAgentSetupNoClientsNonInteractiveShowsHint(t *testing.T) {
 	output, err := executeCommand(setup.cmd)
 
 	require.NoError(t, err)
-	require.Contains(t, output, "No AI coding clients detected on this machine.")
+	require.Contains(t, output, "No supported AI coding clients detected on this machine.")
 	require.Contains(t, output, "Supported clients for automatic setup:")
 	require.Contains(t, output, "Once a client is installed, re-run: stripe agent setup")
 	require.Contains(t, output, "stripe agent setup --skills")

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -385,6 +385,24 @@ func TestAgentSetupUnsupportedAgentInstallsSkills(t *testing.T) {
 	require.Contains(t, output, "1 installed, 0 skipped, 0 errors")
 }
 
+func TestAgentSetupNoClientsShowsMessageNotPicker(t *testing.T) {
+	// No clients detected. Even on an interactive terminal we must show the
+	// informative "nothing detected" message, not a context-free skills picker.
+	setup := newAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{} // nothing detected
+	setup.callingAgent = func() string { return "" }
+	setup.isInteractive = func() bool { return true } // pretend TTY
+	setup.cmd.SetContext(context.Background())
+
+	output, err := executeCommand(setup.cmd)
+
+	require.NoError(t, err)
+	require.Contains(t, output, "No AI coding clients detected on this machine.")
+	require.Contains(t, output, "Supported clients for automatic setup:")
+	require.Contains(t, output, "Once a client is installed, re-run: stripe agent setup")
+	require.Contains(t, output, "stripe agent setup --skills")
+}
+
 func TestAgentSetupAgentScopingWinsOverYes(t *testing.T) {
 	// Inside a coding agent, --yes must NOT broaden to all clients — it still
 	// only sets up the calling agent.

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -242,6 +242,7 @@ func init() {
 	// also, bind flags to the environment variables
 	bindEnv("project-name", "STRIPE_PROJECT_NAME")
 
+	rootCmd.AddCommand(newAgentCmd().cmd)
 	rootCmd.AddCommand(cmddocs.New().WithOptions(cmddocs.WithConfig(&Config)).Root())
 	rootCmd.AddCommand(newCompletionCmd().cmd)
 	rootCmd.AddCommand(newConfigCmd().cmd)


### PR DESCRIPTION
 ### Reviewers
r? @gusnguyen-stripe 
cc @stripe/developer-products

### Summary

Adds a new `stripe agent setup` command that detects installed AI coding clients, installs the Stripe plugin for each, and offers a client-agnostic Stripe skills installation path for agents without a dedicated plugin.

### What it does

**Detection** — scans the machine for installed AI coding clients and reports their Stripe plugin status:
- **Claude Code** — reads `~/.claude/plugins/installed_plugins.json`
- **Cursor** — scans `~/.cursor/plugins/cache/<marketplace>/stripe/<hash>/` (filesystem-based; Cursor has no CLI installer)
- **Codex CLI** — runs `codex plugin list --json` and matches on `pluginId`/`marketplaceName`

**Installation** — installs the Stripe plugin for each client using its native mechanism:
- **Claude** — `claude plugin install stripe@claude-plugins-official` 
- **Codex** — `codex plugin add stripe@openai-curated`
- **Cursor** — no shell installer exists; surfaces a manual-step hint (`/add-plugin stripe` inside Cursor) and counts it as skipped

**Skills** — native Go skills installer (no npx/Node dependency) that fetches `https://docs.stripe.com/.well-known/skills/index.json` and writes each skill's multi-file tree to `.agents/skills/` (local or global). 

**Agent-aware** — detects the calling agent from environment variables (`CLAUDECODE`, `CODEX_THREAD_ID`, `CURSOR_AGENT`, `GEMINI_CLI`, etc.) and auto-scopes behavior:
- Supported agent (Claude/Cursor/Codex) → installs only that agent's plugin, even with `--yes`
- Unsupported agent (Gemini CLI, Cline, etc.) → installs Stripe skills instead
- Never shows the interactive picker inside an agent (some runtimes allocate a PTY that would otherwise trick TTY detection)

**Interactive TUI** — Bubble Tea multi-select checklist for humans at a terminal:
- Shows detected agents (pre-selected) with a visually separated "Install Stripe skills directly" row below
- Skills row triggers a follow-up scope prompt (local vs global) showing resolved absolute paths
- When no clients are detected, shows supported-client guidance and immediately offers to install skills

### Flags

| Flag                           | Behavior                                                                                              |
| ------------------------------ | ----------------------------------------------------------------------------------------------------- |
| `--status`                     | Read-only: compact, color-coded status table (only shows detected clients)                            |
| `--json`                       | Machine-readable status + planned actions                                                             |
| `--yes`                        | Non-interactive: install all detected clients (human CLI) or just the calling agent (inside an agent) |
| `--client <id>`                | Limit to a single client (explicit override, wins over agent detection)                               |
| `--force`                      | Reinstall even when already installed                                                                 |

### Architecture

```
pkg/agentsetup/          — detection + install providers
  provider.go            — Provider interface, Status, Plan, ActionManual
  scanner.go             — shared Scanner (LookPath/ReadFile/HomeDir/WorkDir), pluginClient, scanPlugin
  claude.go              — ClaudeProvider (marketplace-update retry)
  cursor.go              — CursorProvider (filesystem cache detection, manual-step install)
  codex.go               — CodexProvider (JSON detection, post-install verify)
  *_test.go              — per-provider unit tests

pkg/agentskills/         — native skills installer (net/http only, no npx)
  agentskills.go         — FetchIndex, Install (multi-file: SKILL.md + references/*.md)
  agentskills_test.go    — httptest-based tests

pkg/cmd/
  agent.go               — Cobra command, orchestration, agent-aware selection, install loop
  agent_setup_tui.go     — Bubble Tea multi-select + scope radio prompt
  agent_test.go          — 15+ test cases covering all paths
  agent_setup_tui_test.go — model unit tests
```

### Testing
Demo video (may be stale)

https://github.com/user-attachments/assets/9fa8fadc-377b-4b20-a082-5b4bc96356fc


```bash
# Build the file
~/stripe/mint/gocode/bin/go build -o ./stripe ./cmd/stripe

# Smoke (read-only)
./stripe agent setup --status
./stripe agent setup --json

# Interactive (human terminal)
./stripe agent setup

# Simulate agent context
CODEX_THREAD_ID=x ./stripe agent setup      # scopes to Codex only
GEMINI_CLI=1 ./stripe agent setup            # installs skills (no Gemini plugin)
```

---
