### PR TITLE
fix: prevent panic on empty-string values in v2 JSON fixtures

### DIFF
--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -451,11 +451,11 @@ func parseMapForApplicationJSON(params map[string]interface{}, responses map[str
 			}
 
 			switch {
-			case parsed[0:1] == "[" && parsed[len(parsed)-1:] == "]":
+			case strings.HasPrefix(parsed, "[") && strings.HasSuffix(parsed, "]"):
 				paramArray := make([]interface{}, 0)
 				json.Unmarshal([]byte(parsed), &paramArray)
 				result[key] = paramArray
-			case parsed[0:1] == "{" && parsed[len(parsed)-1:] == "}":
+			case strings.HasPrefix(parsed, "{") && strings.HasSuffix(parsed, "}"):
 				paramMap := make(map[string]interface{})
 				json.Unmarshal([]byte(parsed), &paramMap)
 				result[key] = paramMap

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -219,6 +219,24 @@ func TestParseInterfaceToJSONDeeplyNested(t *testing.T) {
 	require.Equal(t, "First Name", gjson.Get(json, "custom_fields.0.label.custom").String())
 }
 
+func TestParseInterfaceToJSONEmptyString(t *testing.T) {
+	// An empty-string value used to panic here because the array/object
+	// sniffing indexed parsed[0:1] and parsed[len(parsed)-1:] on a
+	// zero-length string. It should just come through as "".
+	data := map[string]interface{}{
+		"description": "",
+		"name":        "Bender Bending Rodriguez",
+	}
+
+	output, err := ParseToApplicationJSON(data, make(map[string]gjson.Result))
+	require.NoError(t, err)
+
+	jsonParams, _ := json.Marshal(output)
+	json := string(jsonParams)
+	require.Equal(t, "", gjson.Get(json, "description").String())
+	require.Equal(t, "Bender Bending Rodriguez", gjson.Get(json, "name").String())
+}
+
 func TestParseInterface(t *testing.T) {
 	address := make(map[string]interface{})
 	address["line1"] = "1 Planet Express St"


### PR DESCRIPTION
### Reviewers
r?
cc @stripe/developer-products

### Summary
An empty-string value in a v2 (application/json) fixture crashes the CLI with "slice bounds out of range [:1] with length 0". In parseMapForApplicationJSON the code checks whether a value looks like a JSON array or object with parsed[0:1] and parsed[len(parsed)-1:], and those slice both blow up on a zero-length string. This happens whenever a fixture field is set to "" or a query/env lookup resolves to empty.

The fix swaps those two checks for strings.HasPrefix/HasSuffix, which return false on empty input, so an empty value just falls through and is stored as "". That matches how the form-data path already handles it. I added a regression test that passes an empty-string value through ParseToApplicationJSON; it panics before this change and passes after. Full pkg/parsers suite and go vet are green.

Thanks for taking a look.