### PR TITLE
Fix co-op tmux launch with custom config dirs

### DIFF
--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -346,9 +346,9 @@ func (rc *coopRunCmd) runFallbackWithCommand(stripeBin string, blueprintID strin
 			return err
 		}
 		fmt.Printf("Session started: %s\n", session.ID)
-		fmt.Printf("Open another terminal and run: stripe coop join %s\n", session.ID)
+		fmt.Printf("Open another terminal and run: %s\n", shellCommandWithCoopEnv("stripe coop join "+session.ID))
 	} else {
-		fmt.Println("Open another terminal and run: stripe coop join --wait")
+		fmt.Printf("Open another terminal and run: %s\n", shellCommandWithCoopEnv("stripe coop join --wait"))
 	}
 	fmt.Println()
 

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -180,11 +180,15 @@ func (rc *coopRunCmd) debugAgentPaneCommandBuilder(stripeBin string) coopPaneCom
 			sessionID = session.ID
 		}
 		cmd := fmt.Sprintf("%s coop debug-agent --session %s", strconv.Quote(stripeBin), strconv.Quote(sessionID))
-		if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
-			cmd = fmt.Sprintf("XDG_CONFIG_HOME=%s %s", strconv.Quote(xdgConfigHome), cmd)
-		}
-		return cmd, nil, nil
+		return shellCommandWithCoopEnv(cmd), nil, nil
 	}
+}
+
+func shellCommandWithCoopEnv(cmd string) string {
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" && !strings.HasPrefix(cmd, "XDG_CONFIG_HOME=") {
+		return fmt.Sprintf("XDG_CONFIG_HOME=%s %s", strconv.Quote(xdgConfigHome), cmd)
+	}
+	return cmd
 }
 
 func (rc *coopRunCmd) runInTmuxSplit(stripeBin string, agent *agentInfo, agentPrompt string, autoApprove bool, blueprintID string) error {
@@ -206,6 +210,7 @@ func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprintID st
 		rc.abortStartedSession(session, "agent pane command failed")
 		return err
 	}
+	paneCmd = shellCommandWithCoopEnv(paneCmd)
 
 	if err := runTmux("split-window", "-h", "-p", "60", "bash", "-c", paneCmd); err != nil {
 		if cleanup != nil {
@@ -272,11 +277,14 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprintID stri
 	} else {
 		tuiCmd += " " + session.ID
 	}
+	tuiCmd = shellCommandWithCoopEnv(tuiCmd)
+
 	paneCmd, cleanup, err := buildPaneCmd(session)
 	if err != nil {
 		rc.abortStartedSession(session, "agent pane command failed")
 		return err
 	}
+	paneCmd = shellCommandWithCoopEnv(paneCmd)
 
 	width, height := coopTmuxSessionDimensions()
 	if err := runTmux("new-session", "-d", "-s", sessionName, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height),

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -101,6 +101,38 @@ func TestFallbackPaneBuildFailureAbortsStartedSession(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestFallbackJoinInstructionsIncludeCoopEnv(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	rc := &coopRunCmd{language: "node"}
+	output := captureStdout(t, func() {
+		err := rc.runFallbackWithCommand("/stripe", "one-time-payment", func(session *coop.Session) (string, func(), error) {
+			require.NotNil(t, session)
+			return "true", nil, nil
+		})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Open another terminal and run: XDG_CONFIG_HOME=")
+	assert.Contains(t, output, " stripe coop join coop_")
+}
+
+func TestFallbackWaitInstructionsIncludeCoopEnv(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	rc := &coopRunCmd{language: "node"}
+	output := captureStdout(t, func() {
+		err := rc.runFallbackWithCommand("/stripe", "", func(session *coop.Session) (string, func(), error) {
+			require.Nil(t, session)
+			return "true", nil, nil
+		})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Open another terminal and run: XDG_CONFIG_HOME=")
+	assert.Contains(t, output, " stripe coop join --wait")
+}
+
 func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -131,6 +131,13 @@ func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T
 	require.ErrorIs(t, err, splitErr)
 	assert.True(t, cleanupCalled)
 	assert.True(t, hasTmuxCall(tmuxCalls, "kill-session", "-t", "stripe-coop"))
+	newSessionCall := findTmuxCall(tmuxCalls, "new-session")
+	require.NotNil(t, newSessionCall)
+	assert.Contains(t, newSessionCall[len(newSessionCall)-1], "XDG_CONFIG_HOME=")
+	assert.Contains(t, newSessionCall[len(newSessionCall)-1], " coop join ")
+	splitCall := findTmuxCall(tmuxCalls, "split-window")
+	require.NotNil(t, splitCall)
+	assert.Contains(t, splitCall[len(splitCall)-1], "XDG_CONFIG_HOME=")
 
 	store, err := coop.NewStore(coopConfigFolder())
 	require.NoError(t, err)
@@ -159,4 +166,13 @@ func hasTmuxCall(calls [][]string, want ...string) bool {
 		}
 	}
 	return false
+}
+
+func findTmuxCall(calls [][]string, command string) []string {
+	for _, call := range calls {
+		if len(call) > 0 && call[0] == command {
+			return call
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

While doing post-merge validation of `coop`, the outside-tmux `coop start --debug-agent` path failed when `XDG_CONFIG_HOME` was set. The debug-agent pane inherited the custom config dir, but the TUI `coop join` command in the newly-created tmux session did not, so it looked in the default config dir and could not find the session.

This updates tmux command construction so both the TUI pane and agent/debug-agent pane preserve the co-op config environment.

## Validation

- `env -u CODEX_CI -u CODEX_THREAD_ID -u CODEX_SANDBOX -u CODEX_SANDBOX_NETWORK_DISABLED go test ./... -count=1`
- `golangci-lint run ./...`
- `go test -race ./pkg/coop/... ./pkg/cmd/coop -count=1`
- `scripts/test-coop-debug-agent-tmux.sh`
- Manual outside-tmux smoke with custom `XDG_CONFIG_HOME`, wide terminal size, debug agent review/confirm flow, and completion view
