### PR TITLE
Add plugin resolution source telemetry

### DIFF
--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -628,11 +628,6 @@ func findPlugin(pluginList PluginList, pluginName string) (Plugin, error) {
 	return Plugin{}, fmt.Errorf("could not find a plugin named %s", pluginName)
 }
 
-func selectPluginForUpgrade(localPlugin, manifestPlugin *Plugin) *Plugin {
-	plugin, _ := selectPluginForUpgradeWithSource(localPlugin, manifestPlugin, pluginResolutionSourceCachedManifest)
-	return plugin
-}
-
 func selectPluginForUpgradeWithSource(localPlugin, manifestPlugin *Plugin, manifestSource pluginResolutionSource) (*Plugin, pluginResolutionSource) {
 	switch {
 	case localPlugin == nil:

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -46,6 +46,43 @@ type ResolvedPluginVersion struct {
 	BinaryURL string
 }
 
+type pluginResolutionSource string
+
+const (
+	pluginResolutionEventName = "Plugin Resolution"
+
+	pluginResolutionSourceMetadataEndpoint pluginResolutionSource = "metadata_endpoint"
+	pluginResolutionSourceRemoteManifest   pluginResolutionSource = "remote_manifest"
+	pluginResolutionSourceCachedManifest   pluginResolutionSource = "cached_manifest"
+	pluginResolutionSourceLocalMetadata    pluginResolutionSource = "local_metadata"
+)
+
+// emitPluginResolutionTelemetry records which source was used to resolve a plugin.
+// This is temporary telemetry to measure plugins.toml fallback usage before the
+// legacy manifest path is removed.
+func emitPluginResolutionTelemetry(ctx context.Context, pluginName string, source pluginResolutionSource) {
+	if ctx == nil || pluginName == "" || source == "" {
+		return
+	}
+
+	telemetryClient := stripe.GetTelemetryClient(ctx)
+	if telemetryClient == nil {
+		return
+	}
+
+	metadata := stripe.GetEventMetadata(ctx)
+	if metadata == nil {
+		return
+	}
+
+	metadataCopy := *metadata
+	metadataCopy.SetPluginName(pluginName)
+	metadataCopy.SetPluginResolutionSource(string(source))
+	telemetryCtx := stripe.WithEventMetadata(ctx, &metadataCopy)
+
+	go telemetryClient.SendEvent(telemetryCtx, string(pluginResolutionEventName), string(source))
+}
+
 // Install installs the resolved plugin version. If the metadata lookup already
 // resolved a concrete binary URL, it reuses that result and skips a second
 // metadata request. Otherwise it retries metadata during install so manifest or
@@ -316,28 +353,35 @@ func ListPlugins(ctx context.Context, config config.IConfig, apiBaseURL, dashboa
 // TODO: Remove this legacy plugins.toml path once the minimum supported CLI
 // version no longer depends on the cached manifest for backward compatibility.
 func GetPluginList(ctx context.Context, config config.IConfig, fs afero.Fs) (PluginList, error) {
+	pluginList, _, err := getPluginListWithSource(ctx, config, fs)
+	return pluginList, err
+}
+
+func getPluginListWithSource(ctx context.Context, config config.IConfig, fs afero.Fs) (PluginList, pluginResolutionSource, error) {
 	pluginList, err := getCachedPluginList(config, fs)
 	if os.IsNotExist(err) {
 		log.Debug("The plugin manifest file does not exist. Downloading...")
 		err = RefreshPluginManifest(ctx, config, fs, stripe.DefaultAPIBaseURL)
 		if err != nil {
 			log.Debug("Could not download plugin manifest")
-			return pluginList, err
+			return pluginList, "", err
 		}
-		return getCachedPluginList(config, fs)
+		pluginList, err = getCachedPluginList(config, fs)
+		return pluginList, pluginResolutionSourceRemoteManifest, err
 	}
 
 	if err != nil {
-		return pluginList, err
+		return pluginList, "", err
 	}
 
-	return pluginList, nil
+	return pluginList, pluginResolutionSourceCachedManifest, nil
 }
 
 // LookUpPlugin returns the matching plugin object
 func LookUpPlugin(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
 	plugin, err := readLocalPluginMetadata(config, fs, pluginName)
 	if err == nil {
+		emitPluginResolutionTelemetry(ctx, pluginName, pluginResolutionSourceLocalMetadata)
 		return plugin, nil
 	}
 
@@ -348,19 +392,40 @@ func LookUpPlugin(ctx context.Context, config config.IConfig, fs afero.Fs, plugi
 		}).Debugf("could not read local plugin metadata, falling back to manifest lookup: %s", err)
 	}
 
-	return LookUpPluginInManifest(ctx, config, fs, pluginName)
+	plugin, source, err := lookUpPluginInManifestWithSource(ctx, config, fs, pluginName)
+	if err != nil {
+		return Plugin{}, err
+	}
+
+	emitPluginResolutionTelemetry(ctx, pluginName, source)
+	return plugin, nil
 }
 
 // LookUpPluginInManifest returns plugin metadata from the cached global manifest.
 // TODO: Keep this only while older plugin flows still require plugins.toml for
 // backward compatibility.
 func LookUpPluginInManifest(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {
-	pluginList, err := GetPluginList(ctx, config, fs)
+	plugin, source, err := lookUpPluginInManifestWithSource(ctx, config, fs, pluginName)
 	if err != nil {
 		return Plugin{}, err
 	}
 
-	return findPlugin(pluginList, pluginName)
+	emitPluginResolutionTelemetry(ctx, pluginName, source)
+	return plugin, nil
+}
+
+func lookUpPluginInManifestWithSource(ctx context.Context, config config.IConfig, fs afero.Fs, pluginName string) (Plugin, pluginResolutionSource, error) {
+	pluginList, source, err := getPluginListWithSource(ctx, config, fs)
+	if err != nil {
+		return Plugin{}, "", err
+	}
+
+	plugin, err := findPlugin(pluginList, pluginName)
+	if err != nil {
+		return Plugin{}, "", err
+	}
+
+	return plugin, source, nil
 }
 
 // ResolvePluginForInstall resolves the plugin metadata needed by `stripe plugin install`
@@ -373,6 +438,7 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 
 	resolvedPlugin, err := resolvePluginFromMetadata(ctx, config, fs, pluginName, version, apiBaseURL, dashboardBaseURL, apiKey)
 	if err == nil {
+		emitPluginResolutionTelemetry(ctx, pluginName, pluginResolutionSourceMetadataEndpoint)
 		return resolvedPlugin, nil
 	}
 
@@ -388,7 +454,7 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 		return nil, err
 	}
 
-	manifestPlugin, err := LookUpPluginInManifest(ctx, config, fs, pluginName)
+	manifestPlugin, err := lookUpPluginInCachedManifest(config, fs, pluginName)
 	if err != nil {
 		return nil, &ErrPluginNotFound{Name: pluginName}
 	}
@@ -401,10 +467,12 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 		return nil, fmt.Errorf("could not determine latest version for plugin %s", pluginName)
 	}
 
