### PR TITLE
Send telemetry on unrecognized commands

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -177,6 +177,7 @@ func Execute(ctx context.Context) {
 
 		case strings.Contains(errString, "unknown command"):
 			showSuggestion()
+			recordUnknownCommand(updatedCtx, strings.Join(os.Args[1:], " "))
 
 		default:
 			fmt.Fprintln(os.Stderr, err)

--- a/pkg/cmd/unknown_cmd_telemetry.go
+++ b/pkg/cmd/unknown_cmd_telemetry.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/stripe/stripe-cli/pkg/stripe"
+	"github.com/stripe/stripe-cli/pkg/useragent"
+)
+
+const (
+	unknownCmdBatchFile  = "unknown_commands.json"
+	unknownCmdBatchSize  = 10
+	unknownCmdEventName  = "Unknown Command Attempted"
+)
+
+type unknownCommandEntry struct {
+	Command   string `json:"command"`
+	Timestamp string `json:"timestamp"`
+	Agent     string `json:"agent"`
+}
+
+// recordUnknownCommand records an unknown command attempt in agent environments.
+// It batches entries locally and sends telemetry every unknownCmdBatchSize occurrences.
+func recordUnknownCommand(ctx context.Context, command string) {
+	agent := useragent.DetectAIAgent(os.Getenv)
+	if agent == "" {
+		return
+	}
+
+	telemetryClient := stripe.GetTelemetryClient(ctx)
+	if telemetryClient == nil {
+		return
+	}
+
+	configFolder := Config.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	batchPath := filepath.Join(configFolder, unknownCmdBatchFile)
+
+	entries := loadUnknownCommandBatch(batchPath)
+
+	entries = append(entries, unknownCommandEntry{
+		Command:   command,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Agent:     agent,
+	})
+
+	if len(entries) >= unknownCmdBatchSize {
+		sendUnknownCommandBatch(ctx, telemetryClient, entries)
+		_ = os.Remove(batchPath)
+	} else {
+		saveUnknownCommandBatch(batchPath, entries)
+	}
+}
+
+func loadUnknownCommandBatch(path string) []unknownCommandEntry {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	var entries []unknownCommandEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		log.Debugf("Failed to parse unknown command batch file: %v", err)
+		return nil
+	}
+	return entries
+}
+
+func saveUnknownCommandBatch(path string, entries []unknownCommandEntry) {
+	data, err := json.Marshal(entries)
+	if err != nil {
+		log.Debugf("Failed to marshal unknown command batch: %v", err)
+		return
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Debugf("Failed to create config directory for unknown command batch: %v", err)
+		return
+	}
+
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		log.Debugf("Failed to write unknown command batch file: %v", err)
+	}
+}
+
+func sendUnknownCommandBatch(ctx context.Context, client stripe.TelemetryClient, entries []unknownCommandEntry) {
+	data, err := json.Marshal(entries)
+	if err != nil {
+		log.Debugf("Failed to marshal unknown command batch for telemetry: %v", err)
+		return
+	}
+
+	go client.SendEvent(ctx, unknownCmdEventName, string(data))
+}

--- a/pkg/cmd/unknown_cmd_telemetry.go
+++ b/pkg/cmd/unknown_cmd_telemetry.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	unknownCmdBatchFile  = "unknown_commands.json"
-	unknownCmdBatchSize  = 10
-	unknownCmdEventName  = "Unknown Command Attempted"
+	unknownCmdBatchFile = "unknown_commands.json"
+	unknownCmdBatchSize = 10
+	unknownCmdEventName = "Unknown Command Attempted"
 )
 
 type unknownCommandEntry struct {

--- a/pkg/cmd/unknown_cmd_telemetry.go
+++ b/pkg/cmd/unknown_cmd_telemetry.go
@@ -96,5 +96,5 @@ func sendUnknownCommandBatch(ctx context.Context, client stripe.TelemetryClient,
 		return
 	}
 
-	go client.SendEvent(ctx, unknownCmdEventName, string(data))
+	client.SendEvent(ctx, unknownCmdEventName, string(data))
 }

