### PR TITLE
Add auto-upgrade coverage to curl install canary test

### DIFF
--- a/.github/workflows/curl-install-test.yml
+++ b/.github/workflows/curl-install-test.yml
@@ -11,29 +11,193 @@ name: Curl install test
 permissions:
   contents: read
 jobs:
-  curl-install-macos:
+  upgrade-macos:
     runs-on: macos-latest
+    outputs:
+      failed_step: ${{ steps.result.outputs.failed_step }}
     steps:
-      - run: |
-          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
-          export PATH="$HOME/.stripe/bin:$PATH"
-          stripe --version
+      - name: Get previous release version
+        id: prev-release
+        run: |
+          PREV_VERSION=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/stripe/stripe-cli/releases?per_page=2" | \
+            sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | sed -n '2p')
+          if [ -z "$PREV_VERSION" ]; then
+            echo "Error: could not determine previous release version"
+            exit 1
+          fi
+          echo "version=$PREV_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Previous version: $PREV_VERSION"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  curl-install-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
-          export PATH="$HOME/.stripe/bin:$PATH"
-          stripe --version
+      - name: Get latest release version
+        id: latest-release
+        run: |
+          LATEST_VERSION=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/stripe/stripe-cli/releases/latest" | \
+            sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "Error: could not determine latest release version"
+            exit 1
+          fi
+          echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Latest version: $LATEST_VERSION"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install older version via curl
+        id: install
+        run: |
+          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
+          export PATH="$HOME/.stripe/bin:$PATH"
+          INSTALLED=$(stripe --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ "$INSTALLED" != "${{ steps.prev-release.outputs.version }}" ]; then
+            echo "Error: expected version ${{ steps.prev-release.outputs.version }}, got $INSTALLED"
+            exit 1
+          fi
+          echo "Successfully installed v$INSTALLED"
+        env:
+          VERSION: ${{ steps.prev-release.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger update check
+        id: update-check
+        run: |
+          export PATH="$HOME/.stripe/bin:$PATH"
+          export STRIPE_INSTALL_METHOD=curl
+          stripe --version
+          MARKER="$HOME/.stripe/state/update-available"
+          if [ ! -f "$MARKER" ]; then
+            echo "Error: update marker was not written after running stripe"
+            exit 1
+          fi
+          echo "Update marker found:"
+          cat "$MARKER"
+
+      - name: Verify auto-upgrade
+        id: upgrade
+        run: |
+          export PATH="$HOME/.stripe/bin:$PATH"
+          export STRIPE_INSTALL_METHOD=curl
+          OUTPUT=$(stripe --version 2>&1)
+          echo "$OUTPUT"
+          UPGRADED=$(echo "$OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
+          if [ "$UPGRADED" != "${{ steps.latest-release.outputs.version }}" ]; then
+            echo "Error: expected upgrade to v${{ steps.latest-release.outputs.version }}, got v$UPGRADED"
+            exit 1
+          fi
+          echo "Successfully upgraded to v$UPGRADED"
+
+      - name: Record failed step
+        id: result
+        if: failure()
+        run: |
+          if [ "${{ steps.install.outcome }}" = "failure" ]; then
+            echo "failed_step=install" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.update-check.outcome }}" = "failure" ]; then
+            echo "failed_step=update-check" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.upgrade.outcome }}" = "failure" ]; then
+            echo "failed_step=auto-upgrade" >> "$GITHUB_OUTPUT"
+          else
+            echo "failed_step=setup" >> "$GITHUB_OUTPUT"
+          fi
+
+  upgrade-linux:
+    runs-on: ubuntu-latest
+    outputs:
+      failed_step: ${{ steps.result.outputs.failed_step }}
+    steps:
+      - name: Get previous release version
+        id: prev-release
+        run: |
+          PREV_VERSION=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/stripe/stripe-cli/releases?per_page=2" | \
+            sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | sed -n '2p')
+          if [ -z "$PREV_VERSION" ]; then
+            echo "Error: could not determine previous release version"
+            exit 1
+          fi
+          echo "version=$PREV_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Previous version: $PREV_VERSION"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get latest release version
+        id: latest-release
+        run: |
+          LATEST_VERSION=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/stripe/stripe-cli/releases/latest" | \
+            sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "Error: could not determine latest release version"
+            exit 1
+          fi
+          echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Latest version: $LATEST_VERSION"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install older version via curl
+        id: install
+        run: |
+          curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
+          export PATH="$HOME/.stripe/bin:$PATH"
+          INSTALLED=$(stripe --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ "$INSTALLED" != "${{ steps.prev-release.outputs.version }}" ]; then
+            echo "Error: expected version ${{ steps.prev-release.outputs.version }}, got $INSTALLED"
+            exit 1
+          fi
+          echo "Successfully installed v$INSTALLED"
+        env:
+          VERSION: ${{ steps.prev-release.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger update check
+        id: update-check
+        run: |
+          export PATH="$HOME/.stripe/bin:$PATH"
+          export STRIPE_INSTALL_METHOD=curl
+          stripe --version
+          MARKER="$HOME/.stripe/state/update-available"
+          if [ ! -f "$MARKER" ]; then
+            echo "Error: update marker was not written after running stripe"
+            exit 1
+          fi
+          echo "Update marker found:"
+          cat "$MARKER"
+
+      - name: Verify auto-upgrade
+        id: upgrade
+        run: |
+          export PATH="$HOME/.stripe/bin:$PATH"
+          export STRIPE_INSTALL_METHOD=curl
+          OUTPUT=$(stripe --version 2>&1)
+          echo "$OUTPUT"
+          UPGRADED=$(echo "$OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
+          if [ "$UPGRADED" != "${{ steps.latest-release.outputs.version }}" ]; then
+            echo "Error: expected upgrade to v${{ steps.latest-release.outputs.version }}, got v$UPGRADED"
+            exit 1
+          fi
+          echo "Successfully upgraded to v$UPGRADED"
+
+      - name: Record failed step
+        id: result
+        if: failure()
+        run: |
+          if [ "${{ steps.install.outcome }}" = "failure" ]; then
+            echo "failed_step=install" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.update-check.outcome }}" = "failure" ]; then
+            echo "failed_step=update-check" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.upgrade.outcome }}" = "failure" ]; then
+            echo "failed_step=auto-upgrade" >> "$GITHUB_OUTPUT"
+          else
+            echo "failed_step=setup" >> "$GITHUB_OUTPUT"
+          fi
 
   notify:
     runs-on: ubuntu-latest
