### PR TITLE
[sandboxes cli] Auto-resolve sandbox context in `stripe sandbox new`

### DIFF
--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -417,7 +417,6 @@ type sandboxNewCmd struct {
 	name             string
 	replicaOf        string
 	businessLocation string
-	stripeContext    string
 	copyLiveAccount  bool
 	createBlank      bool
 	activate         bool
@@ -503,12 +502,6 @@ that you have previously logged in with your Stripe account credentials.`,
 	snc.cmd.Flags().BoolVar(&snc.activate, "activate", true, "Request capabilities and activate the sandbox after creation")
 	snc.cmd.Flags().IntVar(&snc.batch, "batch", 1, "Number of sandboxes to create (currently only 1 is supported)")
 
-	// --stripe-context is an internal-only override; playground (play_...) ids are
-	// not user-facing and the command resolves the playground automatically. Kept
-	// hidden for our own testing.
-	snc.cmd.Flags().StringVar(&snc.stripeContext, "stripe-context", "", "Internal: playground compartment (play_...) override")
-	_ = snc.cmd.Flags().MarkHidden("stripe-context")
-
 	snc.cmd.Flags().StringVar(&snc.stripeVersion, "stripe-version", requests.StripeVersionHeaderValue, "Sets the Stripe-Version header")
 	_ = snc.cmd.Flags().MarkHidden("stripe-version")
 
@@ -585,30 +578,25 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 		return nil
 	}
 
-	// Resolve the live workspace to copy / derive the playground from. Copy mode
-	// always needs it (sent as replica_of); blank mode needs it only to resolve
-	// the internal playground when no --stripe-context override is given.
-	// Order: --replica-of override, the livemode compartment saved at login, then
-	// GET /v2/compartments/user_accessible.
-	stripeContext := strings.TrimSpace(snc.stripeContext)
+	// Resolve the live workspace to copy / derive the playground from (both modes
+	// need it). Order: --replica-of override, the livemode compartment saved at
+	// login, then GET /v2/compartments/user_accessible.
 	liveWorkspace := replicaOf
-	if liveWorkspace == "" && (snc.copyLiveAccount || stripeContext == "") {
+	if liveWorkspace == "" {
 		liveWorkspace, err = snc.resolveLiveWorkspace(cmd.Context(), client, authConfigure)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Resolve the playground (play_) unless the internal --stripe-context override
-	// was supplied. Playground ids are not user-facing.
-	if stripeContext == "" {
-		stripeContext, err = snc.resolvePlayground(cmd.Context(), client, authConfigure, liveWorkspace)
-		if err != nil {
-			return err
-		}
+	// Resolve the internal playground (play_) for the live workspace. Playground
+	// ids are not user-facing, so there is no override: the command always derives it.
+	stripeContext, err := snc.resolvePlayground(cmd.Context(), client, authConfigure, liveWorkspace)
+	if err != nil {
+		return err
 	}
 	if !strings.HasPrefix(stripeContext, "play_") {
-		return fmt.Errorf("resolved a non-playground context %q; pass --stripe-context play_... to override", stripeContext)
+		return fmt.Errorf("resolved a non-playground context %q for %s", stripeContext, liveWorkspace)
 	}
 
 	// Mirror the dashboard's create-sandbox request body, including the
@@ -722,7 +710,7 @@ func (snc *sandboxNewCmd) resolveLiveWorkspace(ctx context.Context, client *stri
 // livemode workspace/org via GET /v2/compartments/playground/:id.
 func (snc *sandboxNewCmd) resolvePlayground(ctx context.Context, client *stripe.Client, configure func(*http.Request) error, compartmentID string) (string, error) {
 	if compartmentID == "" {
-		return "", fmt.Errorf("could not determine a live workspace to resolve the playground from; pass --replica-of wksp_... or --stripe-context play_...")
+		return "", fmt.Errorf("could not determine a live workspace to resolve the playground from; pass --replica-of wksp_...")
 	}
 	resp, err := client.PerformRequest(ctx, http.MethodGet, "/v2/compartments/playground/"+url.PathEscape(compartmentID), "", configure)
 	if err != nil {
@@ -743,7 +731,7 @@ func (snc *sandboxNewCmd) resolvePlayground(ctx context.Context, client *stripe.
 		return "", fmt.Errorf("could not parse playground response: %w", err)
 	}
 	if parsed.ID == "" {
-		return "", fmt.Errorf("no playground found for %s; pass --stripe-context play_... to override", compartmentID)
+		return "", fmt.Errorf("no playground found for %s; run 'stripe login' again or pass a different --replica-of wksp_...", compartmentID)
 	}
 	return parsed.ID, nil
 }

--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -524,37 +524,11 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 	}
 	uat := strings.TrimSpace(string(uatBytes))
 
-	// --batch is scaffolded for a future bulk-create shape and currently only
-	// supports 1. Future shape: create N sandboxes under the same playground in a
-	// single invocation via a bounded fan-out (or a batched backend request) that
-	// shares an idempotency prefix, returns the list of created sandboxes, and
-	// reports per-item partial failures instead of aborting the whole batch.
-	// Until that lands, reject >1 explicitly rather than silently creating one.
-	if snc.batch < 1 {
-		return fmt.Errorf("--batch must be >= 1")
+	if err := snc.validateFlags(); err != nil {
+		return err
 	}
-	if snc.batch > 1 {
-		return fmt.Errorf("--batch > 1 is not yet implemented; only --batch 1 is supported today")
-	}
-
-	// Mode selection mirrors the dashboard's create-sandbox modal: copy a live
-	// account, or create a blank sandbox for a country. Exactly one is required.
 	replicaOf := strings.TrimSpace(snc.replicaOf)
 	businessLocation := strings.TrimSpace(snc.businessLocation)
-	switch {
-	case snc.copyLiveAccount && snc.createBlank:
-		return fmt.Errorf("--copy-live-account and --create-blank are mutually exclusive")
-	case !snc.copyLiveAccount && !snc.createBlank:
-		return fmt.Errorf("pass one of --copy-live-account (copy your live account) or --create-blank (a fresh sandbox)")
-	case snc.createBlank && businessLocation == "":
-		return fmt.Errorf("--create-blank requires --business-location (e.g. US)")
-	case snc.createBlank && replicaOf != "":
-		return fmt.Errorf("--replica-of is only valid with --copy-live-account")
-	case snc.copyLiveAccount && businessLocation != "":
-		return fmt.Errorf("--business-location is only valid with --create-blank")
-	case replicaOf != "" && !strings.HasPrefix(replicaOf, "wksp_"):
-		return fmt.Errorf("--replica-of must be a livemode workspace id (wksp_...), got %q", replicaOf)
-	}
 
 	baseURL, err := url.Parse(snc.apiBase)
 	if err != nil {
@@ -651,6 +625,45 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 	return nil
 }
 
+// validateFlags checks --batch and the mutually-exclusive mode selectors
+// (--copy-live-account / --create-blank) and their inputs, mirroring the
+// dashboard's create-sandbox modal. Extracted from runSandboxNewCmd to keep its
+// cyclomatic complexity manageable.
+func (snc *sandboxNewCmd) validateFlags() error {
+	// --batch is scaffolded for a future bulk-create shape and currently only
+	// supports 1. Future shape: create N sandboxes under the same playground in a
+	// single invocation via a bounded fan-out (or a batched backend request) that
+	// shares an idempotency prefix, returns the list of created sandboxes, and
+	// reports per-item partial failures instead of aborting the whole batch.
+	// Until that lands, reject >1 explicitly rather than silently creating one.
+	if snc.batch < 1 {
+		return fmt.Errorf("--batch must be >= 1")
+	}
+	if snc.batch > 1 {
+		return fmt.Errorf("--batch > 1 is not yet implemented; only --batch 1 is supported today")
+	}
+
+	// Mode selection mirrors the dashboard's create-sandbox modal: copy a live
+	// account, or create a blank sandbox for a country. Exactly one is required.
+	replicaOf := strings.TrimSpace(snc.replicaOf)
+	businessLocation := strings.TrimSpace(snc.businessLocation)
+	switch {
+	case snc.copyLiveAccount && snc.createBlank:
+		return fmt.Errorf("--copy-live-account and --create-blank are mutually exclusive")
+	case !snc.copyLiveAccount && !snc.createBlank:
+		return fmt.Errorf("pass one of --copy-live-account (copy your live account) or --create-blank (a fresh sandbox)")
+	case snc.createBlank && businessLocation == "":
+		return fmt.Errorf("--create-blank requires --business-location (e.g. US)")
+	case snc.createBlank && replicaOf != "":
+		return fmt.Errorf("--replica-of is only valid with --copy-live-account")
+	case snc.copyLiveAccount && businessLocation != "":
+		return fmt.Errorf("--business-location is only valid with --create-blank")
+	case replicaOf != "" && !strings.HasPrefix(replicaOf, "wksp_"):
+		return fmt.Errorf("--replica-of must be a livemode workspace id (wksp_...), got %q", replicaOf)
+	}
+	return nil
+}
+
 // resolveLiveWorkspace determines the livemode workspace/org compartment to use
 // as the sandbox's live parent. It first reads the livemode compartment saved at
 // login (no network), then falls back to GET /v2/compartments/user_accessible.
@@ -698,7 +711,7 @@ func (snc *sandboxNewCmd) resolveLiveWorkspace(ctx context.Context, client *stri
 	}
 	switch len(workspaces) {
 	case 0:
-		return "", fmt.Errorf("no livemode workspace found for your account; run `stripe login`, or pass --replica-of wksp_...")
+		return "", fmt.Errorf("no livemode workspace found for your account; run `stripe login`, or pass --replica-of with a wksp_ id")
 	case 1:
 		return workspaces[0], nil
 	default:
@@ -710,7 +723,7 @@ func (snc *sandboxNewCmd) resolveLiveWorkspace(ctx context.Context, client *stri
 // livemode workspace/org via GET /v2/compartments/playground/:id.
 func (snc *sandboxNewCmd) resolvePlayground(ctx context.Context, client *stripe.Client, configure func(*http.Request) error, compartmentID string) (string, error) {
 	if compartmentID == "" {
-		return "", fmt.Errorf("could not determine a live workspace to resolve the playground from; pass --replica-of wksp_...")
+		return "", fmt.Errorf("could not determine a live workspace to resolve the playground from; pass --replica-of with a wksp_ id")
 	}
 	resp, err := client.PerformRequest(ctx, http.MethodGet, "/v2/compartments/playground/"+url.PathEscape(compartmentID), "", configure)
 	if err != nil {
@@ -731,7 +744,7 @@ func (snc *sandboxNewCmd) resolvePlayground(ctx context.Context, client *stripe.
 		return "", fmt.Errorf("could not parse playground response: %w", err)
 	}
 	if parsed.ID == "" {
-		return "", fmt.Errorf("no playground found for %s; run 'stripe login' again or pass a different --replica-of wksp_...", compartmentID)
+		return "", fmt.Errorf("no playground found for %s; run 'stripe login' again or pass a different --replica-of wksp_ id", compartmentID)
 	}
 	return parsed.ID, nil
 }

--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -418,6 +418,8 @@ type sandboxNewCmd struct {
 	replicaOf        string
 	businessLocation string
 	stripeContext    string
+	copyLiveAccount  bool
+	createBlank      bool
 	activate         bool
 	batch            int
 	stripeVersion    string
@@ -492,11 +494,20 @@ that you have previously logged in with your Stripe account credentials.`,
 
 	snc.cmd.Flags().StringVar(&snc.name, "name", "", "Name for the new sandbox")
 	_ = snc.cmd.MarkFlagRequired("name")
-	snc.cmd.Flags().StringVar(&snc.replicaOf, "replica-of", "", "Livemode workspace ID to replicate (wksp_...); mutually exclusive with --business-location")
-	snc.cmd.Flags().StringVar(&snc.businessLocation, "business-location", "", "Country for a fresh blank sandbox (e.g. US); mutually exclusive with --replica-of")
-	snc.cmd.Flags().StringVar(&snc.stripeContext, "stripe-context", "", "Playground compartment (play_...) to create the sandbox under")
+	// Mode selectors mirror the dashboard's create-sandbox modal: copy a live
+	// account, or create a blank sandbox for a country. Exactly one is required.
+	snc.cmd.Flags().BoolVar(&snc.copyLiveAccount, "copy-live-account", false, "Copy your live account into a new sandbox")
+	snc.cmd.Flags().BoolVar(&snc.createBlank, "create-blank", false, "Create a fresh blank sandbox (requires --business-location)")
+	snc.cmd.Flags().StringVar(&snc.businessLocation, "business-location", "", "Country for a --create-blank sandbox (e.g. US)")
+	snc.cmd.Flags().StringVar(&snc.replicaOf, "replica-of", "", "Livemode workspace ID (wksp_...) to copy; defaults to your logged-in account")
 	snc.cmd.Flags().BoolVar(&snc.activate, "activate", true, "Request capabilities and activate the sandbox after creation")
 	snc.cmd.Flags().IntVar(&snc.batch, "batch", 1, "Number of sandboxes to create (currently only 1 is supported)")
+
+	// --stripe-context is an internal-only override; playground (play_...) ids are
+	// not user-facing and the command resolves the playground automatically. Kept
+	// hidden for our own testing.
+	snc.cmd.Flags().StringVar(&snc.stripeContext, "stripe-context", "", "Internal: playground compartment (play_...) override")
+	_ = snc.cmd.Flags().MarkHidden("stripe-context")
 
 	snc.cmd.Flags().StringVar(&snc.stripeVersion, "stripe-version", requests.StripeVersionHeaderValue, "Sets the Stripe-Version header")
 	_ = snc.cmd.Flags().MarkHidden("stripe-version")
@@ -533,27 +544,21 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 		return fmt.Errorf("--batch > 1 is not yet implemented; only --batch 1 is supported today")
 	}
 
