### PR TITLE
Remove legacy get-plugin-url plugin download path

### DIFF
--- a/pkg/cmd/plugin/backfill_test.go
+++ b/pkg/cmd/plugin/backfill_test.go
@@ -109,13 +109,6 @@ func newPluginRegistryServers(t *testing.T, manifest []byte) *pluginRegistryServ
 
 	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/v1/stripecli/get-plugin-url":
-			body, err := json.Marshal(requests.PluginData{
-				PluginBaseURL:       artifactoryServer.URL,
-				AdditionalManifests: nil,
-			})
-			require.NoError(t, err)
-			_, _ = res.Write(body)
 		case "/v1/stripecli/get-plugin-metadata":
 			body, err := json.Marshal(requests.PluginMetadata{
 				BinaryURL:      artifactoryServer.URL + "/appA/2.0.1/" + runtime.GOOS + "/" + runtime.GOARCH + "/stripe-cli-app-a",

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -377,10 +377,7 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	}
 
 	// Pull down bin, verify, and save to disk
-	var err error
-	err = pluginToInstall.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version)
-
-	if err != nil {
+	if err := pluginToInstall.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version); err != nil {
 		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), os.Stdout)
 		return err
 	}

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -321,6 +321,7 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	apiKey, _ := cfg.GetProfile().GetAPIKey(false)
 	pluginToInstall := p
 	pluginDownloadURL := resolvedBinaryURL
+	var metadataLookupErr error
 	metadataBaseURL := apiBaseURL
 	if apiKey == "" && dashboardBaseURL != "" {
 		metadataBaseURL = dashboardBaseURL
@@ -344,6 +345,7 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 
 		pluginMetadata, err := requests.GetPluginMetadata(ctx, apiBaseURL, dashboardBaseURL, stripe.APIVersion, apiKey, cfg.GetProfile(), p.Shortname, version, runtime.GOOS, runtime.GOARCH)
 		if err != nil {
+			metadataLookupErr = err
 			log.WithFields(log.Fields{
 				"prefix": "plugins.plugin.Install",
 			}).Debugf("could not fetch plugin metadata: %s", err)
@@ -361,6 +363,9 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 
 	if pluginDownloadURL == "" {
 		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
+		if metadataLookupErr != nil {
+			return fmt.Errorf("could not resolve download URL for plugin '%s' v%s: failed to fetch plugin metadata: %w", p.Shortname, version, metadataLookupErr)
+		}
 		return fmt.Errorf("could not resolve download URL for plugin '%s' v%s: the plugin metadata endpoint did not return a binary URL", p.Shortname, version)
 	}
 

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -321,7 +321,6 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	apiKey, _ := cfg.GetProfile().GetAPIKey(false)
 	pluginToInstall := p
 	pluginDownloadURL := resolvedBinaryURL
-	downloadURLFromMetadata := resolvedBinaryURL != ""
 	metadataBaseURL := apiBaseURL
 	if apiKey == "" && dashboardBaseURL != "" {
 		metadataBaseURL = dashboardBaseURL
@@ -347,7 +346,7 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 		if err != nil {
 			log.WithFields(log.Fields{
 				"prefix": "plugins.plugin.Install",
-			}).Debugf("could not fetch plugin metadata, falling back to plugin URL lookup: %s", err)
+			}).Debugf("could not fetch plugin metadata: %s", err)
 		} else {
 			pluginFromMetadata, err := p.pluginFromMetadata(pluginMetadata.PluginManifest)
 			if err != nil {
@@ -357,22 +356,12 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 
 			pluginToInstall = pluginFromMetadata
 			pluginDownloadURL = pluginMetadata.BinaryURL
-			downloadURLFromMetadata = true
 		}
 	}
 
 	if pluginDownloadURL == "" {
-		var err error
-		pluginDownloadURL, err = getLegacyPluginDownloadURL(ctx, cfg, apiKey, apiBaseURL, version, pluginToInstall)
-		if err != nil {
-			ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
-
-			log.WithFields(log.Fields{
-				"prefix": "plugins.plugin.Install",
-			}).Debugf("install error: %s", err)
-
-			return errors.New("you don't seem to have access to this plugin")
-		}
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
+		return fmt.Errorf("could not resolve download URL for plugin '%s' v%s: the plugin metadata endpoint did not return a binary URL", p.Shortname, version)
 	}
 
 	// Check if this plugin requires a runtime and install it if needed
@@ -390,20 +379,6 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	// Pull down bin, verify, and save to disk
 	var err error
 	err = pluginToInstall.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version)
