### PR TITLE
Use github.com/vercel/detect-agent  package for AI agent detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
+	github.com/vercel/detect-agent v1.1.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,8 @@ github.com/tidwall/match v1.2.0/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/vercel/detect-agent v1.1.0 h1:qe9Mcd8oTgp3AUG0DWXASGXjINFQkpp+8y0fOUxql5s=
+github.com/vercel/detect-agent v1.1.0/go.mod h1:hQafiuMWbYQSNhDa/2/cxz4V/3m6WRiQWkcllhNULp8=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -26,11 +26,13 @@ import (
 
 // agentClientID maps the AI agent identifiers returned by
 // useragent.DetectAIAgent to this command's provider ids. Agents not backed by
-// a provider (e.g. gemini_cli) map to "".
+// a provider (e.g. "gemini") map to "".
 var agentClientID = map[string]string{
-	"claude_code": agentsetup.ClientClaudeCode,
-	"codex_cli":   agentsetup.ClientCodex,
-	"cursor":      agentsetup.ClientCursor,
+	"claude":     agentsetup.ClientClaudeCode,
+	"cowork":     agentsetup.ClientClaudeCode,
+	"codex":      agentsetup.ClientCodex,
+	"cursor":     agentsetup.ClientCursor,
+	"cursor-cli": agentsetup.ClientCursor,
 }
 
 // providerOrder is the canonical display order for known clients. Providers not
@@ -65,7 +67,7 @@ type agentSetupCmd struct {
 	skillsDirsExist func(localDir, globalDir string) bool
 
 	// callingAgent returns the AI agent invoking this command (e.g.
-	// "claude_code"), or "" for a human shell. Injectable for tests.
+	// "claude"), or "" for a human shell. Injectable for tests.
 	callingAgent func() string
 	// isInteractive reports whether an interactive picker can be shown.
 	// Injectable for tests.
@@ -114,7 +116,7 @@ func newAgentSetupCmd() *agentSetupCmd {
 		skillsLocalDir:  func() (string, error) { return skillsDirUnder(os.Getwd) },
 		skillsGlobalDir: func() (string, error) { return skillsDirUnder(os.UserHomeDir) },
 		skillsDirsExist: skillsDirsExist,
-		callingAgent:    func() string { return useragent.DetectAIAgent(os.Getenv) },
+		callingAgent:    func() string { return useragent.DetectAIAgent() },
 		isInteractive:   isInteractiveTerminal,
 	}
 

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -378,7 +378,7 @@ func TestAgentSetupAutoInstallsForCallingAgent(t *testing.T) {
 	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude, codex.ID(): codex}
 	// Simulate being invoked by Codex CLI — only its plugin should install,
 	// even though Claude is also detected, and with no --client flag.
-	setup.callingAgent = func() string { return "codex_cli" }
+	setup.callingAgent = func() string { return "codex" }
 	setup.cmd.SetContext(context.Background())
 
 	output, err := executeCommand(setup.cmd)
@@ -401,7 +401,7 @@ func TestAgentSetupCallingAgentDoesNotCheckSkills(t *testing.T) {
 
 	setup := testAgentSetupCmd()
 	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude, codex.ID(): codex}
-	setup.callingAgent = func() string { return "codex_cli" }
+	setup.callingAgent = func() string { return "codex" }
 	setup.skillsCheck = func(context.Context, string) (*agentskills.DirStatus, error) {
 		t.Fatal("calling-agent plugin setup should not check skills")
 		return nil, nil
@@ -448,7 +448,7 @@ func TestAgentSetupUnsupportedAgentInstallsSkillsToLocal(t *testing.T) {
 
 	setup := testAgentSetupCmd()
 	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
-	setup.callingAgent = func() string { return "gemini_cli" }
+	setup.callingAgent = func() string { return "gemini" }
 	localDir := filepath.Join(t.TempDir(), ".agents", "skills")
 	setup.skillsInstall = func(_ context.Context, destDir string) ([]string, error) {
 		gotDir = destDir
@@ -536,7 +536,7 @@ func TestAgentSetupAgentScopingWinsOverYes(t *testing.T) {
 
 	setup := testAgentSetupCmd()
 	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude, codex.ID(): codex}
-	setup.callingAgent = func() string { return "codex_cli" }
+	setup.callingAgent = func() string { return "codex" }
 	setup.cmd.SetContext(context.Background())
 
 	output, err := executeCommand(setup.cmd, "--yes")
@@ -580,7 +580,7 @@ func TestAgentSetupAgentNeverUsesInteractivePicker(t *testing.T) {
 
 	setup := testAgentSetupCmd()
 	setup.providers = map[string]agentsetup.Provider{claude.ID(): claude}
-	setup.callingAgent = func() string { return "gemini_cli" }
+	setup.callingAgent = func() string { return "gemini" }
 	setup.isInteractive = func() bool { return true } // simulate a PTY
 	setup.skillsInstall = func(context.Context, string) ([]string, error) {
 		skillsCalled = true
@@ -770,7 +770,7 @@ func TestAgentSetupSkillsSkipWhenCurrent(t *testing.T) {
 	var installCalled bool
 	setup := testAgentSetupCmd()
 	setup.providers = map[string]agentsetup.Provider{}
-	setup.callingAgent = func() string { return "gemini_cli" }
+	setup.callingAgent = func() string { return "gemini" }
 	setup.skillsCheck = mockSkillsCheckCurrent
 	setup.skillsInstall = func(context.Context, string) ([]string, error) {
 		installCalled = true
@@ -791,7 +791,7 @@ func TestAgentSetupSkillsUpdateWhenOutOfDate(t *testing.T) {
 	var installCalled bool
 	setup := testAgentSetupCmd()
 	setup.providers = map[string]agentsetup.Provider{}
-	setup.callingAgent = func() string { return "gemini_cli" }
+	setup.callingAgent = func() string { return "gemini" }
 	setup.skillsCheck = mockSkillsCheckOutOfDate
 	setup.skillsInstall = func(_ context.Context, _ string) ([]string, error) {
 		installCalled = true

--- a/pkg/cmd/claudecodehint.go
+++ b/pkg/cmd/claudecodehint.go
@@ -15,11 +15,12 @@ const claudeCodePluginHint = `<claude-code-hint v="1" type="plugin" value="strip
 // the user to install the Stripe plugin. See
 // https://code.claude.com/docs/en/plugin-hints for the protocol.
 func emitClaudeCodePluginHint() {
-	writeClaudeCodePluginHint(os.Getenv, os.Stderr)
+	writeClaudeCodePluginHint(os.Stderr)
 }
 
-func writeClaudeCodePluginHint(getEnv func(string) string, w io.Writer) {
-	if useragent.DetectAIAgent(getEnv) != "claude_code" {
+func writeClaudeCodePluginHint(w io.Writer) {
+	a := useragent.DetectAIAgent()
+	if a != "claude" && a != "cowork" {
 		return
 	}
 	fmt.Fprintln(w, claudeCodePluginHint)

--- a/pkg/cmd/claudecodehint_test.go
+++ b/pkg/cmd/claudecodehint_test.go
@@ -8,24 +8,21 @@ import (
 )
 
 func TestWriteClaudeCodePluginHint_EmitsWhenSet(t *testing.T) {
+	t.Setenv("AI_AGENT", "")
+	t.Setenv("CLAUDECODE", "1")
 	var buf bytes.Buffer
-	getEnv := func(key string) string {
-		if key == "CLAUDECODE" {
-			return "1"
-		}
-		return ""
-	}
 
-	writeClaudeCodePluginHint(getEnv, &buf)
+	writeClaudeCodePluginHint(&buf)
 
 	assert.Equal(t, claudeCodePluginHint+"\n", buf.String())
 }
 
 func TestWriteClaudeCodePluginHint_SilentWhenUnset(t *testing.T) {
+	t.Setenv("AI_AGENT", "")
+	t.Setenv("CLAUDECODE", "")
 	var buf bytes.Buffer
-	getEnv := func(string) string { return "" }
 
-	writeClaudeCodePluginHint(getEnv, &buf)
+	writeClaudeCodePluginHint(&buf)
 
 	assert.Empty(t, buf.String())
 }

--- a/pkg/cmd/docs/root.go
+++ b/pkg/cmd/docs/root.go
@@ -93,7 +93,7 @@ Read API Reference pages by their identifier:
 		SilenceUsage:      true,
 	}
 
-	agentDetected := useragent.DetectAIAgent(os.Getenv) != ""
+	agentDetected := useragent.DetectAIAgent() != ""
 	r.cmd.PersistentFlags().BoolVar(&r.noPager, "no-pager", agentDetected, "Write output directly to stdout")
 	r.cmd.PersistentFlags().BoolVar(&r.nonInteractive, "non-interactive", agentDetected, "Write output directly without the interactive browser")
 
@@ -158,7 +158,7 @@ func (r *RootCommand) initRenderer() {
 	case "on":
 		// Use default styled rendering (auto-detect dark/light).
 	default:
-		if useragent.DetectAIAgent(os.Getenv) != "" {
+		if useragent.DetectAIAgent() != "" {
 			opts = append(opts, markdown.WithStyle("notty"))
 		}
 	}
@@ -186,7 +186,7 @@ func (r *RootCommand) preRun(_ *cobra.Command, _ []string) error {
 	r.initLogger()
 	r.initRenderer()
 	if r.logger != nil {
-		if a := useragent.DetectAIAgent(os.Getenv); a != "" {
+		if a := useragent.DetectAIAgent(); a != "" {
 			r.logger.WithField("name", a).Debug("agent detected")
 		}
 	}
@@ -229,7 +229,7 @@ func (r *RootCommand) run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *RootCommand) useTUI(cmd *cobra.Command) bool {
-	if r.nonInteractive || r.noPager || useragent.DetectAIAgent(os.Getenv) != "" {
+	if r.nonInteractive || r.noPager || useragent.DetectAIAgent() != "" {
 		return false
 	}
 	f, ok := cmd.OutOrStdout().(*os.File)

--- a/pkg/cmd/docs/search.go
+++ b/pkg/cmd/docs/search.go
@@ -54,7 +54,7 @@ func (r *RootCommand) runSearch(cmd *cobra.Command, args []string) error {
 	styles := ui.DefaultStyles()
 
 	checkmark := styles.SuccessText.Render("✓")
-	disabled := useragent.DetectAIAgent(os.Getenv) != "" || !isStdoutTTY(cmd)
+	disabled := useragent.DetectAIAgent() != "" || !isStdoutTTY(cmd)
 
 	var response *pkgdocs.SearchResponse
 	err := spinner.New().

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -129,8 +129,8 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 		return login.PollForLogin(cmd.Context(), lc.completeURL, &Config)
 	}
 
-	if lc.nonInteractive || !shouldAutoLogin(os.Getenv, term.IsTerminal(int(os.Stdin.Fd()))) {
-		if useragent.DetectAIAgent(os.Getenv) != "" {
+	if lc.nonInteractive || !shouldAutoLogin(term.IsTerminal(int(os.Stdin.Fd()))) {
+		if useragent.DetectAIAgent() != "" {
 			fmt.Fprintln(os.Stderr, "If you do not have an account, run `stripe sandbox create` instead (provisions a claimable sandbox without a browser).")
 		}
 		return login.InitiateLogin(cmd.Context(), lc.dashboardBaseURL, &Config)

--- a/pkg/cmd/login_helpers.go
+++ b/pkg/cmd/login_helpers.go
@@ -6,7 +6,6 @@ import "github.com/stripe/stripe-cli/pkg/useragent"
 // Returns true only when stdin is an interactive terminal and no AI agent is detected.
 // Agents with a real TTY (e.g. Claude Code) and headless environments (CI, /dev/null stdin)
 // both return false, ensuring neither blocks waiting for a browser flow.
-// getEnv and stdinIsTerminal are injected to allow testing.
-func shouldAutoLogin(getEnv func(string) string, stdinIsTerminal bool) bool {
-	return stdinIsTerminal && useragent.DetectAIAgent(getEnv) == ""
+func shouldAutoLogin(stdinIsTerminal bool) bool {
+	return stdinIsTerminal && useragent.DetectAIAgent() == ""
 }

--- a/pkg/cmd/login_helpers_test.go
+++ b/pkg/cmd/login_helpers_test.go
@@ -7,16 +7,24 @@ import (
 )
 
 func TestShouldAutoLogin(t *testing.T) {
-	noAgent := func(string) string { return "" }
-	claudeAgent := func(k string) string {
-		if k == "CLAUDECODE" {
-			return "1"
-		}
-		return ""
-	}
-
-	require.True(t, shouldAutoLogin(noAgent, true))       // interactive terminal, no agent → auto-login
-	require.False(t, shouldAutoLogin(noAgent, false))     // non-TTY stdin (CI, /dev/null) → fast-fail
-	require.False(t, shouldAutoLogin(claudeAgent, true))  // agent with real TTY → fast-fail
-	require.False(t, shouldAutoLogin(claudeAgent, false)) // agent, no TTY → fast-fail
+	t.Run("no agent, interactive terminal", func(t *testing.T) {
+		t.Setenv("AI_AGENT", "")
+		t.Setenv("CLAUDECODE", "")
+		require.True(t, shouldAutoLogin(true))
+	})
+	t.Run("no agent, non-TTY stdin", func(t *testing.T) {
+		t.Setenv("AI_AGENT", "")
+		t.Setenv("CLAUDECODE", "")
+		require.False(t, shouldAutoLogin(false))
+	})
+	t.Run("agent with real TTY", func(t *testing.T) {
+		t.Setenv("AI_AGENT", "")
+		t.Setenv("CLAUDECODE", "1")
+		require.False(t, shouldAutoLogin(true))
+	})
+	t.Run("agent, no TTY", func(t *testing.T) {
+		t.Setenv("AI_AGENT", "")
+		t.Setenv("CLAUDECODE", "1")
+		require.False(t, shouldAutoLogin(false))
+	})
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -158,11 +158,11 @@ func Execute(ctx context.Context) {
 			errRunes := []rune(errString)
 			errRunes[0] = unicode.ToUpper(errRunes[0])
 
-			if !shouldAutoLogin(os.Getenv, term.IsTerminal(int(os.Stdin.Fd()))) {
+			if !shouldAutoLogin(term.IsTerminal(int(os.Stdin.Fd()))) {
 				fmt.Fprintln(os.Stderr, string(errRunes))
 				fmt.Fprintln(os.Stderr, "  If you already have a key: set STRIPE_API_KEY or pass --api-key <key>.")
 				fmt.Fprintln(os.Stderr, "  To authenticate to an existing account: run `stripe login` (outputs a browser URL for the user).")
-				if useragent.DetectAIAgent(os.Getenv) != "" {
+				if useragent.DetectAIAgent() != "" {
 					fmt.Fprintln(os.Stderr, "  If you do not have an account, run `stripe sandbox create` (provisions a claimable sandbox).")
 				}
 			} else {

--- a/pkg/cmd/templates.go
+++ b/pkg/cmd/templates.go
@@ -269,7 +269,7 @@ func WrappedNonRequestParamsFlagUsages(cmd *cobra.Command) string {
 //
 
 func isAIAgent() bool {
-	return useragent.DetectAIAgent(os.Getenv) != ""
+	return useragent.DetectAIAgent() != ""
 }
 
 // AIAgentHelpAnnotationKey is the Cobra annotation key used to store

--- a/pkg/cmd/templates_test.go
+++ b/pkg/cmd/templates_test.go
@@ -45,13 +45,20 @@ func TestGetLoginEmpty(t *testing.T) {
 }
 
 func TestIsAIAgent_Detected(t *testing.T) {
+	t.Setenv("AI_AGENT", "")
 	t.Setenv("CLAUDECODE", "1")
 	assert.True(t, isAIAgent())
 }
 
 func TestIsAIAgent_NotDetected(t *testing.T) {
 	// Ensure none of the agent env vars are set
-	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
+	for _, key := range []string{
+		"AI_AGENT",
+		"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLAUDE_CODE", "CLINE_ACTIVE",
+		"CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI",
+		"CURSOR_TRACE_ID", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE", "OPENCODE_CLIENT",
+		"OPENCLAW_SHELL",
+	} {
 		t.Setenv(key, "")
 	}
 	assert.False(t, isAIAgent())
@@ -138,7 +145,13 @@ func TestAIAgentHelp_SubcommandOnly(t *testing.T) {
 }
 
 func TestAIAgentHelp_NotDetected(t *testing.T) {
-	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
+	for _, key := range []string{
+		"AI_AGENT",
+		"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLAUDE_CODE", "CLINE_ACTIVE",
+		"CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI",
+		"CURSOR_TRACE_ID", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE", "OPENCODE_CLIENT",
+		"OPENCLAW_SHELL",
+	} {
 		t.Setenv(key, "")
 	}
 

--- a/pkg/cmd/unknown_cmd_telemetry.go
+++ b/pkg/cmd/unknown_cmd_telemetry.go
@@ -28,7 +28,7 @@ type unknownCommandEntry struct {
 // recordUnknownCommand records an unknown command attempt in agent environments.
 // It batches entries locally and sends telemetry every unknownCmdBatchSize occurrences.
 func recordUnknownCommand(ctx context.Context, command string) {
-	agent := useragent.DetectAIAgent(os.Getenv)
+	agent := useragent.DetectAIAgent()
 	if agent == "" {
 		return
 	}

--- a/pkg/cmd/unknown_cmd_telemetry_test.go
+++ b/pkg/cmd/unknown_cmd_telemetry_test.go
@@ -33,7 +33,10 @@ func (m *mockUnknownCmdTelemetryClient) SendEvent(_ context.Context, eventName s
 }
 
 func TestRecordUnknownCommand_NotInAgentEnv(t *testing.T) {
+	t.Setenv("AI_AGENT", "")
 	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+	t.Setenv("CURSOR_TRACE_ID", "")
 	t.Setenv("CURSOR_AGENT", "")
 	t.Setenv("CODEX_SANDBOX", "")
 	t.Setenv("CODEX_THREAD_ID", "")
@@ -42,6 +45,7 @@ func TestRecordUnknownCommand_NotInAgentEnv(t *testing.T) {
 	t.Setenv("CLINE_ACTIVE", "")
 	t.Setenv("GEMINI_CLI", "")
 	t.Setenv("OPENCODE", "")
+	t.Setenv("OPENCODE_CLIENT", "")
 	t.Setenv("OPENCLAW_SHELL", "")
 	t.Setenv("ANTIGRAVITY_CLI_ALIAS", "")
 
@@ -60,6 +64,7 @@ func TestRecordUnknownCommand_NotInAgentEnv(t *testing.T) {
 }
 
 func TestRecordUnknownCommand_InAgentEnv_BatchesCommands(t *testing.T) {
+	t.Setenv("AI_AGENT", "")
 	t.Setenv("CLAUDECODE", "1")
 
 	tmpDir := t.TempDir()
@@ -81,12 +86,13 @@ func TestRecordUnknownCommand_InAgentEnv_BatchesCommands(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &entries))
 	assert.Len(t, entries, 9)
 	assert.Equal(t, "stripe foobar", entries[0].Command)
-	assert.Equal(t, "claude_code", entries[0].Agent)
+	assert.Equal(t, "claude", entries[0].Agent)
 
 	assert.Len(t, mock.events, 0)
 }
 
 func TestRecordUnknownCommand_InAgentEnv_SendsAtBatchSize(t *testing.T) {
+	t.Setenv("AI_AGENT", "")
 	t.Setenv("CLAUDECODE", "1")
 
 	tmpDir := t.TempDir()
@@ -111,7 +117,7 @@ func TestRecordUnknownCommand_InAgentEnv_SendsAtBatchSize(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(mock.events[0].value), &entries))
 	assert.Len(t, entries, 10)
 	assert.Equal(t, "stripe bazqux", entries[0].Command)
-	assert.Equal(t, "claude_code", entries[0].Agent)
+	assert.Equal(t, "claude", entries[0].Agent)
 }
 
 func TestRecordUnknownCommand_NoTelemetryClient(t *testing.T) {

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -80,7 +80,7 @@ func NewEventMetadata() *CLIAnalyticsEventMetadata {
 		InvocationID: uuid.NewString(),
 		CLIVersion:   version.Version,
 		OS:           runtime.GOOS,
-		AIAgent:      useragent.DetectAIAgent(os.Getenv),
+		AIAgent:      useragent.DetectAIAgent(),
 		InstallMethod: useragent.DetectInstallMethod(
 			os.Getenv,
 			os.Executable,

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -251,23 +251,23 @@ func TestTelemetryOptedOut(t *testing.T) {
 
 // AI Agent Detection Tests
 func TestDetectAIAgent_WithClaudeCode(t *testing.T) {
-	// Mock env getter that returns CLAUDECODE
-	getEnv := func(key string) string {
-		if key == "CLAUDECODE" {
-			return "1"
-		}
-		return ""
-	}
-	result := useragent.DetectAIAgent(getEnv)
-	require.Equal(t, "claude_code", result)
+	t.Setenv("AI_AGENT", "")
+	t.Setenv("CLAUDECODE", "1")
+	result := useragent.DetectAIAgent()
+	require.Equal(t, "claude", result)
 }
 
 func TestDetectAIAgent_NoAgentDetected(t *testing.T) {
-	// Mock env getter that returns empty strings
-	getEnv := func(key string) string {
-		return ""
+	for _, key := range []string{
+		"AI_AGENT",
+		"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLAUDE_CODE", "CLINE_ACTIVE",
+		"CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI",
+		"CURSOR_TRACE_ID", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE", "OPENCODE_CLIENT",
+		"OPENCLAW_SHELL",
+	} {
+		t.Setenv(key, "")
 	}
-	result := useragent.DetectAIAgent(getEnv)
+	result := useragent.DetectAIAgent()
 	require.Equal(t, "", result)
 }
 
@@ -278,37 +278,30 @@ func TestAIAgentDetection_AllAgents(t *testing.T) {
 		expected string
 	}{
 		{"Antigravity", "ANTIGRAVITY_CLI_ALIAS", "antigravity"},
-		{"Claude Code", "CLAUDECODE", "claude_code"},
+		{"Claude Code", "CLAUDECODE", "claude"},
 		{"Cline", "CLINE_ACTIVE", "cline"},
-		{"Codex CLI", "CODEX_SANDBOX", "codex_cli"},
-		{"Cursor", "CURSOR_AGENT", "cursor"},
-		{"Gemini CLI", "GEMINI_CLI", "gemini_cli"},
-		{"Open Code", "OPENCODE", "open_code"},
+		{"Codex CLI", "CODEX_SANDBOX", "codex"},
+		{"Cursor", "CURSOR_TRACE_ID", "cursor"},
+		{"Cursor CLI", "CURSOR_AGENT", "cursor-cli"},
+		{"Gemini CLI", "GEMINI_CLI", "gemini"},
+		{"Open Code", "OPENCODE", "opencode"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Mock env getter that returns only the specific env var being tested
-			getEnv := func(key string) string {
-				if key == tt.envVar {
-					return "true"
-				}
-				return ""
-			}
-			result := useragent.DetectAIAgent(getEnv)
+			t.Setenv("AI_AGENT", "")
+			t.Setenv(tt.envVar, "true")
+			result := useragent.DetectAIAgent()
 			require.Equal(t, tt.expected, result)
 		})
 	}
 }
 
 func TestAIAgentDetection_Priority(t *testing.T) {
-	// Test that the first matching env var wins (antigravity comes before cursor)
-	getEnv := func(key string) string {
-		if key == "ANTIGRAVITY_CLI_ALIAS" || key == "CURSOR_AGENT" {
-			return "1"
-		}
-		return ""
-	}
-	result := useragent.DetectAIAgent(getEnv)
-	require.Equal(t, "antigravity", result)
+	// cursor is evaluated before antigravity in detect-agent's spec order
+	t.Setenv("AI_AGENT", "")
+	t.Setenv("CURSOR_TRACE_ID", "1")
+	t.Setenv("ANTIGRAVITY_CLI_ALIAS", "1")
+	result := useragent.DetectAIAgent()
+	require.Equal(t, "cursor", result)
 }

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -4,10 +4,11 @@ package useragent
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	detectagent "github.com/vercel/detect-agent"
 
 	"github.com/stripe/stripe-cli/pkg/version"
 )
@@ -95,34 +96,14 @@ func DetectTerminalProgram(getEnv func(string) string) string {
 	return ""
 }
 
-// DetectAIAgent detects if the CLI was invoked by a coding agent, based on well-known env vars.
-// It accepts an environment getter function to allow testing without modifying the actual environment.
-func DetectAIAgent(getEnv func(string) string) string {
-	if getEnv("ANTIGRAVITY_CLI_ALIAS") != "" {
-		return "antigravity"
+// DetectAIAgent detects if the CLI was invoked by a coding agent.
+// Returns the agent's canonical name (e.g. "claude", "cursor") or "" if none detected.
+func DetectAIAgent() string {
+	agent, err := detectagent.Detect()
+	if err != nil {
+		return ""
 	}
-	if getEnv("CLAUDECODE") != "" {
-		return "claude_code"
-	}
-	if getEnv("CLINE_ACTIVE") != "" {
-		return "cline"
-	}
-	if getEnv("CODEX_SANDBOX") != "" || getEnv("CODEX_THREAD_ID") != "" || getEnv("CODEX_SANDBOX_NETWORK_DISABLED") != "" || getEnv("CODEX_CI") != "" {
-		return "codex_cli"
-	}
-	if getEnv("CURSOR_AGENT") != "" {
-		return "cursor"
-	}
-	if getEnv("GEMINI_CLI") != "" {
-		return "gemini_cli"
-	}
-	if getEnv("OPENCODE") != "" {
-		return "open_code"
-	}
-	if getEnv("OPENCLAW_SHELL") != "" {
-		return "openclaw"
-	}
-	return ""
+	return agent.Name
 }
 
 //
@@ -157,7 +138,7 @@ func init() {
 
 func initUserAgent() {
 	encodedUserAgent = "Stripe/v1 stripe-cli/" + version.Version
-	if agent := DetectAIAgent(os.Getenv); agent != "" {
+	if agent := DetectAIAgent(); agent != "" {
 		encodedUserAgent += fmt.Sprintf(" AIAgent/%s", agent)
 	}
 


### PR DESCRIPTION
Replaces manual env-var checks in DetectAIAgent with the vercel/detect-agent package, which centralizes agent detection logic and supports more agents (cowork, augment-cli, goose, junie, replit, github-copilot, kiro, devin) and the CLAUDE_CODE env var alias.

Agent name changes to match the package's canonical names:
- "claude_code" → "claude"
- "codex_cli"   → "codex"
- "gemini_cli"  → "gemini"
- "open_code"   → "opencode"
- CURSOR_AGENT now maps to "cursor-cli"; "cursor" uses CURSOR_TRACE_ID

Removes the getEnv parameter from DetectAIAgent, shouldAutoLogin, and writeClaudeCodePluginHint since the package reads os.Getenv directly. Tests updated to use t.Setenv() instead of mock env getters.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