-	// Stripe-Context must be a playground (play_...) compartment. The backend
-	// (CreateSandboxOp) rejects any non-playground context, so validate it here
-	// to give a clear error rather than a server-side rejection.
-	stripeContext := strings.TrimSpace(snc.stripeContext)
-	if stripeContext == "" {
-		return fmt.Errorf("--stripe-context is required; pass the playground id (play_...) to create the sandbox under")
-	}
-	if !strings.HasPrefix(stripeContext, "play_") {
-		return fmt.Errorf("--stripe-context must be a playground id (play_...), got %q", stripeContext)
-	}
-
-	// The backend requires exactly one of replica_of / business_location (a oneof):
-	// replica_of (a livemode wksp_...) clones a live workspace; business_location
-	// (a country) creates a fresh blank sandbox. Enforce the oneof up front.
+	// Mode selection mirrors the dashboard's create-sandbox modal: copy a live
+	// account, or create a blank sandbox for a country. Exactly one is required.
 	replicaOf := strings.TrimSpace(snc.replicaOf)
 	businessLocation := strings.TrimSpace(snc.businessLocation)
 	switch {
-	case replicaOf != "" && businessLocation != "":
-		return fmt.Errorf("--replica-of and --business-location are mutually exclusive")
-	case replicaOf == "" && businessLocation == "":
-		return fmt.Errorf("pass one of --replica-of (wksp_...) to clone a live workspace, or --business-location (e.g. US) for a blank sandbox")
+	case snc.copyLiveAccount && snc.createBlank:
+		return fmt.Errorf("--copy-live-account and --create-blank are mutually exclusive")
+	case !snc.copyLiveAccount && !snc.createBlank:
+		return fmt.Errorf("pass one of --copy-live-account (copy your live account) or --create-blank (a fresh sandbox)")
+	case snc.createBlank && businessLocation == "":
+		return fmt.Errorf("--create-blank requires --business-location (e.g. US)")
+	case snc.createBlank && replicaOf != "":
+		return fmt.Errorf("--replica-of is only valid with --copy-live-account")
+	case snc.copyLiveAccount && businessLocation != "":
+		return fmt.Errorf("--business-location is only valid with --create-blank")
 	case replicaOf != "" && !strings.HasPrefix(replicaOf, "wksp_"):
 		return fmt.Errorf("--replica-of must be a livemode workspace id (wksp_...), got %q", replicaOf)
 	}
