### PR TITLE
Attempt to fix winget error: "0x8a15000f : Data required by the source is missing"

### DIFF
--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -40,7 +40,6 @@ run_install() {
 
     winget)
         # Re-register the WinGet source AppX package to fix 0x8a15000f "data required is missing".
-        # shellcheck disable=SC2016
         powershell.exe -Command 'Add-AppxPackage -DisableDevelopmentMode -Register (Get-AppxPackage Microsoft.Winget.Source*).InstallLocation\AppXManifest.xml -Verbose'
         # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
         winget source reset --force

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -40,9 +40,8 @@ run_install() {
 
     winget)
         # Re-register the WinGet source AppX package to fix 0x8a15000f "data required is missing".
-        # $m is a PowerShell variable; single quotes intentionally prevent shell expansion.
         # shellcheck disable=SC2016
-        powershell.exe -Command '$m = Get-ChildItem -Path "C:\Program Files\WindowsApps\Microsoft.Winget.Source_*\AppXManifest.xml" -ErrorAction SilentlyContinue | Select-Object -First 1; if ($m) { Add-AppxPackage -DisableDevelopmentMode -Register $m.FullName -Verbose }'
+        powershell.exe -Command 'Add-AppxPackage -DisableDevelopmentMode -Register (Get-AppxPackage Microsoft.Winget.Source*).InstallLocation\AppXManifest.xml -Verbose'
         # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
         winget source reset --force
         # The GitHub Actions Windows image includes the Microsoft Store source,

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -39,6 +39,8 @@ run_install() {
     ;;
 
     winget)
+        # Re-register the WinGet source AppX package to fix 0x8a15000f "data required is missing".
+        powershell.exe -Command 'Add-AppxPackage -DisableDevelopmentMode -Register $(Resolve-Path "C:\Program Files\WindowsApps\Microsoft.Winget.Source_*\AppXManifest.xml") -Verbose'
         # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
         winget source reset --force
         # The GitHub Actions Windows image includes the Microsoft Store source,

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -40,7 +40,7 @@ run_install() {
 
     winget)
         # Re-register the WinGet source AppX package to fix 0x8a15000f "data required is missing".
-        powershell.exe -Command 'Add-AppxPackage -DisableDevelopmentMode -Register (Get-AppxPackage Microsoft.Winget.Source*).InstallLocation\AppXManifest.xml -Verbose'
+        powershell.exe -Command 'Add-AppxPackage -DisableDevelopmentMode -Register (Get-AppxPackage Microsoft.DesktopAppInstaller).InstallLocation\AppXManifest.xml -Verbose'
         # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
         winget source reset --force
         # The GitHub Actions Windows image includes the Microsoft Store source,

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -40,7 +40,8 @@ run_install() {
 
     winget)
         # Re-register the WinGet source AppX package to fix 0x8a15000f "data required is missing".
-        # shellcheck disable=SC2016 -- $m is a PowerShell variable, not a shell variable; single quotes are intentional.
+        # $m is a PowerShell variable; single quotes intentionally prevent shell expansion.
+        # shellcheck disable=SC2016
         powershell.exe -Command '$m = Get-ChildItem -Path "C:\Program Files\WindowsApps\Microsoft.Winget.Source_*\AppXManifest.xml" -ErrorAction SilentlyContinue | Select-Object -First 1; if ($m) { Add-AppxPackage -DisableDevelopmentMode -Register $m.FullName -Verbose }'
         # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
         winget source reset --force

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -39,8 +39,6 @@ run_install() {
     ;;
 
     winget)
-        # Re-register the WinGet source AppX package to fix 0x8a15000f "data required is missing".
-        powershell.exe -Command 'Add-AppxPackage -DisableDevelopmentMode -Register (Get-AppxPackage Microsoft.DesktopAppInstaller).InstallLocation\AppXManifest.xml -Verbose'
         # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
         winget source reset --force
         winget source update winget

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -40,7 +40,7 @@ run_install() {
 
     winget)
         # Re-register the WinGet source AppX package to fix 0x8a15000f "data required is missing".
-        powershell.exe -Command 'Add-AppxPackage -DisableDevelopmentMode -Register $(Resolve-Path "C:\Program Files\WindowsApps\Microsoft.Winget.Source_*\AppXManifest.xml") -Verbose'
+        powershell.exe -Command '$m = Get-ChildItem -Path "C:\Program Files\WindowsApps\Microsoft.Winget.Source_*\AppXManifest.xml" -ErrorAction SilentlyContinue | Select-Object -First 1; if ($m) { Add-AppxPackage -DisableDevelopmentMode -Register $m.FullName -Verbose }'
         # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
         winget source reset --force
         # The GitHub Actions Windows image includes the Microsoft Store source,

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -40,6 +40,7 @@ run_install() {
 
     winget)
         # Re-register the WinGet source AppX package to fix 0x8a15000f "data required is missing".
+        # shellcheck disable=SC2016 -- $m is a PowerShell variable, not a shell variable; single quotes are intentional.
         powershell.exe -Command '$m = Get-ChildItem -Path "C:\Program Files\WindowsApps\Microsoft.Winget.Source_*\AppXManifest.xml" -ErrorAction SilentlyContinue | Select-Object -First 1; if ($m) { Add-AppxPackage -DisableDevelopmentMode -Register $m.FullName -Verbose }'
         # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
         winget source reset --force

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -43,6 +43,7 @@ run_install() {
         powershell.exe -Command 'Add-AppxPackage -DisableDevelopmentMode -Register (Get-AppxPackage Microsoft.DesktopAppInstaller).InstallLocation\AppXManifest.xml -Verbose'
         # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
         winget source reset --force
+        winget source update winget
         # The GitHub Actions Windows image includes the Microsoft Store source,
         # which can block non-interactive installs after a reset by prompting
         # for terms and region data. Remove it and install from the community


### PR DESCRIPTION
This tries to fix this winget error in the package manager test: https://github.com/stripe/stripe-cli/actions/runs/29601198297/job/87953455639

Tested the happy case: https://github.com/stripe/stripe-cli/actions/runs/29605558834/job/87967798594

Since I can't reproduce the issue, I'm going to just wait and see if this works.