### PR TITLE
APPLCM-3762 Add user id to the response

### DIFF
--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -39,6 +39,7 @@ type Profile struct {
 	TerminalPOSDeviceID    string
 	DisplayName            string
 	AccountID              string
+	UserID                 string
 	SandboxClaimURL        string
 	SandboxExpiresAt       string
 	UAT                    string
@@ -48,6 +49,7 @@ type Profile struct {
 // config key names
 const (
 	AccountIDName              = "account_id"
+	UserIDName                 = "user_id"
 	DeviceNameName             = "device_name"
 	DisplayNameName            = "display_name"
 	IsTermsAcceptanceValidName = "is_terms_acceptance_valid"
@@ -84,6 +86,7 @@ var authFieldNames = []string{
 	DeviceNameName,
 	DisplayNameName,
 	AccountIDName,
+	UserIDName,
 	IsTermsAcceptanceValidName,
 	TestModeAPIKeyName,
 	TestModePubKeyName,
@@ -192,6 +195,19 @@ func (p *Profile) GetAccountID() (string, error) {
 	}
 
 	return "", validators.ErrAccountIDNotConfigured
+}
+
+// GetUserID returns the user ID for the given profile.
+func (p *Profile) GetUserID() (string, error) {
+	if p.UserID != "" {
+		return p.UserID, nil
+	}
+
+	if err := viper.ReadInConfig(); err == nil {
+		return viper.GetString(p.GetConfigField(UserIDName)), nil
+	}
+
+	return "", nil
 }
 
 // HasOverrideAPIKey reports whether an in-memory API key override is active
@@ -442,6 +458,10 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 
 	if p.AccountID != "" {
 		runtimeViper.Set(p.GetConfigField(AccountIDName), strings.TrimSpace(p.AccountID))
+	}
+
+	if p.UserID != "" {
+		runtimeViper.Set(p.GetConfigField(UserIDName), strings.TrimSpace(p.UserID))
 	}
 
 	if p.SandboxClaimURL != "" {

--- a/pkg/login/keys/configurer.go
+++ b/pkg/login/keys/configurer.go
@@ -71,6 +71,7 @@ func (c *RAKConfigurer) SaveLoginDetails(response *PollAPIKeyResponse) error {
 		c.cfg.Profile.DisplayName = response.AccountID
 	}
 	c.cfg.Profile.AccountID = response.AccountID
+	c.cfg.Profile.UserID = response.UserID
 
 	profileErr := c.cfg.Profile.CreateProfile()
 	if profileErr != nil {

--- a/pkg/login/keys/polling.go
+++ b/pkg/login/keys/polling.go
@@ -29,6 +29,7 @@ type PollAPIKeyResponse struct {
 	UAT                    string `json:"uat"`
 	LiveContext            string `json:"live_context"`
 	TestWorkspaceID        string `json:"test_workspace_id"`
+	UserID                 string `json:"user_id"`
 }
 
 // PollForKey polls Stripe at the specified interval until either the API key is available or we've reached the max attempts.


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
  Part of APPLCM-3762. The backend now returns a user_id field in the stripecli/auth polling response (captured at login time when the user authenticates via browser). This change plumbs that value through to the CLI profile config so plugins can read it without making
  additional API calls.

### Changes:
  - PollAPIKeyResponse — adds UserID string mapped to "user_id" JSON field
  - RAKConfigurer.SaveLoginDetails — writes UserID from the poll response to the profile
  - Profile — adds UserID field, UserIDName constant, persists it in writeProfile, exposes it via GetUserID(), and includes it in authFieldNames so it's cleared on logout/login

### Testing
After `stripe login` check `~/.config/stripe/config.toml` to see if user_id is stored

<img width="918" height="189" alt="Screenshot 2026-07-16 at 2 49 47 PM" src="https://github.com/user-attachments/assets/2c94bb33-3749-42d4-a638-58460cfe606d" />