@@ -563,42 +568,76 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 		return fmt.Errorf("invalid --api-base %q: %w", snc.apiBase, err)
 	}
 
+	// Low-level client with an empty APIKey so it doesn't set a Bearer auth
+	// header; the UAT is injected per-request as a STRIPE-V2-SIG token instead.
+	client := &stripe.Client{
+		BaseURL: baseURL,
+		APIKey:  "",
+	}
+
+	// authConfigure sets the UAT auth + version headers shared by every call.
+	// The context-resolution GETs (user_accessible, playground) are self-scoped
+	// by the UAT and take no Stripe-Context; only the create call sets it.
+	authConfigure := func(req *http.Request) error {
+		req.Header.Set("Authorization", "STRIPE-V2-SIG "+uat)
+		req.Header.Set("Stripe-Version", snc.stripeVersion)
+		req.Header.Set("Content-Type", stripe.V2ContentType)
+		return nil
+	}
+
+	// Resolve the live workspace to copy / derive the playground from. Copy mode
+	// always needs it (sent as replica_of); blank mode needs it only to resolve
+	// the internal playground when no --stripe-context override is given.
+	// Order: --replica-of override, the livemode compartment saved at login, then
+	// GET /v2/compartments/user_accessible.
+	stripeContext := strings.TrimSpace(snc.stripeContext)
+	liveWorkspace := replicaOf
+	if liveWorkspace == "" && (snc.copyLiveAccount || stripeContext == "") {
+		liveWorkspace, err = snc.resolveLiveWorkspace(cmd.Context(), client, authConfigure)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Resolve the playground (play_) unless the internal --stripe-context override
+	// was supplied. Playground ids are not user-facing.
+	if stripeContext == "" {
+		stripeContext, err = snc.resolvePlayground(cmd.Context(), client, authConfigure, liveWorkspace)
+		if err != nil {
+			return err
+		}
+	}
+	if !strings.HasPrefix(stripeContext, "play_") {
+		return fmt.Errorf("resolved a non-playground context %q; pass --stripe-context play_... to override", stripeContext)
+	}
+
 	// Mirror the dashboard's create-sandbox request body, including the
 	// idempotency_token derived from the create inputs (see newIdempotencyToken).
 	reqBody := map[string]interface{}{
 		"name":              snc.name,
 		"activate_sandbox":  snc.activate,
-		"idempotency_token": newIdempotencyToken(snc.name, businessLocation, replicaOf),
+		"idempotency_token": newIdempotencyToken(snc.name, businessLocation, liveWorkspace),
 	}
-	if replicaOf != "" {
-		reqBody["replica_of"] = replicaOf
-	} else {
+	if snc.createBlank {
 		reqBody["business_location"] = businessLocation
+	} else {
+		reqBody["replica_of"] = liveWorkspace
 	}
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
 		return err
 	}
 
-	// Use the low-level client with an empty APIKey so it doesn't set a Bearer
-	// Authorization header; the UAT is injected via the configure hook below as
-	// a STRIPE-V2-SIG token instead.
-	client := &stripe.Client{
-		BaseURL: baseURL,
-		APIKey:  "",
-	}
-
-	configure := func(req *http.Request) error {
-		req.Header.Set("Authorization", "STRIPE-V2-SIG "+uat)
-		req.Header.Set("Stripe-Version", snc.stripeVersion)
+	// The create call additionally scopes to the resolved playground.
+	createConfigure := func(req *http.Request) error {
+		if cfgErr := authConfigure(req); cfgErr != nil {
+			return cfgErr
+		}
 		req.Header.Set("Stripe-Context", stripeContext)
-		// Content-Type is set to application/json automatically by the client
-		// for /v2/ paths, but set it explicitly to be safe.
-		req.Header.Set("Content-Type", stripe.V2ContentType)
 		return nil
 	}
 
-	resp, err := client.PerformRequest(cmd.Context(), http.MethodPost, "/v2/sandboxes", string(bodyBytes), configure)
+	resp, err := client.PerformRequest(cmd.Context(), http.MethodPost, "/v2/sandboxes", string(bodyBytes), createConfigure)
 	if err != nil {
 		return err
 	}
@@ -622,6 +661,91 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 	}
 
 	return nil
+}
+
+// resolveLiveWorkspace determines the livemode workspace/org compartment to use
+// as the sandbox's live parent. It first reads the livemode compartment saved at
+// login (no network), then falls back to GET /v2/compartments/user_accessible.
+// It returns an error if zero or more than one livemode workspace is found so the
+// caller can disambiguate with --replica-of.
+func (snc *sandboxNewCmd) resolveLiveWorkspace(ctx context.Context, client *stripe.Client, configure func(*http.Request) error) (string, error) {
+	// 1. The livemode compartment pinned at login (what the user was scoped to).
+	if ui, uiErr := Config.Profile.GetUserInfo(); uiErr == nil && ui != nil {
+		for _, c := range ui.Compartments {
+			if c.Livemode && strings.TrimSpace(c.CompartmentID) != "" {
+				return c.CompartmentID, nil
+			}
+		}
+	}
+
+	// 2. Ask the server which accounts this credential can access.
+	resp, err := client.PerformRequest(ctx, http.MethodGet, "/v2/compartments/user_accessible", "", configure)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("could not list your accounts: %s\n%s", resp.Status, string(respBytes))
+	}
+
+	// standalone_workspaces are already filtered to livemode roots by the backend.
+	var parsed struct {
+		StandaloneWorkspaces []struct {
+			ID string `json:"id"`
+		} `json:"standalone_workspaces"`
+	}
+	if err := json.Unmarshal(respBytes, &parsed); err != nil {
+		return "", fmt.Errorf("could not parse accounts response: %w", err)
+	}
+
+	var workspaces []string
+	for _, w := range parsed.StandaloneWorkspaces {
+		if strings.HasPrefix(w.ID, "wksp_") {
+			workspaces = append(workspaces, w.ID)
+		}
+	}
+	switch len(workspaces) {
+	case 0:
+		return "", fmt.Errorf("no livemode workspace found for your account; run `stripe login`, or pass --replica-of wksp_...")
+	case 1:
+		return workspaces[0], nil
+	default:
+		return "", fmt.Errorf("you have multiple livemode workspaces; pass --replica-of wksp_... to choose one")
+	}
+}
+
+// resolvePlayground resolves the internal playground compartment (play_) for a
+// livemode workspace/org via GET /v2/compartments/playground/:id.
+func (snc *sandboxNewCmd) resolvePlayground(ctx context.Context, client *stripe.Client, configure func(*http.Request) error, compartmentID string) (string, error) {
+	if compartmentID == "" {
+		return "", fmt.Errorf("could not determine a live workspace to resolve the playground from; pass --replica-of wksp_... or --stripe-context play_...")
+	}
+	resp, err := client.PerformRequest(ctx, http.MethodGet, "/v2/compartments/playground/"+url.PathEscape(compartmentID), "", configure)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("could not resolve the playground for %s: %s\n%s", compartmentID, resp.Status, string(respBytes))
+	}
+	var parsed struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBytes, &parsed); err != nil {
+		return "", fmt.Errorf("could not parse playground response: %w", err)
+	}
+	if parsed.ID == "" {
+		return "", fmt.Errorf("no playground found for %s; pass --stripe-context play_... to override", compartmentID)
+	}
+	return parsed.ID, nil
 }
 
 // newIdempotencyToken mirrors the dashboard's create-sandbox flow

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -546,43 +546,41 @@ func TestSandboxNewCmd_Success(t *testing.T) {
 	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
 	require.NoError(t, err)
 
-	// Stand up a test server to validate the request shape
+	// --replica-of pins the live workspace; the command resolves its playground,
+	// then creates. The server serves the playground GET and the create POST.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Assert request properties
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/v2/sandboxes", r.URL.Path)
-		assert.Equal(t, "STRIPE-V2-SIG keyinfo_live_faketoken", r.Header.Get("Authorization"))
-		// Stripe-Context must be the playground id, not the livemode workspace.
-		assert.Equal(t, "play_livetest", r.Header.Get("Stripe-Context"))
-		assert.Equal(t, requests.StripeVersionHeaderValue, r.Header.Get("Stripe-Version"))
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
-
-		// Decode and validate the JSON body
-		var body map[string]interface{}
-		err := json.NewDecoder(r.Body).Decode(&body)
-		assert.NoError(t, err)
-		assert.Equal(t, "mytest", body["name"])
-		assert.Equal(t, "wksp_livetest", body["replica_of"])
-		assert.Equal(t, true, body["activate_sandbox"])
-
-		// Return success response
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"id":     "sbx_123",
-			"object": "sandbox",
-		})
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_livetest":
+			assert.Equal(t, "STRIPE-V2-SIG keyinfo_live_faketoken", r.Header.Get("Authorization"))
+			// Resolution GETs are self-scoped by the UAT; no Stripe-Context header.
+			assert.Empty(t, r.Header.Get("Stripe-Context"))
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "play_livetest"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes":
+			assert.Equal(t, "STRIPE-V2-SIG keyinfo_live_faketoken", r.Header.Get("Authorization"))
+			// Stripe-Context must be the resolved playground id, not the workspace.
+			assert.Equal(t, "play_livetest", r.Header.Get("Stripe-Context"))
+			assert.Equal(t, requests.StripeVersionHeaderValue, r.Header.Get("Stripe-Version"))
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			var body map[string]interface{}
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "mytest", body["name"])
+			assert.Equal(t, "wksp_livetest", body["replica_of"])
+			assert.Equal(t, true, body["activate_sandbox"])
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "sbx_123", "object": "sandbox"})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	defer server.Close()
 