-	return &ResolvedPluginVersion{
+	resolvedPlugin = &ResolvedPluginVersion{
 		Plugin:  &manifestPlugin,
 		Version: manifestVersion,
-	}, nil
+	}
+	emitPluginResolutionTelemetry(ctx, pluginName, pluginResolutionSourceRemoteManifest)
+	return resolvedPlugin, nil
 }
 
 // ResolvePluginForUpgrade resolves the latest plugin metadata for
@@ -418,6 +486,7 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 
 	resolvedPlugin, endpointErr := resolvePluginFromMetadata(ctx, config, fs, pluginName, "", apiBaseURL, dashboardBaseURL, apiKey)
 	if endpointErr == nil {
+		emitPluginResolutionTelemetry(ctx, pluginName, pluginResolutionSourceMetadataEndpoint)
 		return resolvedPlugin, nil
 	}
 
@@ -436,17 +505,24 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 		}).Debugf("could not refresh plugin manifest for upgrade fallback: %s", refreshErr)
 	}
 
-	cachedPlugin, cachedErr := resolveCachedPluginForUpgrade(config, fs, pluginName)
+	manifestSource := pluginResolutionSourceCachedManifest
+	if refreshErr == nil {
+		manifestSource = pluginResolutionSourceRemoteManifest
+	}
+
+	cachedPlugin, source, cachedErr := resolveCachedPluginForUpgradeWithSource(config, fs, pluginName, manifestSource)
 	if cachedErr == nil {
 		version, versionErr := getLatestResolvedPluginVersion(pluginName, cachedPlugin)
 		if versionErr != nil {
 			return nil, versionErr
 		}
 
-		return &ResolvedPluginVersion{
+		resolvedPlugin = &ResolvedPluginVersion{
 			Plugin:  cachedPlugin,
 			Version: version,
-		}, nil
+		}
+		emitPluginResolutionTelemetry(ctx, pluginName, source)
+		return resolvedPlugin, nil
 	}
 
 	if refreshErr != nil {
@@ -459,6 +535,11 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 // resolveCachedPluginForUpgrade resolves plugin metadata for upgrade using
 // persisted local metadata and the cached global manifest.
 func resolveCachedPluginForUpgrade(config config.IConfig, fs afero.Fs, pluginName string) (*Plugin, error) {
+	plugin, _, err := resolveCachedPluginForUpgradeWithSource(config, fs, pluginName, pluginResolutionSourceCachedManifest)
+	return plugin, err
+}
+
+func resolveCachedPluginForUpgradeWithSource(config config.IConfig, fs afero.Fs, pluginName string, manifestSource pluginResolutionSource) (*Plugin, pluginResolutionSource, error) {
 	var localPlugin *Plugin
 	localPluginValue, localErr := readLocalPluginMetadata(config, fs, pluginName)
 	if localErr == nil {
@@ -476,16 +557,16 @@ func resolveCachedPluginForUpgrade(config config.IConfig, fs afero.Fs, pluginNam
 		manifestPlugin = &manifestPluginValue
 	}
 
-	plugin := selectPluginForUpgrade(localPlugin, manifestPlugin)
+	plugin, source := selectPluginForUpgradeWithSource(localPlugin, manifestPlugin, manifestSource)
 	if plugin != nil {
-		return plugin, nil
+		return plugin, source, nil
 	}
 
 	if localErr != nil && !os.IsNotExist(localErr) {
-		return nil, localErr
+		return nil, "", localErr
 	}
 
-	return nil, manifestErr
+	return nil, "", manifestErr
 }
 
 // resolvePluginForAutoInstall resolves the freshest plugin metadata to use when
@@ -501,7 +582,7 @@ func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs 
 		"plugin": pluginName,
 	}).Debugf("could not resolve latest plugin metadata for auto-install, falling back to cached metadata: %s", err)
 
