### PR TITLE
Add `--stripe-account` selector to `sandbox new`, drop --replica-of

### DIFF
--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -417,7 +417,7 @@ type sandboxClaimCmd struct {
 type sandboxNewCmd struct {
 	cmd              *cobra.Command
 	name             string
-	replicaOf        string
+	stripeAccount    string
 	businessLocation string
 	copyLiveAccount  bool
 	createBlank      bool
@@ -507,7 +507,7 @@ that you have previously logged in with your Stripe account credentials.`,
 	snc.cmd.Flags().BoolVar(&snc.copyLiveAccount, "copy-live-account", false, "Copy your live account into a new sandbox")
 	snc.cmd.Flags().BoolVar(&snc.createBlank, "create-blank", false, "Create a fresh blank sandbox (requires --business-location)")
 	snc.cmd.Flags().StringVar(&snc.businessLocation, "business-location", "", "Country for a --create-blank sandbox (e.g. US)")
-	snc.cmd.Flags().StringVar(&snc.replicaOf, "replica-of", "", "Livemode workspace ID (wksp_...) to copy; defaults to your logged-in account")
+	snc.cmd.Flags().StringVar(&snc.stripeAccount, "stripe-account", "", "Live account (acct_...) the sandbox belongs to; defaults to your logged-in account")
 	snc.cmd.Flags().BoolVar(&snc.activate, "activate", true, "Request capabilities and activate the sandbox after creation")
 	snc.cmd.Flags().IntVar(&snc.batch, "batch", 1, "Number of sandboxes to create (currently only 1 is supported)")
 
@@ -536,7 +536,7 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 	if err := snc.validateFlags(); err != nil {
 		return err
 	}
-	replicaOf := strings.TrimSpace(snc.replicaOf)
+	stripeAccount := strings.TrimSpace(snc.stripeAccount)
 	businessLocation := strings.TrimSpace(snc.businessLocation)
 
 	baseURL, err := url.Parse(snc.apiBase)
@@ -561,26 +561,34 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 		return nil
 	}
 
-	// Resolve the live workspace to copy / derive the playground from (both modes
-	// need it). Order: --replica-of override, the livemode compartment saved at
-	// login, then GET /v2/compartments/user_accessible.
-	liveWorkspace := replicaOf
-	if liveWorkspace == "" {
+	// Resolve the live account/workspace the sandbox belongs to (its parent). Both
+	// modes need it: copy replicates its settings and blank is still placed under its
+	// playground. --stripe-account (acct_) selects it; otherwise it is resolved from
+	// the logged-in context.
+	var liveAccountName string
+	var liveWorkspace string
+	if stripeAccount != "" {
+		liveWorkspace, liveAccountName, err = resolveWorkspaceByAccount(cmd.Context(), client, authConfigure, stripeAccount)
+		if err != nil {
+			return err
+		}
+	} else {
 		liveWorkspace, err = resolveLiveWorkspace(cmd.Context(), client, authConfigure)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Never copy an organization: replica_of / playground resolution both require a
-	// workspace (wksp_). Guard every resolution path (login context, user_accessible,
-	// --replica-of) at one choke point so an org_ can never slip through.
+	// Guard every resolution path at one choke point: the live parent must be a
+	// workspace (wksp_). A sandbox belongs to an account, never an organization.
 	if !strings.HasPrefix(liveWorkspace, "wksp_") {
-		return fmt.Errorf("resolved live parent %q is not a workspace (wksp_...); sandboxes can only copy an account, not an organization", liveWorkspace)
+		return fmt.Errorf("resolved live parent %q is not a workspace (wksp_...); a sandbox belongs to an account, not an organization", liveWorkspace)
 	}
-	// Surface the auto-resolved account so the default is never silent.
-	if snc.copyLiveAccount {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Copying live workspace %s\n", liveWorkspace)
+	// Surface the resolved parent so it is never a silent default.
+	if liveAccountName != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Creating sandbox under live account %q (%s)\n", liveAccountName, stripeAccount)
+	} else {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Creating sandbox under live workspace %s\n", liveWorkspace)
 	}
 
 	// Resolve the internal playground (play_) for the live workspace. Playground
@@ -634,21 +642,20 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 		return fmt.Errorf("create sandbox failed: %s\n%s", resp.Status, string(respBytes))
 	}
 
-	// Lead with the actionable ids (name, the acct_ to target, the sandbox id), then
-	// include the full response for anything else the caller needs.
+	// Identify the sandbox by its account (acct_); the wksp_test_ compartment id is
+	// internal, so it is not surfaced here (it remains in the full response below).
+	// The create response carries no name, so echo the requested --name.
 	var created struct {
 		ID          string `json:"id"`
 		V1AccountID string `json:"v1_account_id"`
-		Name        string `json:"name"`
 	}
 	_ = json.Unmarshal(respBytes, &created)
 	out := cmd.OutOrStdout()
 	if created.ID != "" {
-		fmt.Fprintf(out, "Created sandbox %q\n", created.Name)
+		fmt.Fprintf(out, "Created sandbox %q\n", snc.name)
 		if created.V1AccountID != "" {
 			fmt.Fprintf(out, "  account: %s\n", created.V1AccountID)
 		}
-		fmt.Fprintf(out, "  sandbox: %s\n", created.ID)
 	}
 	// Pretty-print the JSON response when possible; otherwise print as-is.
 	var pretty bytes.Buffer
@@ -681,7 +688,7 @@ func (snc *sandboxNewCmd) validateFlags() error {
 
 	// Mode selection mirrors the dashboard's create-sandbox modal: copy a live
 	// account, or create a blank sandbox for a country. Exactly one is required.
-	replicaOf := strings.TrimSpace(snc.replicaOf)
+	stripeAccount := strings.TrimSpace(snc.stripeAccount)
 	businessLocation := strings.TrimSpace(snc.businessLocation)
 	switch {
 	case snc.copyLiveAccount && snc.createBlank:
@@ -690,12 +697,12 @@ func (snc *sandboxNewCmd) validateFlags() error {
 		return fmt.Errorf("pass one of --copy-live-account (copy your live account) or --create-blank (a fresh sandbox)")
 	case snc.createBlank && businessLocation == "":
 		return fmt.Errorf("--create-blank requires --business-location (e.g. US)")
-	case snc.createBlank && replicaOf != "":
-		return fmt.Errorf("--replica-of is only valid with --copy-live-account")
 	case snc.copyLiveAccount && businessLocation != "":
 		return fmt.Errorf("--business-location is only valid with --create-blank")
-	case replicaOf != "" && !strings.HasPrefix(replicaOf, "wksp_"):
-		return fmt.Errorf("--replica-of must be a livemode workspace id (wksp_...), got %q", replicaOf)
+	case strings.HasPrefix(stripeAccount, "org_"):
+		return fmt.Errorf("--stripe-account must be an account (acct_...), not an organization (org_...)")
+	case stripeAccount != "" && !strings.HasPrefix(stripeAccount, "acct_"):
+		return fmt.Errorf("--stripe-account must be an account id (acct_...), got %q", stripeAccount)
 	}
 	return nil
 }
@@ -742,11 +749,28 @@ func fetchAccessibleWorkspaces(ctx context.Context, client *stripe.Client, confi
 	return out, nil
 }
 
+// resolveWorkspaceByAccount resolves a live account id (acct_...) to its workspace
+// compartment (wksp_...) by matching the accessible workspace whose merchant_id equals
+// the account. Returns the workspace id and the account's display name. Searches both
+// standalone and org-nested workspaces via fetchAccessibleWorkspaces.
+func resolveWorkspaceByAccount(ctx context.Context, client *stripe.Client, configure func(*http.Request) error, account string) (string, string, error) {
+	accessible, err := fetchAccessibleWorkspaces(ctx, client, configure)
+	if err != nil {
+		return "", "", err
+	}
+	for _, w := range accessible {
+		if w.MerchantID == account && strings.HasPrefix(w.ID, "wksp_") {
+			return w.ID, w.Name, nil
+		}
+	}
+	return "", "", fmt.Errorf("no accessible live account matches %s; check the id or run `stripe login` again", account)
+}
+
 // resolveLiveWorkspace determines the livemode workspace/org compartment to use
 // as the sandbox's live parent. It first reads the livemode compartment saved at
 // login (no network), then falls back to GET /v2/compartments/user_accessible.
 // It returns an error if zero or more than one livemode workspace is found so the
-// caller can disambiguate with --replica-of.
+// caller can disambiguate with --stripe-account.
 func resolveLiveWorkspace(ctx context.Context, client *stripe.Client, configure func(*http.Request) error) (string, error) {
 	// 1. The livemode compartment pinned at login (what the user was scoped to).
 	if ui, uiErr := Config.Profile.GetUserInfo(); uiErr == nil && ui != nil {
@@ -789,11 +813,11 @@ func resolveLiveWorkspace(ctx context.Context, client *stripe.Client, configure 
 	}
 	switch len(workspaces) {
 	case 0:
-		return "", fmt.Errorf("no livemode workspace found for your account; run `stripe login`, or pass --replica-of with a wksp_ id")
+		return "", fmt.Errorf("no livemode workspace found for your account; run `stripe login`, or pass --stripe-account with an acct_ id")
 	case 1:
 		return workspaces[0], nil
 	default:
-		return "", fmt.Errorf("you have multiple livemode workspaces; pass --replica-of wksp_... to choose one")
+		return "", fmt.Errorf("you have multiple livemode workspaces; pass --stripe-account acct_... to choose one")
 	}
 }
 
@@ -801,7 +825,7 @@ func resolveLiveWorkspace(ctx context.Context, client *stripe.Client, configure 
 // livemode workspace/org via GET /v2/compartments/playground/:id.
 func (snc *sandboxNewCmd) resolvePlayground(ctx context.Context, client *stripe.Client, configure func(*http.Request) error, compartmentID string) (string, error) {
 	if compartmentID == "" {
-		return "", fmt.Errorf("could not determine a live workspace to resolve the playground from; pass --replica-of with a wksp_ id")
+		return "", fmt.Errorf("could not determine a live workspace to resolve the playground from")
 	}
 	resp, err := client.PerformRequest(ctx, http.MethodGet, "/v2/compartments/playground/"+url.PathEscape(compartmentID), "", configure)
 	if err != nil {
@@ -822,7 +846,7 @@ func (snc *sandboxNewCmd) resolvePlayground(ctx context.Context, client *stripe.
 		return "", fmt.Errorf("could not parse playground response: %w", err)
 	}
 	if parsed.ID == "" {
-		return "", fmt.Errorf("no playground found for %s; run 'stripe login' again or pass a different --replica-of wksp_ id", compartmentID)
+		return "", fmt.Errorf("no playground found for %s; run 'stripe login' again", compartmentID)
 	}
 	return parsed.ID, nil
 }

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -547,11 +547,18 @@ func TestSandboxNewCmd_Success(t *testing.T) {
 	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
 	require.NoError(t, err)
 
-	// --replica-of pins the live workspace; the command resolves its playground,
-	// then creates. The server serves the playground GET and the create POST.
+	// --stripe-account pins the live account; the command resolves its workspace and playground,
+	// then creates. The server serves the user_accessible GET, playground GET, and the create POST.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
+			assert.Equal(t, "STRIPE-V2-SIG keyinfo_live_faketoken", r.Header.Get("Authorization"))
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{
+					{"id": "wksp_livetest", "name": "Live Test", "merchant_id": "acct_livetest"},
+				},
+			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_livetest":
 			assert.Equal(t, "STRIPE-V2-SIG keyinfo_live_faketoken", r.Header.Get("Authorization"))
 			// Resolution GETs are self-scoped by the UAT; no Stripe-Context header.
@@ -568,7 +575,7 @@ func TestSandboxNewCmd_Success(t *testing.T) {
 			assert.Equal(t, "mytest", body["name"])
 			assert.Equal(t, "wksp_livetest", body["replica_of"])
 			assert.Equal(t, true, body["activate_sandbox"])
-			json.NewEncoder(w).Encode(map[string]interface{}{"id": "sbx_123", "object": "sandbox"})
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "sbx_123", "v1_account_id": "acct_livetest", "object": "sandbox"})
 		default:
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -582,13 +589,13 @@ func TestSandboxNewCmd_Success(t *testing.T) {
 		"--api-base="+server.URL,
 		"--copy-live-account=true",
 		"--create-blank=false",
-		"--replica-of=wksp_livetest",
+		"--stripe-account=acct_livetest",
 		"--name=mytest",
 	)
 
 	require.NoError(t, err)
 	assert.Contains(t, output, "sbx_123")
-	assert.Contains(t, output, "sandbox")
+	assert.Contains(t, output, "mytest")
 }
 
 func TestSandboxNewCmd_ActivateFalse(t *testing.T) {
@@ -600,14 +607,21 @@ func TestSandboxNewCmd_ActivateFalse(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_livetest" {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{
+					{"id": "wksp_livetest", "name": "Live Test", "merchant_id": "acct_livetest"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_livetest":
 			json.NewEncoder(w).Encode(map[string]interface{}{"id": "play_livetest"})
-			return
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes":
+			var body map[string]interface{}
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, false, body["activate_sandbox"])
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "sbx_123", "object": "sandbox"})
 		}
-		var body map[string]interface{}
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, false, body["activate_sandbox"])
-		json.NewEncoder(w).Encode(map[string]interface{}{"id": "sbx_123", "object": "sandbox"})
 	}))
 	defer server.Close()
 
@@ -617,7 +631,7 @@ func TestSandboxNewCmd_ActivateFalse(t *testing.T) {
 		"--api-base="+server.URL,
 		"--copy-live-account=true",
 		"--create-blank=false",
-		"--replica-of=wksp_livetest",
+		"--stripe-account=acct_livetest",
 		"--name=mytest",
 		"--activate=false",
 	)
@@ -634,12 +648,19 @@ func TestSandboxNewCmd_RejectsResolvedNonPlayground(t *testing.T) {
 	// If the playground endpoint returns a non-play_ id, the command must reject it.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_livetest" {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{
+					{"id": "wksp_livetest", "name": "Live Test", "merchant_id": "acct_livetest"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_livetest":
 			json.NewEncoder(w).Encode(map[string]interface{}{"id": "wksp_notaplayground"})
-			return
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
 		}
-		t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
-		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
 
@@ -649,30 +670,11 @@ func TestSandboxNewCmd_RejectsResolvedNonPlayground(t *testing.T) {
 		"--api-base="+server.URL,
 		"--copy-live-account=true",
 		"--create-blank=false",
-		"--replica-of=wksp_livetest",
+		"--stripe-account=acct_livetest",
 		"--name=mytest",
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "non-playground context")
-}
-
-func TestSandboxNewCmd_RejectsNonWorkspaceReplicaOf(t *testing.T) {
-	cleanup := setupSandboxTestConfig(t)
-	defer cleanup()
-
-	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
-	require.NoError(t, err)
-
-	_, err = executeCommand(
-		rootCmd,
-		"sandbox", "new",
-		"--copy-live-account=true",
-		"--create-blank=false",
-		"--replica-of=acct_123",
-		"--name=mytest",
-	)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "workspace id (wksp_...)")
 }
 
 func TestSandboxNewCmd_BlankPath(t *testing.T) {
@@ -682,14 +684,14 @@ func TestSandboxNewCmd_BlankPath(t *testing.T) {
 	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
 	require.NoError(t, err)
 
-	// Blank mode has no --replica-of, so the live workspace is resolved via
+	// Blank mode has no --stripe-account, so the live workspace is resolved via
 	// user_accessible, then its playground, then create.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"standalone_workspaces": []map[string]interface{}{{"id": "wksp_blankparent"}},
+				"standalone_workspaces": []map[string]interface{}{{"id": "wksp_blankparent", "name": "Blank Parent", "merchant_id": "acct_blank"}},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_blankparent":
 			json.NewEncoder(w).Encode(map[string]interface{}{"id": "play_blank"})
@@ -716,13 +718,13 @@ func TestSandboxNewCmd_BlankPath(t *testing.T) {
 		"--api-base="+server.URL,
 		"--create-blank=true",
 		"--copy-live-account=false",
-		"--replica-of=", // clear any value leaked from a prior test's flag state
+		"--stripe-account=", // clear any value leaked from a prior test's flag state
 		"--business-location=US",
 		"--activate=true", // clear any --activate=false leaked from a prior test
 		"--name=blanktest",
 	)
 	require.NoError(t, err)
-	assert.Contains(t, output, "wksp_test_blank")
+	assert.Contains(t, output, "blanktest")
 }
 
 func TestSandboxNewCmd_ModesMutuallyExclusive(t *testing.T) {
@@ -768,7 +770,7 @@ func TestSandboxNewCmd_AutoResolveViaUserAccessible(t *testing.T) {
 	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
 	require.NoError(t, err)
 
-	// No --replica-of: the command must resolve the live workspace via
+	// No --stripe-account: the command must resolve the live workspace via
 	// /v2/compartments/user_accessible, the playground via
 	// /v2/compartments/playground/:id, then create.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -776,7 +778,7 @@ func TestSandboxNewCmd_AutoResolveViaUserAccessible(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"standalone_workspaces": []map[string]interface{}{{"id": "wksp_auto"}},
+				"standalone_workspaces": []map[string]interface{}{{"id": "wksp_auto", "name": "Auto", "merchant_id": "acct_auto"}},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_auto":
 			json.NewEncoder(w).Encode(map[string]interface{}{"id": "play_auto"})
@@ -799,13 +801,13 @@ func TestSandboxNewCmd_AutoResolveViaUserAccessible(t *testing.T) {
 		"--api-base="+server.URL,
 		"--copy-live-account=true",
 		"--create-blank=false",
-		"--replica-of=",
+		"--stripe-account=",
 		"--business-location=",
 		"--activate=true",
 		"--name=autotest",
 	)
 	require.NoError(t, err)
-	assert.Contains(t, output, "sbx_auto")
+	assert.Contains(t, output, "autotest")
 }
 
 func TestSandboxNewCmd_SkipsOrgLoginContext(t *testing.T) {
@@ -880,13 +882,13 @@ livemode = true
 		"--api-base="+server.URL,
 		"--copy-live-account=true",
 		"--create-blank=false",
-		"--replica-of=",
+		"--stripe-account=",
 		"--business-location=",
 		"--activate=true",
 		"--name=orgskiptest",
 	)
 	require.NoError(t, err)
-	assert.Contains(t, output, "sbx_orgskip")
+	assert.Contains(t, output, "orgskiptest")
 }
 
 func TestSandboxNewCmd_MultipleWorkspacesError(t *testing.T) {
@@ -915,7 +917,7 @@ func TestSandboxNewCmd_MultipleWorkspacesError(t *testing.T) {
 		"--api-base="+server.URL,
 		"--copy-live-account=true",
 		"--create-blank=false",
-		"--replica-of=",
+		"--stripe-account=",
 		"--business-location=",
 		"--name=autotest",
 	)
@@ -947,7 +949,7 @@ func TestSandboxNewCmd_NoWorkspaceError(t *testing.T) {
 		"--api-base="+server.URL,
 		"--copy-live-account=true",
 		"--create-blank=false",
-		"--replica-of=",
+		"--stripe-account=",
 		"--business-location=",
 		"--name=autotest",
 	)
@@ -965,7 +967,9 @@ func TestSandboxNewCmd_NoUAT(t *testing.T) {
 		rootCmd,
 		"sandbox", "new",
 		"--name=mytest",
-		"--replica-of=wksp_livetest",
+		"--stripe-account=acct_livetest",
+		"--copy-live-account=true",
+		"--create-blank=false",
 	)
 
 	// Should fail with an error mentioning stripe login
@@ -986,7 +990,9 @@ func TestSandboxNewCmd_BatchNotYetSupported(t *testing.T) {
 	_, err = executeCommand(
 		rootCmd,
 		"sandbox", "new",
-		"--replica-of=wksp_livetest",
+		"--stripe-account=acct_livetest",
+		"--copy-live-account=true",
+		"--create-blank=false",
 		"--name=mytest",
 		"--batch=3",
 	)
@@ -997,12 +1003,168 @@ func TestSandboxNewCmd_BatchNotYetSupported(t *testing.T) {
 	_, err = executeCommand(
 		rootCmd,
 		"sandbox", "new",
-		"--replica-of=wksp_livetest",
+		"--stripe-account=acct_livetest",
+		"--copy-live-account=true",
+		"--create-blank=false",
 		"--name=mytest",
 		"--batch=0",
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--batch must be >= 1")
+}
+
+func TestSandboxNewCmd_ResolvesByStripeAccount(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{
+					{"id": "wksp_target", "name": "Acme", "merchant_id": "acct_target"},
+					{"id": "wksp_other", "name": "Other", "merchant_id": "acct_other"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_target":
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "play_target"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes":
+			assert.Equal(t, "play_target", r.Header.Get("Stripe-Context"))
+			var body map[string]interface{}
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "wksp_target", body["replica_of"])
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "sbx_byacct", "v1_account_id": "acct_target", "object": "sandbox"})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--api-base="+server.URL,
+		"--copy-live-account=true",
+		"--create-blank=false",
+		"--stripe-account=acct_target",
+		"--name=targettest",
+		"--batch=1",
+	)
+
+	require.NoError(t, err)
+}
+
+func TestSandboxNewCmd_StripeAccountBlankMode(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{
+					{"id": "wksp_target", "name": "Acme", "merchant_id": "acct_target"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/playground/wksp_target":
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "play_target"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes":
+			assert.Equal(t, "play_target", r.Header.Get("Stripe-Context"))
+			var body map[string]interface{}
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "US", body["business_location"])
+			_, hasReplica := body["replica_of"]
+			assert.False(t, hasReplica)
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": "sbx_blankacct", "object": "sandbox"})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--api-base="+server.URL,
+		"--create-blank=true",
+		"--copy-live-account=false",
+		"--business-location=US",
+		"--stripe-account=acct_target",
+		"--name=blankaccttest",
+		"--batch=1",
+	)
+
+	require.NoError(t, err)
+}
+
+func TestSandboxNewCmd_StripeAccountNotFound(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible" {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{
+					{"id": "wksp_other", "name": "Other", "merchant_id": "acct_other"},
+				},
+			})
+			return
+		}
+		t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--api-base="+server.URL,
+		"--copy-live-account=true",
+		"--create-blank=false",
+		"--stripe-account=acct_missing",
+		"--business-location=",
+		"--name=missingtest",
+		"--batch=1",
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no accessible live account matches")
+}
+
+func TestSandboxNewCmd_StripeAccountRejectsOrg(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "new",
+		"--copy-live-account=true",
+		"--create-blank=false",
+		"--stripe-account=org_123",
+		"--business-location=",
+		"--name=orgtest",
+		"--batch=1",
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not an organization")
 }
 
 func TestSandboxListCmd_ByStripeAccount(t *testing.T) {


### PR DESCRIPTION
### Summary

PR2 of two for `stripe sandbox new`, stacked on #1777.

The live parent (the account a sandbox belongs to) applies to both modes: `--copy-live-account` replicates its settings and `--create-blank` is still placed under its playground. Naming it by workspace id (`--replica-of wksp_...`) exposed an internal id and was a second, confusing way to say the same thing.

This replaces it with **`--stripe-account acct_...`**, the friendly, dashboard-visible id:
- Valid in **both** modes; defaults to the logged-in account when omitted.
- Resolves `acct_ → wksp_` via `GET /v2/compartments/user_accessible`, matching `merchant_id` across **both** `standalone_workspaces` and org-nested `organizations[].workspaces` (org-nested filtered to livemode), so an account under an organization still resolves without a raw workspace id.
- Input is `acct_` only; an `org_` is rejected up front, a sandbox belongs to an account, not an organization.

`--replica-of` is removed entirely.

### Test plan

- [x] `go test ./pkg/cmd/` (full package) passes.
- [x] New tests: `ResolvesByStripeAccount`, `StripeAccountBlankMode` (proves `--stripe-account` works without `--copy-live-account`), `StripeAccountNotFound`, `StripeAccountRejectsOrg`. Existing tests converted from `--replica-of` to `--stripe-account` with a `user_accessible` mock, assertions preserved.
- [x] `go build ./...`, `go vet ./pkg/cmd/...`, and `make lint` (golangci-lint, 0 issues) all clean.
- [ ] Live QA follow-up: exercise `--create-blank --stripe-account acct_...` end-to-end (backend call shape is unchanged, only the resolved playground differs, so low risk).

### Rollout/revert plan

Safe to revert.

cc @stripe/developer-products
