### PR TITLE
Add ability to list preferences exposed on docs.stripe.com

### DIFF
--- a/pkg/cmd/docs/prefs.go
+++ b/pkg/cmd/docs/prefs.go
@@ -17,8 +17,8 @@ import (
 func (r *RootCommand) newPrefsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "prefs",
-		Short: "Manage docs.stripe.com preferences",
-		Long:  `Manage docs.stripe.com preferences.`,
+		Short: "Manage preferences to customize rendered documentation",
+		Long:  `Manage preferences to customize rendered documentation, such as code snippet languages.`,
 	}
 
 	cmd.AddCommand(r.newPrefsListCmd())
@@ -29,8 +29,8 @@ func (r *RootCommand) newPrefsCmd() *cobra.Command {
 func (r *RootCommand) newPrefsListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "List available docs.stripe.com preferences",
-		Long: `List available docs.stripe.com preferences and their allowed values.
+		Short: "List available preferences for customizing rendered documentation",
+		Long: `List available preferences for customizing rendered documentation and their allowed values.
 
   stripe docs prefs list`,
 		Args: cobra.NoArgs,

--- a/pkg/cmd/docs/prefs.go
+++ b/pkg/cmd/docs/prefs.go
@@ -1,0 +1,82 @@
+package docs
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/list"
+	"github.com/spf13/cobra"
+
+	pkgdocs "github.com/stripe/stripe-cli/pkg/docs"
+	"github.com/stripe/stripe-cli/pkg/docs/pager"
+	"github.com/stripe/stripe-cli/pkg/docs/ui"
+)
+
+func (r *RootCommand) newPrefsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "prefs",
+		Short: "Manage docs.stripe.com preferences",
+		Long:  `Manage docs.stripe.com preferences.`,
+	}
+
+	cmd.AddCommand(r.newPrefsListCmd())
+
+	return cmd
+}
+
+func (r *RootCommand) newPrefsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List available docs.stripe.com preferences",
+		Long: `List available docs.stripe.com preferences and their allowed values.
+
+  stripe docs prefs list`,
+		Args: cobra.NoArgs,
+		RunE: r.runPrefsList,
+	}
+}
+
+func (r *RootCommand) runPrefsList(cmd *cobra.Command, _ []string) error {
+	response, err := r.client.FetchPrefs(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("prefs: %w", err)
+	}
+
+	w := pager.New(cmd.OutOrStdout(), !r.noPager)
+	defer func() { _ = w.Close() }()
+	return r.renderPrefsList(w, response)
+}
+
+func (r *RootCommand) renderPrefsList(w io.Writer, response *pkgdocs.PrefsResponse) error {
+	styles := ui.DefaultStyles()
+	colorOff := r.color() == colorValueOff
+
+	l := list.New().
+		Enumerator(list.Bullet).
+		ItemStyle(lipgloss.NewStyle().MarginBottom(1))
+
+	for _, pref := range response.Prefs {
+		values := strings.Join(pref.Values, ", ")
+		var defaultStr string
+		if pref.Default != nil {
+			defaultStr = fmt.Sprintf(" (default: %s)", *pref.Default)
+		}
+		valuesLine := "Values: " + values + defaultStr
+
+		if colorOff {
+			l.Item(pref.ID + "\n" + pref.Description + "\n" + valuesLine)
+		} else {
+			id := styles.Title.Render(pref.ID)
+			desc := styles.Muted.Render(pref.Description)
+			vals := styles.Muted.Render(valuesLine)
+			l.Item(id + "\n" + desc + "\n" + vals)
+		}
+	}
+
+	if _, err := fmt.Fprintln(w, l.String()); err != nil {
+		return fmt.Errorf("prefs: writing output: %w", err)
+	}
+	return nil
+}

--- a/pkg/cmd/docs/prefs_test.go
+++ b/pkg/cmd/docs/prefs_test.go
@@ -1,0 +1,114 @@
+package docs_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cliconfig "github.com/stripe/stripe-cli/pkg/config"
+
+	cmd "github.com/stripe/stripe-cli/pkg/cmd/docs"
+	"github.com/stripe/stripe-cli/pkg/docs"
+)
+
+func TestPrefsListCommand(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/_endpoint/prefs", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"prefs":[{"id":"lang","category":"code","description":"Programming language","values":["ruby","python","go"],"default":"ruby"},{"id":"theme","category":null,"description":"Color theme","values":["light","dark"],"default":null}]}`)
+	}))
+	defer server.Close()
+
+	client := docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))
+
+	var out bytes.Buffer
+	root := cmd.New().WithOptions(cmd.WithClient(client)).Root()
+	root.SetOut(&out)
+	root.SetArgs([]string{"prefs", "list"})
+
+	err := root.ExecuteContext(context.Background())
+	require.NoError(t, err)
+
+	plainOutput := stripANSI(out.String())
+	assert.Contains(t, plainOutput, "lang")
+	assert.Contains(t, plainOutput, "Programming language")
+	assert.Contains(t, plainOutput, "ruby, python, go")
+	assert.Contains(t, plainOutput, "default: ruby")
+	assert.Contains(t, plainOutput, "theme")
+	assert.Contains(t, plainOutput, "Color theme")
+	assert.Contains(t, plainOutput, "light, dark")
+	assert.Contains(t, plainOutput, "•")
+}
+
+func TestPrefsListCommand_ColorOff(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"prefs":[{"id":"lang","category":null,"description":"Programming language","values":["ruby","python"],"default":"ruby"}]}`)
+	}))
+	defer server.Close()
+
+	client := docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))
+
+	var out bytes.Buffer
+	root := cmd.New().WithOptions(
+		cmd.WithClient(client),
+		cmd.WithConfig(&cliconfig.Config{Color: "off"}),
+	).Root()
+	root.SetOut(&out)
+	root.SetArgs([]string{"prefs", "list"})
+
+	err := root.ExecuteContext(context.Background())
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.NotContains(t, output, "\x1b[", "expected no ANSI escape codes with color off")
+	assert.Contains(t, output, "lang")
+	assert.Contains(t, output, "Programming language")
+	assert.Contains(t, output, "default: ruby")
+}
+
+func TestPrefsListCommand_NoDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"prefs":[{"id":"theme","category":null,"description":"Color theme","values":["light","dark"],"default":null}]}`)
+	}))
+	defer server.Close()
+
+	client := docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))
+
+	var out bytes.Buffer
+	root := cmd.New().WithOptions(cmd.WithClient(client)).Root()
+	root.SetOut(&out)
+	root.SetArgs([]string{"prefs", "list"})
+
+	err := root.ExecuteContext(context.Background())
+	require.NoError(t, err)
+
+	plainOutput := stripANSI(out.String())
+	assert.Contains(t, plainOutput, "light, dark")
+	assert.NotContains(t, plainOutput, "default:")
+}
+
+func TestPrefsListCommand_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))
+
+	root := cmd.New().WithOptions(cmd.WithClient(client)).Root()
+	root.SetOut(new(bytes.Buffer))
+	root.SetArgs([]string{"prefs", "list"})
+
+	err := root.ExecuteContext(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prefs:")
+}

