### PR TITLE
`stripe agent setup`: Add telemetry for plugin detection

### DIFF
--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -204,6 +204,11 @@ func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, _ []string) error {
 	for _, s := range statuses {
 		if s.Detected {
 			sendAgentEvent(ctx, "Agent Setup: Client Detected", s.Client)
+			if s.Plugin.Installed {
+				sendAgentEvent(ctx, "Agent Setup: Plugin Detected", s.Client+":installed")
+			} else {
+				sendAgentEvent(ctx, "Agent Setup: Plugin Detected", s.Client+":not_installed")
+			}
 		}
 	}
 


### PR DESCRIPTION
 ### Reviewers
r? @gusnguyen-stripe 
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Emits telemetry events for each plugin detection we do, where event_name = `Agent Setup: Plugin Detected` and event value =  `{client}:(installed|not_installed)`