-    needs: [curl-install-macos, curl-install-linux]
+    needs: [upgrade-macos, upgrade-linux]
     if: always()
     steps:
       - uses: actions/checkout@v6
@@ -41,12 +205,36 @@ jobs:
           sparse-checkout: |
             scripts/notify.sh
           sparse-checkout-cone-mode: false
+      - name: Build failure summary
+        id: summary
+        if: contains(needs.*.result, 'failure')
+        run: |
+          MACOS_STEP="${{ needs.upgrade-macos.outputs.failed_step }}"
+          LINUX_STEP="${{ needs.upgrade-linux.outputs.failed_step }}"
+
+          MSG=""
+          if [ -n "$MACOS_STEP" ] && [ -n "$LINUX_STEP" ]; then
+            if [ "$MACOS_STEP" = "$LINUX_STEP" ]; then
+              MSG="Step '${MACOS_STEP}' failed on macOS and Linux"
+            else
+              MSG="Step '${MACOS_STEP}' failed on macOS, step '${LINUX_STEP}' failed on Linux"
+            fi
+          elif [ -n "$MACOS_STEP" ]; then
+            MSG="Step '${MACOS_STEP}' failed on macOS"
+          elif [ -n "$LINUX_STEP" ]; then
+            MSG="Step '${LINUX_STEP}' failed on Linux"
+          else
+            MSG="Unknown failure"
+          fi
+
+          echo "msg=$MSG" >> "$GITHUB_OUTPUT"
+
       - run: bash scripts/notify.sh
         env:
           OVERALL_RESULT: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
           PAGERDUTY_DEDUP_KEY: gh-actions-stripe-cli-curl-install-test
-          PAGERDUTY_SUMMARY: "Failed to install Stripe CLI via curl install script. Investigate here: https://github.com/stripe/stripe-cli/actions/workflows/curl-install-test.yml"
-          PAGERDUTY_RESOLVE_SUMMARY: "Stripe CLI curl install script is passing again"
+          PAGERDUTY_SUMMARY: "Curl install test failed: ${{ steps.summary.outputs.msg }}. Investigate: https://github.com/stripe/stripe-cli/actions/workflows/curl-install-test.yml"
+          PAGERDUTY_RESOLVE_SUMMARY: "Curl install test is passing again"
           PAGERDUTY_SEVERITY: critical