--- a/pkg/cmd/docs/root.go
+++ b/pkg/cmd/docs/root.go
@@ -109,6 +109,10 @@ Read API Reference pages by their identifier:
 	apiCmd.GroupID = docsGroup.ID
 	r.cmd.AddCommand(apiCmd)
 
+	prefsCmd := r.newPrefsCmd()
+	prefsCmd.GroupID = docsGroup.ID
+	r.cmd.AddCommand(prefsCmd)
+
 	return r
 }
 

--- a/pkg/docs/client.go
+++ b/pkg/docs/client.go
@@ -178,6 +178,42 @@ func (c *Client) do(req *http.Request) (response, error) {
 	return response{body: body, finalURL: resp.Request.URL}, nil
 }
 
+// Pref represents a single documentation preference.
+type Pref struct {
+	ID          string   `json:"id"`
+	Category    *string  `json:"category"`
+	Description string   `json:"description"`
+	Values      []string `json:"values"`
+	Default     *string  `json:"default"`
+}
+
+// PrefsResponse represents the response from the docs prefs endpoint.
+type PrefsResponse struct {
+	Prefs []Pref `json:"prefs"`
+}
+
+// FetchPrefs retrieves the list of documentation preferences from docs.stripe.com.
+func (c *Client) FetchPrefs(ctx context.Context) (*PrefsResponse, error) {
+	u := c.baseURL.JoinPath("/_endpoint/prefs")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("prefs: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	res, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var response PrefsResponse
+	if err := json.Unmarshal(res.body, &response); err != nil {
+		return nil, fmt.Errorf("prefs: unmarshal response: %w", err)
+	}
+	return &response, nil
+}
+
 // Search sends the request to docs search endpoint and returns a list of search results.
 //
 //	response, err := c.Search(ctx, "payment methods")

--- a/pkg/docs/client_test.go
+++ b/pkg/docs/client_test.go
@@ -427,6 +427,84 @@ func TestSearch(t *testing.T) {
 	}
 }
 
