### PR TITLE
Fix curl install test: use POSIX-compatible set flags

### DIFF
--- a/.github/workflows/curl-install-test.yml
+++ b/.github/workflows/curl-install-test.yml
@@ -1,0 +1,44 @@
+on:
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: 'Skip PagerDuty alert on failure'
+        type: boolean
+        default: true
+  schedule:
+    - cron: '*/10 * * * *' # Every 10 minutes
+name: Curl install test
+permissions:
+  contents: read
+jobs:
+  curl-install-macos:
+    runs-on: macos-latest
+    steps:
+      - run: |
+          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
+          export PATH="$HOME/.stripe/bin:$PATH"
+          stripe --version
+
+  curl-install-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
+          export PATH="$HOME/.stripe/bin:$PATH"
+          stripe --version
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [curl-install-macos, curl-install-linux]
+    if: always()
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/notify.sh
+          sparse-checkout-cone-mode: false
+      - run: bash scripts/notify.sh
+        env:
+          OVERALL_RESULT: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          DRYRUN: ${{ inputs.dryrun }}

--- a/.github/workflows/curl-install-test.yml
+++ b/.github/workflows/curl-install-test.yml
@@ -1,4 +1,6 @@
 on:
+  push:
+    branches: [yx-0708-1] # temporary, remove before merge
   workflow_dispatch:
     inputs:
       dryrun:
@@ -15,7 +17,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - run: |
-          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
+          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/${{ github.sha }}/scripts/install.sh | sh
           export PATH="$HOME/.stripe/bin:$PATH"
           stripe --version
 
@@ -23,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
+          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/${{ github.sha }}/scripts/install.sh | sh
           export PATH="$HOME/.stripe/bin:$PATH"
           stripe --version
 

--- a/.github/workflows/curl-install-test.yml
+++ b/.github/workflows/curl-install-test.yml
@@ -43,4 +43,8 @@ jobs:
         env:
           OVERALL_RESULT: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          PAGERDUTY_DEDUP_KEY: gh-actions-stripe-cli-curl-install-test
+          PAGERDUTY_SUMMARY: "Failed to install Stripe CLI via curl install script. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/curl-install-test.yml"
+          PAGERDUTY_RESOLVE_SUMMARY: "Stripe CLI curl install script is passing again"
+          PAGERDUTY_SEVERITY: critical
           DRYRUN: ${{ inputs.dryrun }}

--- a/.github/workflows/curl-install-test.yml
+++ b/.github/workflows/curl-install-test.yml
@@ -1,6 +1,4 @@
 on:
-  push:
-    branches: [yx-0708-1] # temporary, remove before merge
   workflow_dispatch:
     inputs:
       dryrun:
@@ -17,7 +15,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - run: |
-          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/${{ github.sha }}/scripts/install.sh | sh
+          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
           export PATH="$HOME/.stripe/bin:$PATH"
           stripe --version
 
@@ -25,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/${{ github.sha }}/scripts/install.sh | sh
+          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
           export PATH="$HOME/.stripe/bin:$PATH"
           stripe --version
 
@@ -47,4 +45,4 @@ jobs:
           PAGERDUTY_SUMMARY: "Failed to install Stripe CLI via curl install script. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/curl-install-test.yml"
           PAGERDUTY_RESOLVE_SUMMARY: "Stripe CLI curl install script is passing again"
           PAGERDUTY_SEVERITY: critical
-          DRYRUN: ${{ inputs.dryrun }}
+          DRYRUN: "true" # TODO: switch to ${{ inputs.dryrun }} once confirmed stable

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-set -euo pipefail
+set -eu
 
 INSTALL_DIR="${STRIPE_INSTALL_DIR:-$HOME/.stripe/bin}"
 GITHUB_REPO="stripe/stripe-cli"
+NEEDS_SOURCE=false
 
 main() {
   detect_platform


### PR DESCRIPTION
## Summary
- Fix the issue in curl install script that cause curl install test to fail https://github.com/stripe/stripe-cli/actions/runs/28921532950
- Re-add `curl-install-test.yml` workflow (removed by the revert in #1755)

## Test plan
- [x] Ran `curl-install-test.yml` workflow: https://github.com/stripe/stripe-cli/actions/runs/29129088350