### PR TITLE
Shorten agent setup detection and skills fetch timeouts

### DIFF
--- a/pkg/agentsetup/claude.go
+++ b/pkg/agentsetup/claude.go
@@ -18,7 +18,7 @@ const (
 	ClaudeMarketplace  = "claude-plugins-official"
 	ClaudeDisplayName  = "Claude Code"
 
-	claudeListTimeout = 10 * time.Second
+	claudeListTimeout = 5 * time.Second
 )
 
 // ClaudeProvider detects and configures the Stripe plugin for Claude Code.

--- a/pkg/agentsetup/codex.go
+++ b/pkg/agentsetup/codex.go
@@ -18,7 +18,7 @@ const (
 	TargetCodexPlugin = "stripe@openai-curated"
 	CodexDisplayName  = "Codex CLI"
 
-	codexListTimeout = 10 * time.Second
+	codexListTimeout = 5 * time.Second
 )
 
 // RunOutputFunc runs a command and returns its standard output. It exists so

--- a/pkg/agentskills/agentskills.go
+++ b/pkg/agentskills/agentskills.go
@@ -26,7 +26,7 @@ import (
 var IndexURL = "https://docs.stripe.com/.well-known/skills/index.json"
 
 const (
-	requestTimeout         = 10 * time.Second
+	requestTimeout         = 5 * time.Second
 	skillCheckConcurrency  = 8
 	remoteFetchConcurrency = 8
 )


### PR DESCRIPTION
### Summary
Reduce plugin-list subprocess and skills HTTP timeouts from 10s to 5s.

### Motivation
A hung `claude`/`codex` subprocess or slow docs fetch could stall `stripe agent setup --status` for up to 10s per call. Shorter timeouts cap worst-case latency while existing error handling already degrades gracefully.

### Benchmarks
**Happy path:** no measurable improvement. Measured with pre-built binaries, 10 warmed runs:

| | Median |
|---|---|
| PR2 (parallel skills) | 1.52s |
| this PR | 1.50s |

Delta (~0.02s) is within run-to-run noise. This PR is a worst-case safety cap, not a happy-path optimization.

**Full stack (paired A/B, 12 interleaved runs):**

| | Median |
|---|---|
| baseline (`master`) | 2.53s |
| full stack (this PR) | 1.79s |

Final binary was faster in 12/12 runs (~0.7s median improvement). PR1 accounts for nearly all of this; PR2 adds a small increment; this PR caps stalled-call latency at 5s instead of 10s.

### Test plan
- [x] `go test ./pkg/cmd/... ./pkg/agentsetup/... ./pkg/agentskills/...`
- [x] `make lint`

### Rollout/revert plan
- [x] Safe to revert