-	if err != nil && downloadURLFromMetadata {
-		log.WithFields(log.Fields{
-			"prefix": "plugins.plugin.Install",
-		}).Debugf("could not download plugin from metadata URL, falling back to plugin URL lookup: %s", err)
-
-		fallbackURL, fallbackErr := getLegacyPluginDownloadURL(ctx, cfg, apiKey, apiBaseURL, version, pluginToInstall)
-		if fallbackErr != nil {
-			log.WithFields(log.Fields{
-				"prefix": "plugins.plugin.Install",
-			}).Debugf("could not look up fallback plugin URL after metadata download failed: %s", fallbackErr)
-		} else {
-			err = pluginToInstall.downloadAndSavePlugin(cfg, fallbackURL, fs, version)
-		}
-	}
 
 	if err != nil {
 		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), os.Stdout)
@@ -433,15 +408,6 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	ansi.StopSpinner(spinner, "", os.Stdout)
 
 	return nil
-}
-
-func getLegacyPluginDownloadURL(ctx context.Context, cfg config.IConfig, apiKey, baseURL, version string, plugin *Plugin) (string, error) {
-	pluginData, err := requests.GetPluginData(ctx, baseURL, stripe.APIVersion, apiKey, cfg.GetProfile())
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("%s/%s/%s/%s/%s/%s", pluginData.PluginBaseURL, plugin.Shortname, version, runtime.GOOS, runtime.GOARCH, plugin.Binary), nil
 }
 
 // Uninstall removes a plugin from the disk and from the config's installed plugins list

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -115,8 +115,6 @@ func TestInstallUsesPluginMetadataEndpointWhenAPIKeyAvailable(t *testing.T) {
 			})
 			require.NoError(t, err)
 			res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			t.Fatalf("install should not fall back to /v1/stripecli/get-plugin-url when plugin metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -159,8 +157,6 @@ func TestInstallUsesAnonymousPluginMetadataEndpointWhenAPIKeyUnavailable(t *test
 			})
 			require.NoError(t, err)
 			res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			t.Fatalf("install should not fall back to /v1/stripecli/get-plugin-url when anonymous plugin metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -182,26 +178,16 @@ func TestInstallUsesAnonymousPluginMetadataEndpointWhenAPIKeyUnavailable(t *test
 	require.Equal(t, []string{"appA"}, config.GetInstalledPlugins())
 }
 
-func TestInstallFallsBackIfPluginMetadataEndpointFails(t *testing.T) {
+func TestInstallFailsIfPluginMetadataEndpointFails(t *testing.T) {
 	fs := setUpFS()
 	config := &TestConfig{}
 	config.InitConfig()
-	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-	testServers := setUpServers(t, manifestContent, nil)
-	defer testServers.CloseAll()
 
 	fallbackServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
 		case "/v1/stripecli/get-plugin-metadata":
 			res.WriteHeader(http.StatusInternalServerError)
 			res.Write([]byte(`{"error":{"message":"boom"}}`))
-		case "/v1/stripecli/get-plugin-url":
-			body, err := json.Marshal(requests.PluginData{
-				PluginBaseURL:       testServers.ArtifactoryServer.URL,
-				AdditionalManifests: nil,
-			})
-			require.NoError(t, err)
-			res.Write(body)
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -210,23 +196,20 @@ func TestInstallFallsBackIfPluginMetadataEndpointFails(t *testing.T) {
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "2.0.1", fallbackServer.URL, fallbackServer.URL)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "could not resolve download URL for plugin")
 }
 
