### PR TITLE
Cursor plugin detection

### DIFF
--- a/pkg/agentsetup/cursor.go
+++ b/pkg/agentsetup/cursor.go
@@ -13,25 +13,28 @@ const (
 
 // CursorProvider detects the Stripe plugin for Cursor.
 //
-// Unlike Claude Code, Cursor has no `cursor plugin` CLI and no JSON registry:
-// the `cursor` binary is only the editor launcher, and installed plugins are
-// recorded as a directory tree under ~/.cursor/plugins/cache/<marketplace>/
-// <plugin>/<hash>/ (a `.cache-complete` marker plus a .cursor-plugin/plugin.json
-// metadata file). Detection therefore walks the filesystem.
+// Unlike Claude Code, Cursor has no `cursor plugin` CLI: the `cursor` binary is
+// only the editor launcher. Enabled plugins are recorded in
+// ~/Library/Application Support/Cursor/User/globalStorage/state.vscdb (macOS)
+// under cursor.plugins.installedIds.* keys. When sqlite3 is available, this
+// provider queries that registry; otherwise it falls back to prompting the user
+// to run /add-plugin stripe inside Cursor.
 //
 // Cursor plugins are installed from inside Cursor via the `/add-plugin stripe`
-// slash command; there is no shell CLI installer. This provider therefore
-// detects the plugin from disk and, when it is missing, points the user at the
-// in-app command rather than shelling out.
+// slash command; there is no shell CLI installer.
 type CursorProvider struct {
-	Scanner Scanner
+	Scanner   Scanner
+	RunOutput RunOutputFunc
 }
 
 // NewCursorProvider returns a Cursor setup provider. The RunCommandFunc argument
 // is accepted for signature parity with the other providers but is unused,
 // because Cursor has no CLI installer.
 func NewCursorProvider(scanner Scanner, _ RunCommandFunc) Provider {
-	return CursorProvider{Scanner: scanner}
+	return CursorProvider{
+		Scanner:   scanner,
+		RunOutput: runCommandOutput,
+	}
 }
 
 func (p CursorProvider) ID() string { return ClientCursor }
@@ -52,8 +55,33 @@ func (p CursorProvider) Detect() Status {
 	status.Detected = true
 	status.ExecutablePath = binPath
 	status.Status = StatusMissing
+
+	runOutput := p.RunOutput
+	if runOutput == nil {
+		runOutput = runCommandOutput
+	}
+
+	pluginStatus, err := cursorStripePluginFromVscdb(s, runOutput)
+	if err != nil {
+		status.Error = cursorManualInstallHint
+		return status
+	}
+
+	if pluginStatus.installed {
+		status.Plugin.Installed = true
+		status.Plugin.ID = TargetCursorPlugin
+		status.Plugin.Scope = pluginStatus.scope
+		status.Plugin.Project = pluginStatus.projectPath
+		status.Status = StatusInstalled
+
+		if home, homeErr := s.HomeDir(); homeErr == nil {
+			status.Plugin.Version = cursorPluginVersionFromCache(s, home)
+		}
+		return status
+	}
+
 	// Signal to the TUI that this row is not actionable from the CLI.
-	status.Error = "run /add-plugin stripe inside Cursor agent"
+	status.Error = cursorManualInstallHint
 	return status
 }
 

--- a/pkg/agentsetup/cursor_test.go
+++ b/pkg/agentsetup/cursor_test.go
@@ -1,8 +1,14 @@
 package agentsetup
 
 import (
+	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -20,23 +26,151 @@ func TestCursor_NotDetected(t *testing.T) {
 	require.Equal(t, StatusNotDetected, status.Status)
 }
 
-func TestCursor_DetectedAlwaysMissing(t *testing.T) {
-	provider := CursorProvider{
-		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil }},
-	}
+func TestCursor_DetectedMissingWhenNoSqlite(t *testing.T) {
+	provider := cursorTestProvider(t, nil, nil)
 
 	status := provider.Detect()
 
 	require.True(t, status.Detected)
-	require.Equal(t, "/usr/local/bin/cursor", status.ExecutablePath)
+	require.Equal(t, StatusMissing, status.Status)
+	require.False(t, status.Plugin.Installed)
+	require.Contains(t, status.Error, "/add-plugin stripe")
+}
+
+func TestCursor_DetectedMissingWhenQueryFails(t *testing.T) {
+	provider := cursorTestProvider(t, func(name string) (string, error) {
+		if name == CursorBinaryName || name == sqlite3BinaryName {
+			return "/usr/bin/" + name, nil
+		}
+		return "", errors.New("missing")
+	}, func(context.Context, string, ...string) ([]byte, error) {
+		return nil, errors.New("query failed")
+	})
+
+	status := provider.Detect()
+
+	require.Equal(t, StatusMissing, status.Status)
+	require.False(t, status.Plugin.Installed)
+	require.Contains(t, status.Error, "/add-plugin stripe")
+}
+
+func TestCursor_DetectedMissingWhenNotInstalled(t *testing.T) {
+	workspaceURI := cursorWorkspaceURI(t.TempDir())
+	sqliteOut := sqliteInstalledIdsOutput(
+		"cursor.plugins.installedIds.123|no-workspace|[]",
+		"cursor.plugins.installedIds.123|"+workspaceURI+"|[]",
+	)
+	provider := cursorTestProviderWithWorkspace(t, sqliteOut)
+
+	status := provider.Detect()
+
 	require.Equal(t, StatusMissing, status.Status)
 	require.False(t, status.Plugin.Installed)
 }
 
-func TestCursor_PlanManualWhenNotInstalled(t *testing.T) {
-	provider := CursorProvider{
-		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil }},
+func TestCursor_InstalledUserScope(t *testing.T) {
+	workspaceURI := cursorWorkspaceURI(t.TempDir())
+	sqliteOut := sqliteInstalledIdsOutput(
+		`cursor.plugins.installedIds.123|no-workspace|[{"id":"408","sources":["user"]}]`,
+		"cursor.plugins.installedIds.123|"+workspaceURI+"|[]",
+	)
+	provider := cursorTestProviderWithWorkspace(t, sqliteOut)
+
+	status := provider.Detect()
+
+	require.Equal(t, StatusInstalled, status.Status)
+	require.True(t, status.Plugin.Installed)
+	require.Equal(t, TargetCursorPlugin, status.Plugin.ID)
+	require.Equal(t, "user", status.Plugin.Scope)
+	require.Empty(t, status.Error)
+}
+
+func TestCursor_InstalledProjectScope(t *testing.T) {
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	workspaceURI := cursorWorkspaceURI(projectDir)
+	sqliteOut := sqliteInstalledIdsOutput(
+		"cursor.plugins.installedIds.123|no-workspace|[]",
+		`cursor.plugins.installedIds.123|`+workspaceURI+`|[{"id":"408","sources":["user"]}]`,
+	)
+	provider := cursorTestProvider(t, func(name string) (string, error) {
+		return "/usr/bin/" + name, nil
+	}, func(context.Context, string, ...string) ([]byte, error) {
+		return []byte(sqliteOut), nil
+	})
+	provider.Scanner.WorkDir = func() (string, error) { return projectDir, nil }
+
+	status := provider.Detect()
+
+	require.Equal(t, StatusInstalled, status.Status)
+	require.True(t, status.Plugin.Installed)
+	require.Equal(t, "project", status.Plugin.Scope)
+	require.Equal(t, projectDir, status.Plugin.Project)
+}
+
+func TestCursor_OtherPluginIDsIgnored(t *testing.T) {
+	workspaceURI := cursorWorkspaceURI(t.TempDir())
+	sqliteOut := sqliteInstalledIdsOutput(
+		`cursor.plugins.installedIds.123|no-workspace|[{"id":"999","sources":["user"]}]`,
+		"cursor.plugins.installedIds.123|"+workspaceURI+"|[]",
+	)
+	provider := cursorTestProviderWithWorkspace(t, sqliteOut)
+
+	status := provider.Detect()
+
+	require.Equal(t, StatusMissing, status.Status)
+	require.False(t, status.Plugin.Installed)
+}
+
+func TestCursor_MalformedJSONFallsBackToMissing(t *testing.T) {
+	workspaceURI := cursorWorkspaceURI(t.TempDir())
+	sqliteOut := sqliteInstalledIdsOutput(
+		"cursor.plugins.installedIds.123|no-workspace|{nope",
+		"cursor.plugins.installedIds.123|"+workspaceURI+"|[]",
+	)
+	provider := cursorTestProviderWithWorkspace(t, sqliteOut)
+
+	status := provider.Detect()
+
+	require.Equal(t, StatusMissing, status.Status)
+	require.False(t, status.Plugin.Installed)
+}
+
+func TestCursor_InstalledReadsVersionFromCache(t *testing.T) {
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	writeCursorPluginCache(t, home, "abc123", `{"name":"stripe","version":"0.1.0"}`)
+
+	sqliteOut := sqliteInstalledIdsOutput(
+		`cursor.plugins.installedIds.123|no-workspace|[{"id":"408","sources":["user"]}]`,
+	)
+	provider := cursorTestProvider(t, func(name string) (string, error) {
+		return "/usr/bin/" + name, nil
+	}, func(context.Context, string, ...string) ([]byte, error) {
+		return []byte(sqliteOut), nil
+	})
+	provider.Scanner.HomeDir = func() (string, error) { return home, nil }
+	provider.Scanner.WorkDir = func() (string, error) { return projectDir, nil }
+	dbPath, err := cursorStateDBPath(home, runtime.GOOS)
+	require.NoError(t, err)
+	provider.Scanner.Stat = func(path string) (os.FileInfo, error) {
+		if path == dbPath {
+			return fileInfoStub{}, nil
+		}
+		return os.Stat(path)
 	}
+
+	status := provider.Detect()
+
+	require.Equal(t, StatusInstalled, status.Status)
+	require.Equal(t, "0.1.0", status.Plugin.Version)
+}
+
+func TestCursor_PlanManualWhenNotInstalled(t *testing.T) {
+	provider := cursorTestProvider(t, nil, nil)
 
 	status := provider.Detect()
 	plan := provider.Plan(status, false)
@@ -69,11 +203,102 @@ func TestCursor_PlanNoneWhenInstalled(t *testing.T) {
 }
 
 func TestCursor_ErrorHintForTUIDisable(t *testing.T) {
-	provider := CursorProvider{
-		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil }},
-	}
+	provider := cursorTestProvider(t, nil, nil)
 
 	status := provider.Detect()
 
 	require.Contains(t, status.Error, "/add-plugin stripe")
 }
