### PR TITLE
Handle VirusTotal large file uploads exceeding 32 MB limit

### DIFF
--- a/scripts/upload-zip-to-virustotal.sh
+++ b/scripts/upload-zip-to-virustotal.sh
@@ -22,6 +22,18 @@ if [ -z "$VIRUSTOTAL_API_KEY" ]; then
   exit 1
 fi
 
+VIRUSTOTAL_DIRECT_UPLOAD_LIMIT_BYTES=$((32 * 1024 * 1024))
+VIRUSTOTAL_SCAN_URL="https://www.virustotal.com/vtapi/v2/file/scan"
+VIRUSTOTAL_LARGE_FILE_UPLOAD_URL="https://www.virustotal.com/vtapi/v2/file/scan/upload_url"
+
+getResponseBody() {
+  printf '%s' "$1" | sed -e 's/HTTPSTATUS\:.*//g'
+}
+
+getResponseCode() {
+  printf '%s' "$1" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://'
+}
+
 setVersion () {
   VERSION=$(curl -s "https://api.github.com/repos/stripe/stripe-cli/releases/latest" -u $GITHUB_TOKEN: \
 | jq -r ".tag_name")
@@ -48,6 +60,14 @@ downloadWindowsArtifacts() {
 
 virustotalUpload () {
   for i in $FILES; do
+    local executable_size_bytes
+    local upload_url
+    local upload_url_response
+    local upload_url_body
+    local upload_url_response_code
+    local response
+    local body
+    local response_code
     FILENAME=${i##*/}
 
     echo "Uncompressing archive..."
@@ -56,20 +76,50 @@ virustotalUpload () {
 
     echo "Uploading to VirusTotal..."
 
-    RESPONSE=$(curl -s "https://www.virustotal.com/vtapi/v2/file/scan" -X POST -F "apikey=$VIRUSTOTAL_API_KEY" -F "file=@./stripe.exe" -w "HTTPSTATUS:%{http_code}")
-    BODY=$(echo $RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
-    RESPONSE_CODE=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+    executable_size_bytes=$(wc -c < ./stripe.exe | tr -d '[:space:]')
+    upload_url="$VIRUSTOTAL_SCAN_URL"
 
-    if [[ "$(echo $RESPONSE_CODE | head -c2)" != "20" ]]; then
-      echo "Unable to upload, HTTP response code: $RESPONSE_CODE"
+    if [ "$executable_size_bytes" -gt "$VIRUSTOTAL_DIRECT_UPLOAD_LIMIT_BYTES" ]; then
+      echo "Executable exceeds VirusTotal's 32 MB direct-upload limit ($executable_size_bytes bytes); requesting a large-file upload URL..."
+
+      upload_url_response=$(curl -s "$VIRUSTOTAL_LARGE_FILE_UPLOAD_URL?apikey=$VIRUSTOTAL_API_KEY" -w "HTTPSTATUS:%{http_code}")
+      upload_url_body=$(getResponseBody "$upload_url_response")
+      upload_url_response_code=$(getResponseCode "$upload_url_response")
+
+      if [[ "$(echo "$upload_url_response_code" | head -c2)" != "20" ]]; then
+        echo "Unable to get large-file upload URL, HTTP response code: $upload_url_response_code"
+        exit 1
+      fi
+
+      upload_url=$(echo "$upload_url_body" | jq -r ".upload_url")
+      if [ -z "$upload_url" ] || [ "$upload_url" = "null" ]; then
+        echo "VirusTotal did not return a large-file upload URL"
+        exit 1
+      fi
+
+      response=$(curl -s "$upload_url" -X POST -F "file=@./stripe.exe" -w "HTTPSTATUS:%{http_code}")
+    else
+      response=$(curl -s "$upload_url" -X POST -F "apikey=$VIRUSTOTAL_API_KEY" -F "file=@./stripe.exe" -w "HTTPSTATUS:%{http_code}")
+    fi
+
+    body=$(getResponseBody "$response")
+    response_code=$(getResponseCode "$response")
+
+    if [[ "$(echo "$response_code" | head -c2)" != "20" ]]; then
+      echo "Unable to upload, HTTP response code: $response_code"
       exit 1
     fi
 
-    echo "HTTP response code: $RESPONSE_CODE"
+    echo "HTTP response code: $response_code"
 
     echo "Adding comment..."
 
-    SHA256=$(echo $BODY | jq -r ".sha256")
+    SHA256=$(echo "$body" | jq -r ".sha256")
+    if [ -z "$SHA256" ] || [ "$SHA256" = "null" ]; then
+      echo "VirusTotal upload did not return a sha256 hash"
+      exit 1
+    fi
+
     RESPONSE_CODE=$(curl "https://www.virustotal.com/vtapi/v2/comments/put" -X POST -d "apikey=$VIRUSTOTAL_API_KEY" -d "resource=$SHA256" -d "comment=Stripe CLI $VERSION, uncompressed from $i" -o /dev/null -w "%{http_code}")
 
     if [[ "$(echo $RESPONSE_CODE | head -c2)" != "20" ]]; then
@@ -77,7 +127,7 @@ virustotalUpload () {
       exit 1
     fi
 
-    PERMALINK=$(echo $BODY | jq -r ".permalink")
+    PERMALINK=$(echo "$body" | jq -r ".permalink")
     echo "Permalink: $PERMALINK"
   done;
 }
@@ -87,7 +137,7 @@ printMeta () {
 }
 
 cleanArtifacts () {
-  rm -f "$(pwd)/*.zip" "$(pwd)/*.exe"
+  rm -f ./*.zip ./*.exe
 }
 
 cleanArtifacts

--- a/scripts/upload-zip-to-virustotal.sh
+++ b/scripts/upload-zip-to-virustotal.sh
@@ -34,14 +34,38 @@ getResponseCode() {
   printf '%s' "$1" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://'
 }
 
+getLargeFileUploadURL() {
+  local upload_url
+  local upload_url_body
+  local upload_url_response
+  local upload_url_response_code
+
+  upload_url_response=$(curl -s "$VIRUSTOTAL_LARGE_FILE_UPLOAD_URL?apikey=$VIRUSTOTAL_API_KEY" -w "HTTPSTATUS:%{http_code}")
+  upload_url_body=$(getResponseBody "$upload_url_response")
+  upload_url_response_code=$(getResponseCode "$upload_url_response")
+
+  if [[ "$(echo "$upload_url_response_code" | head -c2)" != "20" ]]; then
+    echo "Unable to get large-file upload URL, HTTP response code: $upload_url_response_code" >&2
+    exit 1
+  fi
+
+  upload_url=$(echo "$upload_url_body" | jq -r ".upload_url")
+  if [ -z "$upload_url" ] || [ "$upload_url" = "null" ]; then
+    echo "VirusTotal did not return a large-file upload URL" >&2
+    exit 1
+  fi
+
+  printf '%s' "$upload_url"
+}
+
 setVersion () {
-  VERSION=$(curl -s "https://api.github.com/repos/stripe/stripe-cli/releases/latest" -u $GITHUB_TOKEN: \
+  VERSION=$(curl -s "https://api.github.com/repos/stripe/stripe-cli/releases/latest" -u "${GITHUB_TOKEN}:" \
 | jq -r ".tag_name")
 }
 
 downloadWindowsArtifacts() {
   echo "Dowloading Windows artifacts..."
-  FILES=$(curl -s "https://api.github.com/repos/stripe/stripe-cli/releases/latest" -u $GITHUB_TOKEN: \
+  FILES=$(curl -s "https://api.github.com/repos/stripe/stripe-cli/releases/latest" -u "${GITHUB_TOKEN}:" \
 | jq -r ".assets[].browser_download_url" \
 | grep "windows" \
 | grep "zip")
@@ -50,7 +74,7 @@ downloadWindowsArtifacts() {
     RESPONSE_CODE=$(curl -L -O -w "%{response_code}" "$i")
     echo "$RESPONSE_CODE"
     code=$(echo "$RESPONSE_CODE" | head -c2)
-    if [ $code != "20" ] && [ $code != "30" ]; then
+    if [ "$code" != "20" ] && [ "$code" != "30" ]; then
       echo "Unable to download $i HTTP response code: $RESPONSE_CODE"
       exit 1
     fi
@@ -62,9 +86,6 @@ virustotalUpload () {
   for i in $FILES; do
     local executable_size_bytes
     local upload_url
-    local upload_url_response
-    local upload_url_body
-    local upload_url_response_code
     local response
     local body
     local response_code
@@ -72,7 +93,7 @@ virustotalUpload () {
 
     echo "Uncompressing archive..."
 
-    unzip -o $FILENAME
+    unzip -o "$FILENAME"
 
     echo "Uploading to VirusTotal..."
 
@@ -81,25 +102,16 @@ virustotalUpload () {
 
     if [ "$executable_size_bytes" -gt "$VIRUSTOTAL_DIRECT_UPLOAD_LIMIT_BYTES" ]; then
       echo "Executable exceeds VirusTotal's 32 MB direct-upload limit ($executable_size_bytes bytes); requesting a large-file upload URL..."
-
-      upload_url_response=$(curl -s "$VIRUSTOTAL_LARGE_FILE_UPLOAD_URL?apikey=$VIRUSTOTAL_API_KEY" -w "HTTPSTATUS:%{http_code}")
-      upload_url_body=$(getResponseBody "$upload_url_response")
-      upload_url_response_code=$(getResponseCode "$upload_url_response")
-
-      if [[ "$(echo "$upload_url_response_code" | head -c2)" != "20" ]]; then
-        echo "Unable to get large-file upload URL, HTTP response code: $upload_url_response_code"
-        exit 1
-      fi
-
-      upload_url=$(echo "$upload_url_body" | jq -r ".upload_url")
-      if [ -z "$upload_url" ] || [ "$upload_url" = "null" ]; then
-        echo "VirusTotal did not return a large-file upload URL"
-        exit 1
-      fi
-
+      upload_url=$(getLargeFileUploadURL)
       response=$(curl -s "$upload_url" -X POST -F "file=@./stripe.exe" -w "HTTPSTATUS:%{http_code}")
     else
       response=$(curl -s "$upload_url" -X POST -F "apikey=$VIRUSTOTAL_API_KEY" -F "file=@./stripe.exe" -w "HTTPSTATUS:%{http_code}")
+
+      if [ "$(getResponseCode "$response")" = "413" ]; then
+        echo "VirusTotal rejected the direct upload with 413; retrying with a large-file upload URL..."
+        upload_url=$(getLargeFileUploadURL)
+        response=$(curl -s "$upload_url" -X POST -F "file=@./stripe.exe" -w "HTTPSTATUS:%{http_code}")
+      fi
     fi
 
     body=$(getResponseBody "$response")
@@ -122,7 +134,7 @@ virustotalUpload () {
 
     RESPONSE_CODE=$(curl "https://www.virustotal.com/vtapi/v2/comments/put" -X POST -d "apikey=$VIRUSTOTAL_API_KEY" -d "resource=$SHA256" -d "comment=Stripe CLI $VERSION, uncompressed from $i" -o /dev/null -w "%{http_code}")
 
-    if [[ "$(echo $RESPONSE_CODE | head -c2)" != "20" ]]; then
+    if [[ "$(echo "$RESPONSE_CODE" | head -c2)" != "20" ]]; then
       echo "Unable to add comment, HTTP response code: $RESPONSE_CODE"
       exit 1
     fi


### PR DESCRIPTION
The CLI executable now exceeds VirusTotal's 32 MB direct-upload limit. Request a large-file upload URL when the executable is too big, and improve error handling and quoting throughout the script.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
