### PR TITLE
coop: fix shell-injection in tmux launcher + wide-layout divider wrapping

### DIFF
--- a/pkg/cmd/coop/coop_debug_agent_test.go
+++ b/pkg/cmd/coop/coop_debug_agent_test.go
@@ -34,7 +34,7 @@ func TestDebugAgentPaneCommandUsesStripeBinaryAndSession(t *testing.T) {
 	cmd, cleanup, err := rc.debugAgentPaneCommandBuilder("/tmp/stripe bin")(&coop.Session{ID: "coop_123"})
 	require.NoError(t, err)
 	assert.Nil(t, cleanup)
-	assert.Equal(t, "XDG_CONFIG_HOME=\"/tmp/xdg config\" \"/tmp/stripe bin\" coop debug-agent --session \"coop_123\"", cmd)
+	assert.Equal(t, "XDG_CONFIG_HOME='/tmp/xdg config' '/tmp/stripe bin' coop debug-agent --session 'coop_123'", cmd)
 }
 
 func TestCoopDebugAgentRerunsRequestedChanges(t *testing.T) {

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -175,7 +175,11 @@ func (rc *coopRunCmd) agentPaneCommandBuilder(agent *agentInfo, discoveryPrompt 
 			os.Remove(promptPath)
 			return "", nil, err
 		}
-		return agentCmd, func() {
+		// The returned command is run via `bash -c`, so the launcher path itself
+		// must be shell-quoted — otherwise a temp dir (TMPDIR) containing a space
+		// or shell syntax would be parsed by bash before the launcher runs. The
+		// cleanup closure keeps the raw path for os.Remove.
+		return shellQuote(agentCmd), func() {
 			os.Remove(promptPath)
 			os.Remove(agentCmd)
 		}, nil

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -21,6 +21,15 @@ type agentInfo struct {
 	path string
 }
 
+// shellQuote wraps s in POSIX single quotes so it is safe to interpolate into a
+// `bash -c` command line. Unlike strconv.Quote (which produces a Go string
+// literal), single quoting neutralizes shell metacharacters including command
+// substitution ($(...), backticks), which would otherwise execute when the
+// generated launcher script runs. Embedded single quotes are escaped as '\”.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 type coopPaneCommandBuilder func(session *coop.Session) (string, func(), error)
 
 var (
@@ -120,7 +129,7 @@ func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApp
 			flags = " --dangerously-skip-permissions"
 		}
 		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
-			strconv.Quote(promptPath), strconv.Quote(promptPath), strconv.Quote(launcherPath), strconv.Quote(agent.path), flags)
+			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path), flags)
 
 	case "codex":
 		flags := ""
@@ -128,11 +137,11 @@ func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApp
 			flags = " --dangerously-bypass-approvals-and-sandbox"
 		}
 		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
-			strconv.Quote(promptPath), strconv.Quote(promptPath), strconv.Quote(launcherPath), strconv.Quote(agent.path), flags)
+			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path), flags)
 
 	default:
 		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s \"$prompt\"\n",
-			strconv.Quote(promptPath), strconv.Quote(promptPath), strconv.Quote(launcherPath), strconv.Quote(agent.path))
+			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path))
 	}
 
 	if err := os.WriteFile(launcherPath, []byte(script), 0700); err != nil {
@@ -179,9 +188,9 @@ func (rc *coopRunCmd) debugAgentPaneCommandBuilder(stripeBin string) coopPaneCom
 		if session != nil {
 			sessionID = session.ID
 		}
-		cmd := fmt.Sprintf("%s coop debug-agent --session %s", strconv.Quote(stripeBin), strconv.Quote(sessionID))
+		cmd := fmt.Sprintf("%s coop debug-agent --session %s", shellQuote(stripeBin), shellQuote(sessionID))
 		if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
-			cmd = fmt.Sprintf("XDG_CONFIG_HOME=%s %s", strconv.Quote(xdgConfigHome), cmd)
+			cmd = fmt.Sprintf("XDG_CONFIG_HOME=%s %s", shellQuote(xdgConfigHome), cmd)
 		}
 		return cmd, nil, nil
 	}
@@ -266,7 +275,7 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprintID stri
 		}
 	}
 
