### PR TITLE
Another attempt at fixing the winget error

### DIFF
--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -39,6 +39,9 @@ run_install() {
     ;;
 
     winget)
+        # Re-register the WinGet source package to avoid 0x8a15000f "data required is missing".
+        # See: https://github.com/microsoft/winget-cli/issues/3068#issuecomment-1934922201
+        powershell.exe -Command "Add-AppPackage -path 'https://cdn.winget.microsoft.com/cache/source.msix'"
         # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
         winget source reset --force
         winget source update winget

--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -42,17 +42,7 @@ run_install() {
         # Re-register the WinGet source package to avoid 0x8a15000f "data required is missing".
         # See: https://github.com/microsoft/winget-cli/issues/3068#issuecomment-1934922201
         powershell.exe -Command "Add-AppPackage -path 'https://cdn.winget.microsoft.com/cache/source.msix'"
-        # Reset the source index to avoid 0x8a15000f "data required is missing" on fresh runners.
-        winget source reset --force
-        winget source update winget
-        # The GitHub Actions Windows image includes the Microsoft Store source,
-        # which can block non-interactive installs after a reset by prompting
-        # for terms and region data. Remove it and install from the community
-        # source directly.
-        if winget source list | grep -q 'msstore'; then
-            winget source remove msstore
-        fi
-        winget install --exact --id Stripe.StripeCli --source winget --accept-source-agreements --accept-package-agreements
+        winget install --exact --id Stripe.StripeCli --source winget
         # winget modifies PATH but the current shell process doesn't inherit the change;
         # explicitly add the WinGet Links directory where the stripe alias was created.
         PATH="$PATH:$(cygpath -u "$LOCALAPPDATA/Microsoft/WinGet/Links")"


### PR DESCRIPTION
Previous attempts at fixing `0x8a15000f : Data required by the source is missing` didn't work, so trying a different one.

Tested the happy case here: https://github.com/stripe/stripe-cli/actions/runs/29652838909/job/88101984535

We'll know that this works if it doesn't fail again.