### PR TITLE
Never copy an organization in `sandbox new`; clarify output

### DIFF
--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -563,6 +563,17 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 		}
 	}
 
+	// Never copy an organization: replica_of / playground resolution both require a
+	// workspace (wksp_). Guard every resolution path (login context, user_accessible,
+	// --replica-of) at one choke point so an org_ can never slip through.
+	if !strings.HasPrefix(liveWorkspace, "wksp_") {
+		return fmt.Errorf("resolved live parent %q is not a workspace (wksp_...); sandboxes can only copy an account, not an organization", liveWorkspace)
+	}
+	// Surface the auto-resolved account so the default is never silent.
+	if snc.copyLiveAccount {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Copying live workspace %s\n", liveWorkspace)
+	}
+
 	// Resolve the internal playground (play_) for the live workspace. Playground
 	// ids are not user-facing, so there is no override: the command always derives it.
 	stripeContext, err := snc.resolvePlayground(cmd.Context(), client, authConfigure, liveWorkspace)
@@ -614,12 +625,28 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 		return fmt.Errorf("create sandbox failed: %s\n%s", resp.Status, string(respBytes))
 	}
 
+	// Lead with the actionable ids (name, the acct_ to target, the sandbox id), then
+	// include the full response for anything else the caller needs.
+	var created struct {
+		ID          string `json:"id"`
+		V1AccountID string `json:"v1_account_id"`
+		Name        string `json:"name"`
+	}
+	_ = json.Unmarshal(respBytes, &created)
+	out := cmd.OutOrStdout()
+	if created.ID != "" {
+		fmt.Fprintf(out, "Created sandbox %q\n", created.Name)
+		if created.V1AccountID != "" {
+			fmt.Fprintf(out, "  account: %s\n", created.V1AccountID)
+		}
+		fmt.Fprintf(out, "  sandbox: %s\n", created.ID)
+	}
 	// Pretty-print the JSON response when possible; otherwise print as-is.
 	var pretty bytes.Buffer
 	if json.Indent(&pretty, respBytes, "", "  ") == nil {
-		fmt.Fprintln(cmd.OutOrStdout(), pretty.String())
+		fmt.Fprintln(out, pretty.String())
 	} else {
-		fmt.Fprintln(cmd.OutOrStdout(), string(respBytes))
+		fmt.Fprintln(out, string(respBytes))
 	}
 
 	return nil
@@ -673,7 +700,7 @@ func (snc *sandboxNewCmd) resolveLiveWorkspace(ctx context.Context, client *stri
 	// 1. The livemode compartment pinned at login (what the user was scoped to).
 	if ui, uiErr := Config.Profile.GetUserInfo(); uiErr == nil && ui != nil {
 		for _, c := range ui.Compartments {
-			if c.Livemode && strings.TrimSpace(c.CompartmentID) != "" {
+			if c.Livemode && strings.HasPrefix(strings.TrimSpace(c.CompartmentID), "wksp_") {
 				return c.CompartmentID, nil
 			}
 		}

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -805,6 +806,87 @@ func TestSandboxNewCmd_AutoResolveViaUserAccessible(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Contains(t, output, "sbx_auto")
+}
+
+func TestSandboxNewCmd_SkipsOrgLoginContext(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	// Write a profiles file with user_info containing an org_ in livemode.
+	// resolveLiveWorkspace must skip it and fall through to user_accessible.
+	profilesFile := Config.ProfilesFile
+	tomlContent := `[default]
+
+[[user_info.compartments]]
+compartment_id = "org_shouldbeskipped"
+livemode = true
+`
+	os.WriteFile(profilesFile, []byte(tomlContent), 0600)
+
+	// Re-read viper with the new file so GetUserInfo sees the org
+	viper.Reset()
+	viper.SetConfigFile(Config.ProfilesFile)
+	err = viper.ReadInConfig()
+	require.NoError(t, err)
+
+	// Verify the org was seeded correctly
+	var ui config.UserInfo
+	err = viper.UnmarshalKey("user_info", &ui)
+	require.NoError(t, err)
+	require.Len(t, ui.Compartments, 1)
+	require.Equal(t, "org_shouldbeskipped", ui.Compartments[0].CompartmentID)
+
+	// Server mock: user_accessible returns wksp_fromlist, playground GET for that,
+	// then create returns sbx_orgskip
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
+			// This is the fallback the test is checking: org_ should be skipped,
+			// so we must hit this endpoint
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{{"id": "wksp_fromlist"}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_fromlist":
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "play_x"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes":
+			var body map[string]interface{}
+			err := json.NewDecoder(r.Body).Decode(&body)
+			require.NoError(t, err)
+			// Must use wksp_fromlist (from user_accessible), NOT the org_
+			assert.Equal(t, "wksp_fromlist", body["replica_of"])
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":            "sbx_orgskip",
+				"v1_account_id": "acct_x",
+				"object":        "sandbox",
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "org_shouldbeskipped"):
+			// If the server ever sees a playground GET for the org_, fail
+			t.Errorf("server received request for org_shouldbeskipped playground, but org_ should have been skipped")
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	output, err := executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--api-base="+server.URL,
+		"--copy-live-account=true",
+		"--create-blank=false",
+		"--replica-of=",
+		"--business-location=",
+		"--activate=true",
+		"--name=orgskiptest",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, output, "sbx_orgskip")
 }
 
 func TestSandboxNewCmd_MultipleWorkspacesError(t *testing.T) {


### PR DESCRIPTION
### Summary

PR1 of two for `stripe sandbox new`.

#1770 made the command auto-resolve the live account to copy (login-pinned context, then `user_accessible`). The login-pinned path only checked livemode, so a user scoped to a livemode organization could have an `org_` handed to `replica_of` and playground resolution, which expect a workspace. That is a silent wrong default: sandboxes copy an account, not an organization.

This change:
- Guards every resolution path to a `wksp_`: the login-pinned context now requires a `wksp_` prefix (a non-workspace context is skipped so resolution falls through to `user_accessible`), plus a final choke-point check before use.
- Rejects an organization with a clear, early error instead of failing deep in the create call.
- Prints the auto-resolved workspace on stderr so the default is never silent.
- Leads the create output with the actionable ids (name, account, sandbox) while still printing the full JSON.

PR2 (follow-up, stacked on this) will add the `--stripe-account acct_` selector so users can choose which live account to copy.

### Test plan

- [x] Added `TestSandboxNewCmd_SkipsOrgLoginContext`: seeds an `org_` login context and asserts the command skips it, resolves the `wksp_` from `user_accessible`, and never passes the `org_` to create.
- [x] `go test ./pkg/cmd -run 'SandboxNew|SandboxCreate'` passes (existing tests unchanged).
- [x] `go build ./...`, `go vet ./pkg/cmd/...`, and `make lint` (golangci-lint, 0 issues) all clean.

### Rollout/revert plan

Safe to revert.

cc @stripe/developer-products
