### PR TITLE
[REVINTEL-886] Add Canary test for Data & Reporting command

### DIFF
--- a/.github/workflows/data-analytics-canary.yml
+++ b/.github/workflows/data-analytics-canary.yml
@@ -1,0 +1,69 @@
+name: Data & Analytics Canary Tests
+
+# Scheduled canary tests for the CLI data/analytics commands
+# (stripe data metrics run, stripe reporting query-runs). These hit preview
+# APIs, so they run on a schedule and alert on failure via PagerDuty rather than
+# gating PRs or releases. The tests are gated behind the "data_analytics_canary"
+# Go build tag (see canary/data_reporting_test.go).
+
+on:
+  schedule:
+    # Run once a day at 09:00 UTC
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: 'Skip PagerDuty alert on failure'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  data-analytics-canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.0'
+
+      - name: Build binary (production-like)
+        run: |
+          go generate ./...
+          CGO_ENABLED=0 go build -ldflags="-s -w" -o stripe ./cmd/stripe
+        shell: bash
+
+      - name: Run data/analytics canary tests
+        id: canary
+        continue-on-error: true
+        run: |
+          go test -tags data_analytics_canary -v -timeout 15m ./canary/... \
+            -run "TestOfflineDataMetricsRunHelp|TestOfflineReporting|TestAPIDataMetricsRun|TestAPIReportingQueryRuns"
+        shell: bash
+        env:
+          STRIPE_CLI_BINARY: ${{ github.workspace }}/stripe
+          STRIPE_API_KEY: ${{ secrets.STRIPE_TEST_API_KEY }}
+          STRIPE_CLI_TELEMETRY_OPTOUT: "1"
+
+      - name: Notify on result
+        if: always()
+        run: bash scripts/notify.sh
+        env:
+          OVERALL_RESULT: ${{ steps.canary.outcome == 'success' && 'success' || 'failure' }}
+          DRYRUN: ${{ inputs.dryrun }}
+          PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_DATA_ANALYTICS_KEY }}
+          PAGERDUTY_DEDUP_KEY: data-analytics-canary
+          PAGERDUTY_SEVERITY: warning
+          PAGERDUTY_SUMMARY: "Data & Analytics canary failed. Investigate: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          PAGERDUTY_RESOLVE_SUMMARY: "Data & Analytics canary is passing again"
+
+      - name: Fail job if canary failed
+        if: steps.canary.outcome == 'failure'
+        run: exit 1

--- a/canary/README.md
+++ b/canary/README.md
@@ -73,10 +73,6 @@ Tests that verify basic CLI functionality without network access:
 | `TestOfflineListenHelp` | `stripe listen --help` | Listen command available |
 | `TestOfflineLogsTailHelp` | `stripe logs tail --help` | Logs tail command available |
 | `TestOfflineLoginHelp` | `stripe login --help` | Login command available |
-| `TestOfflineDataMetricsRunHelp` | `stripe data metrics run --help` | Hidden preview command help renders |
-| `TestOfflineReportingHelp` | `stripe reporting --help` | Reporting command lists `query-runs` |
-| `TestOfflineReportingQueryRunsHelp` | `stripe reporting query-runs --help` | `create`/`retrieve` subcommands listed |
-| `TestOfflineReportingQueryRunsRetrieveHelp` | `stripe reporting query-runs retrieve --help` | Retrieve command help renders |
 
 ### API Tests (`TestAPI*`)
 
@@ -104,13 +100,33 @@ Tests that require a valid Stripe test API key:
 | `TestAPIV2RawGet` | `stripe get /v2/core/events` | Raw GET to v2 path |
 | `TestAPIV2RawPost` | `stripe post /v2/billing/meter_event_session` | Raw POST to v2 path (JSON content-type) |
 | `TestAPIV2TriggerMeterNoMeterFound` | `stripe trigger v1.billing.meter.no_meter_found` | V2 trigger fixtures execute |
