### PR TITLE
Add validation errors for forwarding configuration

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -209,6 +209,10 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		forwardThinConnectURL = lc.forwardThinConnectURL
 	}
 
+	if err := lc.validateForwardingConfig(snapshotEvents, thinEvents, directURL, forwardThinURL, connectURL, forwardThinConnectURL); err != nil {
+		return err
+	}
+
 	p, err := proxy.Init(ctx, &proxy.Config{
 		Client:                client,
 		DeviceName:            deviceName,
@@ -496,4 +500,31 @@ func (lc *listenCmd) resolveForwardURLs() (directURL, connectURL string) {
 		}
 	}
 	return
+}
+
+// validateForwardingConfig checks that forwarding configuration is valid.
+func (lc *listenCmd) validateForwardingConfig(snapshotEvents, thinEvents []string, directURL, forwardThinURL, connectURL, forwardThinConnectURL string) error {
+	isForwarding := lc.forwardURL != "" || lc.forwardConnectURL != ""
+	if !isForwarding {
+		return nil
+	}
+
+	// Must be explicit about subscriptions when forwarding
+	if !lc.allSnapshot && !lc.allThin && len(lc.events) == 0 && len(lc.thinEvents) == 0 {
+		return fmt.Errorf("must specify events to forward using --events, --all-snapshot, or --all-thin")
+	}
+
+	// Cannot forward both snapshot and thin events to the same destination
+	hasSnapshot := len(snapshotEvents) > 0
+	hasThin := len(thinEvents) > 0
+	if hasSnapshot && hasThin {
+		if directURL != "" && directURL == forwardThinURL {
+			return fmt.Errorf("cannot forward both snapshot and thin events to the same destination; use --forward-to and --forward-thin-to to separate them, or use --all-snapshot / --all-thin to subscribe to only one type")
+		}
+		if connectURL != "" && connectURL == forwardThinConnectURL {
+			return fmt.Errorf("cannot forward both snapshot and thin events to the same connect destination; use --forward-connect-to and --forward-thin-connect-to to separate them, or use --all-snapshot / --all-thin to subscribe to only one type")
+		}
+	}
+
+	return nil
 }

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -297,3 +297,90 @@ func TestResolveForwardURLs(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateForwardingConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		lc          listenCmd
+		snapshot    []string
+		thin        []string
+		directURL   string
+		thinURL     string
+		connectURL  string
+		thinConnURL string
+		wantErr     string
+	}{
+		{
+			name:    "no forwarding: no error even without events",
+			lc:      listenCmd{},
+			wantErr: "",
+		},
+		{
+			name:    "forwarding without specifying events: error",
+			lc:      listenCmd{forwardURL: "http://localhost:3000"},
+			wantErr: "must specify events to forward",
+		},
+		{
+			name:      "forwarding with --all-snapshot: no error",
+			lc:        listenCmd{forwardURL: "http://localhost:3000", allSnapshot: true},
+			snapshot:  []string{"*"},
+			directURL: "http://localhost:3000",
+			thinURL:   "",
+			wantErr:   "",
+		},
+		{
+			name:      "forwarding with --all-thin: no error",
+			lc:        listenCmd{forwardURL: "http://localhost:3000", allThin: true},
+			thin:      []string{"*"},
+			directURL: "",
+			thinURL:   "http://localhost:3000",
+			wantErr:   "",
+		},
+		{
+			name:      "forwarding with --events: no error",
+			lc:        listenCmd{forwardURL: "http://localhost:3000", events: []string{"charge.captured"}},
+			snapshot:  []string{"charge.captured"},
+			directURL: "http://localhost:3000",
+			thinURL:   "http://localhost:3000",
+			wantErr:   "",
+		},
+		{
+			name:      "snapshot and thin to same destination: error",
+			lc:        listenCmd{forwardURL: "http://localhost:3000", allSnapshot: true, allThin: true},
+			snapshot:  []string{"*"},
+			thin:      []string{"*"},
+			directURL: "http://localhost:3000",
+			thinURL:   "http://localhost:3000",
+			wantErr:   "cannot forward both snapshot and thin events to the same destination",
+		},
+		{
+			name:      "snapshot and thin to different destinations: no error",
+			lc:        listenCmd{forwardURL: "http://localhost:3000", allSnapshot: true, allThin: true},
+			snapshot:  []string{"*"},
+			thin:      []string{"*"},
+			directURL: "http://localhost:3000",
+			thinURL:   "http://localhost:4000",
+			wantErr:   "",
+		},
+		{
+			name:        "connect: snapshot and thin to same destination: error",
+			lc:          listenCmd{forwardConnectURL: "http://localhost:3000", allSnapshot: true, allThin: true},
+			snapshot:    []string{"*"},
+			thin:        []string{"*"},
+			connectURL:  "http://localhost:3000",
+			thinConnURL: "http://localhost:3000",
+			wantErr:     "cannot forward both snapshot and thin events to the same connect destination",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.lc.validateForwardingConfig(tt.snapshot, tt.thin, tt.directURL, tt.thinURL, tt.connectURL, tt.thinConnURL)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds two validation errors according to the [design](https://docs.google.com/document/d/1khdjM35uRcYnn0SKigf7aI3pXzVQbPLNkim02I4h62w/edit?tab=t.0#heading=h.941p0giewh),  when `--forward-to` or `--forward-connect-to` is used:

1. **Must specify events explicitly** — running `stripe listen --forward-to localhost:3000` without `--events`, `--all-snapshot`, or `--all-thin` now returns an error. This prevents accidentally forwarding all event types to an endpoint that only expects one shape.

2. **Cannot mix snapshot and thin to same destination** — if both snapshot and thin events are subscribed, they must go to different URLs (e.g., `--forward-to` for snapshot, `--forward-thin-to` for thin). This prevents endpoints from receiving unexpected payload formats.

Builds on #1765.

## Test plan

- [x] Unit tests for `validateForwardingConfig()` covering all cases
- [x] No forwarding → no validation (bare `stripe listen` still works)
- [x] Forwarding with `--all-snapshot` → passes
- [x] Forwarding with `--all-thin` → passes
- [x] Forwarding with `--events` → passes
- [x] Forwarding without any event flags → error
- [x] Both types to same URL → error
- [x] Both types to different URLs → passes