### PR TITLE
Add ability to set and unset docs preferences

### DIFF
--- a/pkg/cmd/docs/prefs.go
+++ b/pkg/cmd/docs/prefs.go
@@ -8,11 +8,14 @@ import (
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/list"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	pkgdocs "github.com/stripe/stripe-cli/pkg/docs"
 	"github.com/stripe/stripe-cli/pkg/docs/pager"
 	"github.com/stripe/stripe-cli/pkg/docs/ui"
 )
+
+const docsPrefsConfigKey = "docs_prefs"
 
 func (r *RootCommand) newPrefsCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -22,19 +25,42 @@ func (r *RootCommand) newPrefsCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(r.newPrefsListCmd())
+	cmd.AddCommand(r.newPrefsSetCmd())
+	cmd.AddCommand(r.newPrefsUnsetCmd())
 
 	return cmd
 }
 
 func (r *RootCommand) newPrefsListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
-		Short: "List available preferences for customizing rendered documentation",
-		Long: `List available preferences for customizing rendered documentation and their allowed values.
+		Use:     "list",
+		Short:   "List available preferences for customizing rendered documentation",
+		Long:    `List available preferences for customizing rendered documentation and their allowed values.`,
+		Example: `  stripe docs prefs list`,
+		Args:    cobra.NoArgs,
+		RunE:    r.runPrefsList,
+	}
+}
 
-  stripe docs prefs list`,
-		Args: cobra.NoArgs,
-		RunE: r.runPrefsList,
+func (r *RootCommand) newPrefsSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "set <id> <value>",
+		Short:   "Set a documentation preference",
+		Long:    `Set a documentation preference to a specific value.`,
+		Example: `  stripe docs prefs set server go`,
+		Args:    cobra.ExactArgs(2),
+		RunE:    r.runPrefsSet,
+	}
+}
+
+func (r *RootCommand) newPrefsUnsetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "unset <id>",
+		Short:   "Unset a documentation preference, reverting to the default",
+		Long:    `Remove a previously set documentation preference, reverting to the default.`,
+		Example: `  stripe docs prefs unset server`,
+		Args:    cobra.ExactArgs(1),
+		RunE:    r.runPrefsUnset,
 	}
 }
 
@@ -44,12 +70,86 @@ func (r *RootCommand) runPrefsList(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("prefs: %w", err)
 	}
 
+	current := make(map[string]string)
+	for _, pref := range response.Prefs {
+		if v := r.getDocsPref(pref.ID); v != "" {
+			current[pref.ID] = v
+		}
+	}
+
 	w := pager.New(cmd.OutOrStdout(), !r.noPager)
 	defer func() { _ = w.Close() }()
-	return r.renderPrefsList(w, response)
+	return r.renderPrefsList(w, response, current)
 }
 
