### PR TITLE
Add query runs v2 API

### DIFF
--- a/pkg/cmd/reporting.go
+++ b/pkg/cmd/reporting.go
@@ -1,0 +1,251 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/stripe"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+const queryRunsPath = "/v2/data/reporting/query_runs"
+
+type reportingCmd struct {
+	cmd *cobra.Command
+}
+
+type reportingQueryRunsCmd struct {
+	cmd *cobra.Command
+}
+
+type reportingQueryRunsCreateCmd struct {
+	cmd          *cobra.Command
+	rb           requests.Base
+	sql          string
+	sqlFile      string
+	compressFile bool
+}
+
+type reportingQueryRunsRetrieveCmd struct {
+	cmd *cobra.Command
+	rb  requests.Base
+}
+
+func newReportingCmd() *reportingCmd {
+	rc := &reportingCmd{}
+	rc.cmd = &cobra.Command{
+		Use:   "reporting",
+		Short: "Run Stripe Sigma queries via the Data Reporting API",
+		Long: `Run ad hoc SQL queries against your Stripe data using the Data Reporting API.
+
+Use the query-runs subcommands to kick off a new query and retrieve its
+results. This uses the /v2/data/reporting/query_runs preview API.`,
+		Args: validators.NoArgs,
+		// Hidden while the underlying Query Runs API is in preview. The command
+		// is still runnable; it's just omitted from help output and --map.
+		Hidden: true,
+	}
+
+	rc.cmd.AddCommand(newReportingQueryRunsCmd().cmd)
+	return rc
+}
+
+func newReportingQueryRunsCmd() *reportingQueryRunsCmd {
+	qrc := &reportingQueryRunsCmd{}
+	qrc.cmd = &cobra.Command{
+		Use:   "query-runs",
+		Short: "Create and retrieve QueryRun objects",
+		Long: `Create and retrieve QueryRun objects.
+
+A QueryRun runs a custom SQL query against your Stripe data. Create a query run
+to kick off a query, then retrieve it to poll its status and fetch the download
+URL of the result once the query has completed.`,
+		Args: validators.NoArgs,
+	}
+
+	qrc.cmd.AddCommand(newReportingQueryRunsCreateCmd().cmd)
+	qrc.cmd.AddCommand(newReportingQueryRunsRetrieveCmd().cmd)
+	return qrc
+}
+
+func newReportingQueryRunsCreateCmd() *reportingQueryRunsCreateCmd {
+	cc := &reportingQueryRunsCreateCmd{}
+
+	cc.rb = requests.Base{
+		Method:           http.MethodPost,
+		Profile:          &Config.Profile,
+		IsPreviewCommand: true,
+	}
+
+	cc.cmd = &cobra.Command{
+		Use:   "create",
+		Short: "Create a query run from custom SQL",
+		Long: `Create a query run to execute a custom, ad hoc SQL query against your Stripe data.
+
+Sends a POST request to /v2/data/reporting/query_runs. This is a preview API —
+the Stripe-Version preview header is set automatically.
+
+The query runs asynchronously. The response contains the query run's id and
+status ("running", "succeeded", or "failed"); poll it with
+"stripe preview reporting query-runs retrieve <id>" until the status is
+"succeeded", then use the result's download_url to fetch the output.
+
+Provide the SQL inline with --sql, from a file with --sql-file, or via stdin
+by passing --sql-file -.`,
+		Example: `  # Run an ad hoc query
+  stripe preview reporting query-runs create --sql "SELECT * FROM charges LIMIT 10"
+
+  # Read the SQL from a file
+  stripe preview reporting query-runs create --sql-file ./query.sql
+
+  # Read the SQL from stdin
+  cat query.sql | stripe preview reporting query-runs create --sql-file -`,
+		RunE: cc.runReportingQueryRunsCreateCmd,
+		Args: validators.NoArgs,
+	}
+
+	cc.cmd.Flags().StringVar(&cc.sql, "sql", "", "The SQL query to run [required unless --sql-file is set]")
+	cc.cmd.Flags().StringVar(&cc.sqlFile, "sql-file", "", "Path to a file containing the SQL query to run. Use \"-\" to read from stdin.")
+	cc.cmd.Flags().BoolVar(&cc.compressFile, "compress-file", false, "Compress the result file (sets result_options.compress_file)")
+
+	cc.cmd.Flags().BoolVar(&cc.rb.DryRun, "dry-run", false, "Preview the request without sending it")
+	cc.cmd.Flags().BoolVarP(&cc.rb.Livemode, "live", "", false, "Make a live request (default: test)")
+	cc.cmd.Flags().BoolVarP(&cc.rb.DarkStyle, "dark-style", "", false, "Use a darker color scheme better suited for lighter command-lines")
+
+	cc.cmd.Flags().StringVar(&cc.rb.APIBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
+	cc.cmd.Flags().MarkHidden("api-base") // #nosec G104
+
+	return cc
+}
+
+func newReportingQueryRunsRetrieveCmd() *reportingQueryRunsRetrieveCmd {
+	rc := &reportingQueryRunsRetrieveCmd{}
+
+	rc.rb = requests.Base{
+		Method:           http.MethodGet,
+		Profile:          &Config.Profile,
+		IsPreviewCommand: true,
+	}
+
+	rc.cmd = &cobra.Command{
+		Use:   "retrieve <id>",
+		Short: "Retrieve a query run",
+		Long: `Retrieve a query run by its id to check its status and fetch results.
+
+Sends a GET request to /v2/data/reporting/query_runs/{id}. This is a preview
+API — the Stripe-Version preview header is set automatically.
+
+Once the query run's status is "succeeded", the result's download_url can be
+used to download the query output.`,
+		Example: `  # Retrieve a query run
+  stripe preview reporting query-runs retrieve qryrun_test_123`,
+		Args: validators.ExactArgs(1),
+		RunE: rc.runReportingQueryRunsRetrieveCmd,
+	}
+
+	rc.cmd.Flags().BoolVarP(&rc.rb.Livemode, "live", "", false, "Make a live request (default: test)")
+	rc.cmd.Flags().BoolVarP(&rc.rb.DarkStyle, "dark-style", "", false, "Use a darker color scheme better suited for lighter command-lines")
+
+	rc.cmd.Flags().StringVar(&rc.rb.APIBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
+	rc.cmd.Flags().MarkHidden("api-base") // #nosec G104
+
+	return rc
+}
+
+func (cc *reportingQueryRunsCreateCmd) runReportingQueryRunsCreateCmd(cmd *cobra.Command, args []string) error {
+	sql, err := cc.resolveSQL(cmd)
+	if err != nil {
+		return err
+	}
+
+	apiKey, err := cc.rb.Profile.GetAPIKey(cc.rb.Livemode)
+	if err != nil {
+		return err
+	}
+
+	body := cc.buildRequestBody(sql)
+
+	if cc.rb.DryRun {
+		output, err := cc.rb.BuildDryRunOutput(apiKey, cc.rb.APIBaseURL, queryRunsPath, &requests.RequestParameters{}, body)
+		if err != nil {
+			return err
+		}
+		b, _ := json.MarshalIndent(output, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(b))
+		return nil
+	}
+
+	_, err = cc.rb.MakeRequest(cmd.Context(), apiKey, queryRunsPath, &requests.RequestParameters{}, body, true, nil)
+	return err
+}
+
+// resolveSQL determines the SQL query to run from the --sql / --sql-file flags.
+// Exactly one source must be provided.
+func (cc *reportingQueryRunsCreateCmd) resolveSQL(cmd *cobra.Command) (string, error) {
+	if cc.sql != "" && cc.sqlFile != "" {
+		return "", fmt.Errorf("--sql and --sql-file are mutually exclusive")
+	}
+
+	if cc.sql != "" {
+		return cc.sql, nil
+	}
+
+	if cc.sqlFile != "" {
+		var raw []byte
+		var err error
+		if cc.sqlFile == "-" {
+			raw, err = readAllInput(cmd)
+		} else {
+			raw, err = os.ReadFile(cc.sqlFile)
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to read SQL from %q: %w", cc.sqlFile, err)
+		}
+		sql := strings.TrimSpace(string(raw))
+		if sql == "" {
+			return "", fmt.Errorf("no SQL found in %q", cc.sqlFile)
+		}
+		return sql, nil
+	}
+
+	return "", fmt.Errorf("one of --sql or --sql-file is required")
+}
+
+func (cc *reportingQueryRunsCreateCmd) buildRequestBody(sql string) map[string]interface{} {
+	body := map[string]interface{}{
+		"sql": sql,
+	}
+
+	if cc.compressFile {
+		body["result_options"] = map[string]interface{}{
+			"compress_file": true,
+		}
+	}
+
+	return body
+}
+
+func (rc *reportingQueryRunsRetrieveCmd) runReportingQueryRunsRetrieveCmd(cmd *cobra.Command, args []string) error {
+	apiKey, err := rc.rb.Profile.GetAPIKey(rc.rb.Livemode)
+	if err != nil {
+		return err
+	}
+
+	path := queryRunsPath + "/" + url.PathEscape(args[0])
+
+	_, err = rc.rb.MakeRequest(cmd.Context(), apiKey, path, &requests.RequestParameters{}, nil, true, nil)
+	return err
+}
+
+// readAllInput reads all data from the command's input stream (stdin).
+func readAllInput(cmd *cobra.Command) ([]byte, error) {
+	return io.ReadAll(cmd.InOrStdin())
+}

--- a/pkg/cmd/reporting.go
+++ b/pkg/cmd/reporting.go
@@ -49,9 +49,6 @@ func newReportingCmd() *reportingCmd {
 Use the query-runs subcommands to kick off a new query and retrieve its
 results. This uses the /v2/data/reporting/query_runs preview API.`,
 		Args: validators.NoArgs,
-		// Hidden while the underlying Query Runs API is in preview. The command
-		// is still runnable; it's just omitted from help output and --map.
-		Hidden: true,
 	}
 
 	rc.cmd.AddCommand(newReportingQueryRunsCmd().cmd)
@@ -95,19 +92,19 @@ the Stripe-Version preview header is set automatically.
 
 The query runs asynchronously. The response contains the query run's id and
 status ("running", "succeeded", or "failed"); poll it with
-"stripe preview reporting query-runs retrieve <id>" until the status is
-"succeeded", then use the result's download_url to fetch the output.
+"stripe reporting query-runs retrieve <id>" until the status is "succeeded",
+then use the result's download_url to fetch the output.
 
 Provide the SQL inline with --sql, from a file with --sql-file, or via stdin
 by passing --sql-file -.`,
 		Example: `  # Run an ad hoc query
-  stripe preview reporting query-runs create --sql "SELECT * FROM charges LIMIT 10"
+  stripe reporting query-runs create --sql "SELECT * FROM charges LIMIT 10"
 
   # Read the SQL from a file
-  stripe preview reporting query-runs create --sql-file ./query.sql
+  stripe reporting query-runs create --sql-file ./query.sql
 
   # Read the SQL from stdin
-  cat query.sql | stripe preview reporting query-runs create --sql-file -`,
+  cat query.sql | stripe reporting query-runs create --sql-file -`,
 		RunE: cc.runReportingQueryRunsCreateCmd,
 		Args: validators.NoArgs,
 	}
@@ -146,7 +143,7 @@ API — the Stripe-Version preview header is set automatically.
 Once the query run's status is "succeeded", the result's download_url can be
 used to download the query output.`,
 		Example: `  # Retrieve a query run
-  stripe preview reporting query-runs retrieve qryrun_test_123`,
+  stripe reporting query-runs retrieve qryrun_test_123`,
 		Args: validators.ExactArgs(1),
 		RunE: rc.runReportingQueryRunsRetrieveCmd,
 	}
@@ -178,7 +175,10 @@ func (cc *reportingQueryRunsCreateCmd) runReportingQueryRunsCreateCmd(cmd *cobra
 		if err != nil {
 			return err
 		}
-		b, _ := json.MarshalIndent(output, "", "  ")
+		b, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return err
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), string(b))
 		return nil
 	}

--- a/pkg/cmd/reporting.go
+++ b/pkg/cmd/reporting.go
@@ -158,6 +158,10 @@ used to download the query output.`,
 }
 
 func (cc *reportingQueryRunsCreateCmd) runReportingQueryRunsCreateCmd(cmd *cobra.Command, args []string) error {
+	if err := stripe.ValidateAPIBaseURL(cc.rb.APIBaseURL); err != nil {
+		return err
+	}
+
 	sql, err := cc.resolveSQL(cmd)
 	if err != nil {
 		return err
@@ -234,6 +238,10 @@ func (cc *reportingQueryRunsCreateCmd) buildRequestBody(sql string) map[string]i
 }
 
 func (rc *reportingQueryRunsRetrieveCmd) runReportingQueryRunsRetrieveCmd(cmd *cobra.Command, args []string) error {
+	if err := stripe.ValidateAPIBaseURL(rc.rb.APIBaseURL); err != nil {
+		return err
+	}
+
 	apiKey, err := rc.rb.Profile.GetAPIKey(rc.rb.Livemode)
 	if err != nil {
 		return err

--- a/pkg/cmd/reporting_test.go
+++ b/pkg/cmd/reporting_test.go
@@ -101,6 +101,24 @@ func TestResolveSQL_EmptyFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "no SQL found")
 }
 
+// The CLI intentionally does not validate SQL client-side; syntactically
+// invalid or non-SQL content is passed through verbatim (after trimming) and
+// the API is responsible for rejecting it (query_run_invalid_sql). This test
+// documents that pass-through behavior.
+func TestResolveSQL_NonSQLContentPassedThrough(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notsql.txt")
+	content := "this is not valid sql; DROP???\nrandom text 123"
+	require.NoError(t, os.WriteFile(path, []byte("\n"+content+"\n  "), 0600))
+
+	cc := newReportingQueryRunsCreateCmd()
+	cc.sqlFile = path
+
+	sql, err := cc.resolveSQL(cc.cmd)
+	require.NoError(t, err)
+	assert.Equal(t, content, sql, "file contents are passed through as-is (only outer whitespace trimmed)")
+}
+
 // --- Integration tests: create HTTP request shape ---
 
 func newTestReportingCreateCmd(t *testing.T, serverURL string) *reportingQueryRunsCreateCmd {

--- a/pkg/cmd/reporting_test.go
+++ b/pkg/cmd/reporting_test.go
@@ -1,0 +1,256 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/requests"
+)
+
+// --- Unit tests: buildRequestBody ---
+
+func TestReportingBuildRequestBody_Minimal(t *testing.T) {
+	cc := &reportingQueryRunsCreateCmd{}
+	body := cc.buildRequestBody("SELECT * FROM charges LIMIT 10")
+
+	assert.Equal(t, "SELECT * FROM charges LIMIT 10", body["sql"])
+	assert.Nil(t, body["result_options"])
+}
+
+func TestReportingBuildRequestBody_CompressFile(t *testing.T) {
+	cc := &reportingQueryRunsCreateCmd{compressFile: true}
+	body := cc.buildRequestBody("SELECT 1")
+
+	resultOptions := body["result_options"].(map[string]interface{})
+	assert.Equal(t, true, resultOptions["compress_file"])
+}
+
+// --- Unit tests: resolveSQL ---
+
+func TestResolveSQL_Inline(t *testing.T) {
+	cc := newReportingQueryRunsCreateCmd()
+	cc.sql = "SELECT 1"
+
+	sql, err := cc.resolveSQL(cc.cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT 1", sql)
+}
+
+func TestResolveSQL_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "query.sql")
+	require.NoError(t, os.WriteFile(path, []byte("\n  SELECT * FROM charges  \n"), 0600))
+
+	cc := newReportingQueryRunsCreateCmd()
+	cc.sqlFile = path
+
+	sql, err := cc.resolveSQL(cc.cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT * FROM charges", sql, "file contents should be trimmed")
+}
+
+func TestResolveSQL_FromStdin(t *testing.T) {
+	cc := newReportingQueryRunsCreateCmd()
+	cc.sqlFile = "-"
+	cc.cmd.SetIn(strings.NewReader("SELECT 42\n"))
+
+	sql, err := cc.resolveSQL(cc.cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT 42", sql)
+}
+
+func TestResolveSQL_MissingBoth(t *testing.T) {
+	cc := newReportingQueryRunsCreateCmd()
+
+	_, err := cc.resolveSQL(cc.cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "one of --sql or --sql-file is required")
+}
+
+func TestResolveSQL_MutuallyExclusive(t *testing.T) {
+	cc := newReportingQueryRunsCreateCmd()
+	cc.sql = "SELECT 1"
+	cc.sqlFile = "query.sql"
+
+	_, err := cc.resolveSQL(cc.cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestResolveSQL_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.sql")
+	require.NoError(t, os.WriteFile(path, []byte("   \n"), 0600))
+
+	cc := newReportingQueryRunsCreateCmd()
+	cc.sqlFile = path
+
+	_, err := cc.resolveSQL(cc.cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no SQL found")
+}
+
+// --- Integration tests: create HTTP request shape ---
+
+func newTestReportingCreateCmd(t *testing.T, serverURL string) *reportingQueryRunsCreateCmd {
+	t.Helper()
+	// Ensure the profile API key is used rather than any key set in the
+	// environment running the test.
+	t.Setenv("STRIPE_API_KEY", "")
+	cc := newReportingQueryRunsCreateCmd()
+	cc.rb.Profile = &config.Profile{APIKey: "sk_test_1234567890abcdef"}
+	cc.rb.APIBaseURL = serverURL
+	cc.cmd.SetContext(context.Background())
+	return cc
+}
+
+func TestReportingCreateCmd_HTTPRequest(t *testing.T) {
+	var capturedReq *http.Request
+	var capturedBody []byte
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"qr_123","status":"open"}`))
+	}))
+	defer ts.Close()
+
+	cc := newTestReportingCreateCmd(t, ts.URL)
+	cc.sql = "SELECT * FROM charges LIMIT 10"
+
+	err := cc.runReportingQueryRunsCreateCmd(cc.cmd, []string{})
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq)
+
+	assert.Equal(t, http.MethodPost, capturedReq.Method)
+	assert.Equal(t, queryRunsPath, capturedReq.URL.Path)
+	assert.Equal(t, "Bearer sk_test_1234567890abcdef", capturedReq.Header.Get("Authorization"))
+	assert.Equal(t, "application/json", capturedReq.Header.Get("Content-Type"))
+	assert.Equal(t, requests.StripePreviewVersionHeaderValue, capturedReq.Header.Get("Stripe-Version"))
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(capturedBody, &body))
+	assert.Equal(t, "SELECT * FROM charges LIMIT 10", body["sql"])
+}
+
+func TestReportingCreateCmd_HTTPRequest_CompressFile(t *testing.T) {
+	var capturedBody []byte
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"qr_123"}`))
+	}))
+	defer ts.Close()
+
+	cc := newTestReportingCreateCmd(t, ts.URL)
+	cc.sql = "SELECT 1"
+	cc.compressFile = true
+
+	err := cc.runReportingQueryRunsCreateCmd(cc.cmd, []string{})
+	require.NoError(t, err)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(capturedBody, &body))
+	resultOptions := body["result_options"].(map[string]interface{})
+	assert.Equal(t, true, resultOptions["compress_file"])
+}
+
+func TestReportingCreateCmd_HTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"code":"invalid_sql","type":"invalid_request_error"}}`))
+	}))
+	defer ts.Close()
+
+	cc := newTestReportingCreateCmd(t, ts.URL)
+	cc.sql = "SELECT bad"
+
+	err := cc.runReportingQueryRunsCreateCmd(cc.cmd, []string{})
+	require.Error(t, err)
+
+	var reqErr requests.RequestError
+	require.ErrorAs(t, err, &reqErr)
+	assert.Equal(t, http.StatusBadRequest, reqErr.StatusCode)
+	assert.Equal(t, "invalid_sql", reqErr.ErrorCode)
+}
+
+// --- Integration tests: retrieve HTTP request shape ---
+
+func newTestReportingRetrieveCmd(t *testing.T, serverURL string) *reportingQueryRunsRetrieveCmd {
+	t.Helper()
+	t.Setenv("STRIPE_API_KEY", "")
+	rc := newReportingQueryRunsRetrieveCmd()
+	rc.rb.Profile = &config.Profile{APIKey: "sk_test_1234567890abcdef"}
+	rc.rb.APIBaseURL = serverURL
+	rc.cmd.SetContext(context.Background())
+	return rc
+}
+
+func TestReportingRetrieveCmd_HTTPRequest(t *testing.T) {
+	var capturedReq *http.Request
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"qr_123","status":"completed","result":{"download_url":"https://example.com/f"}}`))
+	}))
+	defer ts.Close()
+
+	rc := newTestReportingRetrieveCmd(t, ts.URL)
+
+	err := rc.runReportingQueryRunsRetrieveCmd(rc.cmd, []string{"qr_123"})
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq)
+
+	assert.Equal(t, http.MethodGet, capturedReq.Method)
+	assert.Equal(t, queryRunsPath+"/qr_123", capturedReq.URL.Path)
+	assert.Equal(t, "Bearer sk_test_1234567890abcdef", capturedReq.Header.Get("Authorization"))
+	assert.Equal(t, requests.StripePreviewVersionHeaderValue, capturedReq.Header.Get("Stripe-Version"))
+}
+
+// --- Unit tests: command construction ---
+
+func TestNewReportingQueryRunsCreateCmd_IsPreview(t *testing.T) {
+	cc := newReportingQueryRunsCreateCmd()
+	assert.True(t, cc.rb.IsPreviewCommand, "query-runs create must use the preview Stripe-Version header")
+	assert.Equal(t, http.MethodPost, cc.rb.Method)
+}
+
+func TestNewReportingQueryRunsRetrieveCmd_IsPreview(t *testing.T) {
+	rc := newReportingQueryRunsRetrieveCmd()
+	assert.True(t, rc.rb.IsPreviewCommand, "query-runs retrieve must use the preview Stripe-Version header")
+	assert.Equal(t, http.MethodGet, rc.rb.Method)
+}
+
+func TestReportingCmd_CommandPaths(t *testing.T) {
+	rc := newReportingCmd()
+
+	createCmd, _, err := rc.cmd.Find([]string{"query-runs", "create"})
+	require.NoError(t, err)
+	assert.Equal(t, "reporting query-runs create", createCmd.CommandPath())
+
+	retrieveCmd, _, err := rc.cmd.Find([]string{"query-runs", "retrieve"})
+	require.NoError(t, err)
+	assert.Equal(t, "reporting query-runs retrieve", retrieveCmd.CommandPath())
+}
+
+func TestNewReportingQueryRunsCreateCmd_Flags(t *testing.T) {
+	cc := newReportingQueryRunsCreateCmd()
+
+	require.NotNil(t, cc.cmd.Flags().Lookup("sql"))
+	require.NotNil(t, cc.cmd.Flags().Lookup("sql-file"))
+	require.NotNil(t, cc.cmd.Flags().Lookup("compress-file"))
+}

