### PR TITLE
Add `stripe sandbox list`

### DIFF
--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/logrusorgru/aurora"
@@ -73,6 +74,7 @@ func newSandboxCmd() *sandboxCmd {
 	// client-side env gate is needed. The authoritative access gate remains
 	// server-side (the UAT allowlist + hzn_sandbox_create), not the client.
 	sc.cmd.AddCommand(newSandboxNewCmd().cmd)
+	sc.cmd.AddCommand(newSandboxListCmd().cmd)
 	return sc
 }
 
@@ -425,6 +427,13 @@ type sandboxNewCmd struct {
 	apiBase          string
 }
 
+type sandboxListCmd struct {
+	cmd           *cobra.Command
+	stripeAccount string
+	stripeVersion string
+	apiBase       string
+}
+
 func newSandboxClaimCmd() *sandboxClaimCmd {
 	scc := &sandboxClaimCmd{}
 	scc.cmd = &cobra.Command{
@@ -557,7 +566,7 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 	// login, then GET /v2/compartments/user_accessible.
 	liveWorkspace := replicaOf
 	if liveWorkspace == "" {
-		liveWorkspace, err = snc.resolveLiveWorkspace(cmd.Context(), client, authConfigure)
+		liveWorkspace, err = resolveLiveWorkspace(cmd.Context(), client, authConfigure)
 		if err != nil {
 			return err
 		}
@@ -664,12 +673,54 @@ func (snc *sandboxNewCmd) validateFlags() error {
 	return nil
 }
 
+// accessibleWorkspace is the subset of a user_accessible / user_accessible_sandboxes
+// entry the sandbox resolvers need. The same shape appears as a standalone workspace,
+// nested under organizations[].workspaces, and as a sandbox entry.
+type accessibleWorkspace struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	MerchantID string `json:"merchant_id"`
+	ReplicaOf  string `json:"replica_of"`
+	Livemode   string `json:"livemode"`
+}
+
+// fetchAccessibleWorkspaces returns the caller's accessible live workspaces (standalone
+// plus org-nested) from GET /v2/compartments/user_accessible.
+func fetchAccessibleWorkspaces(ctx context.Context, client *stripe.Client, configure func(*http.Request) error) ([]accessibleWorkspace, error) {
+	resp, err := client.PerformRequest(ctx, http.MethodGet, "/v2/compartments/user_accessible", "", configure)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("could not list your accounts: %s\n%s", resp.Status, string(respBytes))
+	}
+	var parsed struct {
+		StandaloneWorkspaces []accessibleWorkspace `json:"standalone_workspaces"`
+		Organizations        []struct {
+			Workspaces []accessibleWorkspace `json:"workspaces"`
+		} `json:"organizations"`
+	}
+	if err := json.Unmarshal(respBytes, &parsed); err != nil {
+		return nil, fmt.Errorf("could not parse accounts response: %w", err)
+	}
+	out := append([]accessibleWorkspace{}, parsed.StandaloneWorkspaces...)
+	for _, org := range parsed.Organizations {
+		out = append(out, org.Workspaces...)
+	}
+	return out, nil
+}
+
 // resolveLiveWorkspace determines the livemode workspace/org compartment to use
 // as the sandbox's live parent. It first reads the livemode compartment saved at
 // login (no network), then falls back to GET /v2/compartments/user_accessible.
 // It returns an error if zero or more than one livemode workspace is found so the
 // caller can disambiguate with --replica-of.
-func (snc *sandboxNewCmd) resolveLiveWorkspace(ctx context.Context, client *stripe.Client, configure func(*http.Request) error) (string, error) {
+func resolveLiveWorkspace(ctx context.Context, client *stripe.Client, configure func(*http.Request) error) (string, error) {
 	// 1. The livemode compartment pinned at login (what the user was scoped to).
 	if ui, uiErr := Config.Profile.GetUserInfo(); uiErr == nil && ui != nil {
 		for _, c := range ui.Compartments {
@@ -758,6 +809,163 @@ func (snc *sandboxNewCmd) resolvePlayground(ctx context.Context, client *stripe.
 // v2CreateSandbox call (which does not use the Idempotency-Key header).
 func newIdempotencyToken(name, country, parent string) string {
 	return fmt.Sprintf("%s-%s-%s-%d", name, country, parent, time.Now().Unix())
+}
+
+func newSandboxListCmd() *sandboxListCmd {
+	slc := &sandboxListCmd{}
+	slc.cmd = &cobra.Command{
+		Use:    "list",
+		Short:  "List the sandboxes under a live account",
+		Args:   validators.NoArgs,
+		RunE:   slc.runSandboxListCmd,
+		Hidden: true,
+	}
+
+	slc.cmd.Flags().StringVar(&slc.stripeAccount, "stripe-account", "", "Live account (acct_...) whose sandboxes to list; defaults to your logged-in account")
+	slc.cmd.Flags().StringVar(&slc.stripeVersion, "stripe-version", requests.StripeVersionHeaderValue, "Sets the Stripe-Version header")
+	_ = slc.cmd.Flags().MarkHidden("stripe-version")
+
+	slc.cmd.Flags().StringVar(&slc.apiBase, "api-base", stripe.DefaultAPIBaseURL, "Sets the Stripe API base URL")
+	_ = slc.cmd.Flags().MarkHidden("api-base")
+
+	return slc
+}
+
+func (slc *sandboxListCmd) runSandboxListCmd(cmd *cobra.Command, args []string) error {
+	if config.KeyRing == nil {
+		return fmt.Errorf("credential store unavailable; run `stripe login` first")
+	}
+	uatBytes, err := config.KeyRing.Get(config.UATKeychainItemKey)
+	if err != nil || len(uatBytes) == 0 {
+		return fmt.Errorf("no user access token found; run `stripe login` first")
+	}
+	uat := strings.TrimSpace(string(uatBytes))
+
+	stripeAccount := strings.TrimSpace(slc.stripeAccount)
+	if stripeAccount != "" {
+		if strings.HasPrefix(stripeAccount, "org_") {
+			return fmt.Errorf("--stripe-account must be an account (acct_...), not an organization (org_...)")
+		}
+		if !strings.HasPrefix(stripeAccount, "acct_") {
+			return fmt.Errorf("--stripe-account must be an account id (acct_...), got %q", stripeAccount)
+		}
+	}
+
+	baseURL, err := url.Parse(slc.apiBase)
+	if err != nil {
+		return fmt.Errorf("invalid --api-base %q: %w", slc.apiBase, err)
+	}
+
+	client := &stripe.Client{
+		BaseURL: baseURL,
+		APIKey:  "",
+	}
+
+	authConfigure := func(req *http.Request) error {
+		req.Header.Set("Authorization", "STRIPE-V2-SIG "+uat)
+		req.Header.Set("Stripe-Version", slc.stripeVersion)
+		req.Header.Set("Content-Type", stripe.V2ContentType)
+		return nil
+	}
+
+	// Fetch accessible workspaces once and build maps for translation
+	accessible, err := fetchAccessibleWorkspaces(cmd.Context(), client, authConfigure)
+	if err != nil {
+		return err
+	}
+	acctByWksp := make(map[string]string, len(accessible))
+	nameByWksp := make(map[string]string, len(accessible))
+	for _, w := range accessible {
+		if w.ID != "" {
+			acctByWksp[w.ID] = w.MerchantID
+			nameByWksp[w.ID] = w.Name
+		}
+	}
+
+	// Resolve the live parent (workspace id, acct_, and name)
+	var liveWorkspace, liveAccount, liveName string
+	if stripeAccount != "" {
+		for _, w := range accessible {
+			if w.MerchantID == stripeAccount && strings.HasPrefix(w.ID, "wksp_") {
+				liveWorkspace, liveName = w.ID, w.Name
+				break
+			}
+		}
+		if liveWorkspace == "" {
+			return fmt.Errorf("no accessible live account matches %s; check the id or run `stripe login` again", stripeAccount)
+		}
+		liveAccount = stripeAccount
+	} else {
+		liveWorkspace, err = resolveLiveWorkspace(cmd.Context(), client, authConfigure)
+		if err != nil {
+			return err
+		}
+		liveAccount = acctByWksp[liveWorkspace]
+		liveName = nameByWksp[liveWorkspace]
+	}
+	if !strings.HasPrefix(liveWorkspace, "wksp_") {
+		return fmt.Errorf("resolved live parent %q is not a workspace (wksp_...)", liveWorkspace)
+	}
+
+	// Transparency line (stderr): prefer name, then acct_, never show wksp_ unless nothing else
+	switch {
+	case liveName != "":
+		fmt.Fprintf(cmd.ErrOrStderr(), "Listing sandboxes under live account %q (%s)\n", liveName, liveAccount)
+	case liveAccount != "":
+		fmt.Fprintf(cmd.ErrOrStderr(), "Listing sandboxes under live account %s\n", liveAccount)
+	default:
+		fmt.Fprintf(cmd.ErrOrStderr(), "Listing sandboxes under live workspace %s\n", liveWorkspace)
+	}
+
+	query := "live_compartment_parent_id=" + url.QueryEscape(liveWorkspace)
+	resp, err := client.PerformRequest(cmd.Context(), http.MethodGet, "/v2/compartments/user_accessible_sandboxes", query, authConfigure)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("list sandboxes failed: %s\n%s", resp.Status, string(respBytes))
+	}
+
+	var parsed struct {
+		Workspaces    []accessibleWorkspace `json:"workspaces"`
+		Organizations []struct {
+			Workspaces []accessibleWorkspace `json:"workspaces"`
+		} `json:"organizations"`
+	}
+	if err := json.Unmarshal(respBytes, &parsed); err != nil {
+		return fmt.Errorf("could not parse sandboxes response: %w", err)
+	}
+
+	var sandboxes []accessibleWorkspace
+	sandboxes = append(sandboxes, parsed.Workspaces...)
+	for _, org := range parsed.Organizations {
+		sandboxes = append(sandboxes, org.Workspaces...)
+	}
+
+	if len(sandboxes) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No sandboxes found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ACCOUNT\tNAME\tREPLICA OF")
+	for _, s := range sandboxes {
+		replicaAcct := ""
+		if s.ReplicaOf != "" {
+			replicaAcct = acctByWksp[s.ReplicaOf] // parent's acct_; empty if not found — never show wksp_
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", s.MerchantID, s.Name, replicaAcct)
+	}
+	w.Flush()
+
+	return nil
 }
 
 func isSSHSession() bool {

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -922,3 +922,221 @@ func TestSandboxNewCmd_BatchNotYetSupported(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--batch must be >= 1")
 }
+
+func TestSandboxListCmd_ByStripeAccount(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
+			assert.Equal(t, "STRIPE-V2-SIG keyinfo_live_faketoken", r.Header.Get("Authorization"))
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{
+					{"id": "wksp_target", "name": "Acme", "merchant_id": "acct_target"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible_sandboxes":
+			if r.URL.RawQuery != "live_compartment_parent_id=wksp_target" {
+				t.Errorf("expected live_compartment_parent_id=wksp_target, got %s", r.URL.RawQuery)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"workspaces": []map[string]interface{}{
+					{"id": "wksp_test_a", "name": "sbxA", "merchant_id": "acct_a", "replica_of": "wksp_target"},
+					{"id": "wksp_test_b", "name": "sbxB", "merchant_id": "acct_b", "replica_of": "wksp_target"},
+				},
+			})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	output, err := executeCommand(
+		rootCmd,
+		"sandbox", "list",
+		"--api-base="+server.URL,
+		"--stripe-account=acct_target",
+	)
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "acct_a")
+	assert.Contains(t, output, "acct_b")
+	assert.Contains(t, output, "sbxA")
+	assert.Contains(t, output, "sbxB")
+	assert.Contains(t, output, "acct_target")
+	assert.NotContains(t, output, "wksp_")
+}
+
+func TestSandboxListCmd_AutoResolve(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{
+					{"id": "wksp_solo", "name": "Solo", "merchant_id": "acct_solo"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible_sandboxes":
+			if r.URL.RawQuery != "live_compartment_parent_id=wksp_solo" {
+				t.Errorf("expected live_compartment_parent_id=wksp_solo, got %s", r.URL.RawQuery)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"workspaces": []map[string]interface{}{
+					{"id": "wksp_child", "name": "ChildSbx", "merchant_id": "acct_child", "replica_of": "wksp_solo"},
+				},
+			})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	output, err := executeCommand(
+		rootCmd,
+		"sandbox", "list",
+		"--api-base="+server.URL,
+		"--stripe-account=",
+	)
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "acct_child")
+	assert.Contains(t, output, "ChildSbx")
+	assert.Contains(t, output, "acct_solo")
+	assert.NotContains(t, output, "wksp_")
+}
+
+func TestSandboxListCmd_OrgNestedSandboxes(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{
+					{"id": "wksp_target", "name": "Target", "merchant_id": "acct_target"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible_sandboxes":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"workspaces": []map[string]interface{}{},
+				"organizations": []map[string]interface{}{
+					{
+						"workspaces": []map[string]interface{}{
+							{"id": "wksp_test_org", "name": "orgsbx", "merchant_id": "acct_o", "replica_of": "wksp_target"},
+						},
+					},
+				},
+			})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	output, err := executeCommand(
+		rootCmd,
+		"sandbox", "list",
+		"--api-base="+server.URL,
+		"--stripe-account=acct_target",
+	)
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "acct_o")
+	assert.Contains(t, output, "orgsbx")
+	assert.Contains(t, output, "acct_target")
+	assert.NotContains(t, output, "wksp_")
+}
+
+func TestSandboxListCmd_Empty(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible" {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"standalone_workspaces": []map[string]interface{}{
+					{"id": "wksp_solo", "name": "Solo", "merchant_id": "acct_solo"},
+				},
+			})
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible_sandboxes" {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"workspaces":    []map[string]interface{}{},
+				"organizations": []map[string]interface{}{},
+			})
+			return
+		}
+		t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	output, err := executeCommand(
+		rootCmd,
+		"sandbox", "list",
+		"--api-base="+server.URL,
+		"--stripe-account=",
+	)
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "No sandboxes found")
+}
+
+func TestSandboxListCmd_RejectsOrg(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
+	require.NoError(t, err)
+
+	_, err = executeCommand(
+		rootCmd,
+		"sandbox", "list",
+		"--stripe-account=org_123",
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not an organization")
+}
+
+func TestSandboxListCmd_NoUAT(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	_, err := executeCommand(
+		rootCmd,
+		"sandbox", "list",
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stripe login")
+}


### PR DESCRIPTION
### Summary

Adds `stripe sandbox list` (hidden, pre-GA like `sandbox new`): lists the sandboxes under one live account via `GET /v2/compartments/user_accessible_sandboxes`, scoped to a single live parent (the logged-in account by default, or `--stripe-account acct_...` to pick).

Sandboxes are identified by their **account id (`acct_`)**, never the internal `wksp_test_` compartment id. The table is `ACCOUNT / NAME / REPLICA OF`, and `replica_of` is shown as the live parent's `acct_` (translated from its workspace id via a `wksp_ -> acct_` map built from `user_accessible`). `--stripe-account` takes an `acct_` only; an `org_` is rejected. Reuses the resolution + UAT-auth machinery from `sandbox new` (`resolveLiveWorkspace` promoted to a package function).

This is independent of the other `sandbox new` follow-up branches; it will rebase cleanly onto `sandboxes-cli`.

### Test plan

- [x] `go test ./pkg/cmd/` passes; 6 new tests (`TestSandboxListCmd_*`): by-account, auto-resolve, org-nested flattening, empty, `org_` rejection, missing UAT. Each output test asserts `NotContains("wksp_")` so no workspace id leaks.
- [x] `go build ./...`, `go vet ./pkg/cmd/...`, `make lint` (0 issues) all clean.
- [x] Live-verified on QA: `sandbox list` (both `--stripe-account acct_` and auto-resolve) lists the account's sandboxes by `acct_`, with `replica_of` shown as the live parent's `acct_`, and no `wksp_` in the output.

### Rollout/revert plan

Safe to revert. Hidden command; no backend change (reads an existing INTERNAL endpoint via the login UAT).

cc @stripe/developer-products