+
+### Scheduled Data & Analytics Tests (build tag: `data_analytics_canary`)
+
+Tests for the CLI data/analytics commands (`stripe data metrics run`, `stripe reporting query-runs`) live in `data_reporting_test.go` and are gated behind the `data_analytics_canary` Go build tag. They **do not** run in the normal push/PR/release suite. Instead they run once a day via `.github/workflows/data-analytics-canary.yml`, which builds with `-tags data_analytics_canary` and alerts on failure via PagerDuty (`scripts/notify.sh`) rather than blocking merges or releases.
+
+These commands wrap preview APIs (`metric_query` is Private Preview; `query_runs` is Public Preview). The live tests require the test account/runner to be enabled for those previews — without access they fail with a preview error rather than skip.
+
+| Test | Command | Validates |
+|------|---------|-----------|
+| `TestOfflineDataMetricsRunHelp` | `stripe data metrics run --help` | Hidden preview command help renders |
+| `TestOfflineReportingHelp` | `stripe reporting --help` | Reporting command lists `query-runs` |
+| `TestOfflineReportingQueryRunsHelp` | `stripe reporting query-runs --help` | `create`/`retrieve` subcommands listed |
+| `TestOfflineReportingQueryRunsRetrieveHelp` | `stripe reporting query-runs retrieve --help` | Retrieve command help renders |
 | `TestAPIDataMetricsRunDryRun` | `stripe data metrics run --dry-run` | Metric query request built correctly (no network call) |
 | `TestAPIReportingQueryRunsCreateDryRun` | `stripe reporting query-runs create --dry-run` | Query run request built correctly (no network call) |
 | `TestAPIDataMetricsRunLive` | `stripe data metrics run` | Metric query endpoint (Private Preview) |
 | `TestAPIReportingQueryRunsCreateLive` | `stripe reporting query-runs create` | Query run creation (Public Preview) |
 | `TestAPIReportingQueryRunsRetrieveLive` | `stripe reporting query-runs retrieve` | Query run create → retrieve round trip |
 
-> **Note:** The `Live` tests above call preview APIs and require the test account/runner to be enabled for them (`metric_query` is Private Preview; `query_runs` is Public Preview). Without access they fail with a preview error rather than skip. The `DryRun` tests need a key but make no network call.
+Run them locally with:
+
+```bash
+export STRIPE_CLI_BINARY=$(pwd)/stripe
+export STRIPE_API_KEY=sk_test_...
+go test -tags data_analytics_canary -v ./canary/... \
+  -run "TestOfflineDataMetricsRunHelp|TestOfflineReporting|TestAPIDataMetricsRun|TestAPIReportingQueryRuns"
+```
 
 ## Environment Variables
 
@@ -177,7 +193,7 @@ Canary tests do not run on PRs. Unit tests provide coverage for PR validation.
    - `config_test.go` - Configuration tests
    - `login_test.go` - Authentication tests
    - `v2_api_test.go` - V2 resource/raw API tests
-   - `data_reporting_test.go` - Data & reporting (analytics) command tests
+   - `data_reporting_test.go` - Data & reporting (analytics) commands; gated behind the `data_analytics_canary` build tag and run on a schedule (see above)
 2. Use `TestOffline` prefix for tests without API requirements
 3. Use `TestAPI` prefix and call `requireAPIKey(t)` for API tests
 4. Use isolated config directories via `testutil.CreateTempConfigDir()`

--- a/canary/README.md
+++ b/canary/README.md
@@ -73,6 +73,10 @@ Tests that verify basic CLI functionality without network access:
 | `TestOfflineListenHelp` | `stripe listen --help` | Listen command available |
 | `TestOfflineLogsTailHelp` | `stripe logs tail --help` | Logs tail command available |
 | `TestOfflineLoginHelp` | `stripe login --help` | Login command available |
+| `TestOfflineDataMetricsRunHelp` | `stripe data metrics run --help` | Hidden preview command help renders |
+| `TestOfflineReportingHelp` | `stripe reporting --help` | Reporting command lists `query-runs` |
+| `TestOfflineReportingQueryRunsHelp` | `stripe reporting query-runs --help` | `create`/`retrieve` subcommands listed |
+| `TestOfflineReportingQueryRunsRetrieveHelp` | `stripe reporting query-runs retrieve --help` | Retrieve command help renders |
 
 ### API Tests (`TestAPI*`)
 
@@ -100,6 +104,13 @@ Tests that require a valid Stripe test API key:
 | `TestAPIV2RawGet` | `stripe get /v2/core/events` | Raw GET to v2 path |
 | `TestAPIV2RawPost` | `stripe post /v2/billing/meter_event_session` | Raw POST to v2 path (JSON content-type) |
 | `TestAPIV2TriggerMeterNoMeterFound` | `stripe trigger v1.billing.meter.no_meter_found` | V2 trigger fixtures execute |
+| `TestAPIDataMetricsRunDryRun` | `stripe data metrics run --dry-run` | Metric query request built correctly (no network call) |
+| `TestAPIReportingQueryRunsCreateDryRun` | `stripe reporting query-runs create --dry-run` | Query run request built correctly (no network call) |
+| `TestAPIDataMetricsRunLive` | `stripe data metrics run` | Metric query endpoint (Private Preview) |
+| `TestAPIReportingQueryRunsCreateLive` | `stripe reporting query-runs create` | Query run creation (Public Preview) |
+| `TestAPIReportingQueryRunsRetrieveLive` | `stripe reporting query-runs retrieve` | Query run create → retrieve round trip |
+
+> **Note:** The `Live` tests above call preview APIs and require the test account/runner to be enabled for them (`metric_query` is Private Preview; `query_runs` is Public Preview). Without access they fail with a preview error rather than skip. The `DryRun` tests need a key but make no network call.
 
 ## Environment Variables
 
