### PR TITLE
Copy install-stripe-cli action into repo and reference it locally

### DIFF
--- a/.github/actions/install-stripe-cli/action.yml
+++ b/.github/actions/install-stripe-cli/action.yml
@@ -1,0 +1,29 @@
+name: Install Stripe CLI
+description: Install the Stripe CLI for the current OS
+
+runs:
+  using: composite
+  steps:
+    - name: Install Stripe CLI on Linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+        curl -fsSL https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg > /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee /etc/apt/sources.list.d/stripe.list
+        sudo apt-get update
+        sudo apt-get install -y stripe
+
+    - name: Install Stripe CLI on macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install stripe
+
+    - name: Install Stripe CLI on Windows
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+        winget install Stripe.StripeCli -e --source winget --accept-package-agreements --accept-source-agreements
+        $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH", "User")
+        $stripeDir = Split-Path (Get-Command stripe).Source
+        echo $stripeDir >> $env:GITHUB_PATH

--- a/.github/workflows/plugin-canary.yml
+++ b/.github/workflows/plugin-canary.yml
@@ -39,13 +39,6 @@ jobs:
         run: stripe version
         shell: bash
 
-      - name: Checkout notify script
-        uses: actions/checkout@v6
-        with:
-          sparse-checkout: |
-            scripts/notify.sh
-          sparse-checkout-cone-mode: false
-
       - name: Install and test recent projects plugin versions
         shell: bash
         env:

--- a/.github/workflows/plugin-canary.yml
+++ b/.github/workflows/plugin-canary.yml
@@ -30,6 +30,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - uses: actions/checkout@v6
+
       - name: Install Stripe CLI
         uses: ./.github/actions/install-stripe-cli
 

--- a/.github/workflows/plugin-canary.yml
+++ b/.github/workflows/plugin-canary.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Install Stripe CLI
-        uses: stripe/stripe-cli-ts-plugin-bootstrap/.github/actions/install-stripe-cli@v0.5.4
+        uses: ./.github/actions/install-stripe-cli
 
       - name: Verify CLI installed
         run: stripe version


### PR DESCRIPTION
Moves the composite action from stripe-cli-ts-plugin-bootstrap into this repo so it can be maintained and versioned alongside the CLI itself.

Here is a passing run: https://github.com/stripe/stripe-cli/actions/runs/29942061176