### PR TITLE
Add per-version PagerDuty alerting to plugin canary tests

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -149,4 +149,8 @@ jobs:
         env:
           OVERALL_RESULT: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          PAGERDUTY_DEDUP_KEY: gh-actions-stripe-cli-install-test
+          PAGERDUTY_SUMMARY: "Failed to install Stripe CLI on one or more operating systems. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml"
+          PAGERDUTY_RESOLVE_SUMMARY: "Stripe CLI installation is passing again"
+          PAGERDUTY_SEVERITY: critical
           DRYRUN: ${{ inputs.dryrun }}

--- a/.github/workflows/plugin-canary.yml
+++ b/.github/workflows/plugin-canary.yml
@@ -5,6 +5,11 @@ on:
     # Run every 6 hours
     - cron: '0 */6 * * *'
   workflow_dispatch:
+    inputs:
+      dryrun:
+        description: 'Skip PagerDuty alert on failure'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -32,12 +37,22 @@ jobs:
         run: stripe version
         shell: bash
 
+      - name: Checkout notify script
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/notify.sh
+          sparse-checkout-cone-mode: false
+
       - name: Install and test recent projects plugin versions
         shell: bash
         env:
           STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_API_KEY }}
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DRYRUN: ${{ inputs.dryrun }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
 
           # Fetch the plugin manifest and extract recent versions
           VERSIONS=$(curl -fsSL "https://stripe.jfrog.io/artifactory/stripe-cli-plugins-local/plugins.toml" \
@@ -52,27 +67,40 @@ jobs:
           echo "$VERSIONS"
           echo ""
 
+          FAILURES=0
+
           while IFS= read -r VERSION; do
             echo "=== Testing projects@${VERSION} ==="
 
-            # Install specific version
-            stripe plugin install "projects@${VERSION}"
+            if stripe plugin install "projects@${VERSION}" && \
+               stripe projects --help && \
+               stripe projects catalog; then
+              echo "=== projects@${VERSION} PASSED ==="
 
-            # Verify plugin loads
-            stripe projects --help
+              PAGERDUTY_DEDUP_KEY="plugin-canary-projects-${VERSION}" \
+              PAGERDUTY_SUMMARY="Plugin canary: projects@${VERSION} failed. Investigate: ${GH_RUN_URL}" \
+              PAGERDUTY_RESOLVE_SUMMARY="Plugin canary: projects@${VERSION} is passing again" \
+              PAGERDUTY_SEVERITY="warning" \
+              DRYRUN="${DRYRUN}" \
+              OVERALL_RESULT="success" \
+              bash scripts/notify.sh
+            else
+              echo "=== projects@${VERSION} FAILED ==="
+              FAILURES=$((FAILURES + 1))
 
-            # Verify a subcommand works
-            stripe projects catalog
+              PAGERDUTY_DEDUP_KEY="plugin-canary-projects-${VERSION}" \
+              PAGERDUTY_SUMMARY="Plugin canary: projects@${VERSION} failed. Investigate: ${GH_RUN_URL}" \
+              PAGERDUTY_RESOLVE_SUMMARY="Plugin canary: projects@${VERSION} is passing again" \
+              PAGERDUTY_SEVERITY="warning" \
+              DRYRUN="${DRYRUN}" \
+              OVERALL_RESULT="failure" \
+              bash scripts/notify.sh
+            fi
 
-            echo "=== projects@${VERSION} PASSED ==="
             echo ""
           done <<< "$VERSIONS"
 
-      # TODO: Add alerting once tests are proven stable
-      # - name: Alert on failure
-      #   if: failure() && github.event_name == 'schedule'
-      #   run: |
-      #     curl -X POST "${{ secrets.PLUGIN_CANARY_SLACK_WEBHOOK_URL }}" \
-      #       -H 'Content-Type: application/json' \
-      #       -d "{\"text\": \"🚨 Plugin canary tests failed on ${{ matrix.os }}. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}"
-      #   shell: bash
+          if [ "$FAILURES" -gt 0 ]; then
+            echo "$FAILURES version(s) failed"
+            exit 1
+          fi

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+DEDUP_KEY="${PAGERDUTY_DEDUP_KEY:?must be set}"
+SUMMARY="${PAGERDUTY_SUMMARY:?must be set}"
+RESOLVE_SUMMARY="${PAGERDUTY_RESOLVE_SUMMARY:?must be set}"
+SEVERITY="${PAGERDUTY_SEVERITY:?must be set}"
+
 if [ "${DRYRUN:-false}" = "true" ]; then
     echo "Dry run mode: PagerDuty alerts will be suppressed"
 else
@@ -25,21 +30,21 @@ trigger_pagerduty_alert() {
     if [ "${DRYRUN:-false}" = "true" ]; then
         echo "Dry run: PagerDuty alert would have fired with:"
         echo "  action:    trigger"
-        echo "  dedup_key: gh-actions-stripe-cli-install-test"
-        echo "  summary:   Failed to install Stripe CLI on one or more operating systems. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml"
+        echo "  dedup_key: $DEDUP_KEY"
+        echo "  summary:   $SUMMARY"
         echo "  timestamp: $(date)"
         echo "  source:    Stripe CLI GitHub Actions"
-        echo "  severity:  critical"
+        echo "  severity:  $SEVERITY"
         return 0
     fi
     send_pagerduty_event '{
         "routing_key": "'"$PAGERDUTY_INTEGRATION_KEY"'",
         "event_action": "trigger",
-        "dedup_key": "gh-actions-stripe-cli-install-test",
+        "dedup_key": "'"$DEDUP_KEY"'",
         "payload": {
-            "summary": "Failed to install Stripe CLI on one or more operating systems. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/install-test.yml",
+            "summary": "'"$SUMMARY"'",
             "source": "Stripe CLI GitHub Actions",
-            "severity": "critical",
+            "severity": "'"$SEVERITY"'",
             "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
         }
     }'
@@ -49,17 +54,17 @@ resolve_pagerduty_alert() {
     if [ "${DRYRUN:-false}" = "true" ]; then
         echo "Dry run: PagerDuty resolve would have fired with:"
         echo "  action:    resolve"
-        echo "  dedup_key: gh-actions-stripe-cli-install-test"
-        echo "  summary:   Stripe CLI installation is passing again"
+        echo "  dedup_key: $DEDUP_KEY"
+        echo "  summary:   $RESOLVE_SUMMARY"
         echo "  source:    Stripe CLI GitHub Actions"
         return 0
     fi
     send_pagerduty_event '{
         "routing_key": "'"$PAGERDUTY_INTEGRATION_KEY"'",
         "event_action": "resolve",
-        "dedup_key": "gh-actions-stripe-cli-install-test",
+        "dedup_key": "'"$DEDUP_KEY"'",
         "payload": {
-            "summary": "Stripe CLI installation is passing again",
+            "summary": "'"$RESOLVE_SUMMARY"'",
             "source": "Stripe CLI GitHub Actions",
             "severity": "info"
         }


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

- Parameterize `scripts/notify.sh` to accept dedup key, summary, resolve summary, and severity as required env vars
- Update `install-test.yml` to pass its values explicitly
- Wire PagerDuty alerting into `plugin-canary.yml`: triggers an alert for each failing plugin version (dedup key: plugin-canary-projects-<version>) and auto-resolves when it passes again
- Add dryrun input to plugin-canary