### PR TITLE
Add support for v1. prefix events in stripe trigger

### DIFF
--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -23,6 +23,216 @@ var (
 	eventsOnce sync.Once
 )
 
+// v1TriggerableEvents is the set of snapshot event names that can also be
+// triggered using the "v1." prefix. For example, if "customer.updated" is in
+// this set, both of the following will run the same fixture:
+//
+//	stripe trigger customer.updated
+//	stripe trigger v1.customer.updated
+//
+// Add an entry here when a new thin event becomes available for a snapshot
+// event. The key must exactly match the snapshot event name (i.e. the filename
+// in the triggers/ directory without the .json extension).
+var v1TriggerableEvents = map[string]struct{}{
+	"account.external_account.created":                     {},
+	"account.external_account.deleted":                     {},
+	"account.external_account.updated":                     {},
+	"account.updated":                                      {},
+	"balance.available":                                    {},
+	"billing.alert.triggered":                              {},
+	"billing_portal.configuration.created":                 {},
+	"billing_portal.configuration.updated":                 {},
+	"billing_portal.session.created":                       {},
+	"capability.updated":                                   {},
+	"cash_balance.funds_available":                         {},
+	"charge.captured":                                      {},
+	"charge.dispute.closed":                                {},
+	"charge.dispute.created":                               {},
+	"charge.dispute.funds_reinstated":                      {},
+	"charge.dispute.funds_withdrawn":                       {},
+	"charge.dispute.updated":                               {},
+	"charge.expired":                                       {},
+	"charge.failed":                                        {},
+	"charge.pending":                                       {},
+	"charge.refund.updated":                                {},
+	"charge.refunded":                                      {},
+	"charge.succeeded":                                     {},
+	"charge.updated":                                       {},
+	"checkout.session.async_payment_failed":                {},
+	"checkout.session.async_payment_succeeded":             {},
+	"checkout.session.completed":                           {},
+	"checkout.session.expired":                             {},
+	"climate.order.canceled":                               {},
+	"climate.order.created":                                {},
+	"climate.order.delayed":                                {},
+	"climate.order.delivered":                              {},
+	"climate.order.product_substituted":                    {},
+	"climate.product.created":                              {},
+	"climate.product.pricing_updated":                      {},
+	"coupon.created":                                       {},
+	"coupon.deleted":                                       {},
+	"coupon.updated":                                       {},
+	"credit_note.created":                                  {},
+	"credit_note.updated":                                  {},
+	"credit_note.voided":                                   {},
+	"customer.created":                                     {},
+	"customer.deleted":                                     {},
+	"customer.discount.created":                            {},
+	"customer.discount.deleted":                            {},
+	"customer.discount.updated":                            {},
+	"customer.subscription.created":                        {},
+	"customer.subscription.deleted":                        {},
+	"customer.subscription.paused":                         {},
+	"customer.subscription.pending_update_applied":         {},
+	"customer.subscription.pending_update_expired":         {},
+	"customer.subscription.resumed":                        {},
+	"customer.subscription.trial_will_end":                 {},
+	"customer.subscription.updated":                        {},
+	"customer.tax_id.created":                              {},
+	"customer.tax_id.deleted":                              {},
+	"customer.tax_id.updated":                              {},
+	"customer.updated":                                     {},
+	"customer_cash_balance_transaction.created":            {},
+	"entitlements.active_entitlement_summary.updated":      {},
+	"file.created":                                         {},
+	"financial_connections.account.created":                {},
+	"financial_connections.account.deactivated":            {},
+	"financial_connections.account.disconnected":           {},
+	"financial_connections.account.reactivated":            {},
+	"financial_connections.account.refreshed_balance":      {},
+	"financial_connections.account.refreshed_ownership":    {},
+	"financial_connections.account.refreshed_transactions": {},
+	"identity.verification_session.canceled":               {},
+	"identity.verification_session.created":                {},
+	"identity.verification_session.processing":             {},
+	"identity.verification_session.redacted":               {},
+	"identity.verification_session.requires_input":         {},
+	"identity.verification_session.verified":               {},
+	"invoice.created":                                      {},
+	"invoice.deleted":                                      {},
+	"invoice.finalization_failed":                          {},
+	"invoice.finalized":                                    {},
+	"invoice.marked_uncollectible":                         {},
+	"invoice.overdue":                                      {},
+	"invoice.overpaid":                                     {},
+	"invoice.paid":                                         {},
+	"invoice.payment_action_required":                      {},
+	"invoice.payment_failed":                               {},
+	"invoice.payment_succeeded":                            {},
+	"invoice.sent":                                         {},
+	"invoice.upcoming":                                     {},
+	"invoice.updated":                                      {},
+	"invoice.voided":                                       {},
+	"invoice.will_be_due":                                  {},
+	"invoice_payment.paid":                                 {},
+	"invoiceitem.created":                                  {},
+	"invoiceitem.deleted":                                  {},
+	"issuing_authorization.created":                        {},
+	"issuing_authorization.request":                        {},
+	"issuing_authorization.updated":                        {},
+	"issuing_card.created":                                 {},
+	"issuing_card.updated":                                 {},
+	"issuing_cardholder.created":                           {},
+	"issuing_cardholder.updated":                           {},
+	"issuing_dispute.closed":                               {},
+	"issuing_dispute.created":                              {},
+	"issuing_dispute.funds_reinstated":                     {},
+	"issuing_dispute.funds_rescinded":                      {},
+	"issuing_dispute.submitted":                            {},
+	"issuing_dispute.updated":                              {},
+	"issuing_personalization_design.activated":             {},
+	"issuing_personalization_design.deactivated":           {},
+	"issuing_personalization_design.rejected":              {},
+	"issuing_personalization_design.updated":               {},
+	"issuing_token.created":                                {},
+	"issuing_token.updated":                                {},
+	"issuing_transaction.created":                          {},
+	"issuing_transaction.purchase_details_receipt_updated": {},
+	"issuing_transaction.updated":                          {},
+	"mandate.updated":                                      {},
+	"payment_intent.amount_capturable_updated":             {},
+	"payment_intent.canceled":                              {},
+	"payment_intent.created":                               {},
+	"payment_intent.partially_funded":                      {},
+	"payment_intent.payment_failed":                        {},
+	"payment_intent.processing":                            {},
+	"payment_intent.requires_action":                       {},
+	"payment_intent.succeeded":                             {},
+	"payment_link.created":                                 {},
+	"payment_link.updated":                                 {},
+	"payment_method.attached":                              {},
+	"payment_method.automatically_updated":                 {},
+	"payment_method.detached":                              {},
+	"payment_method.updated":                               {},
+	"payout.canceled":                                      {},
+	"payout.created":                                       {},
+	"payout.failed":                                        {},
+	"payout.paid":                                          {},
+	"payout.reconciliation_completed":                      {},
+	"payout.updated":                                       {},
+	"person.created":                                       {},
+	"person.deleted":                                       {},
+	"person.updated":                                       {},
+	"plan.created":                                         {},
+	"plan.deleted":                                         {},
+	"plan.updated":                                         {},
+	"price.created":                                        {},
+	"price.deleted":                                        {},
+	"price.updated":                                        {},
+	"product.created":                                      {},
+	"product.deleted":                                      {},
+	"product.updated":                                      {},
+	"promotion_code.created":                               {},
+	"promotion_code.updated":                               {},
+	"quote.accepted":                                       {},
+	"quote.canceled":                                       {},
+	"quote.created":                                        {},
+	"quote.finalized":                                      {},
+	"radar.early_fraud_warning.created":                    {},
+	"radar.early_fraud_warning.updated":                    {},
+	"refund.created":                                       {},
+	"refund.failed":                                        {},
+	"refund.updated":                                       {},
+	"review.closed":                                        {},
+	"review.opened":                                        {},
+	"setup_intent.canceled":                                {},
+	"setup_intent.created":                                 {},
+	"setup_intent.requires_action":                         {},
+	"setup_intent.setup_failed":                            {},
+	"setup_intent.succeeded":                               {},
+	"sigma.scheduled_query_run.created":                    {},
+	"source.canceled":                                      {},
+	"source.chargeable":                                    {},
+	"source.failed":                                        {},
+	"source.refund_attributes_required":                    {},
+	"subscription_schedule.aborted":                        {},
+	"subscription_schedule.canceled":                       {},
+	"subscription_schedule.completed":                      {},
+	"subscription_schedule.created":                        {},
+	"subscription_schedule.expiring":                       {},
+	"subscription_schedule.released":                       {},
+	"subscription_schedule.updated":                        {},
+	"tax.settings.updated":                                 {},
+	"tax_rate.created":                                     {},
+	"tax_rate.updated":                                     {},
+	"terminal.reader.action_failed":                        {},
+	"terminal.reader.action_succeeded":                     {},
+	"terminal.reader.action_updated":                       {},
+	"test_helpers.test_clock.advancing":                    {},
+	"test_helpers.test_clock.created":                      {},
+	"test_helpers.test_clock.deleted":                      {},
+	"test_helpers.test_clock.internal_failure":             {},
+	"test_helpers.test_clock.ready":                        {},
+	"topup.canceled":                                       {},
+	"topup.created":                                        {},
+	"topup.failed":                                         {},
+	"topup.reversed":                                       {},
+	"topup.succeeded":                                      {},
+	"transfer.created":                                     {},
+	"transfer.reversed":                                    {},
+	"transfer.updated":                                     {},
+}
+
 // getEvents returns the lazily-initialized event→fixture-path map. The map is built
 // once on first access by scanning the embedded triggers/ directory. Event names are
 // derived from filenames (e.g. customer.created.json → customer.created); fixture files
