### PR TITLE
Add `--events-from` flag to control event source filtering

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -40,6 +40,7 @@ type listenCmd struct {
 	forwardHeaders        []string
 	forwardConnectHeaders []string
 	forwardConnectURL     string
+	eventsFrom            string
 	events                []string
 	latestAPIVersion      bool
 	livemode              bool
@@ -75,7 +76,9 @@ Stripe account.`,
   stripe listen --events charge.captured,charge.updated \
     --forward-to localhost:3000/events
   stripe listen --events v1.billing.meter.no_meter_found \
-    --forward-to localhost:3000/events`,
+    --forward-to localhost:3000/events
+  stripe listen --events v2.core.account.created \
+    --events-from accounts --forward-to localhost:3000/events`,
 		Annotations: map[string]string{
 			AIAgentHelpAnnotationKey: "  Use `--forward-to` to specify where events are sent, e.g. localhost:4242/webhook.\n" +
 				"  Use `--events` to filter to specific event types, e.g. `--events checkout.session.completed`.\n" +
@@ -87,6 +90,7 @@ Stripe account.`,
 
 	lc.cmd.Flags().StringSliceVar(&lc.forwardConnectHeaders, "connect-headers", []string{}, "A comma-separated list of custom headers to forward for Connect. Ex: \"Key1:Value1, Key2:Value2\"")
 	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{"*"}, "A comma-separated list of specific events to listen for. Supports both snapshot events (e.g. charge.captured) and thin events (e.g. v1.billing.meter.no_meter_found)")
+	lc.cmd.Flags().StringVar(&lc.eventsFrom, "events-from", "all", "Event source filter: 'self' (your account only), 'accounts' (connected accounts only), or 'all' (default)")
 	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward events to")
 	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward. Ex: \"Key1:Value1, Key2:Value2\"")
 	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect events to (default: same as --forward-to)")
@@ -190,12 +194,13 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	proxyOutCh := make(chan websocket.IElement)
 
 	snapshotEvents, thinEvents := lc.resolveEvents()
+	directURL, connectURL := lc.resolveForwardURLs()
 
-	forwardThinURL := lc.forwardURL
+	forwardThinURL := directURL
 	if lc.forwardThinURL != "" {
 		forwardThinURL = lc.forwardThinURL
 	}
-	forwardThinConnectURL := lc.forwardConnectURL
+	forwardThinConnectURL := connectURL
 	if lc.forwardThinConnectURL != "" {
 		forwardThinConnectURL = lc.forwardThinConnectURL
 	}
@@ -204,10 +209,10 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		Client:                client,
 		DeviceName:            deviceName,
 		DeviceToken:           &lc.deviceToken,
-		ForwardURL:            lc.forwardURL,
+		ForwardURL:            directURL,
 		ForwardThinURL:        forwardThinURL,
 		ForwardHeaders:        lc.forwardHeaders,
-		ForwardConnectURL:     lc.forwardConnectURL,
+		ForwardConnectURL:     connectURL,
 		ForwardThinConnectURL: forwardThinConnectURL,
 		ForwardConnectHeaders: lc.forwardConnectHeaders,
 		UseConfiguredWebhooks: lc.useConfiguredWebhooks,
@@ -449,4 +454,27 @@ func splitEventsByType(events []string) (snapshotEvents []string, thinEvents []s
 
 func isThinEvent(eventType string) bool {
 	return thinEventPattern.MatchString(eventType)
+}
+
+// resolveForwardURLs determines the direct and connect forwarding URLs based on
+// the --events-from flag and the --forward-to / --forward-connect-to flags.
+func (lc *listenCmd) resolveForwardURLs() (directURL, connectURL string) {
+	switch lc.eventsFrom {
+	case "self":
+		directURL = lc.forwardURL
+		connectURL = ""
+	case "accounts":
+		directURL = ""
+		connectURL = lc.forwardURL
+		if lc.forwardConnectURL != "" {
+			connectURL = lc.forwardConnectURL
+		}
+	default: // "all"
+		directURL = lc.forwardURL
+		connectURL = lc.forwardConnectURL
+		if connectURL == "" {
+			connectURL = lc.forwardURL
+		}
+	}
+	return
 }

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -78,7 +78,7 @@ Stripe account.`,
   stripe listen --events v1.billing.meter.no_meter_found \
     --forward-to localhost:3000/events
   stripe listen --events v2.core.account.created \
-    --events-from accounts --forward-to localhost:3000/events`,
+    --events-from @accounts --forward-to localhost:3000/events`,
 		Annotations: map[string]string{
 			AIAgentHelpAnnotationKey: "  Use `--forward-to` to specify where events are sent, e.g. localhost:4242/webhook.\n" +
 				"  Use `--events` to filter to specific event types, e.g. `--events checkout.session.completed`.\n" +
@@ -90,7 +90,7 @@ Stripe account.`,
 
 	lc.cmd.Flags().StringSliceVar(&lc.forwardConnectHeaders, "connect-headers", []string{}, "A comma-separated list of custom headers to forward for Connect. Ex: \"Key1:Value1, Key2:Value2\"")
 	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{"*"}, "A comma-separated list of specific events to listen for. Supports both snapshot events (e.g. charge.captured) and thin events (e.g. v1.billing.meter.no_meter_found)")
-	lc.cmd.Flags().StringVar(&lc.eventsFrom, "events-from", "all", "Event source filter: 'self' (your account only), 'accounts' (connected accounts only), or 'all' (default)")
+	lc.cmd.Flags().StringVar(&lc.eventsFrom, "events-from", "all", "Event source filter: '@self' (your account only), '@accounts' (connected accounts only), or 'all' (default)")
 	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward events to")
 	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward. Ex: \"Key1:Value1, Key2:Value2\"")
 	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect events to (default: same as --forward-to)")
