### PR TITLE
Stop streaming plugin install output during spinner

### DIFF
--- a/pkg/agentsetup/claude.go
+++ b/pkg/agentsetup/claude.go
@@ -98,9 +98,9 @@ func (p ClaudeProvider) Plan(status Status, force bool) Plan {
 	}
 }
 
-// Apply installs the Stripe Claude Code plugin, refreshing the official plugin
-// marketplace and retrying once if the first attempt fails.
-func (p ClaudeProvider) Apply(ctx context.Context, out io.Writer, plan Plan) error {
+// Apply installs the Stripe Claude Code plugin. On failure it silently refreshes
+// the official marketplace and retries once.
+func (p ClaudeProvider) Apply(ctx context.Context, _ io.Writer, plan Plan) error {
 	if plan.Action == ActionNone {
 		return nil
 	}
@@ -114,15 +114,10 @@ func (p ClaudeProvider) Apply(ctx context.Context, out io.Writer, plan Plan) err
 	}
 
 	updateName, updateArgs := ClaudeMarketplaceUpdateCommand()
-	updateCommand := append([]string{updateName}, updateArgs...)
-	fmt.Fprintf(out, "First install failed. Updating Claude plugin marketplace and retrying: %s\n", strings.Join(updateCommand, " "))
 	if updateErr := p.RunCommand(ctx, updateName, updateArgs...); updateErr != nil {
-		return fmt.Errorf("running %q after install failed: %w", strings.Join(updateCommand, " "), updateErr)
+		return updateErr
 	}
-	if retryErr := p.RunCommand(ctx, name, installArgs...); retryErr != nil {
-		return fmt.Errorf("running %q after marketplace update: %w", strings.Join(plan.Command, " "), retryErr)
-	}
-	return nil
+	return p.RunCommand(ctx, name, installArgs...)
 }
 
 // stripePluginStatus runs `claude plugin list --json` and reports whether the

--- a/pkg/agentsetup/scanner.go
+++ b/pkg/agentsetup/scanner.go
@@ -2,8 +2,10 @@ package agentsetup
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // LookPathFunc matches exec.LookPath and exists to make detection testable.
@@ -24,7 +26,8 @@ type ReadDirFunc func(string) ([]os.DirEntry, error)
 // StatFunc matches os.Stat and exists to make file existence checks testable.
 type StatFunc func(string) (os.FileInfo, error)
 
-// RunCommandFunc runs a command. The production implementation streams stdio.
+// RunCommandFunc runs a command. The production implementation captures output
+// silently and returns a concise error on failure.
 type RunCommandFunc func(context.Context, string, ...string) error
 
 // Scanner scans local agent installations without mutating them.
@@ -72,11 +75,34 @@ func (s Scanner) withDefaults() Scanner {
 	return s
 }
 
-// RunCommand streams a command through the current process stdio.
+// RunCommand runs a command silently. Plugin installs run behind a spinner, so
+// streaming subprocess stdio to the terminal would interleave with our animation.
+// On failure, return a single line from the subprocess output.
 func RunCommand(ctx context.Context, name string, args ...string) error {
 	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	if msg := errorFromOutput(out); msg != "" {
+		return errors.New(msg)
+	}
+	return err
+}
+
+func errorFromOutput(out []byte) string {
+	text := strings.ReplaceAll(string(out), "\r", "\n")
+	var last string
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		last = line
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "failed") || strings.Contains(lower, "error") {
+			return strings.TrimLeft(line, "✘✗× \t")
+		}
+	}
+	return last
 }

--- a/pkg/agentsetup/scanner_test.go
+++ b/pkg/agentsetup/scanner_test.go
@@ -1,0 +1,38 @@
+package agentsetup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorFromOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "empty", raw: "", want: ""},
+		{
+			name: "prefers failed line",
+			raw:  `✘ Failed to install plugin "stripe@claude-plugins-official"`,
+			want: `Failed to install plugin "stripe@claude-plugins-official"`,
+		},
+		{
+			name: "collapses carriage returns",
+			raw:  "Installing...\r✘ failed to write plugin manifest",
+			want: "failed to write plugin manifest",
+		},
+		{
+			name: "falls back to last line",
+			raw:  "starting up\n\nall done here",
+			want: "all done here",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, errorFromOutput([]byte(tc.raw)))
+		})
+	}
+}

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -135,9 +135,24 @@ func TestAgentSetupRetriesAfterMarketplaceUpdate(t *testing.T) {
 		"claude plugin marketplace update " + agentsetup.ClaudeMarketplace,
 		"claude plugin install " + agentsetup.TargetClaudePlugin,
 	}, calls)
-	require.Contains(t, output, "Updating Claude plugin marketplace and retrying")
 	require.Contains(t, output, "done")
 	require.Contains(t, output, "1 installed, 0 updated, 0 skipped, 0 errors")
+}
+
+func TestAgentSetupSurfacesCleanErrorWhenInstallFails(t *testing.T) {
+	setup := newTestAgentSetupCmd(t, claudeMissingPluginScanner(t), func(ctx context.Context, name string, args ...string) error {
+		if len(args) > 1 && args[1] == "marketplace" {
+			return errors.New(`Failed to update marketplace(s): Marketplace 'claude-plugins-official' not found.`)
+		}
+		return errors.New(`Failed to install plugin "stripe@claude-plugins-official"`)
+	})
+
+	output, err := executeCommand(setup.cmd, "--yes")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "1 item(s) failed to set up")
+	require.Contains(t, output, "Failed to update marketplace(s): Marketplace 'claude-plugins-official' not found.")
+	require.Contains(t, output, "0 installed, 0 updated, 0 skipped, 1 errors")
 }
 
 func TestAgentSetupNoClaudeDoesNotFail(t *testing.T) {


### PR DESCRIPTION
## Summary

`stripe agent setup` runs plugin installs behind a spinner. The production
`RunCommand` wired the child process's stdio straight to the terminal, so
output interleaved with the spinner animation and produced garbled results.

This PR captures subprocess output instead and prints one clean error line on
failure. Claude's marketplace refresh retry is now silent.

## What changed

- **`pkg/agentsetup/scanner.go`**: `RunCommand` uses `CombinedOutput()` instead
  of streaming stdio. On failure, `errorFromOutput` picks the first line
  containing "failed" or "error" (or the last line as a fallback).
- **`pkg/agentsetup/claude.go`**: silent marketplace refresh + retry; returns
  the cleaned subprocess error directly.

## Result

Before (garbled — spinner frames interleaved with environment noise and plugin
errors):

```
⣻ 💡 Tip: Set your default model & preferences at https://go/claude-prefs
                                                     ✨ Nexus pre-push hooks
          gru  Surface the Gru code-review rules that apply to your change
⢿ ✘ Failed to install plugin "stripe@claude-plugins-official": Plugin "stripe" not found…
⣯ ✘ Failed to update marketplace(s): Marketplace 'claude-plugins-official' not found.
1 item(s) failed to set up
```

After:

```
Setting up Stripe agent tooling:

  Claude Code
  ✗ error: Failed to update marketplace(s): Marketplace 'claude-plugins-official' not found.

0 installed, 0 updated, 0 skipped, 1 errors
```

## Test plan

- [x] `TestErrorFromOutput` — error line extraction and `\r` collapsing
- [x] `TestAgentSetupSurfacesCleanErrorWhenInstallFails` — clean single-line error
- [x] `TestAgentSetupRetriesAfterMarketplaceUpdate` — silent retry (no mid-spinner message)
- [x] `go build ./...` and `go test ./pkg/agentsetup/... ./pkg/cmd/` pass