### PR TITLE
[sandboxes cli] Match dashboard activation defaults for blank sandboxes

### DIFF
--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -516,7 +516,7 @@ that you have previously logged in with your Stripe account credentials.`,
 	snc.cmd.Flags().BoolVar(&snc.createBlank, "create-blank", false, "Create a fresh blank sandbox (requires --business-location)")
 	snc.cmd.Flags().StringVar(&snc.businessLocation, "business-location", "", "Country for a --create-blank sandbox (e.g. US)")
 	snc.cmd.Flags().StringVar(&snc.stripeAccount, "stripe-account", "", "Live account (acct_...) the sandbox belongs to; defaults to your logged-in account")
-	snc.cmd.Flags().BoolVar(&snc.activate, "activate", true, "Request capabilities and activate the sandbox after creation")
+	snc.cmd.Flags().BoolVar(&snc.activate, "activate", false, "Request capabilities and activate the sandbox after creation")
 	snc.cmd.Flags().IntVar(&snc.batch, "batch", 1, "Number of sandboxes to create (currently only 1 is supported)")
 
 	snc.cmd.Flags().StringVar(&snc.stripeVersion, "stripe-version", requests.StripeVersionHeaderValue, "Sets the Stripe-Version header")
@@ -609,11 +609,16 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 		return fmt.Errorf("resolved a non-playground context %q for %s", stripeContext, liveWorkspace)
 	}
 
+	activateSandbox := snc.activate
+	if snc.copyLiveAccount && !cmd.Flags().Changed("activate") {
+		activateSandbox = true
+	}
+
 	// Mirror the dashboard's create-sandbox request body, including the
 	// idempotency_token derived from the create inputs (see newIdempotencyToken).
 	reqBody := map[string]interface{}{
 		"name":              snc.name,
-		"activate_sandbox":  snc.activate,
+		"activate_sandbox":  activateSandbox,
 		"idempotency_token": newIdempotencyToken(snc.name, businessLocation, liveWorkspace),
 	}
 	if snc.createBlank {

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -28,6 +28,7 @@ import (
 
 func setupSandboxTestConfig(t *testing.T) func() {
 	t.Helper()
+	resetSandboxNewFlagsForTest(t)
 	profilesFile := filepath.Join(t.TempDir(), "config.toml")
 
 	origProfilesFile := Config.ProfilesFile
@@ -64,6 +65,29 @@ func setupSandboxTestConfig(t *testing.T) func() {
 		restoreLoginBrowser()
 		sandbox.GitConfigFunc = origGit
 		viper.Reset()
+	}
+}
+
+func resetSandboxNewFlagsForTest(t *testing.T) {
+	t.Helper()
+	cmd, _, err := rootCmd.Find([]string{"sandbox", "new"})
+	require.NoError(t, err)
+
+	for _, name := range []string{
+		"name",
+		"copy-live-account",
+		"create-blank",
+		"business-location",
+		"stripe-account",
+		"activate",
+		"batch",
+		"stripe-version",
+		"api-base",
+	} {
+		flag := cmd.Flags().Lookup(name)
+		require.NotNil(t, flag)
+		require.NoError(t, flag.Value.Set(flag.DefValue))
+		flag.Changed = false
 	}
 }
 
@@ -703,7 +727,7 @@ func TestSandboxNewCmd_BlankPath(t *testing.T) {
 			assert.Equal(t, "US", body["business_location"])
 			_, hasReplica := body["replica_of"]
 			assert.False(t, hasReplica)
-			assert.Equal(t, true, body["activate_sandbox"])
+			assert.Equal(t, false, body["activate_sandbox"])
 			json.NewEncoder(w).Encode(map[string]interface{}{"id": "wksp_test_blank", "object": "sandbox"})
 		default:
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
@@ -718,9 +742,8 @@ func TestSandboxNewCmd_BlankPath(t *testing.T) {
 		"--api-base="+server.URL,
 		"--create-blank=true",
 		"--copy-live-account=false",
-		"--stripe-account=", // clear any value leaked from a prior test's flag state
+		"--stripe-account=",
 		"--business-location=US",
-		"--activate=true", // clear any --activate=false leaked from a prior test
 		"--name=blanktest",
 	)
 	require.NoError(t, err)
@@ -755,8 +778,8 @@ func TestSandboxNewCmd_RequiresMode(t *testing.T) {
 	_, err = executeCommand(
 		rootCmd,
 		"sandbox", "new",
-		"--copy-live-account=false", // clear leaked flag state so neither mode is set
-		"--create-blank=false",      // clear leaked flag state so neither mode is set
+		"--copy-live-account=false",
+		"--create-blank=false",
 		"--name=mytest",
 	)
 	require.Error(t, err)
@@ -977,8 +1000,6 @@ func TestSandboxNewCmd_NoUAT(t *testing.T) {
 	assert.Contains(t, err.Error(), "stripe login")
 }
 
-// Placed last: sets --batch, which leaks onto the singleton rootCmd flag; keeping
-// it after the other tests avoids that value bleeding into their default (1).
 func TestSandboxNewCmd_BatchNotYetSupported(t *testing.T) {
 	cleanup := setupSandboxTestConfig(t)
 	defer cleanup()
@@ -1084,6 +1105,7 @@ func TestSandboxNewCmd_StripeAccountBlankMode(t *testing.T) {
 			assert.Equal(t, "US", body["business_location"])
 			_, hasReplica := body["replica_of"]
 			assert.False(t, hasReplica)
+			assert.Equal(t, false, body["activate_sandbox"])
 			json.NewEncoder(w).Encode(map[string]interface{}{"id": "sbx_blankacct", "object": "sandbox"})
 		default:
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)


### PR DESCRIPTION
### Reviewers
cc @stripe/sandboxes-engineering 

### Summary
Update `stripe sandbox new` so blank sandbox creation matches the Dashboard default: `--create-blank` sends `activate_sandbox=false` unless `--activate` is explicitly provided.

Copy-live sandbox creation keeps the existing Dashboard behavior by defaulting `activate_sandbox=true` when `--activate` is omitted. The tests now reset the reused sandbox-new Cobra flags between cases and assert the blank-path activation default directly.

### Test plan
- [x] `git diff --check`
- [ ] `go test ./pkg/cmd -run 'TestSandboxNewCmd_(Success|ActivateFalse|BlankPath|StripeAccountBlankMode)'` (not run: `go` is not installed in this agent shell)

### Rollout/revert plan
Safe to revert.