-	// Execute the command with explicit flags
 	output, err := executeCommand(
 		rootCmd,
 		"sandbox", "new",
 		"--api-base="+server.URL,
 		"--copy-live-account=true",
 		"--create-blank=false",
-		"--stripe-context=play_livetest",
 		"--replica-of=wksp_livetest",
 		"--name=mytest",
 	)
@@ -600,13 +598,14 @@ func TestSandboxNewCmd_ActivateFalse(t *testing.T) {
 	require.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		err := json.NewDecoder(r.Body).Decode(&body)
-		assert.NoError(t, err)
-		assert.Equal(t, false, body["activate_sandbox"])
-
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_livetest" {
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "play_livetest"})
+			return
+		}
+		var body map[string]interface{}
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, false, body["activate_sandbox"])
 		json.NewEncoder(w).Encode(map[string]interface{}{"id": "sbx_123", "object": "sandbox"})
 	}))
 	defer server.Close()
@@ -617,7 +616,6 @@ func TestSandboxNewCmd_ActivateFalse(t *testing.T) {
 		"--api-base="+server.URL,
 		"--copy-live-account=true",
 		"--create-blank=false",
-		"--stripe-context=play_livetest",
 		"--replica-of=wksp_livetest",
 		"--name=mytest",
 		"--activate=false",
@@ -625,19 +623,31 @@ func TestSandboxNewCmd_ActivateFalse(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestSandboxNewCmd_RejectsNonPlaygroundContext(t *testing.T) {
+func TestSandboxNewCmd_RejectsResolvedNonPlayground(t *testing.T) {
 	cleanup := setupSandboxTestConfig(t)
 	defer cleanup()
 
 	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
 	require.NoError(t, err)
 
+	// If the playground endpoint returns a non-play_ id, the command must reject it.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_livetest" {
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "wksp_notaplayground"})
+			return
+		}
+		t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
 	_, err = executeCommand(
 		rootCmd,
 		"sandbox", "new",
+		"--api-base="+server.URL,
 		"--copy-live-account=true",
 		"--create-blank=false",
-		"--stripe-context=wksp_livetest",
 		"--replica-of=wksp_livetest",
 		"--name=mytest",
 	)
@@ -657,7 +667,6 @@ func TestSandboxNewCmd_RejectsNonWorkspaceReplicaOf(t *testing.T) {
 		"sandbox", "new",
 		"--copy-live-account=true",
 		"--create-blank=false",
-		"--stripe-context=play_livetest",
 		"--replica-of=acct_123",
 		"--name=mytest",
 	)
@@ -672,19 +681,31 @@ func TestSandboxNewCmd_BlankPath(t *testing.T) {
 	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
 	require.NoError(t, err)
 
+	// Blank mode has no --replica-of, so the live workspace is resolved via
+	// user_accessible, then its playground, then create.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
-		err := json.NewDecoder(r.Body).Decode(&body)
-		assert.NoError(t, err)
-		// Blank path sends business_location and omits replica_of entirely.
-		assert.Equal(t, "US", body["business_location"])
-		_, hasReplica := body["replica_of"]
-		assert.False(t, hasReplica)
-		assert.Equal(t, true, body["activate_sandbox"])
-
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{"id": "wksp_test_blank", "object": "sandbox"})
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{{"id": "wksp_blankparent"}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_blankparent":
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "play_blank"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes":
+			assert.Equal(t, "play_blank", r.Header.Get("Stripe-Context"))
+			var body map[string]interface{}
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			// Blank path sends business_location and omits replica_of entirely.
+			assert.Equal(t, "US", body["business_location"])
+			_, hasReplica := body["replica_of"]
+			assert.False(t, hasReplica)
+			assert.Equal(t, true, body["activate_sandbox"])
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "wksp_test_blank", "object": "sandbox"})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	defer server.Close()
 