@@ -68,6 +278,16 @@ func buildEventsMap() map[string]string {
 			}
 		}
 	}
+
+	for name, path := range m {
+		if _, ok := v1TriggerableEvents[name]; ok {
+			v1Name := "v1." + name
+			if _, exists := m[v1Name]; !exists {
+				m[v1Name] = path
+			}
+		}
+	}
+
 	return m
 }
 
@@ -129,7 +349,13 @@ func EventList() string {
 // EventNames returns an array of all the event names
 func EventNames() []string {
 	names := []string{}
-	for name := range getEvents() {
+	for name, path := range getEvents() {
+		// Hide auto-generated v1. aliases from the public event list.
+		// Native v1. fixture files have a path starting with "triggers/v1."
+		// and are always shown.
+		if strings.HasPrefix(name, "v1.") && !strings.HasPrefix(path, "triggers/v1.") {
+			continue
+		}
 		names = append(names, name)
 	}
 

--- a/pkg/fixtures/triggers_consistency_test.go
+++ b/pkg/fixtures/triggers_consistency_test.go
@@ -185,3 +185,52 @@ func TestEventNamesFollowConvention(t *testing.T) {
 		})
 	}
 }
+
+// TestV1PrefixAliasesRegistered ensures that every snapshot event (no v1./v2. prefix)
+// has a corresponding "v1.<name>" entry in the events map pointing to the same fixture.
+func TestV1PrefixAliasesRegistered(t *testing.T) {
+	evts := getEvents()
+
+	for name, path := range evts {
+		if strings.HasPrefix(name, "v1.") || strings.HasPrefix(name, "v2.") {
+			continue
+		}
+		if _, ok := v1TriggerableEvents[name]; !ok {
+			continue // no thin event for this snapshot event; no v1. alias expected
+		}
+		t.Run(name, func(t *testing.T) {
+			v1Name := "v1." + name
+			v1Path, ok := evts[v1Name]
+			assert.True(t, ok,
+				"expected v1 alias %q to be registered for snapshot event %q", v1Name, name)
+			assert.Equal(t, path, v1Path,
+				"v1 alias %q should point to same fixture path as %q", v1Name, name)
+		})
+	}
+}
+
+// TestNativeV1EventsNotOverridden ensures that events with a dedicated
+// "triggers/v1.*" fixture file (e.g. v1.billing.meter.error_report_triggered)
+// are not replaced by auto-generated snapshot aliases.
+func TestNativeV1EventsNotOverridden(t *testing.T) {
+	evts := getEvents()
+
+	for name, path := range evts {
+		if !strings.HasPrefix(name, "v1.") {
+			continue
+		}
+		// A native v1 event owns a fixture file named after itself.
+		expectedNativePath := "triggers/" + name + ".json"
+		if path != expectedNativePath {
+			// This is an auto-generated alias pointing to a snapshot fixture — skip.
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			content, err := triggers.ReadFile(path)
+			require.NoError(t, err,
+				"native v1 event %q: fixture file %q should be readable", name, path)
+			require.NotEmpty(t, content,
+				"native v1 event %q: fixture file %q should not be empty", name, path)
+		})
+	}
+}


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
Add v1. prefix support to stripe trigger

### What this does
Users can now trigger events using the v1. prefix:

```
stripe trigger v1.customer.updated
stripe trigger v1.charge.failed
stripe trigger v1.payment_intent.succeeded
```


### Coverage
107 events get working v1. aliases immediately. A further 90 events are in the allowlist for forward-compatibility — their aliases activate automatically once fixture files are added, with no further code changes needed.

### Testing

```
stripe trigger v1.customer.updated             # runs customer.updated fixture
stripe trigger v1.charge.failed                # runs charge.failed fixture
stripe trigger v1.billing.meter.no_meter_found # native fixture, unaffected
stripe trigger --help | grep "v1\."            # only native v1. fixtures appear
stripe trigger v1.fake.event                   # errors: not supported
```

New tests in pkg/fixtures/triggers_consistency_test.go:

- Every allowlisted event with a fixture has its v1. alias pointing to the same path
- No snapshot event outside the allowlist gets an automatic v1. alias
- Native v1. fixture files remain readable and unmodified
