### PR TITLE
[stripe agent setup] Polish skills status display

### DIFF
--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -79,8 +79,8 @@ type agentSetupJSON struct {
 }
 
 type skillsScopesJSON struct {
-	Local  agentskills.DirStatus `json:"local"`
-	Global agentskills.DirStatus `json:"global"`
+	Local  *agentskills.DirStatus `json:"local,omitempty"`
+	Global *agentskills.DirStatus `json:"global,omitempty"`
 }
 
 // skillsScopes holds the check result for local and global skill directories.
@@ -573,6 +573,15 @@ func skillsScopeNeedsInstall(d agentskills.DirStatus) bool {
 	return d.Status == agentskills.StatusNotInstalled
 }
 
+// skillsScopeVisible reports whether a scope should be surfaced to the user
+// given the other scope's state. A not-installed scope is hidden when the other
+// scope already has skills, so we don't nag about the scope the user isn't
+// using. Shared by the text (--status) and JSON output paths so they stay
+// consistent.
+func skillsScopeVisible(d agentskills.DirStatus, scopes skillsScopes) bool {
+	return !skillsScopeNeedsInstall(d) || !skillsScopesHasInstalled(scopes)
+}
+
 func (asc *agentSetupCmd) writeJSON(w io.Writer, providers map[string]agentsetup.Provider, statuses []agentsetup.Status, view skillsStatusView) error {
 	result := agentSetupJSON{
 		Status:  aggregateStatus(statuses),
@@ -587,13 +596,20 @@ func (asc *agentSetupCmd) writeJSON(w io.Writer, providers map[string]agentsetup
 		}
 	}
 	if view.show {
-		result.Skills = &skillsScopesJSON{Local: view.scopes.Local, Global: view.scopes.Global}
+		result.Skills = &skillsScopesJSON{}
+		if skillsScopeVisible(view.scopes.Local, view.scopes) {
+			result.Skills.Local = &view.scopes.Local
+		}
+		if skillsScopeVisible(view.scopes.Global, view.scopes) {
+			result.Skills.Global = &view.scopes.Global
+		}
 		if skillsScopeNeedsUpdate(view.scopes.Local) || skillsScopeNeedsUpdate(view.scopes.Global) {
 			result.Actions = append(result.Actions, agentsetup.Plan{
 				Action:  "update_skills",
 				Command: []string{"stripe", "agent", "setup"},
 			})
-		} else if view.allowInstall && (skillsScopeNeedsInstall(view.scopes.Local) || skillsScopeNeedsInstall(view.scopes.Global)) {
+		} else if view.allowInstall && !skillsScopesHasInstalled(view.scopes) &&
+			(skillsScopeNeedsInstall(view.scopes.Local) || skillsScopeNeedsInstall(view.scopes.Global)) {
 			result.Actions = append(result.Actions, agentsetup.Plan{
 				Action:  "install_skills",
 				Command: []string{"stripe", "agent", "setup"},
@@ -751,12 +767,20 @@ func printSkillsStatusTable(w io.Writer, skills skillsScopes, allowInstall bool)
 		{"local", skills.Local},
 		{"global", skills.Global},
 	} {
-		icon, state := skillsScopeStatusLine(w, entry.dir)
 		if skillsScopeNeedsInstall(entry.dir) {
 			needsInstall = true
+			if allowInstall && skillsScopeVisible(entry.dir, skills) {
+				icon := color.Yellow("•").String()
+				fmt.Fprintf(w, "  %s  %-*s  %s  %s\n", icon, scopeWidth, entry.name, "not installed", color.Faint(entry.dir.Dir).String())
+			}
+			continue
 		}
 		if skillsScopeNeedsUpdate(entry.dir) {
 			needsUpdate = true
+		}
+		icon, state := skillsScopeStatusLine(w, entry.dir)
+		if state == "" {
+			continue
 		}
 		fmt.Fprintf(w, "  %s  %-*s  %s  %s\n", icon, scopeWidth, entry.name, state, color.Faint(entry.dir.Dir).String())
 	}
@@ -764,23 +788,22 @@ func printSkillsStatusTable(w io.Writer, skills skillsScopes, allowInstall bool)
 	switch {
 	case needsUpdate:
 		fmt.Fprintf(w, "\nRun %s to update your Stripe skills.\n", color.Bold("stripe agent setup").String())
-	case needsInstall && allowInstall:
+	case needsInstall && allowInstall && !skillsScopesHasInstalled(skills):
 		fmt.Fprintf(w, "\nRun %s to install your Stripe skills.\n", color.Bold("stripe agent setup").String())
 	}
 }
 
 func skillsScopeStatusLine(w io.Writer, d agentskills.DirStatus) (icon, state string) {
 	color := ansi.Color(w)
-	total := len(d.Skills)
 	switch d.Status {
 	case agentskills.StatusError:
 		return color.Red("✗").String(), color.Red("error: " + d.Error).String()
 	case agentskills.StatusCurrent:
-		return color.Green("✔").String(), fmt.Sprintf("%d skills up to date", total)
+		return color.Green("✔").String(), "installed"
 	case agentskills.StatusOutOfDate:
-		return color.Yellow("⚠").String(), fmt.Sprintf("%d of %d skills out of date", d.OutOfDateCount, total)
+		return color.Yellow("⚠").String(), "outdated"
 	default:
-		return color.Yellow("•").String(), "not installed"
+		return "", ""
 	}
 }
 

--- a/pkg/cmd/agent_setup_tui.go
+++ b/pkg/cmd/agent_setup_tui.go
@@ -85,11 +85,11 @@ func skillsRowPresentation(statuses []agentsetup.Status, skills skillsScopes) (l
 
 	hasOutOfDate := skillsScopeNeedsUpdate(skills.Local) || skillsScopeNeedsUpdate(skills.Global)
 	if hasOutOfDate {
-		return label, "Detected outdated Stripe skills", true
+		return label, "detected outdated Stripe skills", true
 	}
 
 	if skills.Local.Status == agentskills.StatusCurrent && skills.Global.Status == agentskills.StatusCurrent {
-		return "Stripe skills", "up to date", false
+		return label, "", false
 	}
 
 	return label, "", len(statuses) == 0

--- a/pkg/cmd/agent_setup_tui_test.go
+++ b/pkg/cmd/agent_setup_tui_test.go
@@ -145,7 +145,7 @@ func TestSelectModel_OutOfDatePreselectsUpdateRow(t *testing.T) {
 	m := newSelectModel(testStatuses(), skills)
 
 	require.Equal(t, "Install Stripe skills", m.rows[len(m.rows)-1].label)
-	require.Equal(t, "Detected outdated Stripe skills", m.rows[len(m.rows)-1].detail)
+	require.Equal(t, "detected outdated Stripe skills", m.rows[len(m.rows)-1].detail)
 	require.True(t, m.rows[len(m.rows)-1].selected)
 }
 
@@ -157,8 +157,8 @@ func TestSelectModel_CurrentSkillsNotPreselected(t *testing.T) {
 
 	m := newSelectModel(testStatuses(), skills)
 
-	require.Equal(t, "Stripe skills", m.rows[len(m.rows)-1].label)
-	require.Equal(t, "up to date", m.rows[len(m.rows)-1].detail)
+	require.Equal(t, "Install Stripe skills", m.rows[len(m.rows)-1].label)
+	require.Empty(t, m.rows[len(m.rows)-1].detail)
 	require.False(t, m.rows[len(m.rows)-1].selected)
 }
 

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -483,7 +483,7 @@ func TestAgentSetupStatusShowsSkillsWhenInstalled(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Contains(t, output, "Stripe skills:")
-	require.Contains(t, output, "out of date")
+	require.Contains(t, output, "outdated")
 	require.Contains(t, output, "Run stripe agent setup to update your Stripe skills.")
 	require.NotContains(t, output, "install your Stripe skills")
 }
@@ -512,6 +512,109 @@ func TestAgentSetupStatusWithNoClientsShowsSkills(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, output, "No supported AI coding clients detected on this machine.")
 	require.Contains(t, output, "Stripe skills:")
+	require.Contains(t, output, "not installed")
+}
+
+func TestAgentSetupStatusWithNoClientsHidesUninstalledScopeWhenOtherInstalled(t *testing.T) {
+	localDir := filepath.Join(t.TempDir(), ".agents", "skills")
+	globalDir := filepath.Join(t.TempDir(), ".agents", "skills")
+
+	tests := []struct {
+		name           string
+		currentScope   string
+		wantInstalled  string
+		wantNotContain string
+	}{
+		{
+			name:           "local installed hides global not installed",
+			currentScope:   localDir,
+			wantInstalled:  "local",
+			wantNotContain: "global",
+		},
+		{
+			name:           "global installed hides local not installed",
+			currentScope:   globalDir,
+			wantInstalled:  "global",
+			wantNotContain: "local",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setup := testAgentSetupCmd()
+			setup.providers = map[string]agentsetup.Provider{}
+			setup.callingAgent = func() string { return "" }
+			setup.skillsLocalDir = func() (string, error) { return localDir, nil }
+			setup.skillsGlobalDir = func() (string, error) { return globalDir, nil }
+			setup.skillsCheck = func(_ context.Context, destDir string) (*agentskills.DirStatus, error) {
+				if destDir == tc.currentScope {
+					return mockSkillsCheckCurrent(context.Background(), destDir)
+				}
+				return mockSkillsCheckNotInstalled(context.Background(), destDir)
+			}
+			setup.cmd.SetContext(context.Background())
+
+			output, err := executeCommand(setup.cmd, "--status")
+
+			require.NoError(t, err)
+			require.Contains(t, output, "Stripe skills:")
+			require.Contains(t, output, tc.wantInstalled)
+			require.Contains(t, output, "installed")
+			require.NotContains(t, output, "not installed")
+			require.NotContains(t, output, tc.wantNotContain)
+			require.NotContains(t, output, "install your Stripe skills")
+		})
+	}
+}
+
+func TestAgentSetupJSONOmitsUninstalledScopeWhenOtherInstalled(t *testing.T) {
+	localDir := filepath.Join(t.TempDir(), ".agents", "skills")
+	globalDir := filepath.Join(t.TempDir(), ".agents", "skills")
+
+	tests := []struct {
+		name         string
+		currentScope string
+	}{
+		{name: "local installed omits global", currentScope: localDir},
+		{name: "global installed omits local", currentScope: globalDir},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setup := testAgentSetupCmd()
+			setup.providers = map[string]agentsetup.Provider{}
+			setup.callingAgent = func() string { return "" }
+			setup.skillsLocalDir = func() (string, error) { return localDir, nil }
+			setup.skillsGlobalDir = func() (string, error) { return globalDir, nil }
+			setup.skillsCheck = func(_ context.Context, destDir string) (*agentskills.DirStatus, error) {
+				if destDir == tc.currentScope {
+					return mockSkillsCheckCurrent(context.Background(), destDir)
+				}
+				return mockSkillsCheckNotInstalled(context.Background(), destDir)
+			}
+			setup.cmd.SetContext(context.Background())
+
+			output, err := executeCommand(setup.cmd, "--json")
+
+			require.NoError(t, err)
+
+			var result agentSetupJSON
+			require.NoError(t, json.Unmarshal([]byte(output), &result))
+			require.NotNil(t, result.Skills)
+			if tc.currentScope == localDir {
+				require.NotNil(t, result.Skills.Local)
+				require.Equal(t, agentskills.StatusCurrent, result.Skills.Local.Status)
+				require.Nil(t, result.Skills.Global)
+			} else {
+				require.NotNil(t, result.Skills.Global)
+				require.Equal(t, agentskills.StatusCurrent, result.Skills.Global.Status)
+				require.Nil(t, result.Skills.Local)
+			}
+			for _, action := range result.Actions {
+				require.NotEqual(t, "install_skills", action.Action)
+			}
+		})
+	}
 }
 
 func TestAgentSetupStatusShowsCTAWhenOutOfDate(t *testing.T) {
@@ -524,7 +627,7 @@ func TestAgentSetupStatusShowsCTAWhenOutOfDate(t *testing.T) {
 	output, err := executeCommand(setup.cmd, "--status")
 
 	require.NoError(t, err)
-	require.Contains(t, output, "out of date")
+	require.Contains(t, output, "outdated")
 	require.Contains(t, output, "Run stripe agent setup to update your Stripe skills.")
 }
 


### PR DESCRIPTION
### Reviewers
r? @jleong-stripe  
cc @stripe/developer-products

### Summary

Polishes skills status presentation in `stripe agent setup` after the core integration lands: simpler status lines, scope-aware output, and smarter install suggestions.

### What it does

**Simpler status lines** — the `--status` skill rows show a plain `installed` / `outdated` state (dropping the per-count text), and the setup TUI skills row is tidied up.

**Scope-aware display** — when one scope is installed and the other is not, show only the installed scope instead of redundant "not installed" lines. This rule is shared between the `--status` text and `--json` output so they stay consistent.

**Install suggestions** — do not suggest a skills install command when the skill is already installed in one of the scopes.

### Stack

PR 4 of 4. Depends on #1758.

### Demo
**With no supported agents**

https://github.com/user-attachments/assets/0b977371-207d-42a8-9ecd-88bf70435e16

**With a supported agent**

https://github.com/user-attachments/assets/ebbcf504-b588-4e26-98c5-8b991317d336



---
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>