-func TestInstallFallsBackIfMetadataBinaryURLReturnsNotFound(t *testing.T) {
+func TestInstallFailsIfMetadataBinaryURLReturnsNotFound(t *testing.T) {
 	fs := setUpFS()
 	config := &TestConfig{}
 	config.InitConfig()
 	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
 
-	var pluginURLLookups int
-
 	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
 		case fmt.Sprintf("/appA/2.0.1/%s/%s/binary", runtime.GOOS, runtime.GOARCH):
 			res.WriteHeader(http.StatusNotFound)
-		case fmt.Sprintf("/appA/2.0.1/%s/%s/stripe-cli-app-a", runtime.GOOS, runtime.GOARCH):
-			res.Write([]byte("hello, I am appA_2.0.1"))
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -242,14 +225,6 @@ func TestInstallFallsBackIfMetadataBinaryURLReturnsNotFound(t *testing.T) {
 			})
 			require.NoError(t, err)
 			res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			pluginURLLookups++
-			body, err := json.Marshal(requests.PluginData{
-				PluginBaseURL:       artifactoryServer.URL,
-				AdditionalManifests: nil,
-			})
-			require.NoError(t, err)
-			res.Write(body)
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -258,30 +233,20 @@ func TestInstallFallsBackIfMetadataBinaryURLReturnsNotFound(t *testing.T) {
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL, stripeServer.URL)
-	require.NoError(t, err)
-	require.Equal(t, 1, pluginURLLookups)
-
-	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
-	fileExists, err := afero.Exists(fs, file)
-	require.NoError(t, err)
-	require.True(t, fileExists)
+	require.Error(t, err)
 }
 
