### PR TITLE
coop: validate blueprint node references

### DIFF
--- a/pkg/cmd/coop/coop_run.go
+++ b/pkg/cmd/coop/coop_run.go
@@ -53,7 +53,7 @@ func (rc *coopAgentRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 
 	bp, err := coop.LoadBlueprint(blueprintID)
 	if err != nil {
-		return outputCoopError(fmt.Sprintf("Blueprint %q not found. Run 'stripe coop recommend' to see available blueprints.", blueprintID), "stripe coop recommend")
+		return outputCoopError(err.Error(), "stripe coop recommend")
 	}
 
 	store, err := coop.NewStore(coopConfigFolder())

--- a/pkg/cmd/coop/coop_run_test.go
+++ b/pkg/cmd/coop/coop_run_test.go
@@ -113,3 +113,56 @@ func TestCoopRunReturnsStructuredErrorForMalformedParam(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, ids)
 }
+
+func TestCoopRunPreservesBlueprintLoadError(t *testing.T) {
+	cmd := newCoopAgentRunCmd().cmd
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"flat"})
+
+	stderr := captureStderr(t, func() {
+		err := cmd.Execute()
+		require.Error(t, err)
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
+	assert.False(t, resp.OK)
+	assert.Contains(t, resp.Error, "ambiguous blueprint prefix")
+	assert.NotContains(t, resp.Error, "not found")
+	assert.Equal(t, "stripe coop recommend", resp.Hint)
+}
+
+func TestCoopRunKeepsNotFoundGuidance(t *testing.T) {
+	cmd := newCoopAgentRunCmd().cmd
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"nonexistent-blueprint"})
+
+	stderr := captureStderr(t, func() {
+		err := cmd.Execute()
+		require.Error(t, err)
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
+	assert.Contains(t, resp.Error, "not found")
+	assert.Equal(t, "stripe coop recommend", resp.Hint)
+}
+
+func TestCoopStartPreservesBlueprintLoadError(t *testing.T) {
+	err := newCoopRunCmd().runCmd(nil, []string{"flat"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous blueprint prefix")
+	assert.NotContains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "stripe coop recommend")
+}
+
+func TestCoopStartKeepsNotFoundGuidance(t *testing.T) {
+	err := newCoopRunCmd().runCmd(nil, []string{"nonexistent-blueprint"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "stripe coop recommend")
+}

--- a/pkg/cmd/coop/coop_start.go
+++ b/pkg/cmd/coop/coop_start.go
@@ -55,7 +55,7 @@ func (rc *coopRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		blueprintID = args[0]
 		if _, err := coop.LoadBlueprint(blueprintID); err != nil {
-			return fmt.Errorf("blueprint %q not found. Run 'stripe coop recommend' to see available blueprints", blueprintID)
+			return fmt.Errorf("%w. Run 'stripe coop recommend' to see available blueprints", err)
 		}
 	}
 

--- a/pkg/coop/blueprint.go
+++ b/pkg/coop/blueprint.go
@@ -4,12 +4,15 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
 
 //go:embed blueprints/*.json
 var blueprintFS embed.FS
+
+var blueprintNodeRefRE = regexp.MustCompile(`\$\{node\.([^}:]+):[^}]+\}`)
 
 // BlueprintStep is a step definition within a blueprint.
 type BlueprintStep struct {
@@ -74,8 +77,54 @@ func LoadBlueprint(id string) (*Blueprint, error) {
 	if err := json.Unmarshal(data, &bp); err != nil {
 		return nil, fmt.Errorf("parsing blueprint %q: %w", id, err)
 	}
+	if err := validateBlueprintReferences(&bp); err != nil {
+		return nil, fmt.Errorf("validating blueprint %q: %w", id, err)
+	}
 
 	return &bp, nil
+}
+
+func validateBlueprintReferences(bp *Blueprint) error {
+	validRefs := map[string]bool{}
+	for _, step := range bp.Steps {
+		for _, node := range step.Nodes {
+			validRefs[step.Key+"."+node.Key] = true
+			for _, request := range node.TestRequests {
+				if request.Key != "" {
+					validRefs[step.Key+"."+node.Key+"."+request.Key] = true
+				}
+			}
+		}
+	}
+
+	data, err := json.Marshal(bp)
+	if err != nil {
+		return err
+	}
+	for _, match := range blueprintNodeRefRE.FindAllSubmatch(data, -1) {
+		ref := string(match[1])
+		if validRefs[ref] {
+			continue
+		}
+		parts := strings.Split(ref, ".")
+		if len(parts) == 3 && validRefs[parts[0]+"."+parts[1]] && isIntegerRefSegment(parts[2]) {
+			continue
+		}
+		return fmt.Errorf("unknown node reference %q", ref)
+	}
+	return nil
+}
+
+func isIntegerRefSegment(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func prefixMatchBlueprint(prefix string) (string, error) {

--- a/pkg/coop/blueprint.go
+++ b/pkg/coop/blueprint.go
@@ -1,10 +1,11 @@
 package coop
 
 import (
+	"bytes"
 	"embed"
 	"encoding/json"
 	"fmt"
-	"regexp"
+	"io"
 	"strings"
 	"time"
 )
@@ -12,7 +13,10 @@ import (
 //go:embed blueprints/*.json
 var blueprintFS embed.FS
 
-var blueprintNodeRefRE = regexp.MustCompile(`\$\{node\.([^}:]+):[^}]+\}`)
+const (
+	blueprintNodeCandidatePrefix = "${node"
+	blueprintNodeRefPrefix       = "${node."
+)
 
 // BlueprintStep is a step definition within a blueprint.
 type BlueprintStep struct {
@@ -101,18 +105,83 @@ func validateBlueprintReferences(bp *Blueprint) error {
 	if err != nil {
 		return err
 	}
-	for _, match := range blueprintNodeRefRE.FindAllSubmatch(data, -1) {
-		ref := string(match[1])
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		value, ok := token.(string)
+		if !ok {
+			continue
+		}
+		if err := validateBlueprintReferenceString(value, validRefs); err != nil {
+			return err
+		}
+	}
+}
+
+func validateBlueprintReferenceString(value string, validRefs map[string]bool) error {
+	for {
+		start := findBlueprintNodeCandidate(value)
+		if start == -1 {
+			return nil
+		}
+		value = value[start:]
+
+		end := strings.IndexByte(value, '}')
+		next := findBlueprintNodeCandidate(value[len(blueprintNodeCandidatePrefix):])
+		if next != -1 {
+			next += len(blueprintNodeCandidatePrefix)
+		}
+		if end == -1 || (next != -1 && next < end) {
+			candidate := value
+			if next != -1 {
+				candidate = value[:next]
+			}
+			return fmt.Errorf("malformed node reference %q: missing closing brace", candidate)
+		}
+
+		placeholder := value[:end+1]
+		if !strings.HasPrefix(placeholder, blueprintNodeRefPrefix) {
+			return fmt.Errorf("malformed node reference %q: expected ${node.<ref>:<field>}", placeholder)
+		}
+		body := placeholder[len(blueprintNodeRefPrefix) : len(placeholder)-1]
+		ref, field, ok := strings.Cut(body, ":")
+		if !ok || ref == "" || field == "" {
+			return fmt.Errorf("malformed node reference %q: expected ${node.<ref>:<field>}", placeholder)
+		}
+
 		if validRefs[ref] {
+			value = value[end+1:]
 			continue
 		}
 		parts := strings.Split(ref, ".")
 		if len(parts) == 3 && validRefs[parts[0]+"."+parts[1]] && isIntegerRefSegment(parts[2]) {
+			value = value[end+1:]
 			continue
 		}
 		return fmt.Errorf("unknown node reference %q", ref)
 	}
-	return nil
+}
+
+func findBlueprintNodeCandidate(value string) int {
+	offset := 0
+	for {
+		start := strings.Index(value[offset:], blueprintNodeCandidatePrefix)
+		if start == -1 {
+			return -1
+		}
+		start += offset
+		after := start + len(blueprintNodeCandidatePrefix)
+		if after == len(value) || value[after] == '.' || value[after] == ':' || value[after] == '}' {
+			return start
+		}
+		offset = after
+	}
 }
 
 func isIntegerRefSegment(value string) bool {

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -103,6 +103,41 @@ func TestLoadBlueprintNotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestValidateBlueprintReferences(t *testing.T) {
+	bp := &Blueprint{
+		ID: "test",
+		Steps: []BlueprintStep{
+			{
+				StepDefinition: StepDefinition{Key: "setup", Title: "Setup"},
+				Nodes: []NodeDefinition{
+					{Key: "create-product", Request: &APIRequest{Path: "/v1/products", Method: "post"}},
+					{Key: "create-clock", TestRequests: []TestHelperRequest{{
+						Key: "create-clock-request",
+						APIRequest: APIRequest{
+							Path:   "/v1/test_helpers/test_clocks",
+							Method: "post",
+						},
+					}}},
+					{Key: "create-checkout", Request: &APIRequest{
+						Path:   "/v1/checkout/sessions",
+						Method: "post",
+						Params: map[string]string{
+							"price": "${node.setup.create-product:default_price}",
+						},
+					}},
+					{Key: "view-clock", Request: &APIRequest{Path: "/v1/test_helpers/test_clocks/${node.setup.create-clock.create-clock-request:id}", Method: "get"}},
+				},
+			},
+		},
+	}
+	require.NoError(t, validateBlueprintReferences(bp))
+
+	bp.Steps[0].Nodes[3].Request.Path = "/v1/products/${node.old.create-product:id}"
+	err := validateBlueprintReferences(bp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown node reference")
+}
+
 func TestLoadBlueprintPrefixMatch(t *testing.T) {
 	bp, err := LoadBlueprint("setup-future")
 	require.NoError(t, err)

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -104,10 +104,10 @@ func TestLoadBlueprintNotFound(t *testing.T) {
 }
 
 func TestValidateBlueprintReferences(t *testing.T) {
-	bp := &Blueprint{
-		ID: "test",
-		Steps: []BlueprintStep{
-			{
+	newBlueprint := func(reference string) *Blueprint {
+		return &Blueprint{
+			ID: "test",
+			Steps: []BlueprintStep{{
 				StepDefinition: StepDefinition{Key: "setup", Title: "Setup"},
 				Nodes: []NodeDefinition{
 					{Key: "create-product", Request: &APIRequest{Path: "/v1/products", Method: "post"}},
@@ -118,24 +118,46 @@ func TestValidateBlueprintReferences(t *testing.T) {
 							Method: "post",
 						},
 					}}},
-					{Key: "create-checkout", Request: &APIRequest{
-						Path:   "/v1/checkout/sessions",
-						Method: "post",
-						Params: map[string]string{
-							"price": "${node.setup.create-product:default_price}",
-						},
-					}},
-					{Key: "view-clock", Request: &APIRequest{Path: "/v1/test_helpers/test_clocks/${node.setup.create-clock.create-clock-request:id}", Method: "get"}},
+					{Key: "wait-for-invoice"},
+					{Key: "use-reference", Request: &APIRequest{Path: reference, Method: "get"}},
 				},
-			},
-		},
+			}},
+		}
 	}
-	require.NoError(t, validateBlueprintReferences(bp))
 
-	bp.Steps[0].Nodes[3].Request.Path = "/v1/products/${node.old.create-product:id}"
-	err := validateBlueprintReferences(bp)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown node reference")
+	tests := []struct {
+		name      string
+		reference string
+		wantError string
+	}{
+		{name: "direct node", reference: "${node.setup.create-product:default_price}"},
+		{name: "named request", reference: "${node.setup.create-clock.create-clock-request:id}"},
+		{name: "numeric result", reference: "${node.setup.wait-for-invoice.0:id}"},
+		{name: "nested field path", reference: "${node.setup.create-product:data[0].price.id}"},
+		{name: "non-node interpolation", reference: "${env:randomName}"},
+		{name: "different placeholder with node prefix", reference: "${nodeVersion}"},
+		{name: "missing field delimiter", reference: "${node.setup.create-product}", wantError: "malformed node reference"},
+		{name: "missing closing brace", reference: "${node.setup.create-product:id", wantError: "malformed node reference"},
+		{name: "missing namespace dot", reference: "${node:setup.create-product:id}", wantError: "malformed node reference"},
+		{name: "empty reference", reference: "${node.:id}", wantError: "malformed node reference"},
+		{name: "empty field", reference: "${node.setup.create-product:}", wantError: "malformed node reference"},
+		{name: "unclosed reference before another", reference: "${node.setup.create-product:id/${node.setup.create-product:id}", wantError: "malformed node reference"},
+		{name: "unknown node", reference: "${node.old.create-product:id}", wantError: "unknown node reference"},
+		{name: "unknown named request", reference: "${node.setup.create-clock.old-request:id}", wantError: "unknown node reference"},
+		{name: "unknown second reference", reference: "${node.setup.create-product:id}/${node.old.create-product:id}", wantError: "unknown node reference"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBlueprintReferences(newBlueprint(tt.reference))
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+		})
+	}
 }
 
 func TestLoadBlueprintPrefixMatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- Validate `${node.<step>.<node>...}` references when a blueprint is loaded (`LoadBlueprint`), so malformed or unknown node references fail fast instead of surfacing as confusing errors mid-session.
- Collect valid `step.node` (and `step.node.request`) keys, then check every `${node...}` reference in the marshaled blueprint against them.
- Allow integer-indexed reference segments (e.g. an indexed test-request) as valid.

## Tests
- `TestValidateBlueprintReferences` — covers valid references, malformed references, and unknown referenced nodes.
- `go test ./pkg/coop/... ./pkg/cmd/coop/...` — all green.

## Base
Based directly on `coop`. First of the co-op product-quality follow-ups; `agent-quality` and `blueprint-schema` build on top and will be opened as `coop` advances.