@@ -165,6 +176,8 @@ Canary tests do not run on PRs. Unit tests provide coverage for PR validation.
    - `logs_test.go` - Log streaming tests
    - `config_test.go` - Configuration tests
    - `login_test.go` - Authentication tests
+   - `v2_api_test.go` - V2 resource/raw API tests
+   - `data_reporting_test.go` - Data & reporting (analytics) command tests
 2. Use `TestOffline` prefix for tests without API requirements
 3. Use `TestAPI` prefix and call `requireAPIKey(t)` for API tests
 4. Use isolated config directories via `testutil.CreateTempConfigDir()`

--- a/canary/data_reporting_test.go
+++ b/canary/data_reporting_test.go
@@ -1,0 +1,301 @@
+package canary
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stripe/stripe-cli/canary/testutil"
+)
+
+// =============================================================================
+// Data & Reporting command canary tests
+//
+// These cover the CLI commands that wrap the v2 data/analytics preview APIs:
+//   - stripe data metrics run        -> POST /v2/data/analytics/metric_query
+//   - stripe reporting query-runs create   -> POST /v2/data/reporting/query_runs
+//   - stripe reporting query-runs retrieve -> GET  /v2/data/reporting/query_runs/{id}
+//
+// The underlying endpoints are Private Preview. Coverage is layered:
+//   - Offline tests verify command registration and help output (no key).
+//   - Dry-run tests exercise the full request-building path without a network
+//     call (needs a key): auth resolution, URL/method, v2 JSON body, and the
+//     preview Stripe-Version header.
+//   - Live tests actually invoke the preview endpoints (needs a key on an
+//     account with preview access). These require the test account/runner to be
+//     enabled for the v2 data/analytics APIs; otherwise they will fail with a
+//     preview access error rather than skip.
+// =============================================================================
+
+// dryRunOutput mirrors requests.DryRunOutput for parsing --dry-run JSON.
+type dryRunOutput struct {
+	DryRun struct {
+		Method  string                 `json:"method"`
+		URL     string                 `json:"url"`
+		Params  map[string]interface{} `json:"params"`
+		Headers map[string]string      `json:"headers"`
+	} `json:"dry_run"`
+}
+
+// --- Offline help / registration tests ---
+
+func TestOfflineDataMetricsRunHelp(t *testing.T) {
+	runner := getRunner(t)
+
+	// "data" is a hidden Private Preview command, but --help still works when
+	// the command path is invoked directly.
+	result, err := runner.Run("data", "metrics", "run", "--help")
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe data metrics run --help': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	for _, flag := range []string{"--metric", "--starts-at", "--ends-at", "--granularity"} {
+		if !strings.Contains(result.Stdout, flag) {
+			errorf(t, "Expected 'data metrics run --help' to mention '%s', got: %s", flag, result.Stdout)
+		}
+	}
+}
+
+func TestOfflineReportingHelp(t *testing.T) {
+	runner := getRunner(t)
+
+	result, err := runner.Run("reporting", "--help")
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe reporting --help': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	if !strings.Contains(result.Stdout, "query-runs") {
+		errorf(t, "Expected 'reporting --help' to list 'query-runs', got: %s", result.Stdout)
+	}
+}
+
+func TestOfflineReportingQueryRunsHelp(t *testing.T) {
+	runner := getRunner(t)
+
+	result, err := runner.Run("reporting", "query-runs", "--help")
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe reporting query-runs --help': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	for _, sub := range []string{"create", "retrieve"} {
+		if !strings.Contains(result.Stdout, sub) {
+			errorf(t, "Expected 'reporting query-runs --help' to list '%s', got: %s", sub, result.Stdout)
+		}
+	}
+}
+
+func TestOfflineReportingQueryRunsRetrieveHelp(t *testing.T) {
+	runner := getRunner(t)
+
+	result, err := runner.Run("reporting", "query-runs", "retrieve", "--help")
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe reporting query-runs retrieve --help': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	if !strings.Contains(result.Stdout, "retrieve") {
+		errorf(t, "Expected 'reporting query-runs retrieve --help' to mention 'retrieve', got: %s", result.Stdout)
+	}
+}
+
+// --- Dry-run tests (require a key, but make no network call) ---
+
+func TestAPIDataMetricsRunDryRun(t *testing.T) {
+	requireAPIKey(t)
+	runner := getRunner(t, testutil.WithEnv(map[string]string{
+		"STRIPE_API_KEY": testutil.GetAPIKey(),
+	}))
+
+	result, err := runner.Run(
+		"data", "metrics", "run",
+		"--metric", "revenue.mrr",
+		"--starts-at", "2026-01-01T00:00:00Z",
+		"--ends-at", "2026-01-31T23:59:59Z",
+		"--granularity", "day",
+		"--dry-run",
+	)
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe data metrics run --dry-run': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	var out dryRunOutput
+	if err := json.Unmarshal([]byte(result.Stdout), &out); err != nil {
+		fatalf(t, "Dry-run output is not valid JSON: %v. Output: %s", err, result.Stdout)
+	}
+
+	if out.DryRun.Method != "POST" {
+		errorf(t, "Expected dry-run method POST, got %q", out.DryRun.Method)
+	}
+	if !strings.HasSuffix(out.DryRun.URL, "/v2/data/analytics/metric_query") {
+		errorf(t, "Expected dry-run URL to target /v2/data/analytics/metric_query, got %q", out.DryRun.URL)
+	}
+	for _, key := range []string{"metrics", "starts_at", "ends_at", "granularity"} {
+		if _, ok := out.DryRun.Params[key]; !ok {
+			errorf(t, "Expected dry-run params to include %q, got: %s", key, result.Stdout)
+		}
+	}
+}
+
+func TestAPIReportingQueryRunsCreateDryRun(t *testing.T) {
+	requireAPIKey(t)
+	runner := getRunner(t, testutil.WithEnv(map[string]string{
+		"STRIPE_API_KEY": testutil.GetAPIKey(),
+	}))
+
+	result, err := runner.Run(
+		"reporting", "query-runs", "create",
+		"--sql", "SELECT id FROM charges LIMIT 1",
+		"--dry-run",
+	)
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe reporting query-runs create --dry-run': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	var out dryRunOutput
+	if err := json.Unmarshal([]byte(result.Stdout), &out); err != nil {
+		fatalf(t, "Dry-run output is not valid JSON: %v. Output: %s", err, result.Stdout)
+	}
+
+	if out.DryRun.Method != "POST" {
+		errorf(t, "Expected dry-run method POST, got %q", out.DryRun.Method)
+	}
+	if !strings.HasSuffix(out.DryRun.URL, "/v2/data/reporting/query_runs") {
+		errorf(t, "Expected dry-run URL to target /v2/data/reporting/query_runs, got %q", out.DryRun.URL)
+	}
+	if _, ok := out.DryRun.Params["sql"]; !ok {
+		errorf(t, "Expected dry-run params to include 'sql', got: %s", result.Stdout)
+	}
+}
+
+// --- Live tests (require a key on an account with preview access) ---
+
+func TestAPIDataMetricsRunLive(t *testing.T) {
+	requireAPIKey(t)
+	runner := getRunner(t, testutil.WithEnv(map[string]string{
+		"STRIPE_API_KEY": testutil.GetAPIKey(),
+	}))
+	runner = runner.WithTimeout(60 * time.Second)
+
+	result, err := runner.Run(
+		"data", "metrics", "run",
+		"--metric", "revenue.mrr",
+		"--starts-at", "2026-01-01T00:00:00Z",
+		"--ends-at", "2026-01-31T23:59:59Z",
+		"--granularity", "month",
+	)
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe data metrics run': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(result.Stdout), &data); err != nil {
+		errorf(t, "Output is not valid JSON: %v. Output: %s", err, result.Stdout)
+	}
+
+	if _, ok := data["data"]; !ok {
+		errorf(t, "Expected metric query response to contain 'data' field, got: %s", result.Stdout)
+	}
+}
+
+func TestAPIReportingQueryRunsCreateLive(t *testing.T) {
+	requireAPIKey(t)
+	runner := getRunner(t, testutil.WithEnv(map[string]string{
+		"STRIPE_API_KEY": testutil.GetAPIKey(),
+	}))
+	runner = runner.WithTimeout(60 * time.Second)
+
+	id := createQueryRun(t, runner)
+	if id == "" {
+		errorf(t, "Expected created query run to have a non-empty id")
+	}
+}
+
+func TestAPIReportingQueryRunsRetrieveLive(t *testing.T) {
+	requireAPIKey(t)
+	runner := getRunner(t, testutil.WithEnv(map[string]string{
+		"STRIPE_API_KEY": testutil.GetAPIKey(),
+	}))
+	runner = runner.WithTimeout(60 * time.Second)
+
+	// Create a query run, then retrieve it by id (round trip).
+	id := createQueryRun(t, runner)
+	if id == "" {
+		fatalf(t, "Cannot retrieve: created query run had no id")
+	}
+
+	result, err := runner.Run("reporting", "query-runs", "retrieve", id)
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe reporting query-runs retrieve %s': %v", id, err)
+	}
+
+	if result.ExitCode != 0 {
+		errorf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(result.Stdout), &data); err != nil {
+		fatalf(t, "Retrieve output is not valid JSON: %v. Output: %s", err, result.Stdout)
+	}
+
+	if got, _ := data["id"].(string); got != id {
+		errorf(t, "Expected retrieved query run id %q, got %q", id, got)
+	}
+
+	if _, ok := data["status"]; !ok {
+		errorf(t, "Expected retrieved query run to contain 'status' field, got: %s", result.Stdout)
+	}
+}
+
+// createQueryRun creates a query run and returns its id. It fails the test if
+// the command errors or the response is missing an id.
+func createQueryRun(t *testing.T, runner *testutil.Runner) string {
+	t.Helper()
+
+	result, err := runner.Run(
+		"reporting", "query-runs", "create",
+		"--sql", "SELECT id FROM charges LIMIT 1",
+	)
+	if err != nil {
+		fatalf(t, "Failed to run 'stripe reporting query-runs create': %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		fatalf(t, "Expected exit code 0, got %d. Stderr: %s", result.ExitCode, result.Stderr)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(result.Stdout), &data); err != nil {
+		fatalf(t, "Create output is not valid JSON: %v. Output: %s", err, result.Stdout)
+	}
+
+	id, _ := data["id"].(string)
+	return id
+}

--- a/canary/data_reporting_test.go
+++ b/canary/data_reporting_test.go
@@ -17,14 +17,16 @@ import (
 //   - stripe reporting query-runs create   -> POST /v2/data/reporting/query_runs
 //   - stripe reporting query-runs retrieve -> GET  /v2/data/reporting/query_runs/{id}
 //
-// The underlying endpoints are Private Preview. Coverage is layered:
+// These are preview APIs: metric_query (data metrics) is Private Preview and
+// its command is hidden; query_runs (reporting) is Public Preview. Coverage is
+// layered:
 //   - Offline tests verify command registration and help output (no key).
 //   - Dry-run tests exercise the full request-building path without a network
 //     call (needs a key): auth resolution, URL/method, v2 JSON body, and the
 //     preview Stripe-Version header.
 //   - Live tests actually invoke the preview endpoints (needs a key on an
 //     account with preview access). These require the test account/runner to be
-//     enabled for the v2 data/analytics APIs; otherwise they will fail with a
+//     enabled for the relevant preview APIs; otherwise they will fail with a
 //     preview access error rather than skip.
 // =============================================================================
 

--- a/canary/data_reporting_test.go
+++ b/canary/data_reporting_test.go
@@ -1,3 +1,12 @@
+//go:build data_analytics_canary
+
+// These data/analytics canary tests are gated behind the "data_analytics_canary"
+// build tag so they don't run as part of the normal push/PR/release canary suite
+// (canary-test.yml). They hit preview APIs and are intended to run only on a
+// schedule via .github/workflows/data-analytics-canary.yml, which builds with
+// -tags data_analytics_canary and alerts on failure instead of blocking merges
+// or releases.
+
 package canary
 
 import (


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

### Summary
Adds end-to-end canary tests for the v2 data/analytics CLI commands (`canary/data_reporting_test.go`), covering:

- `stripe data metrics run` → `POST /v2/data/analytics/metric_query`
- `stripe reporting query-runs create` → `POST /v2/data/reporting/query_runs`
- `stripe reporting query-runs retrieve` → `GET /v2/data/reporting/query_runs/{id}`

Coverage is layered so the suite is useful regardless of the runner's API access:

- **Offline** (no API key): command registration + `--help` output for all three commands (including the hidden `data` preview command).
- **Dry-run** (needs a key, no network call): exercises the full request-building path — auth resolution, request URL/method, v2 JSON body, and the preview `Stripe-Version` header.
- **Live** (needs a key on a preview-enabled account): invokes the real endpoints, including a `create` → `retrieve` round trip that asserts the returned query run id matches.

All three live and offline tests pass against a preview-enabled test account:
<img width="1452" height="396" alt="Screenshot 2026-07-22 at 10 06 19 AM" src="https://github.com/user-attachments/assets/da6539fa-4545-4aed-8aaf-03bd30af7a70" />