-          DRYRUN: "true" # TODO: switch to ${{ inputs.dryrun }} once confirmed stable
+          DRYRUN: ${{ inputs.dryrun || 'true' }}

--- a/.github/workflows/curl-install-test.yml
+++ b/.github/workflows/curl-install-test.yml
@@ -11,54 +11,53 @@ name: Curl install test
 permissions:
   contents: read
 jobs:
+  resolve-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      previous: ${{ steps.versions.outputs.previous }}
+      latest: ${{ steps.versions.outputs.latest }}
+    steps:
+      - name: Fetch release versions
+        id: versions
+        run: |
+          for i in 1 2 3; do
+            RELEASES=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" \
+              "https://api.github.com/repos/stripe/stripe-cli/releases?per_page=2")
+            LATEST=$(echo "$RELEASES" | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | sed -n '1p')
+            PREVIOUS=$(echo "$RELEASES" | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | sed -n '2p')
+            if [ -n "$LATEST" ] && [ -n "$PREVIOUS" ]; then
+              echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+              echo "previous=$PREVIOUS" >> "$GITHUB_OUTPUT"
+              echo "Latest: $LATEST, Previous: $PREVIOUS"
+              exit 0
+            fi
+            echo "Attempt $i: failed to fetch versions, retrying in 10s..."
+            sleep 10
+          done
+          echo "Error: could not determine release versions after 3 attempts"
+          exit 1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   upgrade-macos:
     runs-on: macos-latest
+    needs: [resolve-versions]
     outputs:
       failed_step: ${{ steps.result.outputs.failed_step }}
     steps:
