### PR TITLE
[sandboxes cli] Implement stripe sandbox new: v2 CreateSandbox (copy + blank)

### DIFF
--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -68,21 +68,13 @@ func newSandboxCmd() *sandboxCmd {
 	sc.cmd.AddCommand(createCmd.cmd)
 	sc.cmd.AddCommand(claimCmd.cmd)
 
-	// `sandbox new` is an experimental POC. It is gated behind an env flag so it
-	// is not registered at all (invisible AND unrunnable — `unknown command`)
-	// unless explicitly enabled, on top of being Hidden. This keeps it out of
-	// users' hands pre-GA; the authoritative access gate remains server-side
-	// (the UAT allowlist + hzn_sandbox_create), not the client.
-	if sandboxNewEnabled() {
-		sc.cmd.AddCommand(newSandboxNewCmd().cmd)
-	}
+	// `sandbox new` is an experimental POC. It stays Hidden (kept out of
+	// help/completion) but is always registered — this ships only to the
+	// long-lived sandboxes-cli feature branch, never to master pre-GA, so no
+	// client-side env gate is needed. The authoritative access gate remains
+	// server-side (the UAT allowlist + hzn_sandbox_create), not the client.
+	sc.cmd.AddCommand(newSandboxNewCmd().cmd)
 	return sc
-}
-
-// sandboxNewEnabled reports whether the experimental `stripe sandbox new` command
-// should be registered. Mirrors the STRIPE_CLI_CANARY env-gating pattern.
-func sandboxNewEnabled() bool {
-	return os.Getenv("STRIPE_CLI_ENABLE_SANDBOX_NEW") == "true"
 }
 
 func newSandboxCreateCmd() *sandboxCreateCmd {

--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/logrusorgru/aurora"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -492,6 +491,7 @@ that you have previously logged in with your Stripe account credentials.`,
 	}
 
 	snc.cmd.Flags().StringVar(&snc.name, "name", "", "Name for the new sandbox")
+	_ = snc.cmd.MarkFlagRequired("name")
 	snc.cmd.Flags().StringVar(&snc.replicaOf, "replica-of", "", "Livemode workspace ID to replicate (wksp_...); mutually exclusive with --business-location")
 	snc.cmd.Flags().StringVar(&snc.businessLocation, "business-location", "", "Country for a fresh blank sandbox (e.g. US); mutually exclusive with --replica-of")
 	snc.cmd.Flags().StringVar(&snc.stripeContext, "stripe-context", "", "Playground compartment (play_...) to create the sandbox under")
@@ -519,10 +519,6 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 		return fmt.Errorf("no user access token found; run `stripe login` first")
 	}
 	uat := strings.TrimSpace(string(uatBytes))
-
-	if strings.TrimSpace(snc.name) == "" {
-		return fmt.Errorf("--name is required")
-	}
 
 	// --batch is scaffolded for a future bulk-create shape and currently only
 	// supports 1. Future shape: create N sandboxes under the same playground in a
@@ -567,12 +563,12 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 		return fmt.Errorf("invalid --api-base %q: %w", snc.apiBase, err)
 	}
 
-	// Mirror the dashboard's create-sandbox request body. The idempotency token
-	// guards against duplicate creates if the request is retried.
+	// Mirror the dashboard's create-sandbox request body, including the
+	// idempotency_token derived from the create inputs (see newIdempotencyToken).
 	reqBody := map[string]interface{}{
 		"name":              snc.name,
 		"activate_sandbox":  snc.activate,
-		"idempotency_token": newIdempotencyToken(snc.name),
+		"idempotency_token": newIdempotencyToken(snc.name, businessLocation, replicaOf),
 	}
 	if replicaOf != "" {
 		reqBody["replica_of"] = replicaOf
@@ -628,15 +624,15 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 	return nil
 }
 