@@ -460,10 +460,10 @@ func isThinEvent(eventType string) bool {
 // the --events-from flag and the --forward-to / --forward-connect-to flags.
 func (lc *listenCmd) resolveForwardURLs() (directURL, connectURL string) {
 	switch lc.eventsFrom {
-	case "self":
+	case "@self":
 		directURL = lc.forwardURL
 		connectURL = ""
-	case "accounts":
+	case "@accounts":
 		directURL = ""
 		connectURL = lc.forwardURL
 		if lc.forwardConnectURL != "" {

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -14,13 +14,13 @@ func TestIsThinEvent(t *testing.T) {
 		{"v1.billing.meter.no_meter_found", true},
 		{"v2.core.account.created", true},
 		{"v1.some.event", true},
+		{"v1.", true},
 		{"charge.captured", false},
 		{"customer.created", false},
 		{"payment_intent.succeeded", false},
 		{"*", false},
 		{"", false},
 		{"v1", false},
-		{"v1.", true},
 	}
 
 	for _, tt := range tests {
@@ -172,6 +172,75 @@ func TestMergeAndSplitEvents(t *testing.T) {
 			snapshot, thin := mergeAndSplitEvents(tt.events, tt.thinEvents, tt.eventsExplicit)
 			assert.Equal(t, tt.wantSnapshot, snapshot)
 			assert.Equal(t, tt.wantThin, thin)
+		})
+	}
+}
+
+func TestResolveForwardURLs(t *testing.T) {
+	tests := []struct {
+		name           string
+		eventsFrom     string
+		forwardURL     string
+		forwardConnect string
+		wantDirect     string
+		wantConnect    string
+	}{
+		{
+			name:        "@self routes to direct only",
+			eventsFrom:  "@self",
+			forwardURL:  "http://localhost:3000",
+			wantDirect:  "http://localhost:3000",
+			wantConnect: "",
+		},
+		{
+			name:        "@accounts routes to connect",
+			eventsFrom:  "@accounts",
+			forwardURL:  "http://localhost:3000",
+			wantDirect:  "",
+			wantConnect: "http://localhost:3000",
+		},
+		{
+			name:           "@accounts prefers forward-connect-to if set",
+			eventsFrom:     "@accounts",
+			forwardURL:     "http://localhost:3000",
+			forwardConnect: "http://localhost:4000",
+			wantDirect:     "",
+			wantConnect:    "http://localhost:4000",
+		},
+		{
+			name:        "all routes to both using forward-to",
+			eventsFrom:  "all",
+			forwardURL:  "http://localhost:3000",
+			wantDirect:  "http://localhost:3000",
+			wantConnect: "http://localhost:3000",
+		},
+		{
+			name:           "all uses forward-connect-to for connect if set",
+			eventsFrom:     "all",
+			forwardURL:     "http://localhost:3000",
+			forwardConnect: "http://localhost:4000",
+			wantDirect:     "http://localhost:3000",
+			wantConnect:    "http://localhost:4000",
+		},
+		{
+			name:        "default (empty) behaves like all",
+			eventsFrom:  "",
+			forwardURL:  "http://localhost:3000",
+			wantDirect:  "http://localhost:3000",
+			wantConnect: "http://localhost:3000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := &listenCmd{
+				eventsFrom:        tt.eventsFrom,
+				forwardURL:        tt.forwardURL,
+				forwardConnectURL: tt.forwardConnect,
+			}
+			direct, connect := lc.resolveForwardURLs()
+			assert.Equal(t, tt.wantDirect, direct)
+			assert.Equal(t, tt.wantConnect, connect)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
 Adds `--events-from` flag to `stripe listen` based on our [design](https://docs.google.com/document/d/1khdjM35uRcYnn0SKigf7aI3pXzVQbPLNkim02I4h62w/edit?tab=t.0#heading=h.941p0giewh), matching the `/v2/core/event_destinations` API convention:
  
  - `--events-from @self` — forward only your account's events
  - `--events-from @accounts` — forward only connected account events
  - `--events-from all` — forward both (default, backward compatible)
  
The flag controls forwarding routing — all events are still displayed in the CLI output regardless of the filter.
  `--forward-connect-to` remains available for routing connect events to a separate URL.


 
## Test plan
  
  - [x] Unit tests for `resolveForwardURLs()` covering all `--events-from` values
  - [x] `--events-from @self`: verified self-account events forward
<img width="1251" height="619" alt="Screenshot 2026-07-16 at 2 37 55 PM" src="https://github.com/user-attachments/assets/6b2fbf15-7472-41c5-bfb5-345d446b147f" />

  - [x]  `--events-from @accounts`: verified connected account events forward, self account events do not. We created a customer on the connected account which triggered a `customer.created` event, and we manually triggered a `payment_intent.succeeded` event for the self account. The screenshot below shows only the `customer.created` event got forwarded. 
<img width="1239" height="580" alt="Screenshot 2026-07-16 at 2 43 21 PM" src="https://github.com/user-attachments/assets/4f536347-518f-4834-9698-a1ae239eee21" /> 

 - [x]  `--events-from all`: verified both self and connected account events forward
<img width="1249" height="651" alt="Screenshot 2026-07-16 at 2 41 23 PM" src="https://github.com/user-attachments/assets/655de8d7-d4cd-4339-b46a-f0efc856f6b4" />

  - [x] Default behavior (no flag) : verified existing behavior does not change 
  <img width="1250" height="619" alt="Screenshot 2026-07-16 at 2 39 46 PM" src="https://github.com/user-attachments/assets/a73617cb-028f-456a-b2af-350c6c0f0f2c" />

  - [x] `stripe listen --help` shows `--events-from` with description 
