### PR TITLE
Update copy of `stripe agent setup`

### DIFF
--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -500,16 +500,16 @@ func printStatusTable(w io.Writer, statuses []agentsetup.Status) {
 			state = color.Red("error: " + s.Error).String()
 		case s.Status == agentsetup.StatusInstalled:
 			icon = color.Green("✔").String()
-			state = "Stripe plugin installed"
+			state = "plugin installed"
 			if detail := pluginDetail(s.Plugin); detail != "" {
 				state += "  " + color.Faint(detail).String()
 			}
 		case s.Error != "":
 			icon = color.Yellow("•").String()
-			state = color.Faint(s.Error).String()
+			state = s.Error
 		default:
 			icon = color.Yellow("•").String()
-			state = "Stripe plugin not installed"
+			state = "plugin not installed"
 			needsSetup = true
 		}
 		fmt.Fprintf(w, "  %s  %-*s  %s\n", icon, nameWidth, s.DisplayName, state)

--- a/pkg/cmd/agent_setup_tui.go
+++ b/pkg/cmd/agent_setup_tui.go
@@ -52,13 +52,16 @@ func newSelectModel(statuses []agentsetup.Status) selectModel {
 			kind:   rowAgent,
 			status: s,
 			label:  s.DisplayName,
-			detail: s.ExecutablePath,
 		}
-		// Disable rows where a capability issue prevents installation (e.g. old
-		// Codex without plugin support). These show but are grayed out.
-		if s.Error != "" && s.Status != agentsetup.StatusError {
+		switch {
+		case s.Plugin.Installed:
+			row.disabled = true
+			row.hint = "plugin already installed"
+		case s.Error != "" && s.Status != agentsetup.StatusError:
 			row.disabled = true
 			row.hint = s.Error
+		default:
+			row.detail = "plugin not installed"
 		}
 		row.selected = !row.disabled
 		rows = append(rows, row)
@@ -164,7 +167,7 @@ func (m selectModel) View() tea.View {
 		}
 
 		if r.disabled {
-			line := fmt.Sprintf("%s[-] %-22s %s", pointer, r.label, dividerStyle.Render(r.hint))
+			line := fmt.Sprintf("%s[-] %-22s %s", pointer, r.label, r.hint)
 			body += line + "\n"
 			continue
 		}

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -24,7 +24,7 @@ func TestAgentSetupStatusDoesNotInstall(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, output, "Detected agents with supported Stripe plugins:")
 	require.Contains(t, output, "Claude Code")
-	require.Contains(t, output, "Stripe plugin not installed")
+	require.Contains(t, output, "plugin not installed")
 }
 
 func TestAgentSetupStatusShowsInstalledDetail(t *testing.T) {
@@ -34,7 +34,7 @@ func TestAgentSetupStatusShowsInstalledDetail(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Contains(t, output, "Claude Code")
-	require.Contains(t, output, "Stripe plugin installed")
+	require.Contains(t, output, "plugin installed")
 	require.Contains(t, output, agentsetup.TargetClaudePlugin) // plugin id in the dimmed detail
 	require.Contains(t, output, "2.4.1")
 }


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products


## Summary
- TUI: show plugin status ("plugin not installed" / "plugin already installed" / manual instruction) instead of executable path
- TUI: disable rows where plugin is already installed (`[-]`)
- `--status`: remove "Stripe" prefix from status labels, remove faint styling from Cursor's manual instruction

`stripe agent setup`
<img width="549" height="210" alt="Screenshot 2026-07-07 at 11 02 33 AM" src="https://github.com/user-attachments/assets/59b041a4-d376-49b0-ada8-9043253e1b9f" />

`stripe agent setup --status`
<img width="525" height="111" alt="Screenshot 2026-07-07 at 11 02 49 AM" src="https://github.com/user-attachments/assets/68f92cfd-f1a6-4b34-97af-fac107ed3020" />