-// newIdempotencyToken builds a stable-per-invocation idempotency token from the
-// sandbox name and a random UUID so retried requests within a run don't create
-// duplicate sandboxes.
-func newIdempotencyToken(name string) string {
-	suffix := uuid.NewString()
-	if name == "" {
-		return suffix
-	}
-	return name + "-" + suffix
+// newIdempotencyToken mirrors the dashboard's create-sandbox flow
+// (CreateSandboxFlow.tsx): the token is derived from the create inputs (name,
+// business_location country, and the replica_of parent workspace) plus a
+// wall-clock second. An accidental double-submit of the same command within the
+// same second collapses to one create; distinct invocations create distinct
+// sandboxes. Sent as the body idempotency_token field, matching the dashboard's
+// v2CreateSandbox call (which does not use the Idempotency-Key header).
+func newIdempotencyToken(name, country, parent string) string {
+	return fmt.Sprintf("%s-%s-%s-%d", name, country, parent, time.Now().Unix())
 }
 
 func isSSHSession() bool {

--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -1,15 +1,20 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/mail"
+	"net/url"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/logrusorgru/aurora"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -19,6 +24,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/login"
 	"github.com/stripe/stripe-cli/pkg/open"
+	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/sandbox"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -59,11 +65,24 @@ func newSandboxCmd() *sandboxCmd {
 
 	createCmd := newSandboxCreateCmd()
 	claimCmd := newSandboxClaimCmd()
-	newCmd := newSandboxNewCmd()
 	sc.cmd.AddCommand(createCmd.cmd)
 	sc.cmd.AddCommand(claimCmd.cmd)
-	sc.cmd.AddCommand(newCmd.cmd)
+
+	// `sandbox new` is an experimental POC. It is gated behind an env flag so it
+	// is not registered at all (invisible AND unrunnable — `unknown command`)
+	// unless explicitly enabled, on top of being Hidden. This keeps it out of
+	// users' hands pre-GA; the authoritative access gate remains server-side
+	// (the UAT allowlist + hzn_sandbox_create), not the client.
+	if sandboxNewEnabled() {
+		sc.cmd.AddCommand(newSandboxNewCmd().cmd)
+	}
 	return sc
+}
+
+// sandboxNewEnabled reports whether the experimental `stripe sandbox new` command
+// should be registered. Mirrors the STRIPE_CLI_CANARY env-gating pattern.
+func sandboxNewEnabled() bool {
+	return os.Getenv("STRIPE_CLI_ENABLE_SANDBOX_NEW") == "true"
 }
 
 func newSandboxCreateCmd() *sandboxCreateCmd {
@@ -403,11 +422,15 @@ type sandboxClaimCmd struct {
 }
 
 type sandboxNewCmd struct {
-	cmd           *cobra.Command
-	name          string
-	replicaOf     string
-	stripeContext string
-	apiBase       string
+	cmd              *cobra.Command
+	name             string
+	replicaOf        string
+	businessLocation string
+	stripeContext    string
+	activate         bool
+	batch            int
+	stripeVersion    string
+	apiBase          string
 }
 
 func newSandboxClaimCmd() *sandboxClaimCmd {
@@ -477,8 +500,15 @@ that you have previously logged in with your Stripe account credentials.`,
 	}
 
 	snc.cmd.Flags().StringVar(&snc.name, "name", "", "Name for the new sandbox")
-	snc.cmd.Flags().StringVar(&snc.replicaOf, "replica-of", "", "Livemode workspace ID to replicate (wksp_...)")
-	snc.cmd.Flags().StringVar(&snc.stripeContext, "stripe-context", "", "Stripe-Context compartment to scope the request to")
+	snc.cmd.Flags().StringVar(&snc.replicaOf, "replica-of", "", "Livemode workspace ID to replicate (wksp_...); mutually exclusive with --business-location")
+	snc.cmd.Flags().StringVar(&snc.businessLocation, "business-location", "", "Country for a fresh blank sandbox (e.g. US); mutually exclusive with --replica-of")
+	snc.cmd.Flags().StringVar(&snc.stripeContext, "stripe-context", "", "Playground compartment (play_...) to create the sandbox under")
+	snc.cmd.Flags().BoolVar(&snc.activate, "activate", true, "Request capabilities and activate the sandbox after creation")
+	snc.cmd.Flags().IntVar(&snc.batch, "batch", 1, "Number of sandboxes to create (currently only 1 is supported)")
+
+	snc.cmd.Flags().StringVar(&snc.stripeVersion, "stripe-version", requests.StripeVersionHeaderValue, "Sets the Stripe-Version header")
+	_ = snc.cmd.Flags().MarkHidden("stripe-version")
+
 	snc.cmd.Flags().StringVar(&snc.apiBase, "api-base", stripe.DefaultAPIBaseURL, "Sets the Stripe API base URL")
 	_ = snc.cmd.Flags().MarkHidden("api-base")
 
@@ -486,29 +516,135 @@ that you have previously logged in with your Stripe account credentials.`,
 }
 
 func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) error {
-	// Scaffolded only. The intended behavior is described below as plain steps so
-	// the follow-up PR can implement it directly. The end-to-end flow has already
-	// been validated; authenticating with the logged-in session token works.
-	//
-	//   1. Load the user's session token from the local credential store. If the
-	//      store is unavailable or no token is present, return an error telling the
-	//      user to run `stripe login` first.
-	//   2. Determine which compartment to scope the request to. Prefer the
-	//      --stripe-context and --replica-of flags when provided; otherwise fall
-	//      back to the compartment saved at login. Sandbox creation must be scoped
-	//      to a playground compartment, so this needs to resolve to a playground (or
-	//      be supplied explicitly by flag); return a clear error if it can't be
-	//      determined.
-	//   3. Build the create-sandbox request body, matching the dashboard flow: the
-	//      sandbox name, the workspace to replicate, an "activate" flag, and an
-	//      idempotency token.
-	//   4. Send the create request to the v2 sandboxes endpoint, attaching the
-	//      session token as the request credential along with the API version, the
-	//      compartment context, and a JSON content type.
-	//   5. If the response is not a success status, return an error that includes
-	//      the status and body; otherwise pretty-print the created sandbox as JSON.
-	fmt.Fprintln(cmd.OutOrStdout(), "stripe sandbox new: scaffolded, not yet implemented")
+	// The UAT is stored under the bare keyring key (config.UATKeychainItemKey),
+	// not the per-profile field, so read it directly from the keyring rather
+	// than going through the profile helpers (which read live/test API keys).
+	if config.KeyRing == nil {
+		return fmt.Errorf("credential store unavailable; run `stripe login` first")
+	}
+	uatBytes, err := config.KeyRing.Get(config.UATKeychainItemKey)
+	if err != nil || len(uatBytes) == 0 {
+		return fmt.Errorf("no user access token found; run `stripe login` first")
+	}
+	uat := strings.TrimSpace(string(uatBytes))
+
+	if strings.TrimSpace(snc.name) == "" {
+		return fmt.Errorf("--name is required")
+	}
+
+	// --batch is scaffolded for a future bulk-create shape and currently only
+	// supports 1. Future shape: create N sandboxes under the same playground in a
+	// single invocation via a bounded fan-out (or a batched backend request) that
+	// shares an idempotency prefix, returns the list of created sandboxes, and
+	// reports per-item partial failures instead of aborting the whole batch.
+	// Until that lands, reject >1 explicitly rather than silently creating one.
+	if snc.batch < 1 {
+		return fmt.Errorf("--batch must be >= 1")
+	}
+	if snc.batch > 1 {
+		return fmt.Errorf("--batch > 1 is not yet implemented; only --batch 1 is supported today")
+	}
+
+	// Stripe-Context must be a playground (play_...) compartment. The backend
+	// (CreateSandboxOp) rejects any non-playground context, so validate it here
+	// to give a clear error rather than a server-side rejection.
+	stripeContext := strings.TrimSpace(snc.stripeContext)
+	if stripeContext == "" {
+		return fmt.Errorf("--stripe-context is required; pass the playground id (play_...) to create the sandbox under")
+	}
+	if !strings.HasPrefix(stripeContext, "play_") {
+		return fmt.Errorf("--stripe-context must be a playground id (play_...), got %q", stripeContext)
+	}
+
+	// The backend requires exactly one of replica_of / business_location (a oneof):
+	// replica_of (a livemode wksp_...) clones a live workspace; business_location
+	// (a country) creates a fresh blank sandbox. Enforce the oneof up front.
+	replicaOf := strings.TrimSpace(snc.replicaOf)
+	businessLocation := strings.TrimSpace(snc.businessLocation)
+	switch {
+	case replicaOf != "" && businessLocation != "":
+		return fmt.Errorf("--replica-of and --business-location are mutually exclusive")
+	case replicaOf == "" && businessLocation == "":
+		return fmt.Errorf("pass one of --replica-of (wksp_...) to clone a live workspace, or --business-location (e.g. US) for a blank sandbox")
+	case replicaOf != "" && !strings.HasPrefix(replicaOf, "wksp_"):
+		return fmt.Errorf("--replica-of must be a livemode workspace id (wksp_...), got %q", replicaOf)
+	}
+
+	baseURL, err := url.Parse(snc.apiBase)
+	if err != nil {
+		return fmt.Errorf("invalid --api-base %q: %w", snc.apiBase, err)
+	}
+
+	// Mirror the dashboard's create-sandbox request body. The idempotency token
+	// guards against duplicate creates if the request is retried.
+	reqBody := map[string]interface{}{
+		"name":              snc.name,
+		"activate_sandbox":  snc.activate,
+		"idempotency_token": newIdempotencyToken(snc.name),
+	}
+	if replicaOf != "" {
+		reqBody["replica_of"] = replicaOf
+	} else {
+		reqBody["business_location"] = businessLocation
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return err
+	}
+
+	// Use the low-level client with an empty APIKey so it doesn't set a Bearer
+	// Authorization header; the UAT is injected via the configure hook below as
+	// a STRIPE-V2-SIG token instead.
+	client := &stripe.Client{
+		BaseURL: baseURL,
+		APIKey:  "",
+	}
+
+	configure := func(req *http.Request) error {
+		req.Header.Set("Authorization", "STRIPE-V2-SIG "+uat)
+		req.Header.Set("Stripe-Version", snc.stripeVersion)
+		req.Header.Set("Stripe-Context", stripeContext)
+		// Content-Type is set to application/json automatically by the client
+		// for /v2/ paths, but set it explicitly to be safe.
+		req.Header.Set("Content-Type", stripe.V2ContentType)
+		return nil
+	}
+
+	resp, err := client.PerformRequest(cmd.Context(), http.MethodPost, "/v2/sandboxes", string(bodyBytes), configure)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("create sandbox failed: %s\n%s", resp.Status, string(respBytes))
+	}
+
+	// Pretty-print the JSON response when possible; otherwise print as-is.
+	var pretty bytes.Buffer
+	if json.Indent(&pretty, respBytes, "", "  ") == nil {
+		fmt.Fprintln(cmd.OutOrStdout(), pretty.String())
+	} else {
+		fmt.Fprintln(cmd.OutOrStdout(), string(respBytes))
+	}
+
 	return nil
+}
+
+// newIdempotencyToken builds a stable-per-invocation idempotency token from the
+// sandbox name and a random UUID so retried requests within a run don't create
+// duplicate sandboxes.
+func newIdempotencyToken(name string) string {
+	suffix := uuid.NewString()
+	if name == "" {
+		return suffix
+	}
+	return name + "-" + suffix
 }
 
 func isSSHSession() bool {

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -21,8 +21,15 @@ import (
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/keyring"
 	"github.com/stripe/stripe-cli/pkg/login"
+	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/sandbox"
 )
+
+// `stripe sandbox new` is gated behind this env flag and is only registered on
+// the package-level rootCmd during init(). This package-level initializer runs
+// before any init() function, so it guarantees the command is present for the
+// TestSandboxNewCmd_* tests that execute via the global rootCmd.
+var _ = os.Setenv("STRIPE_CLI_ENABLE_SANDBOX_NEW", "true")
 
 func setupSandboxTestConfig(t *testing.T) func() {
 	t.Helper()
@@ -535,4 +542,272 @@ func TestSandboxClaimCmd_WithClaimURL(t *testing.T) {
 	require.NoError(t, err)
 	// In non-interactive mode, the claim URL is printed to stdout.
 	// Verified by no error — URL goes to os.Stdout which we can't capture.
+}
+
+func TestSandboxNewCmd_Success(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	// Seed a UAT into the in-memory keyring
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	// Stand up a test server to validate the request shape
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Assert request properties
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v2/sandboxes", r.URL.Path)
+		assert.Equal(t, "STRIPE-V2-SIG keyinfo_live_faketoken", r.Header.Get("Authorization"))
+		// Stripe-Context must be the playground id, not the livemode workspace.
+		assert.Equal(t, "play_livetest", r.Header.Get("Stripe-Context"))
+		assert.Equal(t, requests.StripeVersionHeaderValue, r.Header.Get("Stripe-Version"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		// Decode and validate the JSON body
+		var body map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&body)
+		assert.NoError(t, err)
+		assert.Equal(t, "mytest", body["name"])
+		assert.Equal(t, "wksp_livetest", body["replica_of"])
+		assert.Equal(t, true, body["activate_sandbox"])
+
+		// Return success response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":     "sbx_123",
+			"object": "sandbox",
+		})
+	}))
+	defer server.Close()
+
+	// Execute the command with explicit flags
+	output, err := executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--api-base="+server.URL,
+		"--stripe-context=play_livetest",
+		"--replica-of=wksp_livetest",
+		"--name=mytest",
+	)
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "sbx_123")
+	assert.Contains(t, output, "sandbox")
+}
+
+func TestSandboxNewCmd_ActivateFalse(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&body)
+		assert.NoError(t, err)
+		assert.Equal(t, false, body["activate_sandbox"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": "sbx_123", "object": "sandbox"})
+	}))
+	defer server.Close()
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--api-base="+server.URL,
+		"--stripe-context=play_livetest",
+		"--replica-of=wksp_livetest",
+		"--name=mytest",
+		"--activate=false",
+	)
+	require.NoError(t, err)
+}
+
+func TestSandboxNewCmd_RejectsNonPlaygroundContext(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--stripe-context=wksp_livetest",
+		"--replica-of=wksp_livetest",
+		"--name=mytest",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "playground id (play_...)")
+}
+
+func TestSandboxNewCmd_RejectsNonWorkspaceReplicaOf(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--stripe-context=play_livetest",
+		"--replica-of=acct_123",
+		"--name=mytest",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace id (wksp_...)")
+}
+
+func TestSandboxNewCmd_BlankPath(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&body)
+		assert.NoError(t, err)
+		// Blank path sends business_location and omits replica_of entirely.
+		assert.Equal(t, "US", body["business_location"])
+		_, hasReplica := body["replica_of"]
+		assert.False(t, hasReplica)
+		assert.Equal(t, true, body["activate_sandbox"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": "wksp_test_blank", "object": "sandbox"})
+	}))
+	defer server.Close()
+
+	output, err := executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--api-base="+server.URL,
+		"--stripe-context=play_livetest",
+		"--replica-of=", // clear any value leaked from a prior test's flag state
+		"--business-location=US",
+		"--activate=true", // clear any --activate=false leaked from a prior test
+		"--name=blanktest",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, output, "wksp_test_blank")
+}
+
+func TestSandboxNewCmd_ReplicaOfAndBusinessLocationMutuallyExclusive(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--stripe-context=play_livetest",
+		"--replica-of=wksp_livetest",
+		"--business-location=US",
+		"--name=mytest",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestSandboxNewCmd_RequiresReplicaOfOrBusinessLocation(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--stripe-context=play_livetest",
+		"--replica-of=",        // clear leaked flag state so neither is set
+		"--business-location=", // clear leaked flag state so neither is set
+		"--name=mytest",
+	)
+	require.Error(t, err)
+	// Unique to the "neither provided" error; the mutually-exclusive error also
+	// mentions --business-location, so assert on this distinct phrase.
+	assert.Contains(t, err.Error(), "pass one of")
+}
+
+func TestSandboxNewCmd_GatedByEnv(t *testing.T) {
+	hasNew := func(sc *sandboxCmd) bool {
+		for _, c := range sc.cmd.Commands() {
+			if c.Name() == "new" {
+				return true
+			}
+		}
+		return false
+	}
+
+	// With the flag set, the command is registered.
+	t.Setenv("STRIPE_CLI_ENABLE_SANDBOX_NEW", "true")
+	assert.True(t, hasNew(newSandboxCmd()))
+
+	// Without it, the command is not registered at all.
+	t.Setenv("STRIPE_CLI_ENABLE_SANDBOX_NEW", "")
+	assert.False(t, hasNew(newSandboxCmd()))
+}
+
+func TestSandboxNewCmd_NoUAT(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	// Don't seed a UAT — keyring is empty
+	// Execute the command
+	_, err := executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--name=mytest",
+		"--stripe-context=wksp_livetest",
+		"--replica-of=wksp_livetest",
+	)
+
+	// Should fail with an error mentioning stripe login
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stripe login")
+}
+
+// Placed last: sets --batch, which leaks onto the singleton rootCmd flag; keeping
+// it after the other tests avoids that value bleeding into their default (1).
+func TestSandboxNewCmd_BatchNotYetSupported(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	// --batch is optional (defaults to 1); >1 is rejected until bulk-create lands.
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--stripe-context=play_livetest",
+		"--replica-of=wksp_livetest",
+		"--name=mytest",
+		"--batch=3",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not yet implemented")
+
+	// batch < 1 is invalid.
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--stripe-context=play_livetest",
+		"--replica-of=wksp_livetest",
+		"--name=mytest",
+		"--batch=0",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--batch must be >= 1")
 }

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -25,12 +25,6 @@ import (
 	"github.com/stripe/stripe-cli/pkg/sandbox"
 )
 