-      - name: Get previous release version
-        id: prev-release
-        run: |
-          PREV_VERSION=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" \
-            "https://api.github.com/repos/stripe/stripe-cli/releases?per_page=2" | \
-            sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | sed -n '2p')
-          if [ -z "$PREV_VERSION" ]; then
-            echo "Error: could not determine previous release version"
-            exit 1
-          fi
-          echo "version=$PREV_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Previous version: $PREV_VERSION"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get latest release version
-        id: latest-release
-        run: |
-          LATEST_VERSION=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" \
-            "https://api.github.com/repos/stripe/stripe-cli/releases/latest" | \
-            sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
-          if [ -z "$LATEST_VERSION" ]; then
-            echo "Error: could not determine latest release version"
-            exit 1
-          fi
-          echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Latest version: $LATEST_VERSION"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install older version via curl
         id: install
         run: |
           curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
           export PATH="$HOME/.stripe/bin:$PATH"
           INSTALLED=$(stripe --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          if [ "$INSTALLED" != "${{ steps.prev-release.outputs.version }}" ]; then
-            echo "Error: expected version ${{ steps.prev-release.outputs.version }}, got $INSTALLED"
+          if [ "$INSTALLED" != "${{ needs.resolve-versions.outputs.previous }}" ]; then
+            echo "Error: expected version ${{ needs.resolve-versions.outputs.previous }}, got $INSTALLED"
             exit 1
           fi
           echo "Successfully installed v$INSTALLED"
         env:
-          VERSION: ${{ steps.prev-release.outputs.version }}
+          VERSION: ${{ needs.resolve-versions.outputs.previous }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trigger update check
@@ -83,8 +82,8 @@ jobs:
           OUTPUT=$(stripe --version 2>&1)
           echo "$OUTPUT"
           UPGRADED=$(echo "$OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
-          if [ "$UPGRADED" != "${{ steps.latest-release.outputs.version }}" ]; then
-            echo "Error: expected upgrade to v${{ steps.latest-release.outputs.version }}, got v$UPGRADED"
+          if [ "$UPGRADED" != "${{ needs.resolve-versions.outputs.latest }}" ]; then
+            echo "Error: expected upgrade to v${{ needs.resolve-versions.outputs.latest }}, got v$UPGRADED"
             exit 1
           fi
           echo "Successfully upgraded to v$UPGRADED"
@@ -99,58 +98,27 @@ jobs:
             echo "failed_step=update-check" >> "$GITHUB_OUTPUT"
           elif [ "${{ steps.upgrade.outcome }}" = "failure" ]; then
             echo "failed_step=auto-upgrade" >> "$GITHUB_OUTPUT"
-          else
-            echo "failed_step=setup" >> "$GITHUB_OUTPUT"
           fi
 
   upgrade-linux:
     runs-on: ubuntu-latest
+    needs: [resolve-versions]
     outputs:
       failed_step: ${{ steps.result.outputs.failed_step }}
     steps:
-      - name: Get previous release version
-        id: prev-release
-        run: |
-          PREV_VERSION=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" \
-            "https://api.github.com/repos/stripe/stripe-cli/releases?per_page=2" | \
-            sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | sed -n '2p')
-          if [ -z "$PREV_VERSION" ]; then
-            echo "Error: could not determine previous release version"
-            exit 1
-          fi
-          echo "version=$PREV_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Previous version: $PREV_VERSION"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get latest release version
-        id: latest-release
-        run: |
-          LATEST_VERSION=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" \
-            "https://api.github.com/repos/stripe/stripe-cli/releases/latest" | \
-            sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
-          if [ -z "$LATEST_VERSION" ]; then
-            echo "Error: could not determine latest release version"
-            exit 1
-          fi
-          echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Latest version: $LATEST_VERSION"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install older version via curl
         id: install
         run: |
           curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh
           export PATH="$HOME/.stripe/bin:$PATH"
           INSTALLED=$(stripe --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          if [ "$INSTALLED" != "${{ steps.prev-release.outputs.version }}" ]; then
-            echo "Error: expected version ${{ steps.prev-release.outputs.version }}, got $INSTALLED"
+          if [ "$INSTALLED" != "${{ needs.resolve-versions.outputs.previous }}" ]; then
+            echo "Error: expected version ${{ needs.resolve-versions.outputs.previous }}, got $INSTALLED"
             exit 1
           fi
           echo "Successfully installed v$INSTALLED"
         env:
-          VERSION: ${{ steps.prev-release.outputs.version }}
+          VERSION: ${{ needs.resolve-versions.outputs.previous }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trigger update check
@@ -175,8 +143,8 @@ jobs:
           OUTPUT=$(stripe --version 2>&1)
           echo "$OUTPUT"
           UPGRADED=$(echo "$OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
-          if [ "$UPGRADED" != "${{ steps.latest-release.outputs.version }}" ]; then
-            echo "Error: expected upgrade to v${{ steps.latest-release.outputs.version }}, got v$UPGRADED"
+          if [ "$UPGRADED" != "${{ needs.resolve-versions.outputs.latest }}" ]; then
+            echo "Error: expected upgrade to v${{ needs.resolve-versions.outputs.latest }}, got v$UPGRADED"
             exit 1
           fi
           echo "Successfully upgraded to v$UPGRADED"
@@ -191,23 +159,23 @@ jobs:
             echo "failed_step=update-check" >> "$GITHUB_OUTPUT"
           elif [ "${{ steps.upgrade.outcome }}" = "failure" ]; then
             echo "failed_step=auto-upgrade" >> "$GITHUB_OUTPUT"
-          else
-            echo "failed_step=setup" >> "$GITHUB_OUTPUT"
           fi
 
   notify:
     runs-on: ubuntu-latest
-    needs: [upgrade-macos, upgrade-linux]
+    needs: [resolve-versions, upgrade-macos, upgrade-linux]
     if: always()
     steps:
       - uses: actions/checkout@v6
+        if: needs.resolve-versions.result == 'success' && contains(needs.*.result, 'failure')
         with:
           sparse-checkout: |
             scripts/notify.sh
           sparse-checkout-cone-mode: false
+
       - name: Build failure summary
         id: summary
-        if: contains(needs.*.result, 'failure')
+        if: needs.resolve-versions.result == 'success' && contains(needs.*.result, 'failure')
         run: |
           MACOS_STEP="${{ needs.upgrade-macos.outputs.failed_step }}"
           LINUX_STEP="${{ needs.upgrade-linux.outputs.failed_step }}"
@@ -229,12 +197,30 @@ jobs:
 
           echo "msg=$MSG" >> "$GITHUB_OUTPUT"
 
-      - run: bash scripts/notify.sh
+      - name: Trigger PagerDuty alert
+        if: needs.resolve-versions.result == 'success' && contains(needs.*.result, 'failure')
+        run: bash scripts/notify.sh
         env:
-          OVERALL_RESULT: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+          OVERALL_RESULT: failure
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
           PAGERDUTY_DEDUP_KEY: gh-actions-stripe-cli-curl-install-test
           PAGERDUTY_SUMMARY: "Curl install test failed: ${{ steps.summary.outputs.msg }}. Investigate: https://github.com/stripe/stripe-cli/actions/workflows/curl-install-test.yml"
           PAGERDUTY_RESOLVE_SUMMARY: "Curl install test is passing again"
           PAGERDUTY_SEVERITY: critical
-          DRYRUN: ${{ inputs.dryrun || 'true' }}
+          DRYRUN: "true" # TODO: switch to ${{ inputs.dryrun }} once confirmed stable
+
+      - name: Resolve PagerDuty alert
+        if: needs.upgrade-macos.result == 'success' && needs.upgrade-linux.result == 'success'
+        run: bash scripts/notify.sh
+        env:
+          OVERALL_RESULT: success
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+          PAGERDUTY_DEDUP_KEY: gh-actions-stripe-cli-curl-install-test
+          PAGERDUTY_SUMMARY: "unused"
+          PAGERDUTY_RESOLVE_SUMMARY: "Curl install test is passing again"
+          PAGERDUTY_SEVERITY: critical
+          DRYRUN: "true" # TODO: switch to ${{ inputs.dryrun }} once confirmed stable
+
+      - name: Skip notification (setup failure)
+        if: needs.resolve-versions.result == 'failure'
+        run: echo "Setup job (version resolution) failed — likely transient GitHub API issue. Skipping PagerDuty alert."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,16 +80,22 @@ http_download() {
 }
 
 get_latest_version() {
-  VERSION=$(http_get "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" | \
+  LATEST_VERSION=$(http_get "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" | \
     sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
 
-  if [ -z "$VERSION" ]; then
+  if [ -z "$LATEST_VERSION" ]; then
     echo "Error: could not determine latest version."
     echo "Check your internet connection or try again later."
     exit 1
   fi
 
-  echo "Latest version: v$VERSION"
+  if [ -n "${VERSION:-}" ]; then
+    VERSION=$(echo "$VERSION" | sed 's/^v//')
+    echo "Installing requested version: v$VERSION (latest is v$LATEST_VERSION)"
+  else
+    VERSION="$LATEST_VERSION"
+    echo "Latest version: v$VERSION"
+  fi
 }
 
 download_and_verify() {
@@ -183,10 +189,23 @@ setup_path() {
   NEEDS_SOURCE=true
 }
 
+version_lt() {
+  # Returns 0 (true) if $1 < $2 using sort -V for version comparison
+  [ "$1" != "$2" ] && [ "$(printf '%s\n%s' "$1" "$2" | sort -V | head -n1)" = "$1" ]
+}
+
 print_success() {
   echo ""
   echo "stripe v${VERSION} installed to $INSTALL_DIR/stripe"
   echo ""
+  if [ "$VERSION" != "$LATEST_VERSION" ] && version_lt "$VERSION" "$LATEST_VERSION"; then
+    echo "Note: You installed v${VERSION}, but the latest is v${LATEST_VERSION}."
+    echo "Auto-update will upgrade you to the latest on next run."
+    echo "To stay on this version, set STRIPE_NO_AUTO_UPDATE=1 or add to ~/.config/stripe/config.toml:"
+    echo "  [settings]"
+    echo "  auto_update = false"
+    echo ""
+  fi
   if [ "$NEEDS_SOURCE" = "true" ]; then
     echo "Run 'source $PROFILE' or open a new terminal, then:"
   fi


### PR DESCRIPTION
## Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
- Replaces the simple "install latest and check version" curl install test with one that also validates auto-upgrade e2e
- Test flow: install previous release -> verify install -> trigger update check -> confirm auto upgrade to latest version
- Pagerduty alerts include which step failed (install / update-check / auto-upgrade) and on which OS
- Transient setup failures (e.g., GitHub API rate limiting) retry 3x and skip paging