-func (r *RootCommand) renderPrefsList(w io.Writer, response *pkgdocs.PrefsResponse) error {
+func (r *RootCommand) runPrefsSet(cmd *cobra.Command, args []string) error {
+	id, value := args[0], args[1]
+
+	response, err := r.client.FetchPrefs(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("prefs: %w", err)
+	}
+
+	var found *pkgdocs.Pref
+	for i := range response.Prefs {
+		if response.Prefs[i].ID == id {
+			found = &response.Prefs[i]
+			break
+		}
+	}
+	if found == nil {
+		return fmt.Errorf("prefs: unknown preference %q", id)
+	}
+
+	if len(found.Values) > 0 {
+		valid := false
+		for _, v := range found.Values {
+			if v == value {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return fmt.Errorf("prefs: invalid value %q for %q; allowed: %s", value, id, strings.Join(found.Values, ", "))
+		}
+	}
+
+	if err := r.writeDocsPref(id, value); err != nil {
+		return fmt.Errorf("prefs: writing config: %w", err)
+	}
+
+	check := "✓"
+	prefID := id
+	prefValue := value
+	if r.color() != colorValueOff {
+		styles := ui.DefaultStyles()
+		check = styles.SuccessText.Render(check)
+		prefID = styles.Title.Render(id)
+		prefValue = styles.SuccessText.Render(value)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s Preference %s set to %s\n", check, prefID, prefValue)
+	return nil
+}
+
+func (r *RootCommand) runPrefsUnset(cmd *cobra.Command, args []string) error {
+	id := args[0]
+
+	if err := r.deleteDocsPref(id); err != nil {
+		return fmt.Errorf("prefs: removing config: %w", err)
+	}
+
+	check := "✓"
+	prefID := id
+	if r.color() != colorValueOff {
+		styles := ui.DefaultStyles()
+		check = styles.SuccessText.Render(check)
+		prefID = styles.Title.Render(id)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s Preference %s unset\n", check, prefID)
+	return nil
+}
+
+func (r *RootCommand) renderPrefsList(w io.Writer, response *pkgdocs.PrefsResponse, current map[string]string) error {
 	styles := ui.DefaultStyles()
 	colorOff := r.color() == colorValueOff
 
@@ -65,6 +165,10 @@ func (r *RootCommand) renderPrefsList(w io.Writer, response *pkgdocs.PrefsRespon
 		}
 		valuesLine := "Values: " + values + defaultStr
 
+		if currentVal, ok := current[pref.ID]; ok {
+			valuesLine += fmt.Sprintf(" [current: %s]", currentVal)
+		}
+
 		if colorOff {
 			l.Item(pref.ID + "\n" + pref.Description + "\n" + valuesLine)
 		} else {
@@ -79,4 +183,25 @@ func (r *RootCommand) renderPrefsList(w io.Writer, response *pkgdocs.PrefsRespon
 		return fmt.Errorf("prefs: writing output: %w", err)
 	}
 	return nil
+}
+
+func (r *RootCommand) getDocsPref(id string) string {
+	if r.cfg == nil {
+		return ""
+	}
+	return viper.GetString(r.cfg.Profile.GetConfigField(docsPrefsConfigKey + "." + id))
+}
+
+func (r *RootCommand) writeDocsPref(id, value string) error {
+	if r.cfg == nil {
+		return fmt.Errorf("no configuration available")
+	}
+	return r.cfg.Profile.WriteConfigField(docsPrefsConfigKey+"."+id, value)
+}
+
+func (r *RootCommand) deleteDocsPref(id string) error {
+	if r.cfg == nil {
+		return fmt.Errorf("no configuration available")
+	}
+	return r.cfg.Profile.DeleteConfigField(docsPrefsConfigKey + "." + id)
 }

--- a/pkg/cmd/docs/prefs_test.go
+++ b/pkg/cmd/docs/prefs_test.go
@@ -243,3 +243,26 @@ func TestPrefsUnsetCommand(t *testing.T) {
 	assert.Contains(t, stripANSI(out.String()), "Preference lang unset")
 	assert.Equal(t, "", viper.GetString("default.docs_prefs.lang"))
 }
+
+func TestPrefsUnsetCommand_NoOps(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "unknown pref", args: []string{"prefs", "unset", "unknown_pref"}},
+		{name: "not set", args: []string{"prefs", "unset", "lang"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, cleanup := setupPrefsTestConfig(t)
+			defer cleanup()
+
+			client := docs.NewClient("test").WithOptions(docs.WithBaseURL("http://unused"))
+			root := cmd.New().WithOptions(cmd.WithClient(client), cmd.WithConfig(cfg)).Root()
+			root.SetOut(new(bytes.Buffer))
+			root.SetArgs(tt.args)
+
+			require.NoError(t, root.ExecuteContext(context.Background()))
+		})
+	}
+}

--- a/pkg/cmd/docs/prefs_test.go
+++ b/pkg/cmd/docs/prefs_test.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,6 +19,28 @@ import (
 	cmd "github.com/stripe/stripe-cli/pkg/cmd/docs"
 	"github.com/stripe/stripe-cli/pkg/docs"
 )
+
+func setupPrefsTestConfig(t *testing.T) (*cliconfig.Config, func()) {
+	t.Helper()
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(profilesFile, []byte{}, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	viper.Reset()
+	viper.SetConfigType("toml")
+	viper.SetConfigFile(profilesFile)
+	viper.SetConfigPermissions(os.FileMode(0600))
+
+	cfg := &cliconfig.Config{
+		ProfilesFile: profilesFile,
+		Profile: cliconfig.Profile{
+			ProfileName: "default",
+		},
+	}
+
+	return cfg, func() { viper.Reset() }
+}
 
 func TestPrefsListCommand(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -111,4 +136,110 @@ func TestPrefsListCommand_ServerError(t *testing.T) {
 	err := root.ExecuteContext(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "prefs:")
+}
+
+func TestPrefsListCommand_ShowsCurrentValue(t *testing.T) {
+	cfg, cleanup := setupPrefsTestConfig(t)
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"prefs":[{"id":"lang","category":null,"description":"Programming language","values":["ruby","python","go"],"default":"ruby"}]}`)
+	}))
+	defer server.Close()
+
+	// Pre-set a value in config.
+	require.NoError(t, cfg.Profile.WriteConfigField("docs_prefs.lang", "python"))
+
+	client := docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))
+	var out bytes.Buffer
+	root := cmd.New().WithOptions(
+		cmd.WithClient(client),
+		cmd.WithConfig(&cliconfig.Config{Color: "off", Profile: cfg.Profile}),
+	).Root()
+	root.SetOut(&out)
+	root.SetArgs([]string{"prefs", "list"})
+
+	require.NoError(t, root.ExecuteContext(context.Background()))
+	assert.Contains(t, out.String(), "[current: python]")
+}
+
+func TestPrefsSetCommand(t *testing.T) {
+	cfg, cleanup := setupPrefsTestConfig(t)
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"prefs":[{"id":"lang","category":null,"description":"Programming language","values":["ruby","python","go"],"default":"ruby"}]}`)
+	}))
+	defer server.Close()
+
+	client := docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))
+	var out bytes.Buffer
+	root := cmd.New().WithOptions(cmd.WithClient(client), cmd.WithConfig(cfg)).Root()
+	root.SetOut(&out)
+	root.SetArgs([]string{"prefs", "set", "lang", "python"})
+
+	require.NoError(t, root.ExecuteContext(context.Background()))
+	assert.Contains(t, stripANSI(out.String()), "Preference lang set to python")
+	assert.Equal(t, "python", viper.GetString("default.docs_prefs.lang"))
+}
+
+func TestPrefsSetCommand_InvalidValue(t *testing.T) {
+	cfg, cleanup := setupPrefsTestConfig(t)
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"prefs":[{"id":"lang","category":null,"description":"Programming language","values":["ruby","python","go"],"default":"ruby"}]}`)
+	}))
+	defer server.Close()
+
+	client := docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))
+	root := cmd.New().WithOptions(cmd.WithClient(client), cmd.WithConfig(cfg)).Root()
+	root.SetOut(new(bytes.Buffer))
+	root.SetArgs([]string{"prefs", "set", "lang", "javascript"})
+
+	err := root.ExecuteContext(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid value")
+	assert.Contains(t, err.Error(), "javascript")
+}
+
+func TestPrefsSetCommand_UnknownPref(t *testing.T) {
+	cfg, cleanup := setupPrefsTestConfig(t)
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"prefs":[{"id":"lang","category":null,"description":"Programming language","values":["ruby","python"],"default":"ruby"}]}`)
+	}))
+	defer server.Close()
+
+	client := docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))
+	root := cmd.New().WithOptions(cmd.WithClient(client), cmd.WithConfig(cfg)).Root()
+	root.SetOut(new(bytes.Buffer))
+	root.SetArgs([]string{"prefs", "set", "unknown_pref", "value"})
+
+	err := root.ExecuteContext(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown preference")
+}
+
+func TestPrefsUnsetCommand(t *testing.T) {
+	cfg, cleanup := setupPrefsTestConfig(t)
+	defer cleanup()
+
+	require.NoError(t, cfg.Profile.WriteConfigField("docs_prefs.lang", "python"))
+	assert.Equal(t, "python", viper.GetString("default.docs_prefs.lang"))
+
+	client := docs.NewClient("test").WithOptions(docs.WithBaseURL("http://unused"))
+	var out bytes.Buffer
+	root := cmd.New().WithOptions(cmd.WithClient(client), cmd.WithConfig(cfg)).Root()
+	root.SetOut(&out)
+	root.SetArgs([]string{"prefs", "unset", "lang"})
+
+	require.NoError(t, root.ExecuteContext(context.Background()))
+	assert.Contains(t, stripANSI(out.String()), "Preference lang unset")
+	assert.Equal(t, "", viper.GetString("default.docs_prefs.lang"))
 }


### PR DESCRIPTION
### Summary and motivation

Adds `stripe docs prefs set` and `stripe docs prefs unset` commands to persist documentation preferences locally. Also updates `stripe docs prefs list` to show the currently configured value for each preference.

Preferences are stored in the CLI config file under the active profile, so they carry over between sessions. `set` validates the ID and value against the live list from docs.stripe.com before writing.

### Test plan

- [X] Changes are covered by unit tests (including failures and edge cases)
- [X] Changes were tested manually

To test manually:

```bash
make
./stripe docs prefs list
./stripe docs prefs set server go
./stripe docs prefs list   # should show [current: go] next to server
./stripe docs prefs unset server
./stripe docs prefs list   # [current: ...] should be gone
```

You should see a styled success message on set/unset (`✓ Preference server set to go`), and the list should reflect the current value inline with each preference's allowed values.

<img width="966" height="310" alt="CleanShot 2026-07-21 at 10 48 30" src="https://github.com/user-attachments/assets/5f7e259c-e37a-490e-bac8-4c592b0a0242" />
