### PR TITLE
Remove orphaned PluginResolutionSource telemetry field

### DIFF
--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -37,20 +37,20 @@ const DefaultTelemetryEndpoint = "https://r.stripe.com/0"
 
 // CLIAnalyticsEventMetadata is the structure that holds telemetry data context that is ultimately sent to the Stripe Analytics Service.
 type CLIAnalyticsEventMetadata struct {
-	InvocationID           string `url:"invocation_id"`                      // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
-	UserAgent              string `url:"user_agent"`                         // the application that is used to create this request
-	CommandPath            string `url:"command_path"`                       // the command or gRPC method that initiated this request
-	CommandFlags           string `url:"command_flags"`                      // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
-	PluginName string `url:"plugin_name,omitempty"` // the plugin being installed, when relevant
-	Merchant   string `url:"merchant"`              // the merchant ID: ex. acct_xxxx
-	CLIVersion             string `url:"cli_version"`                        // the version of the CLI
-	OS                     string `url:"os"`                                 // the OS of the system
-	GeneratedResource      bool   `url:"generated_resource"`                 // whether or not this was a generated resource
-	AIAgent                string `url:"ai_agent,omitempty"`                 // the AI coding agent that invoked the CLI, if any
-	InstallMethod          string `url:"install_method,omitempty"`           // how the CLI was installed
-	InTmux                 bool   `url:"in_tmux"`                            // whether the CLI was invoked from within tmux
-	InScreen               bool   `url:"in_screen"`                          // whether the CLI was invoked from within GNU Screen
-	TerminalProgram        string `url:"terminal_program,omitempty"`         // the terminal program that invoked the CLI, if any
+	InvocationID      string `url:"invocation_id"`              // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
+	UserAgent         string `url:"user_agent"`                 // the application that is used to create this request
+	CommandPath       string `url:"command_path"`               // the command or gRPC method that initiated this request
+	CommandFlags      string `url:"command_flags"`              // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
+	PluginName        string `url:"plugin_name,omitempty"`      // the plugin being installed, when relevant
+	Merchant          string `url:"merchant"`                   // the merchant ID: ex. acct_xxxx
+	CLIVersion        string `url:"cli_version"`                // the version of the CLI
+	OS                string `url:"os"`                         // the OS of the system
+	GeneratedResource bool   `url:"generated_resource"`         // whether or not this was a generated resource
+	AIAgent           string `url:"ai_agent,omitempty"`         // the AI coding agent that invoked the CLI, if any
+	InstallMethod     string `url:"install_method,omitempty"`   // how the CLI was installed
+	InTmux            bool   `url:"in_tmux"`                    // whether the CLI was invoked from within tmux
+	InScreen          bool   `url:"in_screen"`                  // whether the CLI was invoked from within GNU Screen
+	TerminalProgram   string `url:"terminal_program,omitempty"` // the terminal program that invoked the CLI, if any
 }
 
 // TelemetryClient is an interface that can send two types of events: an API request, and just general events.
