### PR TITLE
Clean up `stripe agent setup --json` output 

### DIFF
--- a/pkg/agentsetup/cursor.go
+++ b/pkg/agentsetup/cursor.go
@@ -51,7 +51,7 @@ func (p CursorProvider) Detect() Status {
 	}
 	status.Detected = true
 	status.ExecutablePath = binPath
-	status.Status = StatusMissing
+	status.Status = StatusUnknown
 	// Signal to the TUI that this row is not actionable from the CLI.
 	status.Error = "run /add-plugin stripe inside Cursor agent"
 	return status

--- a/pkg/agentsetup/cursor_test.go
+++ b/pkg/agentsetup/cursor_test.go
@@ -20,7 +20,7 @@ func TestCursor_NotDetected(t *testing.T) {
 	require.Equal(t, StatusNotDetected, status.Status)
 }
 
-func TestCursor_DetectedAlwaysMissing(t *testing.T) {
+func TestCursor_DetectedAlwaysUnknown(t *testing.T) {
 	provider := CursorProvider{
 		Scanner: Scanner{LookPath: func(string) (string, error) { return "/usr/local/bin/cursor", nil }},
 	}
@@ -29,7 +29,7 @@ func TestCursor_DetectedAlwaysMissing(t *testing.T) {
 
 	require.True(t, status.Detected)
 	require.Equal(t, "/usr/local/bin/cursor", status.ExecutablePath)
-	require.Equal(t, StatusMissing, status.Status)
+	require.Equal(t, StatusUnknown, status.Status)
 	require.False(t, status.Plugin.Installed)
 }
 

--- a/pkg/agentsetup/provider.go
+++ b/pkg/agentsetup/provider.go
@@ -11,6 +11,7 @@ const (
 	StatusNotDetected = "not_detected"
 	StatusInstalled   = "installed"
 	StatusMissing     = "missing"
+	StatusUnknown     = "unknown"
 	StatusError       = "error"
 
 	ActionNone      = "none"

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -71,7 +71,6 @@ type agentSetupCmd struct {
 }
 
 type agentSetupJSON struct {
-	Status  string              `json:"status"`
 	Clients []agentsetup.Status `json:"clients"`
 	Skills  *skillsScopesJSON   `json:"skills,omitempty"`
 	Actions []agentsetup.Plan   `json:"actions,omitempty"`
@@ -584,7 +583,6 @@ func skillsScopeVisible(d agentskills.DirStatus, scopes skillsScopes) bool {
 
 func (asc *agentSetupCmd) writeJSON(w io.Writer, providers map[string]agentsetup.Provider, statuses []agentsetup.Status, view skillsStatusView) error {
 	result := agentSetupJSON{
-		Status:  aggregateStatus(statuses),
 		Clients: statuses,
 	}
 	for _, status := range statuses {
@@ -676,30 +674,6 @@ func detectedStatuses(statuses []agentsetup.Status) []agentsetup.Status {
 		}
 	}
 	return detected
-}
-
-// aggregateStatus collapses per-client statuses into a single headline status,
-// surfacing the most actionable state first.
-func aggregateStatus(statuses []agentsetup.Status) string {
-	var missing, installed bool
-	for _, s := range statuses {
-		switch s.Status {
-		case agentsetup.StatusError:
-			return agentsetup.StatusError
-		case agentsetup.StatusMissing:
-			missing = true
-		case agentsetup.StatusInstalled:
-			installed = true
-		}
-	}
-	switch {
-	case missing:
-		return agentsetup.StatusMissing
-	case installed:
-		return agentsetup.StatusInstalled
-	default:
-		return agentsetup.StatusNotDetected
-	}
 }
 
 // printStatusTable renders a compact, aligned, color-coded view of each client

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -62,7 +62,6 @@ func TestAgentSetupJSONReportsActionWithoutInstalling(t *testing.T) {
 
 	var result agentSetupJSON
 	require.NoError(t, json.Unmarshal([]byte(output), &result))
-	require.Equal(t, agentsetup.StatusMissing, result.Status)
 	require.Len(t, result.Clients, 1)
 	require.True(t, result.Clients[0].Detected)
 	require.False(t, result.Clients[0].Plugin.Installed)


### PR DESCRIPTION
 ### Reviewers
r? @gusnguyen-stripe 
cc @stripe/developer-products

 ### Summary
Two improvements to the machine-readable output:

1. **Remove top-level `status` field.** The aggregate status was derived by collapsing all per-client statuses into a single value, but it wasn't reliable — a single unresolved client would poison it regardless of whether anything actionable remained. Consumers can derive their own aggregate from the `clients` array if needed.

2. **Report Cursor as `status: unknown` instead of `missing`.** Cursor's plugin can't be verified from the CLI, so `missing` was misleading — it implies we checked and found nothing, when we actually can't check at all. Use`unknown` instead until we build out a proper detection method. 