### PR TITLE
Add scheduled trigger for auto-upgrade canary test

### DIFF
--- a/.github/workflows/autoupgrade-test-trigger.yml
+++ b/.github/workflows/autoupgrade-test-trigger.yml
@@ -1,0 +1,14 @@
+on:
+  schedule:
+    - cron: '*/10 * * * *' # Every 10 minutes
+name: Auto-upgrade test (trigger)
+permissions:
+  actions: write
+  contents: read
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run autoupgrade-test.yml --ref v2 --repo stripe/stripe-cli
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a small scheduled workflow that dispatches the auto-upgrade canary test (on v2) every 10 minutes
- Needed because GitHub Actions `schedule` triggers only run on the default branch (master), but the canary test itself lives on v2 (#1815) where the auto-upgrade code is 

## Context
- The actual canary test: PR #1815 (targets v2)
- This trigger simply runs `gh workflow run autoupgrade-test.yml --ref v2`

## Test plan
- [ ] Merge this after PR #1815 is merged to v2
- [ ] Manually trigger via `workflow_dispatch` to verify it dispatches correctly