### PR TITLE
Fix curl install test rate limiting by passing GITHUB_TOKEN

### DIFF
--- a/.github/workflows/curl-install-test.yml
+++ b/.github/workflows/curl-install-test.yml
@@ -18,6 +18,8 @@ jobs:
           curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
           export PATH="$HOME/.stripe/bin:$PATH"
           stripe --version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   curl-install-linux:
     runs-on: ubuntu-latest
@@ -26,6 +28,8 @@ jobs:
           curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
           export PATH="$HOME/.stripe/bin:$PATH"
           stripe --version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify:
     runs-on: ubuntu-latest

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,9 +49,17 @@ detect_platform() {
 http_get() {
   url="$1"
   if command -v curl >/dev/null 2>&1; then
-    curl -sSL "$url"
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+      curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" "$url"
+    else
+      curl -sSL "$url"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$url"
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+      wget -qO- --header="Authorization: Bearer $GITHUB_TOKEN" "$url"
+    else
+      wget -qO- "$url"
+    fi
   else
     echo "Error: curl or wget is required but neither is installed."
     exit 1


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
The install script's GitHub API call was unauthenticated (60 req/hr limit), causing CI failures on shared runner IPs. Pass GITHUB_TOKEN from the workflow and use it as a Bearer token in http_get when available.


### Testing
Ran the workflow and it passed https://github.com/stripe/stripe-cli/actions/runs/29314603754