-func TestInstallFallsBackIfMetadataBinaryURLVerificationFails(t *testing.T) {
+func TestInstallFailsIfMetadataBinaryDownloadFails(t *testing.T) {
 	fs := setUpFS()
 	config := &TestConfig{}
 	config.InitConfig()
 	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-
-	var pluginURLLookups int
 
 	artifactoryServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
 		case fmt.Sprintf("/appA/2.0.1/%s/%s/binary", runtime.GOOS, runtime.GOARCH):
 			res.WriteHeader(http.StatusInternalServerError)
 			res.Write([]byte("html error page"))
-		case fmt.Sprintf("/appA/2.0.1/%s/%s/stripe-cli-app-a", runtime.GOOS, runtime.GOARCH):
-			res.Write([]byte("hello, I am appA_2.0.1"))
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -297,14 +262,6 @@ func TestInstallFallsBackIfMetadataBinaryURLVerificationFails(t *testing.T) {
 			})
 			require.NoError(t, err)
 			res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			pluginURLLookups++
-			body, err := json.Marshal(requests.PluginData{
-				PluginBaseURL:       artifactoryServer.URL,
-				AdditionalManifests: nil,
-			})
-			require.NoError(t, err)
-			res.Write(body)
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -313,13 +270,7 @@ func TestInstallFallsBackIfMetadataBinaryURLVerificationFails(t *testing.T) {
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
 	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL, stripeServer.URL)
-	require.NoError(t, err)
-	require.Equal(t, 1, pluginURLLookups)
-
-	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
-	fileExists, err := afero.Exists(fs, file)
-	require.NoError(t, err)
-	require.True(t, fileExists)
+	require.Error(t, err)
 }
 
 func TestInstallPersistsLocalMetadataWithoutManifest(t *testing.T) {
@@ -347,8 +298,6 @@ func TestInstallPersistsLocalMetadataWithoutManifest(t *testing.T) {
 			})
 			require.NoError(t, err)
 			res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			t.Fatalf("install should not fall back to /v1/stripecli/get-plugin-url when plugin metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -390,8 +339,6 @@ func TestResolvePluginForInstallUsesMetadataWithoutCachedManifest(t *testing.T) 
 			})
 			require.NoError(t, err)
 			res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			t.Fatalf("install resolution should not fall back to /v1/stripecli/get-plugin-url when metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -430,8 +377,6 @@ func TestResolvePluginForInstallResolvesLatestVersionFromMetadata(t *testing.T) 
 			})
 			require.NoError(t, err)
 			res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			t.Fatalf("install resolution should not fall back to /v1/stripecli/get-plugin-url when metadata can resolve latest")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -458,8 +403,6 @@ func TestResolvePluginForInstallFallsBackToCachedLocalMetadataWhenMetadataFails(
 		case "/v1/stripecli/get-plugin-metadata":
 			res.WriteHeader(http.StatusInternalServerError)
 			_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
-		case "/v1/stripecli/get-plugin-url":
-			t.Fatalf("install resolution should not fall back to /v1/stripecli/get-plugin-url when cached metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -503,8 +446,6 @@ func TestResolvedPluginInstallUsesResolvedMetadataWithoutSecondLookup(t *testing
 			})
 			require.NoError(t, err)
 			res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			t.Fatalf("resolved install should not fall back to /v1/stripecli/get-plugin-url when metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -543,7 +484,6 @@ func TestResolvedPluginInstallRetriesMetadataAfterCachedLocalFallback(t *testing
 `, runtime.GOARCH, runtime.GOOS, binarySum)
 
 	var metadataLookups int
-	var pluginURLLookups int
 
 	nodeBinaryPath := GetNodeBinaryPath(config, "20")
 	require.NoError(t, fs.MkdirAll(filepath.Dir(nodeBinaryPath), 0755))
@@ -589,14 +529,6 @@ func TestResolvedPluginInstallRetriesMetadataAfterCachedLocalFallback(t *testing
 			})
 			require.NoError(t, err)
 			_, _ = res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			pluginURLLookups++
-			body, err := json.Marshal(requests.PluginData{
-				PluginBaseURL:       artifactoryServer.URL,
-				AdditionalManifests: nil,
-			})
-			require.NoError(t, err)
-			_, _ = res.Write(body)
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -606,12 +538,10 @@ func TestResolvedPluginInstallRetriesMetadataAfterCachedLocalFallback(t *testing
 	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "generate", "1.0.0", stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	require.Equal(t, 1, metadataLookups)
-	require.Equal(t, 0, pluginURLLookups)
 
 	err = resolvedPlugin.Install(context.Background(), config, fs, stripeServer.URL, stripeServer.URL)
 	require.NoError(t, err)
 	require.Equal(t, 2, metadataLookups)
-	require.Equal(t, 0, pluginURLLookups)
 
 	cachedPlugin, err := readLocalPluginMetadata(config, fs, "generate")
 	require.NoError(t, err)
@@ -731,29 +661,32 @@ func TestPluginFromMetadataPreservesRuntimeRequirements(t *testing.T) {
 	require.Equal(t, "20", release.Runtime["node"])
 }
 
-func TestInstallSucceedsIfNoAPIKey(t *testing.T) {
+func TestInstallFailsIfNoAPIKeyAndMetadataReturnsNoBinaryURL(t *testing.T) {
 	fs := setUpFS()
 	config := &TestConfig{}
 	config.InitConfig()
 	config.Profile.APIKey = ""
 	manifestContent, _ := os.ReadFile("./test_artifacts/plugins.toml")
-	testServers := setUpServers(t, manifestContent, nil)
 
-	originalPluginBaseURL := requests.DefaultPluginData.PluginBaseURL
-	requests.DefaultPluginData.PluginBaseURL = testServers.ArtifactoryServer.URL
-	defer func() {
-		requests.DefaultPluginData.PluginBaseURL = originalPluginBaseURL
-	}()
+	dashboardServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/ajax/stripecli/plugins_metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "",
+				PluginManifest: string(singlePluginManifest(t, "appA", manifestContent, nil)),
+			})
+			require.NoError(t, err)
+			res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer dashboardServer.Close()
 
 	plugin, _ := LookUpPlugin(context.Background(), config, fs, "appA")
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", testServers.StripeServer.URL, testServers.StripeServer.URL)
-	require.Nil(t, err)
-	file := fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension())
-	fileExists, err := afero.Exists(fs, file)
-	require.Nil(t, err)
-	require.True(t, fileExists)
-
-	require.Equal(t, []string{"appA"}, config.GetInstalledPlugins())
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", dashboardServer.URL, dashboardServer.URL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "could not resolve download URL for plugin")
 }
 
 func TestInstallFailsIfChecksumCouldNotBeFound(t *testing.T) {

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -198,6 +198,8 @@ func TestInstallFailsIfPluginMetadataEndpointFails(t *testing.T) {
 	err := plugin.Install(context.Background(), config, fs, "2.0.1", fallbackServer.URL, fallbackServer.URL)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "could not resolve download URL for plugin")
+	require.Contains(t, err.Error(), "failed to fetch plugin metadata")
+	require.Contains(t, err.Error(), "boom")
 }
 
 func TestInstallFailsIfMetadataBinaryURLReturnsNotFound(t *testing.T) {

--- a/pkg/plugins/test_utils.go
+++ b/pkg/plugins/test_utils.go
@@ -128,16 +128,6 @@ func setUpServers(t *testing.T, manifestContent []byte, additionalManifests map[
 	// The checksums in the test toml files are the same for each OS variation of the release for unit testing purposes
 	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		switch req.URL.Path {
-		case "/v1/stripecli/get-plugin-url":
-			pd := requests.PluginData{
-				PluginBaseURL:       artifactoryServer.URL,
-				AdditionalManifests: additionalManifestNames,
-			}
-			body, err := json.Marshal(pd)
-			if err != nil {
-				t.Error(err)
-			}
-			res.Write(body)
 		case "/v1/stripecli/get-plugin-metadata", "/ajax/stripecli/plugins_metadata":
 			pluginName := req.URL.Query().Get("plugin")
 			version := req.URL.Query().Get("version")

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -388,8 +388,6 @@ func TestResolvePluginForInstallUsesAnonymousMetadataWithoutCachedManifest(t *te
 			})
 			require.NoError(t, err)
 			_, _ = res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			t.Fatalf("install resolution should not fall back to /v1/stripecli/get-plugin-url when anonymous metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -430,8 +428,6 @@ func TestResolvePluginForInstallFallsBackToCachedLocalMetadataWhenEndpointFails(
 		case "/v1/stripecli/get-plugin-metadata":
 			res.WriteHeader(http.StatusInternalServerError)
 			_, _ = res.Write([]byte(`{"error":{"message":"boom"}}`))
-		case "/v1/stripecli/get-plugin-url":
-			t.Fatalf("install resolution should not hit /v1/stripecli/get-plugin-url when cached metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -561,8 +557,6 @@ func TestResolvePluginForUpgradeUsesMetadataEndpointWhenAvailable(t *testing.T) 
 			})
 			require.NoError(t, err)
 			_, _ = res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			t.Fatalf("upgrade resolution should not fall back to /v1/stripecli/get-plugin-url when plugin metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}
@@ -635,8 +629,6 @@ func TestResolvePluginForUpgradeUsesAnonymousMetadataEndpointWhenAPIKeyUnavailab
 			})
 			require.NoError(t, err)
 			_, _ = res.Write(body)
-		case "/v1/stripecli/get-plugin-url":
-			t.Fatalf("upgrade resolution should not fall back to /v1/stripecli/get-plugin-url when anonymous plugin metadata is available")
 		default:
 			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
 		}

--- a/pkg/requests/plugin.go
+++ b/pkg/requests/plugin.go
@@ -11,25 +11,10 @@ import (
 	"github.com/stripe/stripe-cli/pkg/config"
 )
 
-// PluginData contains the plugin download information
-type PluginData struct {
-	PluginBaseURL       string   `json:"base_url"`
-	AdditionalManifests []string `json:"additional_manifests,omitempty"`
-}
-
 // PluginMetadata contains plugin-specific manifest and binary information.
 type PluginMetadata struct {
 	BinaryURL      string `json:"binary_url"`
 	PluginManifest string `json:"plugin_manifest"`
-}
-
-// defaultPluginBaseURL is the repository where plugins are hosted.
-// This is used as a fallback if the user is not logged in to the CLI.
-const defaultPluginBaseURL = "https://stripe.jfrog.io/artifactory/stripe-cli-plugins-local"
-
-var DefaultPluginData = PluginData{
-	PluginBaseURL:       defaultPluginBaseURL,
-	AdditionalManifests: []string{},
 }
 
 func getPluginMetadataPath(apiKey string) string {
@@ -54,41 +39,6 @@ func getPluginEndpointBaseURL(apiKey, apiBaseURL, dashboardBaseURL string) strin
 	}
 
 	return apiBaseURL
-}
-
-// GetPluginData returns the plugin download information
-func GetPluginData(ctx context.Context, baseURL, apiVersion, apiKey string, profile *config.Profile) (PluginData, error) {
-	// If no API key is available, use hardcoded fallback values
-	if apiKey == "" {
-		log.Debug("No API key available, using default plugin data")
-		return DefaultPluginData, nil
-	}
-
-	log.Debug("API key available, fetching plugin URL")
-
-	params := &RequestParameters{
-		data:    []string{},
-		version: apiVersion,
-	}
-
-	base := &Base{
-		Profile:        profile,
-		Method:         http.MethodGet,
-		SuppressOutput: true,
-		APIBaseURL:     baseURL,
-	}
-	// /v1/stripecli/get-plugin-url
-	resp, err := base.MakeRequest(ctx, apiKey, "/v1/stripecli/get-plugin-url", params, make(map[string]interface{}), true, nil)
-	if err != nil {
-		return PluginData{}, err
-	}
-
-	data := PluginData{}
-	if err := json.Unmarshal(resp, &data); err != nil {
-		return PluginData{}, fmt.Errorf("failed to decode plugin data response: %w", err)
-	}
-
-	return data, nil
 }
 
 // GetPluginMetadata returns plugin-specific manifest and binary information.


### PR DESCRIPTION
The plugin install/upgrade flow now relies exclusively on the per-plugin metadata endpoint (get-plugin-metadata / plugins_metadata). The legacy GetPluginData path (hitting /v1/stripecli/get-plugin-url or returning a hardcoded jfrog default) was only kept as a fallback and is no longer needed.

This removes:
- GetPluginData, PluginData, DefaultPluginData, defaultPluginBaseURL from pkg/requests/plugin.go
- getLegacyPluginDownloadURL and both call sites in pkg/plugins/plugin.go
- All /v1/stripecli/get-plugin-url test handlers and assertions


When the metadata endpoint does not return a binary URL, install now fails with a clear error instead of silently falling back to the legacy endpoint.

The get-plugin-metadata / plugins_metadata endpoints are stable: no 500 errors for the past 20 days

https://logscale.corp.stripe.com/main-view/search?live=false&query=((%23repo%3Dbapi-srv%20%23is_canonical%3Dtrue%20CANONICAL-API-LINE)%20OR%20(%23repo%3Dmain%20%23is_canonical%3Dtrue%20CANONICAL-MANAGE-LINE))%0Apath%3D%22%2Fv1%2Fstripecli%2Fget-plugin-metadata%22%20status%3E404%0A%0A&start=30d&tz=UTC


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