-// `stripe sandbox new` is gated behind this env flag and is only registered on
-// the package-level rootCmd during init(). This package-level initializer runs
-// before any init() function, so it guarantees the command is present for the
-// TestSandboxNewCmd_* tests that execute via the global rootCmd.
-var _ = os.Setenv("STRIPE_CLI_ENABLE_SANDBOX_NEW", "true")
-
 func setupSandboxTestConfig(t *testing.T) func() {
 	t.Helper()
 	profilesFile := filepath.Join(t.TempDir(), "config.toml")
@@ -738,25 +732,6 @@ func TestSandboxNewCmd_RequiresReplicaOfOrBusinessLocation(t *testing.T) {
 	// Unique to the "neither provided" error; the mutually-exclusive error also
 	// mentions --business-location, so assert on this distinct phrase.
 	assert.Contains(t, err.Error(), "pass one of")
-}
-
-func TestSandboxNewCmd_GatedByEnv(t *testing.T) {
-	hasNew := func(sc *sandboxCmd) bool {
-		for _, c := range sc.cmd.Commands() {
-			if c.Name() == "new" {
-				return true
-			}
-		}
-		return false
-	}
-
-	// With the flag set, the command is registered.
-	t.Setenv("STRIPE_CLI_ENABLE_SANDBOX_NEW", "true")
-	assert.True(t, hasNew(newSandboxCmd()))
-
-	// Without it, the command is not registered at all.
-	t.Setenv("STRIPE_CLI_ENABLE_SANDBOX_NEW", "")
-	assert.False(t, hasNew(newSandboxCmd()))
 }
 
 func TestSandboxNewCmd_NoUAT(t *testing.T) {


### PR DESCRIPTION
Business logic for the hidden `stripe sandbox new` command. Stacked on #1753 (the scaffold).

Wires the command to POST /v2/sandboxes using the logged-in UAT (STRIPE-V2-SIG). Two create modes (a oneof; exactly one required):
- copy: `--replica-of <wksp_>` clones a livemode workspace
- blank: `--business-location <country>` creates a fresh sandbox

Stripe-Context must be a playground (`play_`), validated client-side since the backend rejects a non-playground context. `--activate` toggles capability activation (default true). `--batch` is optional (default 1; >1 rejected today, with a future-shape comment).

Command stays Hidden and is registered only behind `STRIPE_CLI_ENABLE_SANDBOX_NEW`; the authoritative access gate is server-side (UAT allowlist + hzn_sandbox_create).

Stacking note: based on the scaffold branch for a clean logic-only diff; will retarget to `sandboxes-cli` once #1753 merges. Part of the long-lived `sandboxes-cli` feature branch, not for merge to master until the feature is release-ready.