### PR TITLE
Add CI workflow for curl-based install script

### DIFF
--- a/.github/workflows/curl-install-test.yml
+++ b/.github/workflows/curl-install-test.yml
@@ -1,0 +1,54 @@
+on:
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: 'Skip PagerDuty alert on failure'
+        type: boolean
+        default: true
+  schedule:
+    - cron: '*/10 * * * *' # Every 10 minutes
+name: Curl install test
+permissions:
+  contents: read
+jobs:
+  curl-install-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/install.sh
+          sparse-checkout-cone-mode: false
+      - run: |
+          sh scripts/install.sh
+          export PATH="$HOME/.stripe/bin:$PATH"
+          stripe --version
+
+  curl-install-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/install.sh
+          sparse-checkout-cone-mode: false
+      - run: |
+          sh scripts/install.sh
+          export PATH="$HOME/.stripe/bin:$PATH"
+          stripe --version
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [curl-install-macos, curl-install-linux]
+    if: always()
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/notify.sh
+          sparse-checkout-cone-mode: false
+      - run: bash scripts/notify.sh
+        env:
+          OVERALL_RESULT: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          DRYRUN: ${{ inputs.dryrun }}

--- a/.github/workflows/curl-install-test.yml
+++ b/.github/workflows/curl-install-test.yml
@@ -14,26 +14,16 @@ jobs:
   curl-install-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
-        with:
-          sparse-checkout: |
-            scripts/install.sh
-          sparse-checkout-cone-mode: false
       - run: |
-          sh scripts/install.sh
+          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
           export PATH="$HOME/.stripe/bin:$PATH"
           stripe --version
 
   curl-install-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-        with:
-          sparse-checkout: |
-            scripts/install.sh
-          sparse-checkout-cone-mode: false
       - run: |
-          sh scripts/install.sh
+          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
           export PATH="$HOME/.stripe/bin:$PATH"
           stripe --version
 


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

- Adds a dedicated GitHub Actions workflow that tests the curl install path on macOS and Linux every 10 minutes
- Runs the exact command users run: `curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh`
- Verifies the installed binary works with `stripe --version`