### PR TITLE
Add telemetry to curl install script and auto-updater

### DIFF
--- a/pkg/autoupdate/checker.go
+++ b/pkg/autoupdate/checker.go
@@ -70,6 +70,7 @@ func CheckForUpdate() {
 		DownloadURL: url,
 		Checksum:    checksum,
 	})
+	sendTelemetryEvent("Auto-Update Available", fmt.Sprintf("from=%s to=%s", current, latestClean))
 }
 
 func isMajorVersionChange(current, latest string) bool {

--- a/pkg/autoupdate/telemetry.go
+++ b/pkg/autoupdate/telemetry.go
@@ -1,0 +1,68 @@
+package autoupdate
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/stripe/stripe-cli/pkg/version"
+)
+
+var telemetryEndpoint = "https://r.stripe.com/0"
+
+func init() {
+	if raw := os.Getenv("STRIPE_TELEMETRY_URL"); raw != "" {
+		telemetryEndpoint = raw
+	}
+}
+
+func sendTelemetryEvent(eventName, eventValue string) {
+	if isTelemetryOptedOut() {
+		return
+	}
+
+	data := url.Values{}
+	data.Set("client_id", "stripe-cli")
+	data.Set("event_id", uuid.NewString())
+	data.Set("event_name", eventName)
+	data.Set("event_value", eventValue)
+	data.Set("created", fmt.Sprint(time.Now().Unix()))
+	data.Set("cli_version", version.Version)
+	data.Set("os", runtime.GOOS)
+	data.Set("arch", runtime.GOARCH)
+	data.Set("install_method", "curl")
+
+	req, err := http.NewRequest(http.MethodPost, telemetryEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		log.Debug("autoupdate telemetry: failed to create request: ", err)
+		return
+	}
+
+	req.Header.Set("origin", "stripe-cli")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Debug("autoupdate telemetry: failed to send event: ", err)
+		return
+	}
+	resp.Body.Close()
+}
+
+func isTelemetryOptedOut() bool {
+	for _, key := range []string{"STRIPE_CLI_TELEMETRY_OPTOUT", "DO_NOT_TRACK"} {
+		val := strings.ToLower(os.Getenv(key))
+		if val == "1" || val == "true" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/autoupdate/telemetry_test.go
+++ b/pkg/autoupdate/telemetry_test.go
@@ -1,0 +1,80 @@
+package autoupdate
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSendTelemetryEvent(t *testing.T) {
+	var received bool
+	var gotBody string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = true
+		assert.Equal(t, "stripe-cli", r.Header.Get("origin"))
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		err := r.ParseForm()
+		assert.NoError(t, err)
+		gotBody = r.Form.Get("event_name")
+
+		assert.Equal(t, "stripe-cli", r.Form.Get("client_id"))
+		assert.Equal(t, "curl", r.Form.Get("install_method"))
+		assert.NotEmpty(t, r.Form.Get("event_id"))
+		assert.NotEmpty(t, r.Form.Get("created"))
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	original := telemetryEndpoint
+	telemetryEndpoint = server.URL
+	defer func() { telemetryEndpoint = original }()
+
+	sendTelemetryEvent("Auto-Update Succeeded", "from=1.0.0 to=1.1.0")
+
+	assert.True(t, received)
+	assert.Equal(t, "Auto-Update Succeeded", gotBody)
+}
+
+func TestSendTelemetryEvent_OptedOut(t *testing.T) {
+	var received bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	original := telemetryEndpoint
+	telemetryEndpoint = server.URL
+	defer func() { telemetryEndpoint = original }()
+
+	t.Setenv("STRIPE_CLI_TELEMETRY_OPTOUT", "1")
+
+	sendTelemetryEvent("Auto-Update Succeeded", "from=1.0.0 to=1.1.0")
+
+	assert.False(t, received)
+}
+
+func TestSendTelemetryEvent_DoNotTrack(t *testing.T) {
+	var received bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	original := telemetryEndpoint
+	telemetryEndpoint = server.URL
+	defer func() { telemetryEndpoint = original }()
+
+	t.Setenv("DO_NOT_TRACK", "true")
+
+	sendTelemetryEvent("Auto-Update Succeeded", "from=1.0.0 to=1.1.0")
+
+	assert.False(t, received)
+}

--- a/pkg/autoupdate/updater.go
+++ b/pkg/autoupdate/updater.go
@@ -61,12 +61,14 @@ func ApplyIfPending() {
 
 	if err := downloadAndReplace(marker, exe); err != nil {
 		fmt.Fprintf(os.Stderr, "Auto-update failed: %v. Continuing with current version.\n", err)
+		sendTelemetryEvent("Auto-Update Failed", fmt.Sprintf("from=%s to=%s error=%s", current, target, err.Error()))
 		ClearMarker()
 		return
 	}
 
 	ClearMarker()
 	fmt.Fprintf(os.Stderr, "Updated successfully ✓\n")
+	sendTelemetryEvent("Auto-Update Succeeded", fmt.Sprintf("from=%s to=%s", current, target))
 
 	reexec(exe)
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,8 @@ set -eu
 INSTALL_DIR="${STRIPE_INSTALL_DIR:-$HOME/.stripe/bin}"
 GITHUB_REPO="stripe/stripe-cli"
 NEEDS_SOURCE=false
+TELEMETRY_URL="${STRIPE_TELEMETRY_URL:-https://r.stripe.com/0}"
+INSTALL_SUCCESS=false
 
 main() {
   detect_platform
@@ -11,6 +13,8 @@ main() {
   download_and_verify
   install_binary
   setup_path
+  INSTALL_SUCCESS=true
+  send_telemetry "Install Succeeded" "version=$VERSION"
   print_success
 }
 
@@ -103,7 +107,7 @@ download_and_verify() {
   BASE_URL="https://github.com/${GITHUB_REPO}/releases/download/v${VERSION}"
 
   TMP_DIR=$(mktemp -d)
-  trap 'rm -rf "$TMP_DIR"' EXIT
+  trap 'rm -rf "$TMP_DIR"; if [ "$INSTALL_SUCCESS" = "false" ]; then send_telemetry "Install Failed" "version=${VERSION:-unknown}"; fi' EXIT
 
   echo "Downloading stripe v${VERSION}..."
   http_download "$BASE_URL/$ARCHIVE" "$TMP_DIR/$ARCHIVE"
@@ -192,6 +196,23 @@ setup_path() {
 version_lt() {
   # Returns 0 (true) if $1 < $2 using sort -V for version comparison
   [ "$1" != "$2" ] && [ "$(printf '%s\n%s' "$1" "$2" | sort -V | head -n1)" = "$1" ]
+}
+
+send_telemetry() {
+  event_name="$1"
+  event_value="$2"
+
+  case "${STRIPE_CLI_TELEMETRY_OPTOUT:-}${DO_NOT_TRACK:-}" in
+    *1*|*true*|*TRUE*) return ;;
+  esac
+
+  telemetry_data="client_id=stripe-cli&event_name=${event_name}&event_value=${event_value}&os=${OS:-unknown}&arch=${ARCH_LABEL:-unknown}&cli_version=${VERSION:-unknown}&install_method=curl"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -sS --max-time 3 -X POST -H "origin: stripe-cli" -H "Content-Type: application/x-www-form-urlencoded" -d "$telemetry_data" "$TELEMETRY_URL" >/dev/null 2>&1 || true
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q --timeout=3 -O /dev/null --post-data="$telemetry_data" --header="origin: stripe-cli" --header="Content-Type: application/x-www-form-urlencoded" "$TELEMETRY_URL" 2>/dev/null || true
+  fi
 }
 
 print_success() {


### PR DESCRIPTION
## Summary
- Add telemetry events to the curl install script (`Install Succeeded`, `Install Failed`)
- Add telemetry events to the auto-updater (`Auto-Update Available`, `Auto-Update Succeeded`, `Auto-Update Failed`)
- Events include OS, architecture, CLI version, and install method
- Respects `STRIPE_CLI_TELEMETRY_OPTOUT` and `DO_NOT_TRACK` opt-out env vars