### PR TITLE
Unify snapshot and thin event flags into `--events` and `--forward-to`

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -23,6 +24,8 @@ import (
 	"github.com/stripe/stripe-cli/pkg/websocket"
 )
 
+var thinEventPattern = regexp.MustCompile(`^v\d+\.`)
+
 const (
 	webhooksWebSocketFeature     = "webhooks"
 	destinationsWebSocketFeature = "v2_events"
@@ -34,13 +37,10 @@ type listenCmd struct {
 	cmd *cobra.Command
 
 	forwardURL            string
-	forwardThinURL        string
 	forwardHeaders        []string
 	forwardConnectHeaders []string
 	forwardConnectURL     string
-	forwardThinConnectURL string
 	events                []string
-	thinEvents            []string
 	latestAPIVersion      bool
 	livemode              bool
 	useConfiguredWebhooks bool
@@ -69,8 +69,8 @@ Stripe account.`,
 		Example: `stripe listen
   stripe listen --events charge.captured,charge.updated \
     --forward-to localhost:3000/events
-  stripe listen --thin-events v1.billing.meter.no_meter_found \
-    --forward-thin-to localhost:3000/thin-events`,
+  stripe listen --events v1.billing.meter.no_meter_found \
+    --forward-to localhost:3000/events`,
 		Annotations: map[string]string{
 			AIAgentHelpAnnotationKey: "  Use `--forward-to` to specify where events are sent, e.g. localhost:4242/webhook.\n" +
 				"  Use `--events` to filter to specific event types, e.g. `--events checkout.session.completed`.\n" +
@@ -81,13 +81,10 @@ Stripe account.`,
 	}
 
 	lc.cmd.Flags().StringSliceVar(&lc.forwardConnectHeaders, "connect-headers", []string{}, "A comma-separated list of custom headers to forward for Connect. Ex: \"Key1:Value1, Key2:Value2\"")
-	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{"*"}, "A comma-separated list of specific events to listen for. For a list of all possible events, see: https://stripe.com/docs/api/events/types")
-	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward webhook events to")
+	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{"*"}, "A comma-separated list of specific events to listen for. Supports both snapshot events (e.g. charge.captured) and thin events (e.g. v1.billing.meter.no_meter_found)")
+	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward events to")
 	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward. Ex: \"Key1:Value1, Key2:Value2\"")
-	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect webhook events to (default: same as normal events)")
-	lc.cmd.Flags().StringSliceVar(&lc.thinEvents, "thin-events", []string{}, "A comma-separated list of thin events to listen for.")
-	lc.cmd.Flags().StringVar(&lc.forwardThinURL, "forward-thin-to", "", "The URL to forward thin events to")
-	lc.cmd.Flags().StringVar(&lc.forwardThinConnectURL, "forward-thin-connect-to", "", "The URL to forward thin Connect events to")
+	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect events to (default: same as normal events)")
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
 	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test)")
 	lc.cmd.Flags().BoolVarP(&lc.printJSON, "print-json", "j", false, "Print full JSON objects to stdout.")
@@ -179,15 +176,17 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	proxyVisitor := lc.createVisitor(logger, lc.format, lc.printJSON)
 	proxyOutCh := make(chan websocket.IElement)
 
+	snapshotEvents, thinEvents := lc.splitEventsByType()
+
 	p, err := proxy.Init(ctx, &proxy.Config{
 		Client:                client,
 		DeviceName:            deviceName,
 		DeviceToken:           &lc.deviceToken,
 		ForwardURL:            lc.forwardURL,
-		ForwardThinURL:        lc.forwardThinURL,
+		ForwardThinURL:        lc.forwardURL,
 		ForwardHeaders:        lc.forwardHeaders,
 		ForwardConnectURL:     lc.forwardConnectURL,
-		ForwardThinConnectURL: lc.forwardThinConnectURL,
+		ForwardThinConnectURL: lc.forwardConnectURL,
 		ForwardConnectHeaders: lc.forwardConnectHeaders,
 		UseConfiguredWebhooks: lc.useConfiguredWebhooks,
 		WebSocketFeatures:     lc.getFeatures(),
@@ -197,8 +196,8 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		Log:                   logger,
 		NoWSS:                 lc.noWSS,
 		Timeout:               lc.timeout,
-		Events:                lc.events,
-		ThinEvents:            lc.thinEvents,
+		Events:                snapshotEvents,
+		ThinEvents:            thinEvents,
 		OutCh:                 proxyOutCh,
 		LoggedInAccountID:     accountID,
 	})
@@ -359,15 +358,48 @@ func (lc *listenCmd) createVisitor(logger *log.Logger, format string, printJSON 
 }
 
 func (lc *listenCmd) getFeatures() []string {
-	features := []string{}
+	needsSnapshot := false
+	needsThin := false
 
-	if len(lc.events) > 0 {
+	for _, e := range lc.events {
+		if e == "*" {
+			needsSnapshot = true
+			needsThin = true
+			break
+		}
+		if isThinEvent(e) {
+			needsThin = true
+		} else {
+			needsSnapshot = true
+		}
+	}
+
+	features := []string{}
+	if needsSnapshot {
 		features = append(features, webhooksWebSocketFeature)
 	}
-
-	if len(lc.thinEvents) > 0 {
+	if needsThin {
 		features = append(features, destinationsWebSocketFeature)
 	}
-
 	return features
+}
+
+// splitEventsByType separates the unified --events list into snapshot and thin
+// event lists for the proxy, which still uses two separate channels internally.
+func (lc *listenCmd) splitEventsByType() (snapshotEvents []string, thinEvents []string) {
+	for _, e := range lc.events {
+		if e == "*" {
+			snapshotEvents = append(snapshotEvents, "*")
+			thinEvents = append(thinEvents, "*")
+		} else if isThinEvent(e) {
+			thinEvents = append(thinEvents, e)
+		} else {
+			snapshotEvents = append(snapshotEvents, e)
+		}
+	}
+	return
+}
+
+func isThinEvent(eventType string) bool {
+	return thinEventPattern.MatchString(eventType)
 }

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -189,8 +189,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	proxyVisitor := lc.createVisitor(logger, lc.format, lc.printJSON)
 	proxyOutCh := make(chan websocket.IElement)
 
-	lc.mergeDeprecatedFlags()
-	snapshotEvents, thinEvents := lc.splitEventsByType()
+	snapshotEvents, thinEvents := lc.resolveEvents()
 
 	forwardThinURL := lc.forwardURL
 	if lc.forwardThinURL != "" {
@@ -382,7 +381,7 @@ func (lc *listenCmd) createVisitor(logger *log.Logger, format string, printJSON 
 
 func (lc *listenCmd) getFeatures() []string {
 	needsSnapshot := false
-	needsThin := false
+	needsThin := len(lc.thinEvents) > 0
 
 	for _, e := range lc.events {
 		if e == "*" {
@@ -407,10 +406,34 @@ func (lc *listenCmd) getFeatures() []string {
 	return features
 }
 
-// splitEventsByType separates the unified --events list into snapshot and thin
-// event lists for the proxy, which still uses two separate channels internally.
-func (lc *listenCmd) splitEventsByType() (snapshotEvents []string, thinEvents []string) {
-	for _, e := range lc.events {
+// resolveEvents merges deprecated --thin-events into the unified --events list,
+// then splits into snapshot and thin event lists for the proxy.
+func (lc *listenCmd) resolveEvents() (snapshotEvents []string, thinEvents []string) {
+	eventsExplicit := lc.cmd.Flags().Changed("events")
+	return mergeAndSplitEvents(lc.events, lc.thinEvents, eventsExplicit)
+}
+
+// mergeAndSplitEvents combines the events and deprecated thinEvents lists,
+// then splits into snapshot and thin event lists for the proxy.
+func mergeAndSplitEvents(events, thinEvents []string, eventsExplicit bool) (snapshotEvents []string, thinEventsOut []string) {
+	if len(thinEvents) > 0 && !eventsExplicit {
+		// --thin-events used without explicit --events: subscribe to all snapshot
+		// events (the default behavior) plus only the specified thin events.
+		return []string{"*"}, thinEvents
+	}
+
+	// Merge deprecated thin events into the unified list
+	merged := events
+	if len(thinEvents) > 0 {
+		merged = append(merged, thinEvents...)
+	}
+
+	return splitEventsByType(merged)
+}
+
+// splitEventsByType separates an event list into snapshot and thin event lists.
+func splitEventsByType(events []string) (snapshotEvents []string, thinEvents []string) {
+	for _, e := range events {
 		switch {
 		case e == "*":
 			snapshotEvents = append(snapshotEvents, "*")
@@ -426,12 +449,4 @@ func (lc *listenCmd) splitEventsByType() (snapshotEvents []string, thinEvents []
 
 func isThinEvent(eventType string) bool {
 	return thinEventPattern.MatchString(eventType)
-}
-
-// mergeDeprecatedFlags folds deprecated --thin-events values into the unified
-// --events list so the rest of the code only needs to look at lc.events.
-func (lc *listenCmd) mergeDeprecatedFlags() {
-	if len(lc.thinEvents) > 0 {
-		lc.events = append(lc.events, lc.thinEvents...)
-	}
 }

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -388,12 +388,13 @@ func (lc *listenCmd) getFeatures() []string {
 // event lists for the proxy, which still uses two separate channels internally.
 func (lc *listenCmd) splitEventsByType() (snapshotEvents []string, thinEvents []string) {
 	for _, e := range lc.events {
-		if e == "*" {
+		switch {
+		case e == "*":
 			snapshotEvents = append(snapshotEvents, "*")
 			thinEvents = append(thinEvents, "*")
-		} else if isThinEvent(e) {
+		case isThinEvent(e):
 			thinEvents = append(thinEvents, e)
-		} else {
+		default:
 			snapshotEvents = append(snapshotEvents, e)
 		}
 	}

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -53,6 +53,11 @@ type listenCmd struct {
 	noWSS                 bool
 	timeout               int64
 	deviceToken           string
+
+	// Deprecated flags (kept for backward compatibility)
+	thinEvents            []string
+	forwardThinURL        string
+	forwardThinConnectURL string
 }
 
 func newListenCmd() *listenCmd {
@@ -84,7 +89,15 @@ Stripe account.`,
 	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{"*"}, "A comma-separated list of specific events to listen for. Supports both snapshot events (e.g. charge.captured) and thin events (e.g. v1.billing.meter.no_meter_found)")
 	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward events to")
 	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward. Ex: \"Key1:Value1, Key2:Value2\"")
-	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect events to (default: same as normal events)")
+	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect events to (default: same as --forward-to)")
+
+	// Deprecated flags
+	lc.cmd.Flags().StringSliceVar(&lc.thinEvents, "thin-events", []string{}, "A comma-separated list of thin events to listen for.")
+	lc.cmd.Flags().MarkDeprecated("thin-events", "use --events instead, which now accepts both snapshot and thin event types")
+	lc.cmd.Flags().StringVar(&lc.forwardThinURL, "forward-thin-to", "", "The URL to forward thin events to")
+	lc.cmd.Flags().MarkDeprecated("forward-thin-to", "use --forward-to instead, which now forwards both snapshot and thin events")
+	lc.cmd.Flags().StringVar(&lc.forwardThinConnectURL, "forward-thin-connect-to", "", "The URL to forward thin Connect events to")
+	lc.cmd.Flags().MarkDeprecated("forward-thin-connect-to", "use --forward-connect-to instead")
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
 	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test)")
 	lc.cmd.Flags().BoolVarP(&lc.printJSON, "print-json", "j", false, "Print full JSON objects to stdout.")