@@ -694,7 +715,6 @@ func TestSandboxNewCmd_BlankPath(t *testing.T) {
 		"--api-base="+server.URL,
 		"--create-blank=true",
 		"--copy-live-account=false",
-		"--stripe-context=play_livetest",
 		"--replica-of=", // clear any value leaked from a prior test's flag state
 		"--business-location=US",
 		"--activate=true", // clear any --activate=false leaked from a prior test
@@ -747,8 +767,8 @@ func TestSandboxNewCmd_AutoResolveViaUserAccessible(t *testing.T) {
 	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
 	require.NoError(t, err)
 
-	// No --replica-of and no --stripe-context: the command must resolve the live
-	// workspace via /v2/compartments/user_accessible, the playground via
+	// No --replica-of: the command must resolve the live workspace via
+	// /v2/compartments/user_accessible, the playground via
 	// /v2/compartments/playground/:id, then create.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -779,7 +799,6 @@ func TestSandboxNewCmd_AutoResolveViaUserAccessible(t *testing.T) {
 		"--copy-live-account=true",
 		"--create-blank=false",
 		"--replica-of=",
-		"--stripe-context=",
 		"--business-location=",
 		"--activate=true",
 		"--name=autotest",
@@ -815,7 +834,6 @@ func TestSandboxNewCmd_MultipleWorkspacesError(t *testing.T) {
 		"--copy-live-account=true",
 		"--create-blank=false",
 		"--replica-of=",
-		"--stripe-context=",
 		"--business-location=",
 		"--name=autotest",
 	)
@@ -848,7 +866,6 @@ func TestSandboxNewCmd_NoWorkspaceError(t *testing.T) {
 		"--copy-live-account=true",
 		"--create-blank=false",
 		"--replica-of=",
-		"--stripe-context=",
 		"--business-location=",
 		"--name=autotest",
 	)
@@ -866,7 +883,6 @@ func TestSandboxNewCmd_NoUAT(t *testing.T) {
 		rootCmd,
 		"sandbox", "new",
 		"--name=mytest",
-		"--stripe-context=wksp_livetest",
 		"--replica-of=wksp_livetest",
 	)
 
@@ -888,7 +904,6 @@ func TestSandboxNewCmd_BatchNotYetSupported(t *testing.T) {
 	_, err = executeCommand(
 		rootCmd,
 		"sandbox", "new",
-		"--stripe-context=play_livetest",
 		"--replica-of=wksp_livetest",
 		"--name=mytest",
 		"--batch=3",
@@ -900,7 +915,6 @@ func TestSandboxNewCmd_BatchNotYetSupported(t *testing.T) {
 	_, err = executeCommand(
 		rootCmd,
 		"sandbox", "new",
-		"--stripe-context=play_livetest",
 		"--replica-of=wksp_livetest",
 		"--name=mytest",
 		"--batch=0",

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -580,6 +580,8 @@ func TestSandboxNewCmd_Success(t *testing.T) {
 		rootCmd,
 		"sandbox", "new",
 		"--api-base="+server.URL,
+		"--copy-live-account=true",
+		"--create-blank=false",
 		"--stripe-context=play_livetest",
 		"--replica-of=wksp_livetest",
 		"--name=mytest",
@@ -613,6 +615,8 @@ func TestSandboxNewCmd_ActivateFalse(t *testing.T) {
 		rootCmd,
 		"sandbox", "new",
 		"--api-base="+server.URL,
+		"--copy-live-account=true",
+		"--create-blank=false",
 		"--stripe-context=play_livetest",
 		"--replica-of=wksp_livetest",
 		"--name=mytest",
@@ -631,12 +635,14 @@ func TestSandboxNewCmd_RejectsNonPlaygroundContext(t *testing.T) {
 	_, err = executeCommand(
 		rootCmd,
 		"sandbox", "new",
+		"--copy-live-account=true",
+		"--create-blank=false",
 		"--stripe-context=wksp_livetest",
 		"--replica-of=wksp_livetest",
 		"--name=mytest",
 	)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "playground id (play_...)")
+	assert.Contains(t, err.Error(), "non-playground context")
 }
 
 func TestSandboxNewCmd_RejectsNonWorkspaceReplicaOf(t *testing.T) {
@@ -649,6 +655,8 @@ func TestSandboxNewCmd_RejectsNonWorkspaceReplicaOf(t *testing.T) {
 	_, err = executeCommand(
 		rootCmd,
 		"sandbox", "new",
+		"--copy-live-account=true",
+		"--create-blank=false",
 		"--stripe-context=play_livetest",
 		"--replica-of=acct_123",
 		"--name=mytest",
@@ -684,6 +692,8 @@ func TestSandboxNewCmd_BlankPath(t *testing.T) {
 		rootCmd,
 		"sandbox", "new",
 		"--api-base="+server.URL,
+		"--create-blank=true",
+		"--copy-live-account=false",
 		"--stripe-context=play_livetest",
 		"--replica-of=", // clear any value leaked from a prior test's flag state
 		"--business-location=US",
@@ -694,7 +704,7 @@ func TestSandboxNewCmd_BlankPath(t *testing.T) {
 	assert.Contains(t, output, "wksp_test_blank")
 }
 
-func TestSandboxNewCmd_ReplicaOfAndBusinessLocationMutuallyExclusive(t *testing.T) {
+func TestSandboxNewCmd_ModesMutuallyExclusive(t *testing.T) {
 	cleanup := setupSandboxTestConfig(t)
 	defer cleanup()
 
@@ -704,16 +714,15 @@ func TestSandboxNewCmd_ReplicaOfAndBusinessLocationMutuallyExclusive(t *testing.
 	_, err = executeCommand(
 		rootCmd,
 		"sandbox", "new",
-		"--stripe-context=play_livetest",
-		"--replica-of=wksp_livetest",
-		"--business-location=US",
+		"--copy-live-account=true",
+		"--create-blank=true",
 		"--name=mytest",
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
-func TestSandboxNewCmd_RequiresReplicaOfOrBusinessLocation(t *testing.T) {
+func TestSandboxNewCmd_RequiresMode(t *testing.T) {
 	cleanup := setupSandboxTestConfig(t)
 	defer cleanup()
 
@@ -723,15 +732,128 @@ func TestSandboxNewCmd_RequiresReplicaOfOrBusinessLocation(t *testing.T) {
 	_, err = executeCommand(
 		rootCmd,
 		"sandbox", "new",
-		"--stripe-context=play_livetest",
-		"--replica-of=",        // clear leaked flag state so neither is set
-		"--business-location=", // clear leaked flag state so neither is set
+		"--copy-live-account=false", // clear leaked flag state so neither mode is set
+		"--create-blank=false",      // clear leaked flag state so neither mode is set
 		"--name=mytest",
 	)
 	require.Error(t, err)
-	// Unique to the "neither provided" error; the mutually-exclusive error also
-	// mentions --business-location, so assert on this distinct phrase.
 	assert.Contains(t, err.Error(), "pass one of")
+}
+
+func TestSandboxNewCmd_AutoResolveViaUserAccessible(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	// No --replica-of and no --stripe-context: the command must resolve the live
+	// workspace via /v2/compartments/user_accessible, the playground via
+	// /v2/compartments/playground/:id, then create.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{{"id": "wksp_auto"}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_auto":
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "play_auto"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes":
+			assert.Equal(t, "play_auto", r.Header.Get("Stripe-Context"))
+			var body map[string]interface{}
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "wksp_auto", body["replica_of"])
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "sbx_auto", "object": "sandbox"})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	output, err := executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--api-base="+server.URL,
+		"--copy-live-account=true",
+		"--create-blank=false",
+		"--replica-of=",
+		"--stripe-context=",
+		"--business-location=",
+		"--activate=true",
+		"--name=autotest",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, output, "sbx_auto")
+}
+
+func TestSandboxNewCmd_MultipleWorkspacesError(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible" {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{{"id": "wksp_a"}, {"id": "wksp_b"}},
+			})
+			return
+		}
+		t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--api-base="+server.URL,
+		"--copy-live-account=true",
+		"--create-blank=false",
+		"--replica-of=",
+		"--stripe-context=",
+		"--business-location=",
+		"--name=autotest",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple livemode workspaces")
+}
+
+func TestSandboxNewCmd_NoWorkspaceError(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible" {
+			json.NewEncoder(w).Encode(map[string]interface{}{"standalone_workspaces": []map[string]interface{}{}})
+			return
+		}
+		t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--api-base="+server.URL,
+		"--copy-live-account=true",
+		"--create-blank=false",
+		"--replica-of=",
+		"--stripe-context=",
+		"--business-location=",
+		"--name=autotest",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no livemode workspace")
 }
 
 func TestSandboxNewCmd_NoUAT(t *testing.T) {


### PR DESCRIPTION
## What

Make `stripe sandbox new` resolve compartment context automatically, so it needs only `--name` plus a mode flag. Removes the two required inputs that were internal or user-hostile: `--stripe-context` and a mandatory `--replica-of`.

## Why

`play_` playground ids are internal-only and should never be user-facing, and forcing users to hand-supply both the playground and the livemode workspace was poor UX. The dashboard derives both from the logged-in session; this brings the CLI in line.

## How

- Mode selectors `--copy-live-account` / `--create-blank` (exactly one required), mirroring the dashboard's create-sandbox modal. `--business-location` pairs with `--create-blank`.
- The live workspace is resolved from the compartment saved at login (`Profile.UserInfo`), falling back to `GET /v2/compartments/user_accessible` when absent. `--replica-of` remains an override for which live account to copy.
- The playground (`play_`) is resolved via `GET /v2/compartments/playground/:id`. `--stripe-context` is now a hidden, internal-only override.
- No API key required: the UAT authenticates every call, and the resolution GETs are self-scoped (no `Stripe-Context` header).

## Testing

- Unit (12 pass): new `AutoResolveViaUserAccessible` (full GET -> GET -> POST), `MultipleWorkspacesError`, `NoWorkspaceError`, mode selection/validation, plus the existing copy/blank/activate paths.
- Live against qa-api with just a logged-in UAT (no keys, no context/replica flags):
  - copy: `sandbox new --name ... --copy-live-account` -> created a sandbox (exit 0).
  - blank: `sandbox new --name ... --create-blank --business-location US` -> created a sandbox (exit 0).

## Notes

- Command stays `Hidden` (experimental POC); targets the `sandboxes-cli` feature branch.
- Follow-ups, not in this PR: `--access-level`, duplicate-name pre-check via `user_accessible_sandboxes`, and a `sandbox list` companion.