-	tuiCmd := fmt.Sprintf("%s coop join", strconv.Quote(stripeBin))
+	tuiCmd := fmt.Sprintf("%s coop join", shellQuote(stripeBin))
 	if blueprintID == "" {
 		tuiCmd += " --wait"
 	} else {

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -2,6 +2,8 @@ package coopcmd
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"charm.land/huh/v2"
@@ -182,4 +184,29 @@ func TestShellQuoteNeutralizesShellMetacharacters(t *testing.T) {
 			assert.True(t, len(got) >= 2 && got[0] == '\'' && got[len(got)-1] == '\'')
 		})
 	}
+}
+
+// TestAgentPaneCommandShellQuotesLauncherPath guards the launcher path itself
+// (not just the values inside the generated script) against a TMPDIR containing
+// a space or shell syntax, since the pane command is executed via `bash -c`.
+func TestAgentPaneCommandShellQuotesLauncherPath(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "dir with $(spaces)")
+	require.NoError(t, os.MkdirAll(tmp, 0o755))
+	t.Setenv("TMPDIR", tmp)
+
+	rc := &coopRunCmd{}
+	build := rc.agentPaneCommandBuilder(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, "discovery prompt", false)
+	paneCmd, cleanup, err := build(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	defer cleanup()
+
+	// The generated launcher is the only .sh under the temp dir.
+	matches, err := filepath.Glob(filepath.Join(tmp, "*.sh"))
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+
+	// The pane command must be exactly the single-quoted launcher path, so
+	// `bash -c` executes the launcher instead of parsing the path.
+	assert.Equal(t, shellQuote(matches[0]), paneCmd)
 }

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -160,3 +160,26 @@ func hasTmuxCall(calls [][]string, want ...string) bool {
 	}
 	return false
 }