@@ -176,17 +189,27 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	proxyVisitor := lc.createVisitor(logger, lc.format, lc.printJSON)
 	proxyOutCh := make(chan websocket.IElement)
 
+	lc.mergeDeprecatedFlags()
 	snapshotEvents, thinEvents := lc.splitEventsByType()
+
+	forwardThinURL := lc.forwardURL
+	if lc.forwardThinURL != "" {
+		forwardThinURL = lc.forwardThinURL
+	}
+	forwardThinConnectURL := lc.forwardConnectURL
+	if lc.forwardThinConnectURL != "" {
+		forwardThinConnectURL = lc.forwardThinConnectURL
+	}
 
 	p, err := proxy.Init(ctx, &proxy.Config{
 		Client:                client,
 		DeviceName:            deviceName,
 		DeviceToken:           &lc.deviceToken,
 		ForwardURL:            lc.forwardURL,
-		ForwardThinURL:        lc.forwardURL,
+		ForwardThinURL:        forwardThinURL,
 		ForwardHeaders:        lc.forwardHeaders,
 		ForwardConnectURL:     lc.forwardConnectURL,
-		ForwardThinConnectURL: lc.forwardConnectURL,
+		ForwardThinConnectURL: forwardThinConnectURL,
 		ForwardConnectHeaders: lc.forwardConnectHeaders,
 		UseConfiguredWebhooks: lc.useConfiguredWebhooks,
 		WebSocketFeatures:     lc.getFeatures(),
@@ -403,4 +426,12 @@ func (lc *listenCmd) splitEventsByType() (snapshotEvents []string, thinEvents []
 
 func isThinEvent(eventType string) bool {
 	return thinEventPattern.MatchString(eventType)
+}
+
+// mergeDeprecatedFlags folds deprecated --thin-events values into the unified
+// --events list so the rest of the code only needs to look at lc.events.
+func (lc *listenCmd) mergeDeprecatedFlags() {
+	if len(lc.thinEvents) > 0 {
+		lc.events = append(lc.events, lc.thinEvents...)
+	}
 }

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsThinEvent(t *testing.T) {
+	tests := []struct {
+		eventType string
+		want      bool
+	}{
+		{"v1.billing.meter.no_meter_found", true},
+		{"v2.core.account.created", true},
+		{"v1.some.event", true},
+		{"charge.captured", false},
+		{"customer.created", false},
+		{"payment_intent.succeeded", false},
+		{"*", false},
+		{"", false},
+		{"v1", false},
+		{"v1.", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.eventType, func(t *testing.T) {
+			got := isThinEvent(tt.eventType)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSplitEventsByType(t *testing.T) {
+	tests := []struct {
+		name              string
+		events            []string
+		wantSnapshot      []string
+		wantThin          []string
+	}{
+		{
+			name:         "wildcard splits to both",
+			events:       []string{"*"},
+			wantSnapshot: []string{"*"},
+			wantThin:     []string{"*"},
+		},
+		{
+			name:         "snapshot events only",
+			events:       []string{"charge.captured", "customer.created"},
+			wantSnapshot: []string{"charge.captured", "customer.created"},
+			wantThin:     nil,
+		},
+		{
+			name:         "thin events only",
+			events:       []string{"v1.billing.meter.no_meter_found", "v2.core.account.created"},
+			wantSnapshot: nil,
+			wantThin:     []string{"v1.billing.meter.no_meter_found", "v2.core.account.created"},
+		},
+		{
+			name:         "mixed events",
+			events:       []string{"charge.captured", "v1.billing.meter.no_meter_found"},
+			wantSnapshot: []string{"charge.captured"},
+			wantThin:     []string{"v1.billing.meter.no_meter_found"},
+		},
+		{
+			name:         "empty events returns nil",
+			events:       []string{},
+			wantSnapshot: nil,
+			wantThin:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := &listenCmd{events: tt.events}
+			snapshot, thin := lc.splitEventsByType()
+			assert.Equal(t, tt.wantSnapshot, snapshot)
+			assert.Equal(t, tt.wantThin, thin)
+		})
+	}
+}
+
+func TestGetFeatures(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []string
+		want   []string
+	}{
+		{
+			name:   "wildcard opens both channels",
+			events: []string{"*"},
+			want:   []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
+		},
+		{
+			name:   "snapshot events only opens webhooks",
+			events: []string{"charge.captured"},
+			want:   []string{webhooksWebSocketFeature},
+		},
+		{
+			name:   "thin events only opens v2_events",
+			events: []string{"v1.billing.meter.no_meter_found"},
+			want:   []string{destinationsWebSocketFeature},
+		},
+		{
+			name:   "mixed events opens both",
+			events: []string{"charge.captured", "v1.billing.meter.no_meter_found"},
+			want:   []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := &listenCmd{events: tt.events}
+			got := lc.getFeatures()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -72,8 +72,7 @@ func TestSplitEventsByType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lc := &listenCmd{events: tt.events}
-			snapshot, thin := lc.splitEventsByType()
+			snapshot, thin := splitEventsByType(tt.events)
 			assert.Equal(t, tt.wantSnapshot, snapshot)
 			assert.Equal(t, tt.wantThin, thin)
 		})
@@ -117,41 +116,62 @@ func TestGetFeatures(t *testing.T) {
 	}
 }
 
-func TestMergeDeprecatedFlags(t *testing.T) {
+func TestMergeAndSplitEvents(t *testing.T) {
 	tests := []struct {
-		name       string
-		events     []string
-		thinEvents []string
-		wantEvents []string
+		name           string
+		events         []string
+		thinEvents     []string
+		eventsExplicit bool
+		wantSnapshot   []string
+		wantThin       []string
 	}{
 		{
-			name:       "thin-events merged into events",
-			events:     []string{"*"},
-			thinEvents: []string{"v1.billing.meter.no_meter_found"},
-			wantEvents: []string{"*", "v1.billing.meter.no_meter_found"},
+			name:           "thin-events without explicit --events: snapshot wildcard + specific thin",
+			events:         []string{"*"},
+			thinEvents:     []string{"v1.billing.meter.no_meter_found"},
+			eventsExplicit: false,
+			wantSnapshot:   []string{"*"},
+			wantThin:       []string{"v1.billing.meter.no_meter_found"},
 		},
 		{
-			name:       "no thin-events leaves events unchanged",
-			events:     []string{"charge.captured"},
-			thinEvents: []string{},
-			wantEvents: []string{"charge.captured"},
+			name:           "thin-events with explicit --events: merged and split",
+			events:         []string{"charge.captured"},
+			thinEvents:     []string{"v1.billing.meter.no_meter_found"},
+			eventsExplicit: true,
+			wantSnapshot:   []string{"charge.captured"},
+			wantThin:       []string{"v1.billing.meter.no_meter_found"},
 		},
 		{
-			name:       "only thin-events",
-			events:     []string{"*"},
-			thinEvents: []string{"v1.billing.meter.no_meter_found", "v2.core.account.created"},
-			wantEvents: []string{"*", "v1.billing.meter.no_meter_found", "v2.core.account.created"},
+			name:           "thin-events with explicit wildcard --events: all of both",
+			events:         []string{"*"},
+			thinEvents:     []string{"v1.billing.meter.no_meter_found"},
+			eventsExplicit: true,
+			wantSnapshot:   []string{"*"},
+			wantThin:       []string{"*", "v1.billing.meter.no_meter_found"},
+		},
+		{
+			name:           "no thin-events: normal split",
+			events:         []string{"charge.captured"},
+			thinEvents:     []string{},
+			eventsExplicit: true,
+			wantSnapshot:   []string{"charge.captured"},
+			wantThin:       nil,
+		},
+		{
+			name:           "no thin-events with wildcard: both channels",
+			events:         []string{"*"},
+			thinEvents:     []string{},
+			eventsExplicit: false,
+			wantSnapshot:   []string{"*"},
+			wantThin:       []string{"*"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lc := &listenCmd{
-				events:     tt.events,
-				thinEvents: tt.thinEvents,
-			}
-			lc.mergeDeprecatedFlags()
-			assert.Equal(t, tt.wantEvents, lc.events)
+			snapshot, thin := mergeAndSplitEvents(tt.events, tt.thinEvents, tt.eventsExplicit)
+			assert.Equal(t, tt.wantSnapshot, snapshot)
+			assert.Equal(t, tt.wantThin, thin)
 		})
 	}
 }

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -116,3 +116,42 @@ func TestGetFeatures(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeDeprecatedFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		events     []string
+		thinEvents []string
+		wantEvents []string
+	}{
+		{
+			name:       "thin-events merged into events",
+			events:     []string{"*"},
+			thinEvents: []string{"v1.billing.meter.no_meter_found"},
+			wantEvents: []string{"*", "v1.billing.meter.no_meter_found"},
+		},
+		{
+			name:       "no thin-events leaves events unchanged",
+			events:     []string{"charge.captured"},
+			thinEvents: []string{},
+			wantEvents: []string{"charge.captured"},
+		},
+		{
+			name:       "only thin-events",
+			events:     []string{"*"},
+			thinEvents: []string{"v1.billing.meter.no_meter_found", "v2.core.account.created"},
+			wantEvents: []string{"*", "v1.billing.meter.no_meter_found", "v2.core.account.created"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := &listenCmd{
+				events:     tt.events,
+				thinEvents: tt.thinEvents,
+			}
+			lc.mergeDeprecatedFlags()
+			assert.Equal(t, tt.wantEvents, lc.events)
+		})
+	}
+}

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -33,10 +33,10 @@ func TestIsThinEvent(t *testing.T) {
 
 func TestSplitEventsByType(t *testing.T) {
 	tests := []struct {
-		name              string
-		events            []string
-		wantSnapshot      []string
-		wantThin          []string
+		name         string
+		events       []string
+		wantSnapshot []string
+		wantThin     []string
 	}{
 		{
 			name:         "wildcard splits to both",


### PR DESCRIPTION
## Summary
Unify --events and --thin-events into a single --events flag that accepts both snapshot and thin event types. The CLI auto-detects the type from the event name pattern (^v\d+\. = thin).

  - `--thin-events`, `--forward-thin-to`, `--forward-thin-connect-to` are deprecated (still work, print a warning)
  - `--forward-to` forwards both payload styles to the same destination
  - `*`  opens both websocket channels (snapshot + thin)

  Before:
 ```
  stripe listen --events charge.captured --forward-to localhost:4242
  stripe listen --thin-events v1.billing.meter.no_meter_found --forward-thin-to localhost:4242
```

  After:
```
  stripe listen -e charge.captured,v1.billing.meter.no_meter_found --forward-to localhost:4242
```


## Testing
- [X] Added automated tests in pkg/cmd/listen_test.go
- [X] Manually verified `stripe listen -e charge.captured,v1.billing.meter.no_meter_found --forward-to localhost:4242` receives and forwards both event types
- [X] Manually verified deprecated flags still work and print a warning instructing users to use `--events` and `--forward-to`