### PR TITLE
autoupdate 1/3: Add config and detection utilities

### DIFF
--- a/pkg/autoupdate/config.go
+++ b/pkg/autoupdate/config.go
@@ -1,0 +1,81 @@
+// Package autoupdate implements automatic version updates for curl-installed Stripe CLI binaries.
+package autoupdate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+)
+
+// IsOptedOut reports whether the user has disabled auto-update.
+func IsOptedOut() bool {
+	if os.Getenv("STRIPE_NO_AUTO_UPDATE") != "" {
+		return true
+	}
+
+	configFolder := getConfigFolder()
+	configFile := filepath.Join(configFolder, "config.toml")
+
+	v := viper.New()
+	v.SetConfigType("toml")
+	v.SetConfigFile(configFile)
+
+	if err := v.ReadInConfig(); err != nil {
+		return false
+	}
+
+	return !v.GetBool("settings.auto_update") && v.IsSet("settings.auto_update")
+}
+
+// IsCurlInstall reports whether the current binary was installed via curl (lives in ~/.stripe/bin/).
+func IsCurlInstall() bool {
+	if method := os.Getenv("STRIPE_INSTALL_METHOD"); method != "" {
+		return method == "curl"
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+
+	home, err := homedir.Dir()
+	if err != nil {
+		return false
+	}
+
+	stripeBinDir := filepath.Join(home, ".stripe", "bin")
+	exeLower := strings.ToLower(filepath.ToSlash(exe))
+	expectedLower := strings.ToLower(filepath.ToSlash(stripeBinDir))
+
+	return strings.HasPrefix(exeLower, expectedLower)
+}
+
+func getConfigFolder() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "stripe")
+	}
+	home, err := homedir.Dir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "stripe")
+}
+
+// GetStateDirFn is the active implementation; tests can override it.
+var GetStateDirFn = getStateDirDefault
+
+// GetStateDir returns the path to the autoupdate state directory.
+func GetStateDir() string {
+	return GetStateDirFn()
+}
+
+func getStateDirDefault() string {
+	home, err := homedir.Dir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".stripe", "state")
+}

--- a/pkg/autoupdate/config_test.go
+++ b/pkg/autoupdate/config_test.go
@@ -1,0 +1,48 @@
+package autoupdate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsOptedOut_EnvVar(t *testing.T) {
+	t.Setenv("STRIPE_NO_AUTO_UPDATE", "1")
+	assert.True(t, IsOptedOut())
+}
+
+func TestIsOptedOut_NoConfig(t *testing.T) {
+	t.Setenv("STRIPE_NO_AUTO_UPDATE", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	assert.False(t, IsOptedOut())
+}
+
+func TestIsOptedOut_ConfigSetFalse(t *testing.T) {
+	t.Setenv("STRIPE_NO_AUTO_UPDATE", "")
+	configDir := t.TempDir()
+	stripeDir := filepath.Join(configDir, "stripe")
+	os.MkdirAll(stripeDir, 0755)
+	os.WriteFile(filepath.Join(stripeDir, "config.toml"), []byte("[settings]\nauto_update = false\n"), 0644)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	assert.True(t, IsOptedOut())
+}
+
+func TestIsOptedOut_ConfigSetTrue(t *testing.T) {
+	t.Setenv("STRIPE_NO_AUTO_UPDATE", "")
+	configDir := t.TempDir()
+	stripeDir := filepath.Join(configDir, "stripe")
+	os.MkdirAll(stripeDir, 0755)
+	os.WriteFile(filepath.Join(stripeDir, "config.toml"), []byte("[settings]\nauto_update = true\n"), 0644)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	assert.False(t, IsOptedOut())
+}
+
+func TestIsCurlInstall_EnvOverride(t *testing.T) {
+	t.Setenv("STRIPE_INSTALL_METHOD", "curl")
+	assert.True(t, IsCurlInstall())
+
+	t.Setenv("STRIPE_INSTALL_METHOD", "homebrew")
+	assert.False(t, IsCurlInstall())
+}


### PR DESCRIPTION
## Summary

- Introduce `pkg/autoupdate` package with helpers to detect whether the CLI was installed via curl (`~/.stripe/bin/`) and whether auto-update is opted out
- Opt-out via `STRIPE_NO_AUTO_UPDATE=1` env var or `auto_update = false` in `~/.config/stripe/config.toml`
- Exposes `GetStateDir()` for later use by the checker and updater

This is **part 1/3** of the auto-update feature for curl-installed binaries.
Stack: **this** → #1768 (checker) → #1769 (apply)

## Test plan

- [x] Unit tests for opt-out detection (env var, config.toml true/false, missing config)
- [x] Unit test for curl install detection via env override

🤖 Generated with [Claude Code](https://claude.com/claude-code)