-	cachedPlugin, cachedErr := resolveCachedPluginForUpgrade(config, fs, pluginName)
+	cachedPlugin, source, cachedErr := resolveCachedPluginForUpgradeWithSource(config, fs, pluginName, pluginResolutionSourceCachedManifest)
 	if cachedErr != nil {
 		return nil, fmt.Errorf("could not resolve plugin %s for auto-install: latest lookup failed: %v; cached lookup failed: %w", pluginName, err, cachedErr)
 	}
@@ -511,10 +592,12 @@ func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs 
 		return nil, versionErr
 	}
 
-	return &ResolvedPluginVersion{
+	resolvedPlugin = &ResolvedPluginVersion{
 		Plugin:  cachedPlugin,
 		Version: version,
-	}, nil
+	}
+	emitPluginResolutionTelemetry(ctx, pluginName, source)
+	return resolvedPlugin, nil
 }
 
 func getCachedPluginList(config config.IConfig, fs afero.Fs) (PluginList, error) {
@@ -546,15 +629,20 @@ func findPlugin(pluginList PluginList, pluginName string) (Plugin, error) {
 }
 
 func selectPluginForUpgrade(localPlugin, manifestPlugin *Plugin) *Plugin {
+	plugin, _ := selectPluginForUpgradeWithSource(localPlugin, manifestPlugin, pluginResolutionSourceCachedManifest)
+	return plugin
+}
+
+func selectPluginForUpgradeWithSource(localPlugin, manifestPlugin *Plugin, manifestSource pluginResolutionSource) (*Plugin, pluginResolutionSource) {
 	switch {
 	case localPlugin == nil:
-		return mergePluginMetadata(manifestPlugin, nil)
+		return mergePluginMetadata(manifestPlugin, nil), manifestSource
 	case manifestPlugin == nil:
-		return mergePluginMetadata(localPlugin, nil)
+		return mergePluginMetadata(localPlugin, nil), pluginResolutionSourceLocalMetadata
 	case comparePluginVersions(localPlugin.LookUpLatestVersion(), manifestPlugin.LookUpLatestVersion()) >= 0:
-		return mergePluginMetadata(localPlugin, manifestPlugin)
+		return mergePluginMetadata(localPlugin, manifestPlugin), pluginResolutionSourceLocalMetadata
 	default:
-		return mergePluginMetadata(manifestPlugin, localPlugin)
+		return mergePluginMetadata(manifestPlugin, localPlugin), manifestSource
 	}
 }
 

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/afero"
@@ -21,6 +23,65 @@ import (
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 )
+
+type telemetryEvent struct {
+	eventName              string
+	eventValue             string
+	pluginName             string
+	pluginResolutionSource string
+}
+
+type recordingTelemetryClient struct {
+	mu     sync.Mutex
+	events []telemetryEvent
+}
+
+func (c *recordingTelemetryClient) SendAPIRequestEvent(ctx context.Context, requestID string, livemode bool) (*http.Response, error) {
+	return nil, nil
+}
+
+func (c *recordingTelemetryClient) SendEvent(ctx context.Context, eventName string, eventValue string) {
+	event := telemetryEvent{
+		eventName:  eventName,
+		eventValue: eventValue,
+	}
+	if metadata := stripe.GetEventMetadata(ctx); metadata != nil {
+		event.pluginName = metadata.PluginName
+		event.pluginResolutionSource = metadata.PluginResolutionSource
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, event)
+}
+
+func (c *recordingTelemetryClient) snapshot() []telemetryEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	events := make([]telemetryEvent, len(c.events))
+	copy(events, c.events)
+	return events
+}
+
+func pluginTelemetryContext(client stripe.TelemetryClient) context.Context {
+	metadata := stripe.NewEventMetadata()
+	metadata.SetCommandPath("stripe test")
+	return stripe.WithTelemetryClient(stripe.WithEventMetadata(context.Background(), metadata), client)
+}
+
+func requireSinglePluginResolutionEvent(t *testing.T, client *recordingTelemetryClient) telemetryEvent {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return len(client.snapshot()) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	events := client.snapshot()
+	require.Len(t, events, 1)
+	require.Equal(t, pluginResolutionEventName, events[0].eventName)
+	return events[0]
+}
 
 // CustomTestConfig is a test config that allows overriding the config folder path
 type CustomTestConfig struct {
@@ -230,6 +291,55 @@ func TestLookUpPluginUsesLocalMetadataWhenManifestMissing(t *testing.T) {
 	plugin, err := LookUpPlugin(context.Background(), config, fs, "local-plugin")
 	require.NoError(t, err)
 	require.Equal(t, localPlugin, plugin)
+}
+
+func TestLookUpPluginEmitsLocalMetadataTelemetry(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+
+	localPlugin := Plugin{
+		Shortname:        "local-plugin",
+		Binary:           "stripe-cli-local-plugin",
+		MagicCookieValue: "LOCAL-PLUGIN-COOKIE",
+		Releases: []Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+			},
+		},
+	}
+	require.NoError(t, writeLocalPluginMetadata(config, fs, localPlugin))
+
+	telemetryClient := &recordingTelemetryClient{}
+	ctx := pluginTelemetryContext(telemetryClient)
+
+	plugin, err := LookUpPlugin(ctx, config, fs, "local-plugin")
+	require.NoError(t, err)
+	require.Equal(t, localPlugin, plugin)
+
+	event := requireSinglePluginResolutionEvent(t, telemetryClient)
+	require.Equal(t, string(pluginResolutionSourceLocalMetadata), event.eventValue)
+	require.Equal(t, "local-plugin", event.pluginName)
+	require.Equal(t, string(pluginResolutionSourceLocalMetadata), event.pluginResolutionSource)
+}
+
+func TestLookUpPluginEmitsCachedManifestTelemetry(t *testing.T) {
+	fs := setUpFS()
+	config := &TestConfig{}
+
+	telemetryClient := &recordingTelemetryClient{}
+	ctx := pluginTelemetryContext(telemetryClient)
+
+	plugin, err := LookUpPlugin(ctx, config, fs, "appB")
+	require.NoError(t, err)
+	require.Equal(t, "appB", plugin.Shortname)
+
+	event := requireSinglePluginResolutionEvent(t, telemetryClient)
+	require.Equal(t, string(pluginResolutionSourceCachedManifest), event.eventValue)
+	require.Equal(t, "appB", event.pluginName)
+	require.Equal(t, string(pluginResolutionSourceCachedManifest), event.pluginResolutionSource)
 }
 
 func TestGetInstalledPluginNamesIncludesLocalMetadata(t *testing.T) {
@@ -524,6 +634,40 @@ func TestResolvePluginForInstallUsesAnonymousMetadataWithoutCachedManifest(t *te
 	require.True(t, os.IsNotExist(err))
 }
 
+func TestResolvePluginForInstallEmitsMetadataEndpointTelemetry(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+
+	telemetryClient := &recordingTelemetryClient{}
+	ctx := pluginTelemetryContext(telemetryClient)
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "https://example.test/appA/2.0.1",
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			_, _ = res.Write(body)
+		default:
+			t.Fatalf("unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(ctx, config, fs, "appA", "2.0.1", stripeServer.URL, stripeServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, "appA", resolvedPlugin.Plugin.Shortname)
+
+	event := requireSinglePluginResolutionEvent(t, telemetryClient)
+	require.Equal(t, string(pluginResolutionSourceMetadataEndpoint), event.eventValue)
+	require.Equal(t, "appA", event.pluginName)
+	require.Equal(t, string(pluginResolutionSourceMetadataEndpoint), event.pluginResolutionSource)
+}
+
 func TestResolvePluginForInstallFallsBackToManifestLookupWhenAnonymousMetadataFails(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
@@ -564,6 +708,45 @@ func TestResolvePluginForInstallFallsBackToManifestLookupWhenAnonymousMetadataFa
 
 	_, err = fs.Stat("/plugins.toml")
 	require.NoError(t, err)
+}
+
+func TestResolvePluginForInstallEmitsRemoteManifestTelemetry(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
+	testServers := setUpServers(t, manifestContent, nil)
+	defer testServers.CloseAll()
+
+	telemetryClient := &recordingTelemetryClient{}
+	ctx := pluginTelemetryContext(telemetryClient)
+
+	failingServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			res.WriteHeader(http.StatusInternalServerError)
+			_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
+		case "/v1/stripecli/get-plugin-url":
+			body, err := json.Marshal(requests.PluginData{
+				PluginBaseURL:       testServers.ArtifactoryServer.URL,
+				AdditionalManifests: nil,
+			})
+			require.NoError(t, err)
+			_, _ = res.Write(body)
+		default:
+			t.Fatalf("unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer failingServer.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(ctx, config, fs, "appA", "2.0.1", failingServer.URL, failingServer.URL)
+	require.NoError(t, err)
+	require.Equal(t, "appA", resolvedPlugin.Plugin.Shortname)
+
+	event := requireSinglePluginResolutionEvent(t, telemetryClient)
+	require.Equal(t, string(pluginResolutionSourceRemoteManifest), event.eventValue)
+	require.Equal(t, "appA", event.pluginName)
+	require.Equal(t, string(pluginResolutionSourceRemoteManifest), event.pluginResolutionSource)
 }
 
 func TestResolvePluginForUpgradeUsesMetadataEndpointWhenAvailable(t *testing.T) {

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -37,20 +37,21 @@ const DefaultTelemetryEndpoint = "https://r.stripe.com/0"
 
 // CLIAnalyticsEventMetadata is the structure that holds telemetry data context that is ultimately sent to the Stripe Analytics Service.
 type CLIAnalyticsEventMetadata struct {
-	InvocationID      string `url:"invocation_id"`              // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
-	UserAgent         string `url:"user_agent"`                 // the application that is used to create this request
-	CommandPath       string `url:"command_path"`               // the command or gRPC method that initiated this request
-	CommandFlags      string `url:"command_flags"`              // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
-	PluginName        string `url:"plugin_name,omitempty"`      // the plugin being installed, when relevant
-	Merchant          string `url:"merchant"`                   // the merchant ID: ex. acct_xxxx
-	CLIVersion        string `url:"cli_version"`                // the version of the CLI
-	OS                string `url:"os"`                         // the OS of the system
-	GeneratedResource bool   `url:"generated_resource"`         // whether or not this was a generated resource
-	AIAgent           string `url:"ai_agent,omitempty"`         // the AI coding agent that invoked the CLI, if any
-	InstallMethod     string `url:"install_method,omitempty"`   // how the CLI was installed
-	InTmux            bool   `url:"in_tmux"`                    // whether the CLI was invoked from within tmux
-	InScreen          bool   `url:"in_screen"`                  // whether the CLI was invoked from within GNU Screen
-	TerminalProgram   string `url:"terminal_program,omitempty"` // the terminal program that invoked the CLI, if any
+	InvocationID           string `url:"invocation_id"`                      // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
+	UserAgent              string `url:"user_agent"`                         // the application that is used to create this request
+	CommandPath            string `url:"command_path"`                       // the command or gRPC method that initiated this request
+	CommandFlags           string `url:"command_flags"`                      // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
+	PluginName             string `url:"plugin_name,omitempty"`              // the plugin being installed, when relevant
+	PluginResolutionSource string `url:"plugin_resolution_source,omitempty"` // temporary source used to resolve plugin metadata
+	Merchant               string `url:"merchant"`                           // the merchant ID: ex. acct_xxxx
+	CLIVersion             string `url:"cli_version"`                        // the version of the CLI
+	OS                     string `url:"os"`                                 // the OS of the system
+	GeneratedResource      bool   `url:"generated_resource"`                 // whether or not this was a generated resource
+	AIAgent                string `url:"ai_agent,omitempty"`                 // the AI coding agent that invoked the CLI, if any
+	InstallMethod          string `url:"install_method,omitempty"`           // how the CLI was installed
+	InTmux                 bool   `url:"in_tmux"`                            // whether the CLI was invoked from within tmux
+	InScreen               bool   `url:"in_screen"`                          // whether the CLI was invoked from within GNU Screen
+	TerminalProgram        string `url:"terminal_program,omitempty"`         // the terminal program that invoked the CLI, if any
 }
 
 // TelemetryClient is an interface that can send two types of events: an API request, and just general events.
@@ -159,6 +160,11 @@ func (e *CLIAnalyticsEventMetadata) SetCommandFlags(commandFlags string) {
 // SetPluginName sets the plugin name on the CLIAnalyticsEventContext object
 func (e *CLIAnalyticsEventMetadata) SetPluginName(pluginName string) {
 	e.PluginName = pluginName
+}
+
+// SetPluginResolutionSource sets the source used to resolve plugin metadata on the CLIAnalyticsEventContext object.
+func (e *CLIAnalyticsEventMetadata) SetPluginResolutionSource(pluginResolutionSource string) {
+	e.PluginResolutionSource = pluginResolutionSource
 }
 
 // SendAPIRequestEvent is a special function for API requests

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -89,6 +89,12 @@ func TestSetPluginName(t *testing.T) {
 	require.Equal(t, "apps", tel.PluginName)
 }
 
+func TestSetPluginResolutionSource(t *testing.T) {
+	tel := stripe.NewEventMetadata()
+	tel.SetPluginResolutionSource("metadata_endpoint")
+	require.Equal(t, "metadata_endpoint", tel.PluginResolutionSource)
+}
+
 // AnalyticsClient Tests
 func TestSendAPIRequestEvent(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -107,6 +113,7 @@ func TestSendAPIRequestEvent(t *testing.T) {
 		require.Contains(t, bodyString, "merchant=acct_1234")
 		require.Contains(t, bodyString, "os=darwin")
 		require.Contains(t, bodyString, "plugin_name=apps")
+		require.Contains(t, bodyString, "plugin_resolution_source=metadata_endpoint")
 		require.Contains(t, bodyString, "request_id=req_zzz")
 		require.Contains(t, bodyString, "terminal_program=iTerm.app")
 		require.Contains(t, bodyString, "user_agent=Unit+Test")
@@ -117,17 +124,18 @@ func TestSendAPIRequestEvent(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	telemetryMetadata := &stripe.CLIAnalyticsEventMetadata{
-		InvocationID:      "123456",
-		UserAgent:         "Unit Test",
-		CLIVersion:        "master",
-		OS:                "darwin",
-		CommandPath:       "stripe test",
-		PluginName:        "apps",
-		Merchant:          "acct_1234",
-		GeneratedResource: false,
-		InTmux:            true,
-		InScreen:          true,
-		TerminalProgram:   "iTerm.app",
+		InvocationID:           "123456",
+		UserAgent:              "Unit Test",
+		CLIVersion:             "master",
+		OS:                     "darwin",
+		CommandPath:            "stripe test",
+		PluginName:             "apps",
+		PluginResolutionSource: "metadata_endpoint",
+		Merchant:               "acct_1234",
+		GeneratedResource:      false,
+		InTmux:                 true,
+		InScreen:               true,
+		TerminalProgram:        "iTerm.app",
 	}
 	processCtx := stripe.WithEventMetadata(context.Background(), telemetryMetadata)
 	analyticsClient := stripe.AnalyticsTelemetryClient{BaseURL: baseURL, HTTPClient: &http.Client{}}
@@ -171,6 +179,7 @@ func TestSendEvent(t *testing.T) {
 		require.Contains(t, bodyString, "merchant=acct_1234")
 		require.Contains(t, bodyString, "os=darwin")
 		require.Contains(t, bodyString, "plugin_name=apps")
+		require.Contains(t, bodyString, "plugin_resolution_source=metadata_endpoint")
 		require.Contains(t, bodyString, "terminal_program=iTerm.app")
 		require.Contains(t, bodyString, "user_agent=Unit+Test")
 		// ai_agent should not be present when empty (omitempty)
@@ -180,17 +189,18 @@ func TestSendEvent(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	telemetryMetadata := &stripe.CLIAnalyticsEventMetadata{
-		InvocationID:      "123456",
-		UserAgent:         "Unit Test",
-		CLIVersion:        "master",
-		OS:                "darwin",
-		CommandPath:       "stripe test",
-		PluginName:        "apps",
-		Merchant:          "acct_1234",
-		GeneratedResource: false,
-		InTmux:            true,
-		InScreen:          true,
-		TerminalProgram:   "iTerm.app",
+		InvocationID:           "123456",
+		UserAgent:              "Unit Test",
+		CLIVersion:             "master",
+		OS:                     "darwin",
+		CommandPath:            "stripe test",
+		PluginName:             "apps",
+		PluginResolutionSource: "metadata_endpoint",
+		Merchant:               "acct_1234",
+		GeneratedResource:      false,
+		InTmux:                 true,
+		InScreen:               true,
+		TerminalProgram:        "iTerm.app",
 	}
 	processCtx := stripe.WithEventMetadata(context.Background(), telemetryMetadata)
 	analyticsClient := stripe.AnalyticsTelemetryClient{BaseURL: baseURL, HTTPClient: &http.Client{}}


### PR DESCRIPTION
Track which source (metadata endpoint, remote manifest, cached manifest, or local metadata) was used to resolve plugin metadata. This temporary telemetry will help measure plugins.toml fallback usage before removing the legacy manifest path.




 ### Reviewers
r? @vcheung-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