+func strPtr(s string) *string { return &s }
+
+func TestFetchPrefs(t *testing.T) {
+	tests := []struct {
+		name      string
+		handler   http.HandlerFunc
+		wantErr   string
+		wantCheck func(t *testing.T, got *PrefsResponse)
+	}{
+		{
+			name: "success with multiple prefs",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/_endpoint/prefs", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Accept"))
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"prefs":[{"id":"lang","category":"code","description":"Programming language","values":["ruby","python"],"default":"ruby"},{"id":"theme","category":null,"description":"Color theme","values":["light","dark"],"default":null}]}`)
+			},
+			wantCheck: func(t *testing.T, got *PrefsResponse) {
+				require.Len(t, got.Prefs, 2)
+				assert.Equal(t, "lang", got.Prefs[0].ID)
+				assert.Equal(t, strPtr("code"), got.Prefs[0].Category)
+				assert.Equal(t, "Programming language", got.Prefs[0].Description)
+				assert.Equal(t, []string{"ruby", "python"}, got.Prefs[0].Values)
+				assert.Equal(t, strPtr("ruby"), got.Prefs[0].Default)
+				assert.Equal(t, "theme", got.Prefs[1].ID)
+				assert.Nil(t, got.Prefs[1].Category)
+				assert.Nil(t, got.Prefs[1].Default)
+			},
+		},
+		{
+			name: "empty prefs list",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"prefs":[]}`)
+			},
+			wantCheck: func(t *testing.T, got *PrefsResponse) {
+				assert.Empty(t, got.Prefs)
+			},
+		},
+		{
+			name: "non-200 response returns error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr: "returned 500",
+		},
+		{
+			name: "invalid json returns error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"prefs":[`)
+			},
+			wantErr: "prefs: unmarshal response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := NewClient("0.1.0").WithOptions(WithBaseURL(server.URL))
+			got, err := client.FetchPrefs(context.Background())
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.wantCheck != nil {
+				tt.wantCheck(t, got)
+			}
+		})
+	}
+}
+
 // evictingMockCache always returns a miss, simulating TTL expiry.
 type evictingMockCache struct{}
 


### PR DESCRIPTION
### Summary and motivation

Adds a `stripe docs prefs list` command that fetches and displays the user-configurable documentation preferences available on docs.stripe.com (e.g. language, theme).

<img width="980" height="128" alt="CleanShot 2026-07-20 at 11 37 32" src="https://github.com/user-attachments/assets/5f6d35bf-cfc2-4f08-aa63-b638f7c48ffd" />

### Test plan

- [X] Changes are covered by unit tests (including failures and edge cases)
- [X] Changes were tested manually

To test manually:

```bash
make
./stripe docs prefs list
```

You should see a bullet list of available preferences, each showing the preference ID, description, allowed values, and default (if one exists).