+
+func TestShellQuoteNeutralizesShellMetacharacters(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "/usr/local/bin/claude", `'/usr/local/bin/claude'`},
+		{"command substitution", "/tmp/a$(touch pwned)b", `'/tmp/a$(touch pwned)b'`},
+		{"backticks", "/tmp/`whoami`", "'/tmp/`whoami`'"},
+		{"embedded single quote", "it's", `'it'\''s'`},
+		{"empty", "", `''`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shellQuote(tc.in)
+			assert.Equal(t, tc.want, got)
+			// The quoted form must contain no bare $(, backtick, or unescaped quote
+			// that could break out of the single-quoted context.
+			assert.True(t, len(got) >= 2 && got[0] == '\'' && got[len(got)-1] == '\'')
+		})
+	}
+}

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -192,7 +192,10 @@ func TestShellQuoteNeutralizesShellMetacharacters(t *testing.T) {
 func TestAgentPaneCommandShellQuotesLauncherPath(t *testing.T) {
 	tmp := filepath.Join(t.TempDir(), "dir with $(spaces)")
 	require.NoError(t, os.MkdirAll(tmp, 0o755))
+	// Redirect os.CreateTemp across platforms: Unix reads TMPDIR, Windows TMP/TEMP.
 	t.Setenv("TMPDIR", tmp)
+	t.Setenv("TMP", tmp)
+	t.Setenv("TEMP", tmp)
 
 	rc := &coopRunCmd{}
 	build := rc.agentPaneCommandBuilder(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, "discovery prompt", false)

--- a/pkg/coop/tui/model.go
+++ b/pkg/coop/tui/model.go
@@ -49,6 +49,11 @@ type Model struct {
 	viewport viewport.Model
 	ready    bool
 
+	// outlineWidthOverride, when > 0, constrains outline rule and wrap widths to a
+	// specific column width instead of the full content width. Used by the split
+	// workspace so dividers and wrapped text fit the narrow left column.
+	outlineWidthOverride int
+
 	spinner        spinner.Model
 	err            error
 	sdkSnippet     string

--- a/pkg/coop/tui/outline.go
+++ b/pkg/coop/tui/outline.go
@@ -21,6 +21,16 @@ func (m Model) useSplitWorkspace() bool {
 	return m.width >= 100 && m.session != nil && !m.session.IsComplete()
 }
 
+// outlineWidth returns the column width the step outline should render into.
+// In the split workspace this is the narrow left column; otherwise the full
+// content width.
+func (m Model) outlineWidth() int {
+	if m.outlineWidthOverride > 0 {
+		return m.outlineWidthOverride
+	}
+	return m.contentWidth()
+}
+
 func (m Model) renderSplitWorkspace() string {
 	leftW := m.width / 3
 	if leftW < 34 {
@@ -35,7 +45,12 @@ func (m Model) renderSplitWorkspace() string {
 		return m.renderStepOutline().content
 	}
 
-	nav := m.renderStepOutline().content
+	// Constrain the outline's rules and wrapping to the left column so dividers
+	// and long titles don't overflow and wrap into a broken multi-line mess.
+	// Scoped to the outline copy only — the right detail panel keeps full width.
+	navModel := m
+	navModel.outlineWidthOverride = leftW
+	nav := navModel.renderStepOutline().content
 	detail := m.renderSplitDetail(rightW)
 	left := lipgloss.NewStyle().
 		Width(leftW).
@@ -136,7 +151,7 @@ func (m Model) renderStepLine(ch coop.SessionStep, stepIndex int, selected bool)
 	if m.stepCollapsed(stepIndex) {
 		if summary := m.collapsedStepSummary(stepIndex); summary != "" {
 			candidate := line + "  " + m.theme.MutedStyle.Render(summary)
-			if lipgloss.Width(candidate) <= m.contentWidth() {
+			if lipgloss.Width(candidate) <= m.outlineWidth() {
 				line = candidate
 			}
 		}
@@ -145,7 +160,7 @@ func (m Model) renderStepLine(ch coop.SessionStep, stepIndex int, selected bool)
 }
 
 func (m Model) outlineRuleWidth() int {
-	w := m.contentWidth() - rowCursorWidth - rowRightGap
+	w := m.outlineWidth() - rowCursorWidth - rowRightGap
 	if w < 20 {
 		return 20
 	}
@@ -286,7 +301,7 @@ func (m Model) renderNodeLine(node coop.SessionNode, idx int, includedInStepRevi
 	}
 
 	if annText != "" {
-		wrapW := m.contentWidth() - 8
+		wrapW := m.outlineWidth() - 8
 		if wrapW < 20 {
 			wrapW = 20
 		}

--- a/pkg/coop/tui/outline_wide_test.go
+++ b/pkg/coop/tui/outline_wide_test.go
@@ -1,0 +1,39 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSplitWorkspaceOutlineFitsLeftColumn guards against the split-workspace
+// regression where the outline's divider rules and titles were sized to the
+// full terminal width and wrapped into a broken multi-line mess inside the
+// narrow left column.
+func TestSplitWorkspaceOutlineFitsLeftColumn(t *testing.T) {
+	m := testModel()
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 140, Height: 50})
+	m = updated.(Model)
+
+	require.True(t, m.useSplitWorkspace(), "expected split workspace at width 140")
+
+	leftW := m.width / 3
+	if leftW > 48 {
+		leftW = 48
+	}
+
+	navModel := m
+	navModel.outlineWidthOverride = leftW
+	out := navModel.renderStepOutline().content
+
+	for i, ln := range strings.Split(out, "\n") {
+		require.LessOrEqualf(t, lipgloss.Width(ln), leftW,
+			"outline line %d overflows left column (%d): %q", i, leftW, ln)
+	}
+
+	// Sanity: the full split render still produces both columns and does not panic.
+	require.NotEmpty(t, m.renderSplitWorkspace())
+}


### PR DESCRIPTION
**Stack 1/3** (base: `coop`). The two release-blocking findings from the co-op mode review.

### 1. Shell-quoting in the tmux launcher (security)
The launcher built a `bash -c` script by interpolating paths with `strconv.Quote`, which produces a **Go** string literal, not shell quoting. Inside bash double quotes, `$(...)` and backticks still execute — so an env-controlled path (`TMPDIR`, `XDG_CONFIG_HOME`) or a hostile `--agent` value could inject commands. Replaced with a POSIX `shellQuote` helper (single-quote + `'\''` escaping) at all interpolation sites; kept `strconv.Itoa` for numeric args.

### 2. Wide-terminal layout wrapping (UX)
In the split workspace (width ≥ 100) the outline's divider rules and titles were sized to the full terminal width (up to 80) and wrapped into a broken multi-line mess inside the ~43-col left column — visible on any normal wide terminal. Added an `outlineWidthOverride` so the outline renders to the left-column width; the right detail panel keeps full width.

Dropped a third reported item (completion-header "tab leak") after verifying it's a `tmux capture-pane` artifact of bubbletea's cursor-movement optimization, not a defect — the real `View()` output is tab-free at every stage.

**Tests:** unit test for `shellQuote` metacharacter neutralization; regression test that the split outline fits the left column; updated an existing debug-agent test that had encoded the old unsafe double-quoting. Full race suite + golangci-lint clean; debug-agent tmux smoke test 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)