+
+func TestCursorWorkspaceURI(t *testing.T) {
+	require.Equal(t, "file:///Users/foo/project", cursorWorkspaceURI("/Users/foo/project"))
+	require.Equal(t, "file:///C:/Users/foo/project", cursorWorkspaceURI(`C:\Users\foo\project`))
+}
+
+func TestParseCursorInstalledIdsOutput(t *testing.T) {
+	workspaceURI := "file:///tmp/project"
+	output := sqliteInstalledIdsOutput(
+		`cursor.plugins.installedIds.1|no-workspace|[{"id":"408","sources":["user"]}]`,
+		"cursor.plugins.installedIds.1|"+workspaceURI+"|[]",
+	)
+
+	user, project, path := parseCursorInstalledIdsOutput(output, workspaceURI)
+	require.True(t, user)
+	require.False(t, project)
+	require.Empty(t, path)
+}
+
+func TestCursorInstalledIdsContainsStripe(t *testing.T) {
+	require.True(t, cursorInstalledIdsContainsStripe(`[{"id":"408","sources":["user"]}]`))
+	require.False(t, cursorInstalledIdsContainsStripe(`[{"id":"999"}]`))
+	require.False(t, cursorInstalledIdsContainsStripe(`{nope`))
+}
+
+func cursorTestProviderWithWorkspace(t *testing.T, sqliteOut string) CursorProvider {
+	t.Helper()
+	workDir := t.TempDir()
+	return cursorTestProvider(t, func(name string) (string, error) {
+		if name == CursorBinaryName || name == sqlite3BinaryName {
+			return "/usr/bin/" + name, nil
+		}
+		return "", errors.New("missing")
+	}, func(context.Context, string, ...string) ([]byte, error) {
+		return []byte(sqliteOut), nil
+	}, func() (string, error) { return workDir, nil })
+}
+
+func cursorTestProvider(t *testing.T, lookPath LookPathFunc, runOutput RunOutputFunc, workDir ...func() (string, error)) CursorProvider {
+	t.Helper()
+
+	if lookPath == nil {
+		lookPath = func(name string) (string, error) {
+			if name == CursorBinaryName {
+				return "/usr/local/bin/cursor", nil
+			}
+			return "", errors.New("missing")
+		}
+	}
+
+	home := t.TempDir()
+	dbPath, err := cursorStateDBPath(home, runtime.GOOS)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	require.NoError(t, os.WriteFile(dbPath, []byte{}, 0o644))
+
+	scanner := Scanner{
+		LookPath: lookPath,
+		HomeDir:  func() (string, error) { return home, nil },
+		WorkDir:  func() (string, error) { return t.TempDir(), nil },
+		ReadFile: os.ReadFile,
+		ReadDir:  os.ReadDir,
+		Stat:     os.Stat,
+	}
+	if len(workDir) > 0 {
+		scanner.WorkDir = workDir[0]
+	}
+
+	return CursorProvider{
+		Scanner:   scanner,
+		RunOutput: runOutput,
+	}
+}
+
+func sqliteInstalledIdsOutput(rows ...string) string {
+	return strings.Join(rows, "\n")
+}
+
+func writeCursorPluginCache(t *testing.T, home, hash, pluginJSON string) {
+	t.Helper()
+	hashPath := filepath.Join(home, CursorPluginsDir, "cache", CursorMarketplace, CursorPluginName, hash)
+	require.NoError(t, os.MkdirAll(filepath.Join(hashPath, ".cursor-plugin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(hashPath, ".cursor-plugin", "plugin.json"), []byte(pluginJSON), 0o644))
+}
+
+type fileInfoStub struct{}
+
+func (fileInfoStub) Name() string       { return "state.vscdb" }
+func (fileInfoStub) Size() int64        { return 0 }
+func (fileInfoStub) Mode() os.FileMode  { return 0 }
+func (fileInfoStub) ModTime() time.Time { return time.Time{} }
+func (fileInfoStub) IsDir() bool        { return false }
+func (fileInfoStub) Sys() any { return nil }

--- a/pkg/agentsetup/cursor_vscdb.go
+++ b/pkg/agentsetup/cursor_vscdb.go
@@ -1,0 +1,232 @@
+package agentsetup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	CursorMarketplace            = "cursor-public"
+	TargetCursorPlugin           = "stripe@cursor-public"
+	CursorPluginName             = "stripe"
+	CursorPluginsDir             = ".cursor/plugins"
+	cursorStripeMarketplaceID    = "408" // numeric ID for stripe@cursor-public in Cursor's marketplace
+	cursorVscdbQueryTimeout      = 5 * time.Second
+	cursorManualInstallHint      = "run /add-plugin stripe inside Cursor agent"
+	sqlite3BinaryName            = "sqlite3"
+)
+
+// cursorInstalledPlugin is an entry in Cursor's state.vscdb installedIds JSON array.
+type cursorInstalledPlugin struct {
+	ID      string   `json:"id"`
+	Sources []string `json:"sources"`
+}
+
+// cursorStripePluginStatus is the result of querying Cursor's plugin registry.
+type cursorStripePluginStatus struct {
+	installed         bool
+	supportsDetection bool
+	scope             string
+	projectPath       string
+}
+
+// cursorStateDBPath returns the path to Cursor's global state.vscdb for the
+// current platform.
+func cursorStateDBPath(home, goos string) (string, error) {
+	switch goos {
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "Cursor", "User", "globalStorage", "state.vscdb"), nil
+	case "linux":
+		return filepath.Join(home, ".config", "Cursor", "User", "globalStorage", "state.vscdb"), nil
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return "", fmt.Errorf("APPDATA is not set")
+		}
+		return filepath.Join(appData, "Cursor", "User", "globalStorage", "state.vscdb"), nil
+	default:
+		return "", fmt.Errorf("unsupported OS %q", goos)
+	}
+}
+
+// cursorWorkspaceURI returns the file:// URI Cursor uses for a local workspace folder.
+func cursorWorkspaceURI(absPath string) string {
+	slashPath := strings.ReplaceAll(absPath, "\\", "/")
+	if strings.HasPrefix(slashPath, "/") {
+		return "file://" + slashPath
+	}
+	return "file:///" + slashPath
+}
+
+// cursorStripePluginFromVscdb reports whether the Stripe Cursor plugin is enabled
+// at user-global or current-project scope by querying state.vscdb via sqlite3.
+// When sqlite3 or the database is unavailable, supportsDetection is false.
+func cursorStripePluginFromVscdb(s Scanner, runOutput RunOutputFunc) (cursorStripePluginStatus, error) {
+	result := cursorStripePluginStatus{}
+
+	if _, err := s.LookPath(sqlite3BinaryName); err != nil {
+		return result, nil
+	}
+
+	home, err := s.HomeDir()
+	if err != nil {
+		return result, err
+	}
+
+	dbPath, err := cursorStateDBPath(home, runtime.GOOS)
+	if err != nil {
+		return result, err
+	}
+
+	if _, err := s.Stat(dbPath); err != nil {
+		return result, nil
+	}
+
+	cwd, err := s.WorkDir()
+	if err != nil {
+		return result, err
+	}
+	workspaceURI, err := filepath.Abs(cwd)
+	if err != nil {
+		return result, err
+	}
+	workspaceURI = cursorWorkspaceURI(workspaceURI)
+
+	query := fmt.Sprintf(
+		`SELECT key, value FROM ItemTable WHERE key LIKE 'cursor.plugins.installedIds.%%|no-workspace' OR key LIKE 'cursor.plugins.installedIds.%%|%s';`,
+		escapeSQLiteString(workspaceURI),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), cursorVscdbQueryTimeout)
+	defer cancel()
+
+	out, err := runOutput(ctx, sqlite3BinaryName, dbPath, query)
+	if err != nil {
+		return result, nil
+	}
+
+	userInstalled, projectInstalled, projectPath := parseCursorInstalledIdsOutput(string(out), workspaceURI)
+	result.supportsDetection = true
+
+	switch {
+	case userInstalled && projectInstalled:
+		result.installed = true
+		result.scope = "user"
+	case userInstalled:
+		result.installed = true
+		result.scope = "user"
+	case projectInstalled:
+		result.installed = true
+		result.scope = "project"
+		result.projectPath = projectPath
+	}
+
+	return result, nil
+}
+
+func escapeSQLiteString(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+// parseCursorInstalledIdsOutput parses sqlite3 stdout for enabled Stripe plugin
+// entries. Keys use '|' as a delimiter between the account prefix and scope URI.
+func parseCursorInstalledIdsOutput(output, workspaceURI string) (userInstalled, projectInstalled bool, projectPath string) {
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		key, value, ok := splitCursorInstalledIdsRow(line)
+		if !ok {
+			continue
+		}
+
+		if !cursorInstalledIdsContainsStripe(value) {
+			continue
+		}
+
+		scopeURI := cursorInstalledIdsScopeURI(key)
+		switch scopeURI {
+		case "no-workspace":
+			userInstalled = true
+		case workspaceURI:
+			projectInstalled = true
+			projectPath = workspaceURIToPath(workspaceURI)
+		}
+	}
+	return userInstalled, projectInstalled, projectPath
+}
+
+func splitCursorInstalledIdsRow(line string) (key, value string, ok bool) {
+	idx := strings.Index(line, "[")
+	if idx <= 1 {
+		return "", "", false
+	}
+	return strings.TrimSpace(line[:idx-1]), strings.TrimSpace(line[idx:]), true
+}
+
+func cursorInstalledIdsScopeURI(key string) string {
+	if i := strings.LastIndex(key, "|"); i >= 0 {
+		return key[i+1:]
+	}
+	return ""
+}
+
+func workspaceURIToPath(uri string) string {
+	if !strings.HasPrefix(uri, "file://") {
+		return ""
+	}
+	path := strings.TrimPrefix(uri, "file://")
+	if strings.HasPrefix(path, "/") && len(path) > 2 && path[2] == ':' {
+		// file:///C:/path on Windows
+		path = path[1:]
+	}
+	return filepath.FromSlash(path)
+}
+
+func cursorInstalledIdsContainsStripe(valueJSON string) bool {
+	var plugins []cursorInstalledPlugin
+	if err := json.Unmarshal([]byte(valueJSON), &plugins); err != nil {
+		return false
+	}
+	for _, plugin := range plugins {
+		if plugin.ID == cursorStripeMarketplaceID {
+			return true
+		}
+	}
+	return false
+}
+
+// cursorPluginVersionFromCache reads the Stripe plugin version from Cursor's
+// on-disk plugin cache. The cache alone does not indicate enablement.
+func cursorPluginVersionFromCache(s Scanner, home string) string {
+	cacheRoot := filepath.Join(home, CursorPluginsDir, "cache", CursorMarketplace, CursorPluginName)
+	hashes, err := s.ReadDir(cacheRoot)
+	if err != nil {
+		return ""
+	}
+
+	for _, hash := range hashes {
+		if !hash.IsDir() {
+			continue
+		}
+		body, err := s.ReadFile(filepath.Join(cacheRoot, hash.Name(), ".cursor-plugin", "plugin.json"))
+		if err != nil {
+			continue
+		}
+		var meta struct {
+			Version string `json:"version"`
+		}
+		if json.Unmarshal(body, &meta) == nil && meta.Version != "" {
+			return meta.Version
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

### Summary
New `pkg/agentsetup/cursor_vscdb.go`:
* Resolves state.vscdb path (macOS / Linux / Windows)
* Shells out to sqlite3 to query enabled plugin IDs
* Treats Stripe as installed if marketplace ID 408 appears at:
  * User scope: no-workspace
  * Project scope: file://<cwd> (matches Claude/Codex user+project behavior)
* Parses sqlite output
* Reads version from ~/.cursor/plugins/cache/cursor-public/stripe/*/.cursor-plugin/plugin.json for display only (not used for detection)

Updated `pkg/agentsetup/cursor.go`:
* Detect() uses vscdb helper with injectable RunOutput
* Populates Plugin.ID (stripe@cursor-public), Plugin.Scope, Plugin.Project, Plugin.Version on success

Fall back to manual hint if this fails
 ### Motivation
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Add detection of Cursor plugin in `stripe agent setup` by querying Cursor's state `state.vscdb` via shelling out to sqlite CLI. When it's missing or detection isn't possible, behavior is unchanged: show a manual step to run /add-plugin stripe inside Cursor. 

We still can't programmatically install, so this PR stops at detection.

Source: https://github.com/cursor/plugins/issues/136 