@@ -160,7 +160,6 @@ func (e *CLIAnalyticsEventMetadata) SetCommandFlags(commandFlags string) {
 func (e *CLIAnalyticsEventMetadata) SetPluginName(pluginName string) {
 	e.PluginName = pluginName
 }
-
 
 // SendAPIRequestEvent is a special function for API requests
 func (a *AnalyticsTelemetryClient) SendAPIRequestEvent(ctx context.Context, requestID string, livemode bool) (*http.Response, error) {

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -41,9 +41,8 @@ type CLIAnalyticsEventMetadata struct {
 	UserAgent              string `url:"user_agent"`                         // the application that is used to create this request
 	CommandPath            string `url:"command_path"`                       // the command or gRPC method that initiated this request
 	CommandFlags           string `url:"command_flags"`                      // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
-	PluginName             string `url:"plugin_name,omitempty"`              // the plugin being installed, when relevant
-	PluginResolutionSource string `url:"plugin_resolution_source,omitempty"` // temporary source used to resolve plugin metadata
-	Merchant               string `url:"merchant"`                           // the merchant ID: ex. acct_xxxx
+	PluginName string `url:"plugin_name,omitempty"` // the plugin being installed, when relevant
+	Merchant   string `url:"merchant"`              // the merchant ID: ex. acct_xxxx
 	CLIVersion             string `url:"cli_version"`                        // the version of the CLI
 	OS                     string `url:"os"`                                 // the OS of the system
 	GeneratedResource      bool   `url:"generated_resource"`                 // whether or not this was a generated resource
@@ -162,10 +161,6 @@ func (e *CLIAnalyticsEventMetadata) SetPluginName(pluginName string) {
 	e.PluginName = pluginName
 }
 
-// SetPluginResolutionSource sets the source used to resolve plugin metadata on the CLIAnalyticsEventContext object.
-func (e *CLIAnalyticsEventMetadata) SetPluginResolutionSource(pluginResolutionSource string) {
-	e.PluginResolutionSource = pluginResolutionSource
-}
 
 // SendAPIRequestEvent is a special function for API requests
 func (a *AnalyticsTelemetryClient) SendAPIRequestEvent(ctx context.Context, requestID string, livemode bool) (*http.Response, error) {

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -89,11 +89,6 @@ func TestSetPluginName(t *testing.T) {
 	require.Equal(t, "apps", tel.PluginName)
 }
 
-func TestSetPluginResolutionSource(t *testing.T) {
-	tel := stripe.NewEventMetadata()
-	tel.SetPluginResolutionSource("metadata_endpoint")
-	require.Equal(t, "metadata_endpoint", tel.PluginResolutionSource)
-}
 
 // AnalyticsClient Tests
 func TestSendAPIRequestEvent(t *testing.T) {
@@ -113,7 +108,6 @@ func TestSendAPIRequestEvent(t *testing.T) {
 		require.Contains(t, bodyString, "merchant=acct_1234")
 		require.Contains(t, bodyString, "os=darwin")
 		require.Contains(t, bodyString, "plugin_name=apps")
-		require.Contains(t, bodyString, "plugin_resolution_source=metadata_endpoint")
 		require.Contains(t, bodyString, "request_id=req_zzz")
 		require.Contains(t, bodyString, "terminal_program=iTerm.app")
 		require.Contains(t, bodyString, "user_agent=Unit+Test")
@@ -130,7 +124,6 @@ func TestSendAPIRequestEvent(t *testing.T) {
 		OS:                     "darwin",
 		CommandPath:            "stripe test",
 		PluginName:             "apps",
-		PluginResolutionSource: "metadata_endpoint",
 		Merchant:               "acct_1234",
 		GeneratedResource:      false,
 		InTmux:                 true,
@@ -179,7 +172,6 @@ func TestSendEvent(t *testing.T) {
 		require.Contains(t, bodyString, "merchant=acct_1234")
 		require.Contains(t, bodyString, "os=darwin")
 		require.Contains(t, bodyString, "plugin_name=apps")
-		require.Contains(t, bodyString, "plugin_resolution_source=metadata_endpoint")
 		require.Contains(t, bodyString, "terminal_program=iTerm.app")
 		require.Contains(t, bodyString, "user_agent=Unit+Test")
 		// ai_agent should not be present when empty (omitempty)
@@ -195,7 +187,6 @@ func TestSendEvent(t *testing.T) {
 		OS:                     "darwin",
 		CommandPath:            "stripe test",
 		PluginName:             "apps",
-		PluginResolutionSource: "metadata_endpoint",
 		Merchant:               "acct_1234",
 		GeneratedResource:      false,
 		InTmux:                 true,

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -89,7 +89,6 @@ func TestSetPluginName(t *testing.T) {
 	require.Equal(t, "apps", tel.PluginName)
 }
 
-
 // AnalyticsClient Tests
 func TestSendAPIRequestEvent(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -118,17 +117,17 @@ func TestSendAPIRequestEvent(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	telemetryMetadata := &stripe.CLIAnalyticsEventMetadata{
-		InvocationID:           "123456",
-		UserAgent:              "Unit Test",
-		CLIVersion:             "master",
-		OS:                     "darwin",
-		CommandPath:            "stripe test",
-		PluginName:             "apps",
-		Merchant:               "acct_1234",
-		GeneratedResource:      false,
-		InTmux:                 true,
-		InScreen:               true,
-		TerminalProgram:        "iTerm.app",
+		InvocationID:      "123456",
+		UserAgent:         "Unit Test",
+		CLIVersion:        "master",
+		OS:                "darwin",
+		CommandPath:       "stripe test",
+		PluginName:        "apps",
+		Merchant:          "acct_1234",
+		GeneratedResource: false,
+		InTmux:            true,
+		InScreen:          true,
+		TerminalProgram:   "iTerm.app",
 	}
 	processCtx := stripe.WithEventMetadata(context.Background(), telemetryMetadata)
 	analyticsClient := stripe.AnalyticsTelemetryClient{BaseURL: baseURL, HTTPClient: &http.Client{}}
@@ -181,17 +180,17 @@ func TestSendEvent(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	telemetryMetadata := &stripe.CLIAnalyticsEventMetadata{
-		InvocationID:           "123456",
-		UserAgent:              "Unit Test",
-		CLIVersion:             "master",
-		OS:                     "darwin",
-		CommandPath:            "stripe test",
-		PluginName:             "apps",
-		Merchant:               "acct_1234",
-		GeneratedResource:      false,
-		InTmux:                 true,
-		InScreen:               true,
-		TerminalProgram:        "iTerm.app",
+		InvocationID:      "123456",
+		UserAgent:         "Unit Test",
+		CLIVersion:        "master",
+		OS:                "darwin",
+		CommandPath:       "stripe test",
+		PluginName:        "apps",
+		Merchant:          "acct_1234",
+		GeneratedResource: false,
+		InTmux:            true,
+		InScreen:          true,
+		TerminalProgram:   "iTerm.app",
 	}
 	processCtx := stripe.WithEventMetadata(context.Background(), telemetryMetadata)
 	analyticsClient := stripe.AnalyticsTelemetryClient{BaseURL: baseURL, HTTPClient: &http.Client{}}


### PR DESCRIPTION
The SetPluginResolutionSource setter and PluginResolutionSource struct field are no longer called after removing the plugin resolution telemetry emission in the plugins.toml removal PR.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
