### PR TITLE
Accept full docs.stripe.com URLs as path arguments

### DIFF
--- a/pkg/cmd/docs/root.go
+++ b/pkg/cmd/docs/root.go
@@ -207,11 +207,6 @@ func (r *RootCommand) run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	path := args[0]
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + strings.Join(args, "/")
-	}
-
 	if r.client == nil {
 		return fmt.Errorf("docs client not initialized")
 	}
@@ -219,13 +214,30 @@ func (r *RootCommand) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("markdown renderer not initialized")
 	}
 
-	ref := &url.URL{Path: path}
+	ref := parseDocsRef(args)
 	page, err := r.client.FetchPage(cmd.Context(), ref)
 	if err != nil {
 		return fmt.Errorf("fetching page: %w", err)
 	}
 
 	return r.show(cmd, &page)
+}
+
+// parseDocsRef converts command-line arguments into a URL reference for FetchPage.
+//
+// If the first argument is a full docs.stripe.com URL, its path and query
+// string are extracted. Otherwise the arguments are joined as a path fragment,
+// prefixing a leading "/" if absent.
+func parseDocsRef(args []string) *url.URL {
+	first := args[0]
+	if u, err := url.Parse(first); err == nil && u.Host == "docs.stripe.com" {
+		return &url.URL{Path: u.Path, RawQuery: u.RawQuery, Fragment: u.Fragment}
+	}
+	path := first
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + strings.Join(args, "/")
+	}
+	return &url.URL{Path: path}
 }
 
 func (r *RootCommand) useTUI(cmd *cobra.Command) bool {

--- a/pkg/cmd/docs/root_test.go
+++ b/pkg/cmd/docs/root_test.go
@@ -26,6 +26,62 @@ func TestNew(t *testing.T) {
 	assert.NotEmpty(t, root.Short)
 }
 
+func TestRootParsesDocsURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantPath string
+	}{
+		{
+			name:     "full docs.stripe.com URL",
+			args:     []string{"https://docs.stripe.com/connect/accounts"},
+			wantPath: "/connect/accounts",
+		},
+		{
+			name:     "full docs.stripe.com URL with query",
+			args:     []string{"https://docs.stripe.com/api/customers?api_version=2024-06-30"},
+			wantPath: "/api/customers",
+		},
+		{
+			name:     "plain path unchanged",
+			args:     []string{"/payments"},
+			wantPath: "/payments",
+		},
+		{
+			name:     "multi-segment args joined",
+			args:     []string{"connect", "accounts"},
+			wantPath: "/connect/accounts",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				fmt.Fprint(w, "# Test\n\nContent.")
+			}))
+			defer server.Close()
+
+			client := docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))
+			renderer, err := markdown.NewRenderer()
+			require.NoError(t, err)
+
+			var out bytes.Buffer
+			root := cmd.New().WithOptions(
+				cmd.WithClient(client),
+				cmd.WithRenderer(renderer),
+			).Root()
+			root.SetOut(&out)
+			root.SetArgs(tc.args)
+
+			err = root.ExecuteContext(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPath, gotPath)
+		})
+	}
+}
+
 func TestRootPrefixesPath(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/connect/accounts", r.URL.Path)


### PR DESCRIPTION
### Summary and motivation

`stripe docs` now accepts a full `https://docs.stripe.com/...` URL as its argument, extracting the path instead of treating the whole URL as a literal path segment.

When reading docs from the terminal, it's natural to copy a URL directly from the browser. Previously this would produce a nonsensical request; now pasting a full URL and passing a bare path are both valid.

### Test plan

- [X] Changes are covered by unit tests (including failures and edge cases)
- [X] Changes were tested manually

To test manually:
```bash
make
./stripe docs https://docs.stripe.com/payments
```