### PR TITLE
Add `--all-snapshot` and `--all-thin` flags for event subscriptions

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -42,6 +42,8 @@ type listenCmd struct {
 	forwardConnectURL     string
 	eventsFrom            string
 	events                []string
+	allSnapshot           bool
+	allThin               bool
 	latestAPIVersion      bool
 	livemode              bool
 	useConfiguredWebhooks bool
@@ -73,12 +75,12 @@ local machine by connecting directly to Stripe's API. You can test the latest
 API version, filter events, or even load your saved webhook endpoints from your
 Stripe account.`,
 		Example: `stripe listen
-  stripe listen --events charge.captured,charge.updated \
+  stripe listen --all-snapshot --forward-to localhost:3000/events
+  stripe listen --all-thin --forward-to localhost:3000/events
+  stripe listen --events charge.captured,v1.billing.meter.no_meter_found \
     --forward-to localhost:3000/events
-  stripe listen --events v1.billing.meter.no_meter_found \
-    --forward-to localhost:3000/events
-  stripe listen --events v2.core.account.created \
-    --events-from @accounts --forward-to localhost:3000/events`,
+  stripe listen --all-thin --events-from @accounts \
+    --forward-to localhost:3000/events`,
 		Annotations: map[string]string{
 			AIAgentHelpAnnotationKey: "  Use `--forward-to` to specify where events are sent, e.g. localhost:4242/webhook.\n" +
 				"  Use `--events` to filter to specific event types, e.g. `--events checkout.session.completed`.\n" +
@@ -89,7 +91,9 @@ Stripe account.`,
 	}
 
 	lc.cmd.Flags().StringSliceVar(&lc.forwardConnectHeaders, "connect-headers", []string{}, "A comma-separated list of custom headers to forward for Connect. Ex: \"Key1:Value1, Key2:Value2\"")
-	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{"*"}, "A comma-separated list of specific events to listen for. Supports both snapshot events (e.g. charge.captured) and thin events (e.g. v1.billing.meter.no_meter_found)")
+	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{}, "A comma-separated list of specific events to listen for. Supports both snapshot events (e.g. charge.captured) and thin events (e.g. v1.billing.meter.no_meter_found)")
+	lc.cmd.Flags().BoolVar(&lc.allSnapshot, "all-snapshot", false, "Subscribe to all snapshot events")
+	lc.cmd.Flags().BoolVar(&lc.allThin, "all-thin", false, "Subscribe to all thin events")
 	lc.cmd.Flags().StringVar(&lc.eventsFrom, "events-from", "all", "Event source filter: '@self' (your account only), '@accounts' (connected accounts only), or 'all' (default)")
 	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward events to")
 	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward. Ex: \"Key1:Value1, Key2:Value2\"")
@@ -385,20 +389,21 @@ func (lc *listenCmd) createVisitor(logger *log.Logger, format string, printJSON 
 }
 
 func (lc *listenCmd) getFeatures() []string {
-	needsSnapshot := false
-	needsThin := len(lc.thinEvents) > 0
+	needsSnapshot := lc.allSnapshot
+	needsThin := lc.allThin || len(lc.thinEvents) > 0
 
 	for _, e := range lc.events {
-		if e == "*" {
-			needsSnapshot = true
-			needsThin = true
-			break
-		}
 		if isThinEvent(e) {
 			needsThin = true
 		} else {
 			needsSnapshot = true
 		}
+	}
+
+	// bare "stripe listen" with no event flags opens both channels
+	if !needsSnapshot && !needsThin {
+		needsSnapshot = true
+		needsThin = true
 	}
 
 	features := []string{}
@@ -415,12 +420,12 @@ func (lc *listenCmd) getFeatures() []string {
 // then splits into snapshot and thin event lists for the proxy.
 func (lc *listenCmd) resolveEvents() (snapshotEvents []string, thinEvents []string) {
 	eventsExplicit := lc.cmd.Flags().Changed("events")
-	return mergeAndSplitEvents(lc.events, lc.thinEvents, eventsExplicit)
+	return mergeAndSplitEvents(lc.events, lc.thinEvents, eventsExplicit, lc.allSnapshot, lc.allThin)
 }
 
 // mergeAndSplitEvents combines the events and deprecated thinEvents lists,
 // then splits into snapshot and thin event lists for the proxy.
-func mergeAndSplitEvents(events, thinEvents []string, eventsExplicit bool) (snapshotEvents []string, thinEventsOut []string) {
+func mergeAndSplitEvents(events, thinEvents []string, eventsExplicit, allSnapshot, allThin bool) (snapshotEvents []string, thinEventsOut []string) {
 	if len(thinEvents) > 0 && !eventsExplicit {
 		// --thin-events used without explicit --events: subscribe to all snapshot
 		// events (the default behavior) plus only the specified thin events.
@@ -433,11 +438,18 @@ func mergeAndSplitEvents(events, thinEvents []string, eventsExplicit bool) (snap
 		merged = append(merged, thinEvents...)
 	}
 
-	return splitEventsByType(merged)
+	return splitEventsByType(merged, allSnapshot, allThin)
 }
 
 // splitEventsByType separates an event list into snapshot and thin event lists.
-func splitEventsByType(events []string) (snapshotEvents []string, thinEvents []string) {
+func splitEventsByType(events []string, allSnapshot, allThin bool) (snapshotEvents []string, thinEvents []string) {
+	if allSnapshot {
+		snapshotEvents = append(snapshotEvents, "*")
+	}
+	if allThin {
+		thinEvents = append(thinEvents, "*")
+	}
+
 	for _, e := range events {
 		switch {
 		case e == "*":
@@ -449,6 +461,13 @@ func splitEventsByType(events []string) (snapshotEvents []string, thinEvents []s
 			snapshotEvents = append(snapshotEvents, e)
 		}
 	}
+
+	// bare "stripe listen" with no event flags subscribes to everything
+	if len(snapshotEvents) == 0 && len(thinEvents) == 0 {
+		snapshotEvents = []string{"*"}
+		thinEvents = []string{"*"}
+	}
+
 	return
 }
 

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -35,13 +35,51 @@ func TestSplitEventsByType(t *testing.T) {
 	tests := []struct {
 		name         string
 		events       []string
+		allSnapshot  bool
+		allThin      bool
 		wantSnapshot []string
 		wantThin     []string
 	}{
 		{
-			name:         "wildcard splits to both",
-			events:       []string{"*"},
+			name:         "bare listen with no flags subscribes to everything",
+			events:       []string{},
 			wantSnapshot: []string{"*"},
+			wantThin:     []string{"*"},
+		},
+		{
+			name:         "all-snapshot adds wildcard for snapshot",
+			allSnapshot:  true,
+			events:       []string{},
+			wantSnapshot: []string{"*"},
+			wantThin:     nil,
+		},
+		{
+			name:         "all-thin adds wildcard for thin",
+			allThin:      true,
+			events:       []string{},
+			wantSnapshot: nil,
+			wantThin:     []string{"*"},
+		},
+		{
+			name:         "both all-snapshot and all-thin",
+			allSnapshot:  true,
+			allThin:      true,
+			events:       []string{},
+			wantSnapshot: []string{"*"},
+			wantThin:     []string{"*"},
+		},
+		{
+			name:         "all-snapshot with specific thin events",
+			allSnapshot:  true,
+			events:       []string{"v1.billing.meter.no_meter_found"},
+			wantSnapshot: []string{"*"},
+			wantThin:     []string{"v1.billing.meter.no_meter_found"},
+		},
+		{
+			name:         "all-thin with specific snapshot events",
+			allThin:      true,
+			events:       []string{"charge.captured"},
+			wantSnapshot: []string{"charge.captured"},
 			wantThin:     []string{"*"},
 		},
 		{
@@ -62,17 +100,11 @@ func TestSplitEventsByType(t *testing.T) {
 			wantSnapshot: []string{"charge.captured"},
 			wantThin:     []string{"v1.billing.meter.no_meter_found"},
 		},
-		{
-			name:         "empty events returns nil",
-			events:       []string{},
-			wantSnapshot: nil,
-			wantThin:     nil,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			snapshot, thin := splitEventsByType(tt.events)
+			snapshot, thin := splitEventsByType(tt.events, tt.allSnapshot, tt.allThin)
 			assert.Equal(t, tt.wantSnapshot, snapshot)
 			assert.Equal(t, tt.wantThin, thin)
 		})
@@ -81,14 +113,31 @@ func TestSplitEventsByType(t *testing.T) {
 
 func TestGetFeatures(t *testing.T) {
 	tests := []struct {
-		name   string
-		events []string
-		want   []string
+		name        string
+		events      []string
+		allSnapshot bool
+		allThin     bool
+		want        []string
 	}{
 		{
-			name:   "wildcard opens both channels",
-			events: []string{"*"},
-			want:   []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
+			name: "bare listen opens both channels",
+			want: []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
+		},
+		{
+			name:        "all-snapshot opens webhooks only",
+			allSnapshot: true,
+			want:        []string{webhooksWebSocketFeature},
+		},
+		{
+			name:    "all-thin opens v2_events only",
+			allThin: true,
+			want:    []string{destinationsWebSocketFeature},
+		},
+		{
+			name:        "both all flags open both channels",
+			allSnapshot: true,
+			allThin:     true,
+			want:        []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
 		},
 		{
 			name:   "snapshot events only opens webhooks",
@@ -109,7 +158,11 @@ func TestGetFeatures(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lc := &listenCmd{events: tt.events}
+			lc := &listenCmd{
+				events:      tt.events,
+				allSnapshot: tt.allSnapshot,
+				allThin:     tt.allThin,
+			}
 			got := lc.getFeatures()
 			assert.Equal(t, tt.want, got)
 		})
@@ -169,7 +222,7 @@ func TestMergeAndSplitEvents(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			snapshot, thin := mergeAndSplitEvents(tt.events, tt.thinEvents, tt.eventsExplicit)
+			snapshot, thin := mergeAndSplitEvents(tt.events, tt.thinEvents, tt.eventsExplicit, false, false)
 			assert.Equal(t, tt.wantSnapshot, snapshot)
 			assert.Equal(t, tt.wantThin, thin)
 		})


### PR DESCRIPTION
## Summary
Adds `--all-snapshot` and `--all-thin` flags to `stripe listen` for explicit wildcard control over event subscriptions:
  
  - `--all-snapshot`: subscribe to all snapshot events 
  - `--all-thin`:  subscribe to all thin events 
  - Bare `stripe listen` (no flags):  subscribe to everything, same as before
    
  ## Test plan
  
  - [x] Unit tests for `splitEventsByType()` with `allSnapshot`/`allThin` combinations
  - [x] Unit tests for `getFeatures()` verifying correct WebSocket channels open
  - [x] `--all-snapshot`: only snapshot events forwarded 
 
<img width="1078" height="489" alt="Screenshot 2026-07-16 at 3 34 21 PM" src="https://github.com/user-attachments/assets/b6d0ad1a-2748-4203-af43-dfe18bde5227" />

  - [x] `--all-thin`: only thin events forwarded
 
<img width="1078" height="460" alt="Screenshot 2026-07-16 at 3 35 37 PM" src="https://github.com/user-attachments/assets/64007833-1fcc-487a-8bdd-48bc5ea10939" />


  - [x] Bare `stripe listen`: both snapshot & thin events
  
<img width="1074" height="498" alt="Screenshot 2026-07-16 at 3 36 53 PM" src="https://github.com/user-attachments/assets/928cd170-13dd-4c03-a2c2-371a8ad7f54b" />

  - [x] `--all-snapshot --events v1.billing.meter.no_meter_found`: all snapshot + specific thin event
 
<img width="1036" height="279" alt="Screenshot 2026-07-16 at 3 51 40 PM" src="https://github.com/user-attachments/assets/fc135c8d-d764-4359-91ca-2cbe3bd9ff2a" />

  - [x] `stripe listen --help` shows both new flags