--- a/pkg/cmd/unknown_cmd_telemetry_test.go
+++ b/pkg/cmd/unknown_cmd_telemetry_test.go
@@ -6,9 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,7 +15,6 @@ import (
 )
 
 type mockUnknownCmdTelemetryClient struct {
-	mu     sync.Mutex
 	events []struct {
 		name  string
 		value string
@@ -29,8 +26,6 @@ func (m *mockUnknownCmdTelemetryClient) SendAPIRequestEvent(_ context.Context, _
 }
 
 func (m *mockUnknownCmdTelemetryClient) SendEvent(_ context.Context, eventName string, eventValue string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.events = append(m.events, struct {
 		name  string
 		value string
@@ -88,9 +83,7 @@ func TestRecordUnknownCommand_InAgentEnv_BatchesCommands(t *testing.T) {
 	assert.Equal(t, "stripe foobar", entries[0].Command)
 	assert.Equal(t, "claude_code", entries[0].Agent)
 
-	mock.mu.Lock()
 	assert.Len(t, mock.events, 0)
-	mock.mu.Unlock()
 }
 
 func TestRecordUnknownCommand_InAgentEnv_SendsAtBatchSize(t *testing.T) {
@@ -111,14 +104,7 @@ func TestRecordUnknownCommand_InAgentEnv_SendsAtBatchSize(t *testing.T) {
 	_, err := os.Stat(batchPath)
 	assert.True(t, os.IsNotExist(err))
 
-	require.Eventually(t, func() bool {
-		mock.mu.Lock()
-		defer mock.mu.Unlock()
-		return len(mock.events) == 1
-	}, 1*time.Second, 10*time.Millisecond)
-
-	mock.mu.Lock()
-	defer mock.mu.Unlock()
+	require.Len(t, mock.events, 1)
 	assert.Equal(t, unknownCmdEventName, mock.events[0].name)
 
 	var entries []unknownCommandEntry

--- a/pkg/cmd/unknown_cmd_telemetry_test.go
+++ b/pkg/cmd/unknown_cmd_telemetry_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/stripe"
+)
+
+type mockUnknownCmdTelemetryClient struct {
+	mu     sync.Mutex
+	events []struct {
+		name  string
+		value string
+	}
+}
+
+func (m *mockUnknownCmdTelemetryClient) SendAPIRequestEvent(_ context.Context, _ string, _ bool) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *mockUnknownCmdTelemetryClient) SendEvent(_ context.Context, eventName string, eventValue string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, struct {
+		name  string
+		value string
+	}{eventName, eventValue})
+}
+
+func TestRecordUnknownCommand_NotInAgentEnv(t *testing.T) {
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CURSOR_AGENT", "")
+	t.Setenv("CODEX_SANDBOX", "")
+	t.Setenv("CODEX_THREAD_ID", "")
+	t.Setenv("CODEX_SANDBOX_NETWORK_DISABLED", "")
+	t.Setenv("CODEX_CI", "")
+	t.Setenv("CLINE_ACTIVE", "")
+	t.Setenv("GEMINI_CLI", "")
+	t.Setenv("OPENCODE", "")
+	t.Setenv("OPENCLAW_SHELL", "")
+	t.Setenv("ANTIGRAVITY_CLI_ALIAS", "")
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	ctx := context.Background()
+	mock := &mockUnknownCmdTelemetryClient{}
+	ctx = stripe.WithTelemetryClient(ctx, mock)
+
+	recordUnknownCommand(ctx, "stripe foobar")
+
+	batchPath := filepath.Join(tmpDir, "stripe", unknownCmdBatchFile)
+	_, err := os.Stat(batchPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestRecordUnknownCommand_InAgentEnv_BatchesCommands(t *testing.T) {
+	t.Setenv("CLAUDECODE", "1")
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	ctx := context.Background()
+	mock := &mockUnknownCmdTelemetryClient{}
+	ctx = stripe.WithTelemetryClient(ctx, mock)
+
+	for i := 0; i < 9; i++ {
+		recordUnknownCommand(ctx, "stripe foobar")
+	}
+
+	batchPath := filepath.Join(tmpDir, "stripe", unknownCmdBatchFile)
+	data, err := os.ReadFile(batchPath)
+	require.NoError(t, err)
+
+	var entries []unknownCommandEntry
+	require.NoError(t, json.Unmarshal(data, &entries))
+	assert.Len(t, entries, 9)
+	assert.Equal(t, "stripe foobar", entries[0].Command)
+	assert.Equal(t, "claude_code", entries[0].Agent)
+
+	mock.mu.Lock()
+	assert.Len(t, mock.events, 0)
+	mock.mu.Unlock()
+}
+
+func TestRecordUnknownCommand_InAgentEnv_SendsAtBatchSize(t *testing.T) {
+	t.Setenv("CLAUDECODE", "1")
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	ctx := context.Background()
+	mock := &mockUnknownCmdTelemetryClient{}
+	ctx = stripe.WithTelemetryClient(ctx, mock)
+
+	for i := 0; i < unknownCmdBatchSize; i++ {
+		recordUnknownCommand(ctx, "stripe bazqux")
+	}
+
+	batchPath := filepath.Join(tmpDir, "stripe", unknownCmdBatchFile)
+	_, err := os.Stat(batchPath)
+	assert.True(t, os.IsNotExist(err))
+
+	require.Eventually(t, func() bool {
+		mock.mu.Lock()
+		defer mock.mu.Unlock()
+		return len(mock.events) == 1
+	}, 1*time.Second, 10*time.Millisecond)
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	assert.Equal(t, unknownCmdEventName, mock.events[0].name)
+
+	var entries []unknownCommandEntry
+	require.NoError(t, json.Unmarshal([]byte(mock.events[0].value), &entries))
+	assert.Len(t, entries, 10)
+	assert.Equal(t, "stripe bazqux", entries[0].Command)
+	assert.Equal(t, "claude_code", entries[0].Agent)
+}
+
+func TestRecordUnknownCommand_NoTelemetryClient(t *testing.T) {
+	t.Setenv("CLAUDECODE", "1")
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	ctx := context.Background()
+	recordUnknownCommand(ctx, "stripe foobar")
+
+	batchPath := filepath.Join(tmpDir, "stripe", unknownCmdBatchFile)
+	_, err := os.Stat(batchPath)
+	assert.True(t, os.IsNotExist(err))
+}


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
https://jira.corp.stripe.com/browse/DEVAI-1146


### Testing
https://logscale.corp.stripe.com/main-view/search?live=false&query=%22ARECIBO-EVENT%22%0A%7C%20%22context.p_client_id%22%20%3D%20%22stripe-cli%22%0A%7C%20groupBy(%22context.p_event_name%22)&start=2h&tz=UTC

```
keshavc@st-keshavc2(laptop) ~/stripe/stripe-cli % ./bin/stripe foobar
Unknown command "foobar" for "stripe".
See "stripe --help" for a list of available commands.
keshavc@st-keshavc2(laptop) ~/stripe/stripe-cli % cat ~/.config/stripe/unknown_commands.json
cat: /Users/keshavc/.config/stripe/unknown_commands.json: No such file or directory
keshavc@st-keshavc2(laptop) ~/stripe/stripe-cli % CLAUDECODE=1 ./bin/stripe foobar
<claude-code-hint v="1" type="plugin" value="stripe@claude-plugins-official" />
Unknown command "foobar" for "stripe".
See "stripe --help" for a list of available commands.
keshavc@st-keshavc2(laptop) ~/stripe/stripe-cli % cat ~/.config/stripe/unknown_commands.json
[{"command":"foobar","timestamp":"2026-07-06T22:06:12Z","agent":"claude_code"}]% 
```