--- a/pkg/cmd/reporting_test.go
+++ b/pkg/cmd/reporting_test.go
@@ -119,6 +119,29 @@ func TestResolveSQL_NonSQLContentPassedThrough(t *testing.T) {
 	assert.Equal(t, content, sql, "file contents are passed through as-is (only outer whitespace trimmed)")
 }
 
+// --- Unit tests: API base URL validation ---
+
+func TestReportingCreateCmd_InvalidAPIBaseURL(t *testing.T) {
+	t.Setenv("STRIPE_API_KEY", "")
+	cc := newReportingQueryRunsCreateCmd()
+	cc.rb.Profile = &config.Profile{APIKey: "sk_test_1234567890abcdef"}
+	cc.rb.APIBaseURL = "http://evil.example.com"
+	cc.sql = "SELECT 1"
+
+	err := cc.runReportingQueryRunsCreateCmd(cc.cmd, []string{})
+	require.Error(t, err)
+}
+
+func TestReportingRetrieveCmd_InvalidAPIBaseURL(t *testing.T) {
+	t.Setenv("STRIPE_API_KEY", "")
+	rc := newReportingQueryRunsRetrieveCmd()
+	rc.rb.Profile = &config.Profile{APIKey: "sk_test_1234567890abcdef"}
+	rc.rb.APIBaseURL = "http://evil.example.com"
+
+	err := rc.runReportingQueryRunsRetrieveCmd(rc.cmd, []string{"qryrun_test_123"})
+	require.Error(t, err)
+}
+
 // --- Integration tests: create HTTP request shape ---
 
 func newTestReportingCreateCmd(t *testing.T, serverURL string) *reportingQueryRunsCreateCmd {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -242,6 +242,7 @@ func init() {
 	// also, bind flags to the environment variables
 	bindEnv("project-name", "STRIPE_PROJECT_NAME")
 
+	rootCmd.AddCommand(newReportingCmd().cmd)
 	rootCmd.AddCommand(cmddocs.New().WithOptions(cmddocs.WithConfig(&Config)).Root())
 	rootCmd.AddCommand(newCompletionCmd().cmd)
 	rootCmd.AddCommand(newConfigCmd().cmd)
@@ -268,12 +269,6 @@ func init() {
 	rootCmd.AddCommand(newPluginCmd().cmd)
 	resources.AddAllResourcesCmds(rootCmd, &Config)
 	registerHTTPCmds(rootCmd)
-
-	// Data Reporting query runs is a preview API, so nest it under `stripe
-	// preview` to signal it's not GA. The command itself is also hidden.
-	if preview, ok := cmdutil.FindSubCmd(rootCmd, "preview"); ok {
-		preview.AddCommand(newReportingCmd().cmd)
-	}
 	err := resource.AddDatabasesCmd(rootCmd, &Config)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -268,6 +268,12 @@ func init() {
 	rootCmd.AddCommand(newPluginCmd().cmd)
 	resources.AddAllResourcesCmds(rootCmd, &Config)
 	registerHTTPCmds(rootCmd)
+
+	// Data Reporting query runs is a preview API, so nest it under `stripe
+	// preview` to signal it's not GA. The command itself is also hidden.
+	if preview, ok := cmdutil.FindSubCmd(rootCmd, "preview"); ok {
+		preview.AddCommand(newReportingCmd().cmd)
+	}
 	err := resource.AddDatabasesCmd(rootCmd, &Config)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
### Reviewers
r? @
cc @stripe/developer-products

### Summary
Adds a new `stripe reporting query-runs` command for the v2 Data
Reporting Query Runs API (`/v2/data/reporting/query_runs`), letting users run
ad hoc SQL queries against their Stripe data from the CLI.

Previously the CLI could only `GET` Sigma scheduled queries via the older
`/v1/sigma` endpoint; it had no way to kick off new or ad hoc queries. This adds:

- `stripe reporting query-runs create` — `POST /v2/data/reporting/query_runs`.
  Specify custom SQL inline with `--sql`, from a file with `--sql-file <path>`,
  or via stdin with `--sql-file -`. Supports `--compress-file`
  (`result_options.compress_file`) and the standard `--dry-run` / `--live`.
- `stripe reporting query-runs retrieve <id>` — `GET /v2/data/reporting/query_runs/{id}`
  to poll status (`running` → `succeeded`/`failed`) and fetch the result's
  download URL (`result.file.download_url.url`).

The API is in public preview, so the request builder sets the
`Stripe-Version: 2026-06-24.preview` header and JSON content-type automatically
(via `IsPreviewCommand`). Implemented as a manual command (modeled on
`stripe analytics query`) rather than relying on the auto-generated resource
command, to give first-class SQL flags and a stable command path.

The command is registered as a normal top-level command (like `analytics`,
`listen`, etc.) — it is not hidden and not nested under the `stripe preview`
namespace, since the API is public preview rather than private. Note the
`.preview` in the version header is just the API version pin and is independent
of the CLI `preview` command namespace.

Includes unit + HTTP-integration tests covering request body construction, SQL
resolution (inline/file/stdin/non-SQL pass-through/error cases), the outgoing
request shape (method, path, auth, content-type, version header), and error
handling.

### Test plan
- `go build ./...`, `go vet ./pkg/cmd/`, and `go test ./pkg/cmd/` pass.
- Manually verified against a test-mode account:
  - `stripe reporting query-runs create --sql "SELECT * FROM charges LIMIT 10"`
    returns a `qryrun_...` id with `status: running`.
  - `stripe reporting query-runs retrieve <id>` transitions `running` →
    `succeeded`, and `result.file.download_url.url` is populated on success
    (the URL is short-lived and expires ~5 min after retrieval).
  - `--dry-run` shows the expected POST, JSON body, and preview version header.
  
<img width="938" height="224" alt="Screenshot 2026-07-06 at 11 51 29 AM" src="https://github.com/user-attachments/assets/a93b39ff-8cf9-4a5a-8bef-b21d4f17d15c" />
<img width="1043" height="434" alt="Screenshot 2026-07-06 at 11 51 39 AM" src="https://github.com/user-attachments/assets/a71cd9d4-8cb3-46b6-9d75-d4bc7b394e72" />

