### PR TITLE
Co-op: resume agents after late review decisions

### DIFF
--- a/pkg/cmd/coop/coop_agent.go
+++ b/pkg/cmd/coop/coop_agent.go
@@ -50,6 +50,7 @@ func newCoopAgentCmd() *coopAgentCmd {
 	ac.cmd.AddCommand(newCoopAgentReportCheckCmd().cmd)
 	ac.cmd.AddCommand(newCoopAgentSkipCmd().cmd)
 	ac.cmd.AddCommand(newCoopAgentAwaitReviewCmd().cmd)
+	ac.cmd.AddCommand(newCoopAgentResumeCmd().cmd)
 	ac.cmd.AddCommand(newCoopAgentNextActionCmd().cmd)
 	ac.cmd.AddCommand(newCoopAgentStartFollowupCmd().cmd)
 	configureAgentCommand(ac.cmd)

--- a/pkg/cmd/coop/coop_agent_resume.go
+++ b/pkg/cmd/coop/coop_agent_resume.go
@@ -1,0 +1,36 @@
+package coopcmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func newCoopAgentResumeCmd() *coopAgentActionCmd {
+	c := &coopAgentActionCmd{}
+	c.cmd = &cobra.Command{
+		Use:   "resume",
+		Short: "Return the exact command for the current Co-op lifecycle state",
+		Args:  agentNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(c.session) == "" {
+				return outputCoopError(
+					"--session flag is required",
+					"Provide the Co-op session to resume.",
+					coop.ResumeTemplate(),
+				)
+			}
+			service, err := newWorkflowService()
+			if err != nil {
+				return outputAgentError(err)
+			}
+			resp, err := service.Resume(c.session)
+			return outputAgentResponse(resp, err)
+		},
+	}
+	c.cmd.Flags().StringVar(&c.session, "session", "", "Session ID")
+	configureAgentCommand(c.cmd)
+	return c
+}

--- a/pkg/cmd/coop/coop_agent_resumer.go
+++ b/pkg/cmd/coop/coop_agent_resumer.go
@@ -1,0 +1,98 @@
+package coopcmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/tui"
+)
+
+const coopAgentPaneOption = "@stripe_coop_agent"
+
+var runTmuxOutput = func(args ...string) (string, error) {
+	out, err := exec.Command("tmux", args...).CombinedOutput()
+	return string(out), err
+}
+
+type tmuxAgentResumer struct {
+	tuiPane  string
+	keyDelay time.Duration
+	mu       sync.Mutex
+}
+
+func newTmuxAgentResumer(tuiPane string) *tmuxAgentResumer {
+	return &tmuxAgentResumer{tuiPane: tuiPane, keyDelay: 100 * time.Millisecond}
+}
+
+func (r *tmuxAgentResumer) Notify(sessionID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	pane, err := r.findAgentPane()
+	if err != nil {
+		return err
+	}
+	resumeCommand := coop.ResumeCommand(sessionID)
+	prompt := fmt.Sprintf("Human input updated Stripe Co-op session %s. Resume neutrally: run exactly `%s`. If its JSON has a non-empty `next`, run that command exactly; otherwise continue your current work.", sessionID, resumeCommand)
+	if err := runTmux("send-keys", "-t", pane, "-l", prompt); err != nil {
+		return fmt.Errorf("sending Co-op resume prompt: %w", err)
+	}
+	// Agent TUIs can coalesce rapid input as a paste. Give the literal text one
+	// bounded beat to land before submitting it as a turn.
+	if r.keyDelay > 0 {
+		time.Sleep(r.keyDelay)
+	}
+	if err := runTmux("send-keys", "-t", pane, "Enter"); err != nil {
+		return fmt.Errorf("submitting Co-op resume prompt: %w", err)
+	}
+	return nil
+}
+
+func (r *tmuxAgentResumer) findAgentPane() (string, error) {
+	out, err := runTmuxOutput("list-panes", "-t", r.tuiPane, "-F", "#{pane_id}\t#{@stripe_coop_agent}")
+	if err != nil {
+		return "", fmt.Errorf("listing Co-op tmux panes: %w", err)
+	}
+	var panes []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		pane, tag, ok := strings.Cut(line, "\t")
+		if ok && strings.TrimSpace(tag) == "1" {
+			panes = append(panes, strings.TrimSpace(pane))
+		}
+	}
+	if len(panes) != 1 {
+		return "", fmt.Errorf("expected one Co-op agent pane, found %d", len(panes))
+	}
+	return panes[0], nil
+}
+
+func coopTUIOptions() []tui.Option {
+	options := []tui.Option{tui.WithSandboxClaimURL(coopSandboxClaimURL())}
+	if tuiPane := os.Getenv("TMUX_PANE"); tuiPane != "" {
+		resumer := newTmuxAgentResumer(tuiPane)
+		options = append(options, tui.WithReviewDecisionNotifier(resumer.Notify))
+	}
+	return options
+}
+
+func splitCoopAgentPane(args ...string) (string, error) {
+	args = append([]string{"split-window", "-P", "-F", "#{pane_id}"}, args...)
+	out, err := runTmuxOutput(args...)
+	if err != nil {
+		return "", err
+	}
+	pane := strings.TrimSpace(out)
+	if pane == "" {
+		return "", fmt.Errorf("tmux split-window returned an empty pane ID")
+	}
+	if err := runTmux("set-option", "-p", "-t", pane, coopAgentPaneOption, "1"); err != nil {
+		_ = runTmux("kill-pane", "-t", pane)
+		return "", fmt.Errorf("tagging Co-op agent pane: %w", err)
+	}
+	return pane, nil
+}

--- a/pkg/cmd/coop/coop_agent_resumer_test.go
+++ b/pkg/cmd/coop/coop_agent_resumer_test.go
@@ -1,0 +1,83 @@
+package coopcmd
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitCoopAgentPaneTagsReturnedPane(t *testing.T) {
+	originalRunTmux := runTmux
+	originalRunTmuxOutput := runTmuxOutput
+	var calls [][]string
+	runTmuxOutput = func(args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return "%7\n", nil
+	}
+	runTmux = func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalRunTmuxOutput
+	})
+
+	pane, err := splitCoopAgentPane("-h", "bash", "-c", "agent")
+
+	require.NoError(t, err)
+	assert.Equal(t, "%7", pane)
+	require.Len(t, calls, 2)
+	assert.Equal(t, []string{"split-window", "-P", "-F", "#{pane_id}", "-h", "bash", "-c", "agent"}, calls[0])
+	assert.Equal(t, []string{"set-option", "-p", "-t", "%7", coopAgentPaneOption, "1"}, calls[1])
+}
+
+func TestTmuxAgentResumerSerializesConcurrentWakeUps(t *testing.T) {
+	originalRunTmux := runTmux
+	originalRunTmuxOutput := runTmuxOutput
+	var callsMu sync.Mutex
+	var calls [][]string
+	runTmuxOutput = func(args ...string) (string, error) {
+		return "%1\t\n%2\t1\n", nil
+	}
+	runTmux = func(args ...string) error {
+		callsMu.Lock()
+		defer callsMu.Unlock()
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalRunTmuxOutput
+	})
+
+	resumer := newTmuxAgentResumer("%1")
+	resumer.keyDelay = 0
+	var wg sync.WaitGroup
+	errs := make(chan error, 3)
+	for _, sessionID := range []string{"session_one", "session_two", "session_three"} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- resumer.Notify(sessionID)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	callsMu.Lock()
+	defer callsMu.Unlock()
+	require.Len(t, calls, 6)
+	for i := 0; i < len(calls); i += 2 {
+		require.Len(t, calls[i], 5)
+		assert.Equal(t, []string{"send-keys", "-t", "%2", "-l"}, calls[i][:4])
+		assert.True(t, strings.Contains(calls[i][4], "stripe coop agent resume --session=session_"))
+		assert.Equal(t, []string{"send-keys", "-t", "%2", "Enter"}, calls[i+1])
+	}
+}

--- a/pkg/cmd/coop/coop_agent_test.go
+++ b/pkg/cmd/coop/coop_agent_test.go
@@ -56,6 +56,28 @@ func TestCoopAgentStartWorkCommand(t *testing.T) {
 	assert.Equal(t, coop.NodeActive, node.State)
 }
 
+func TestCoopAgentResumeCommandReturnsExactCurrentCommandWithoutMutation(t *testing.T) {
+	store, session := setupAgentCommandTest(t)
+	cmd := newCoopAgentResumeCmd().cmd
+	cmd.SetArgs([]string{"--session", session.ID})
+
+	output := captureStdout(t, func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &resp))
+	require.True(t, resp.OK)
+	assert.Equal(t, "pending", resp.State)
+	assert.Equal(t, `stripe coop agent start-work --session=agent_test_session --step=1 --note="Beginning: Node 1"`, resp.Next)
+
+	loaded, err := store.Read(session.ID)
+	require.NoError(t, err)
+	node, err := loaded.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodePending, node.State)
+}
+
 func TestCoopAgentReportCheckCommand(t *testing.T) {
 	store, session := setupAgentCommandTest(t)
 	_, err := store.Update(session.ID, func(session *coop.Session) error {

--- a/pkg/cmd/coop/coop_join.go
+++ b/pkg/cmd/coop/coop_join.go
@@ -87,7 +87,7 @@ func (jc *coopJoinCmd) runJoinCmd(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 	}
 
-	return tui.Run(store, session.ID, tui.WithSandboxClaimURL(coopSandboxClaimURL()))
+	return tui.Run(store, session.ID, coopTUIOptions()...)
 }
 
 type sessionChoice struct {

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -238,7 +238,7 @@ func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprint *coo
 	}
 	paneCmd = shellCommandWithCoopEnv(paneCmd)
 
-	if err := runTmux("split-window", "-h", "-p", "60", "bash", "-c", paneCmd); err != nil {
+	if _, err := splitCoopAgentPane("-h", "-p", "60", "bash", "-c", paneCmd); err != nil {
 		if cleanup != nil {
 			cleanup()
 		}
@@ -247,7 +247,7 @@ func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprint *coo
 	}
 
 	if blueprint != nil {
-		return tui.Run(store, session.ID, tui.WithSandboxClaimURL(coopSandboxClaimURL()))
+		return tui.Run(store, session.ID, coopTUIOptions()...)
 	}
 
 	return runCoopTUIWait(store)
@@ -317,8 +317,8 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 		return fmt.Errorf("tmux new-session failed: %w", err)
 	}
 
-	if err := runTmux("split-window", "-h", "-t", sessionName, "-p", "60",
-		"bash", "-c", paneCmd); err != nil {
+	agentPane, err := splitCoopAgentPane("-h", "-t", sessionName, "-p", "60", "bash", "-c", paneCmd)
+	if err != nil {
 		if cleanup != nil {
 			cleanup()
 		}
@@ -327,7 +327,7 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 		return fmt.Errorf("tmux split-window failed: %w", err)
 	}
 
-	runTmux("select-pane", "-t", sessionName+":0.1")
+	runTmux("select-pane", "-t", agentPane)
 
 	attach := exec.Command("tmux", "attach-session", "-t", sessionName)
 	attach.Stdin = os.Stdin
@@ -414,5 +414,5 @@ func runCoopTUIWait(store *coop.Store) error {
 			existingIDs[id] = true
 		}
 	}
-	return tui.RunWaiting(store, existingIDs, tui.WithSandboxClaimURL(coopSandboxClaimURL()))
+	return tui.RunWaiting(store, existingIDs, coopTUIOptions()...)
 }

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -63,6 +63,7 @@ func TestExplicitBlueprintPromptIsCompactBootstrap(t *testing.T) {
 	assert.Contains(t, prompt, "agent_prompt and next fields")
 	assert.Contains(t, prompt, "production-grade Stripe integration")
 	assert.Contains(t, prompt, "context from the current app or codebase")
+	assert.Contains(t, prompt, "stripe coop agent resume")
 	assert.NotContains(t, prompt, `"ok": true`)
 	assert.NotContains(t, prompt, `"agent_instructions"`)
 	assert.NotContains(t, prompt, `"nodes"`)
@@ -267,19 +268,26 @@ func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T
 	splitErr := errors.New("split failed")
 	var tmuxCalls [][]string
 	originalRunTmux := runTmux
+	originalRunTmuxOutput := runTmuxOutput
 	runTmux = func(args ...string) error {
 		tmuxCalls = append(tmuxCalls, append([]string(nil), args...))
 		switch args[0] {
 		case "has-session":
 			return errors.New("session not found")
-		case "split-window":
-			return splitErr
 		default:
 			return nil
 		}
 	}
+	runTmuxOutput = func(args ...string) (string, error) {
+		tmuxCalls = append(tmuxCalls, append([]string(nil), args...))
+		if args[0] == "split-window" {
+			return "", splitErr
+		}
+		return "", nil
+	}
 	t.Cleanup(func() {
 		runTmux = originalRunTmux
+		runTmuxOutput = originalRunTmuxOutput
 	})
 
 	cleanupCalled := false

--- a/pkg/cmd/coop/coop_run.go
+++ b/pkg/cmd/coop/coop_run.go
@@ -228,7 +228,7 @@ For each node:
 4. Report the implementation with "stripe coop agent report-work".
 5. Continue with the response's next command. If a task does not apply, use "stripe coop agent skip" with a reason.
 
-Only await human review when the next command says to. Before awaiting, run the supplied review command, keep useful servers running, and give the developer concrete actions and expected results. Co-op returns from await-review after %s; allow the shell command at least %s so the structured timeout response arrives. Re-run it if Co-op reports a timeout. If changes are requested, redo the affected node from the feedback. After the final confirmation, immediately run the returned next command.
+Only await human review when the next command says to. Before awaiting, run the supplied review command, keep useful servers running, and give the developer concrete actions and expected results. Co-op returns from await-review after %s; allow the shell command at least %s so the structured timeout response arrives. Re-run it if Co-op reports a timeout. If Co-op wakes you after later human input, run the exact stripe coop agent resume command it provides, then run a non-empty next command exactly; an empty next means another handoff already advanced the session. If changes are requested, redo the affected node from the feedback. After the final confirmation, immediately run the returned next command.
 
 Never pass full card numbers to Stripe APIs or CLI commands. Collect card details only through hosted Checkout, Payment Element, or another official client-side integration. If an API needs a test payment method, use a supported test PaymentMethod ID such as pm_card_visa.`,
 		preamble,

--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -70,7 +70,8 @@ active ──→ completed    (all nodes done/skipped, or "stripe coop stop")
 | `stripe coop agent report-work --step <n>` | Record implementation and outputs, then mark a node complete |
 | `stripe coop agent report-check --step <n>` | Add a verification check |
 | `stripe coop agent skip --step <n>` | Skip a node |
-| `stripe coop agent await-review --step <n>` | Block until developer confirms or requests changes |
+| `stripe coop agent await-review --step <n>` | Block for up to five minutes until developer confirms or requests changes |
+| `stripe coop agent resume --session <id>` | Read the current lifecycle state and return its exact next command without mutating it |
 | `stripe coop agent next-action` | Show post-completion options (blocks until selection) |
 | `stripe coop agent start-followup` | Start an internal guided follow-up session selected from next actions |
 
@@ -143,7 +144,9 @@ $ stripe coop start one-time-payment --language=node
 #      stripe coop agent report-work --session=coop_abc123 --step=2 --file=server.js --lines=5-20 --note="Created product" --output=id=prod_123
 #      stripe coop agent await-review --session=coop_abc123 --step=2   ← blocks until developer confirms
 # 6. Developer sees progress live, presses 'c' to confirm
-# 7. Agent continues to next step
+# 7. TUI sends a one-shot neutral resume prompt to the agent pane; if the
+#    original await result already advanced the session, resume returns no next
+#    command. Otherwise the agent runs the exact returned command.
 # 8. After all steps: agent runs "stripe coop agent next-action --session=coop_abc123"
 # 9. Developer picks what to do next from TUI suggestions
 ```
@@ -170,11 +173,13 @@ Blueprint nodes with `"is_informational_node": true` skip human review:
 
 ## Heartbeat
 
-When the agent runs `stripe coop agent await-review`, it writes a `.heartbeat` file every 500ms. The TUI checks this file:
+When the agent runs `stripe coop agent await-review`, it writes a `.heartbeat` file every 500ms. The waiter intentionally ends after five minutes and returns the exact `await-review` retry command. A shell tool can stop waiting, or an agent turn can finish, before that Co-op timeout. The TUI checks the heartbeat file:
 - **Fresh heartbeat (< 5s old):** Agent is actively waiting for confirmation
 - **No heartbeat + no session update in 2min:** Show idle warning
 
 The heartbeat file is cleaned up when `await` exits. The command advertises its five-minute wait as `wait_timeout_seconds`; agent harnesses should allow at least six minutes so the structured timeout response can arrive.
+
+After a confirm or request-changes decision, a tmux-launched TUI sends one neutral prompt to the tagged agent pane. The prompt runs `stripe coop agent resume --session=<id>`, which reads the latest durable state and returns an exact `next` command when action is needed. It returns an empty `next` when another handoff already advanced the session, so duplicate delivery is safe and no permanent poller is needed.
 
 ## Resuming
 
@@ -186,7 +191,7 @@ Use `stripe coop join --resume` to pick from recent sessions.
 |-------|------------|
 | Node is active | Rejoin the session and check the agent pane/TUI state |
 | Node or step is in review | Rejoin the session and confirm or request changes |
-| Agent appears idle | Rejoin the session; the TUI shows heartbeat/idle state |
+| Agent appears idle | Rejoin the session. In the agent pane run `stripe coop agent resume --session=<id>` if the automatic tmux wake-up is unavailable |
 | Need a specific older session | Run `stripe coop join --resume` |
 
 ## Blueprint loading

--- a/pkg/coop/commands.go
+++ b/pkg/coop/commands.go
@@ -49,6 +49,12 @@ func AwaitReviewCommand(sessionID string, nodeNumber int) string {
 	return fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", sessionID, nodeNumber)
 }
 
+// ResumeCommand returns the exact command for reading the current lifecycle
+// continuation without mutating the session.
+func ResumeCommand(sessionID string) string {
+	return fmt.Sprintf("stripe coop agent resume --session=%s", sessionID)
+}
+
 // NextActionCommand returns the exact command for waiting on or completing a
 // post-session action.
 func NextActionCommand(sessionID, completed string) string {
@@ -85,6 +91,14 @@ func SessionStepTemplate(action string) Continuation {
 func NextActionTemplate() Continuation {
 	return commandTemplate(
 		"stripe coop agent next-action --session=\"<session>\"",
+		commandInput("session", "--session", "Co-op session ID."),
+	)
+}
+
+// ResumeTemplate returns the continuation for a missing session ID.
+func ResumeTemplate() Continuation {
+	return commandTemplate(
+		"stripe coop agent resume --session=\"<session>\"",
 		commandInput("session", "--session", "Co-op session ID."),
 	)
 }

--- a/pkg/coop/commands_test.go
+++ b/pkg/coop/commands_test.go
@@ -14,6 +14,7 @@ func TestExactCoopCommands(t *testing.T) {
 	assert.Equal(t, "stripe coop stop --session=coop_123", StopCommand("coop_123"))
 	assert.Equal(t, `stripe coop agent start-work --session=coop_123 --step=2 --note="Beginning: Product"`, StartWorkCommand("coop_123", 2, "Beginning: Product"))
 	assert.Equal(t, "stripe coop agent await-review --session=coop_123 --step=2", AwaitReviewCommand("coop_123", 2))
+	assert.Equal(t, "stripe coop agent resume --session=coop_123", ResumeCommand("coop_123"))
 	assert.Equal(t, "stripe coop agent next-action --session=coop_123", NextActionCommand("coop_123", ""))
 	assert.Equal(t, "stripe coop agent next-action --session=coop_123 --completed=deploy", NextActionCommand("coop_123", "deploy"))
 	assert.Equal(t, `stripe coop agent start-followup --session="coop_123" --action="deploy" --target="Vercel"`, StartFollowupCommand("coop_123", "deploy", "Vercel"))

--- a/pkg/coop/tui/app.go
+++ b/pkg/coop/tui/app.go
@@ -9,9 +9,20 @@ import (
 
 type Option func(*Model)
 
+// ReviewDecisionNotifier wakes an agent after a human review decision. The
+// notifier must be one-shot and non-blocking from the TUI's perspective; it is
+// run as a Bubble Tea command after the session update is durable.
+type ReviewDecisionNotifier func(sessionID string) error
+
 func WithSandboxClaimURL(claimURL string) Option {
 	return func(m *Model) {
 		m.sandboxClaimURL = claimURL
+	}
+}
+
+func WithReviewDecisionNotifier(notify ReviewDecisionNotifier) Option {
+	return func(m *Model) {
+		m.reviewDecisionNotifier = notify
 	}
 }
 

--- a/pkg/coop/tui/model.go
+++ b/pkg/coop/tui/model.go
@@ -62,11 +62,12 @@ type Model struct {
 	sdkLoading     bool
 	sdkLoadingNode int
 
-	waiting            bool
-	waitingMessage     string
-	existingSessionIDs map[string]bool
-	lastUpdateTime     time.Time
-	agentIsIdle        bool
+	waiting                bool
+	waitingMessage         string
+	existingSessionIDs     map[string]bool
+	lastUpdateTime         time.Time
+	agentIsIdle            bool
+	reviewDecisionNotifier ReviewDecisionNotifier
 
 	isDark  bool
 	focused bool // true when terminal has focus (default: true, updated via FocusMsg/BlurMsg)
@@ -876,10 +877,11 @@ func (m *Model) handleConfirm() tea.Cmd {
 	}
 	m.resizeViewport()
 	m.syncViewport()
+	notify := m.notifyReviewDecision()
 	if m.session.IsComplete() && m.session.ParentSessionID != "" {
-		return m.returnToParent()
+		return tea.Batch(notify, m.returnToParent())
 	}
-	return nil
+	return notify
 }
 
 func (m *Model) startReject() tea.Cmd {
@@ -909,8 +911,7 @@ func (m Model) handleRejectionKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.syncViewport()
 		return m, nil
 	case key.Matches(msg, m.keys.Submit):
-		m.handleReject(strings.TrimSpace(m.rejectionInput.Value()))
-		return m, nil
+		return m, m.handleReject(strings.TrimSpace(m.rejectionInput.Value()))
 	}
 	return m.updateRejectionInput(msg)
 }
@@ -924,22 +925,22 @@ func (m Model) updateRejectionInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m *Model) handleReject(note string) {
+func (m *Model) handleReject(note string) tea.Cmd {
 	if m.session == nil {
-		return
+		return nil
 	}
 	if note == "" {
 		m.rejectionError = "Add a short note so the agent knows what to change."
 		m.resizeViewport()
 		m.syncViewport()
-		return
+		return nil
 	}
 	if !m.reviewTargetStillValid(m.rejectTarget) {
 		m.clearRejectionState()
 		m.setStatus("Review target changed. Request changes canceled.", 4*time.Second)
 		m.resizeViewport()
 		m.syncViewport()
-		return
+		return nil
 	}
 	target := m.rejectTarget
 	session, err := workflow.NewService(m.store).RequestChanges(m.session.ID, target.nodeNumbers, note)
@@ -947,7 +948,7 @@ func (m *Model) handleReject(note string) {
 		m.rejectionError = fmt.Sprintf("failed to request changes: %v", err)
 		m.resizeViewport()
 		m.syncViewport()
-		return
+		return nil
 	}
 	m.session = session
 	m.lastVersion = m.session.Version
@@ -959,6 +960,23 @@ func (m *Model) handleReject(note string) {
 	m.setStatus("Feedback sent. Waiting for agent...", 5*time.Second)
 	m.resizeViewport()
 	m.syncViewport()
+	return m.notifyReviewDecision()
+}
+
+func (m Model) notifyReviewDecision() tea.Cmd {
+	if m.reviewDecisionNotifier == nil || m.session == nil {
+		return nil
+	}
+	sessionID := m.session.ID
+	notify := m.reviewDecisionNotifier
+	return func() tea.Msg {
+		if err := notify(sessionID); err != nil {
+			return statusMsg{
+				message: fmt.Sprintf("Agent wake-up failed. In the agent pane, run: %s", coop.ResumeCommand(sessionID)),
+			}
+		}
+		return statusMsg{message: "Human decision sent. Waiting for agent...", ttl: 5 * time.Second}
+	}
 }
 
 type reviewTarget struct {

--- a/pkg/coop/tui/model_test.go
+++ b/pkg/coop/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"image/color"
 	"strings"
 	"testing"
@@ -134,6 +135,94 @@ func TestUpdateKeyConfirm(t *testing.T) {
 
 	node, _ := updated.session.NodeByNumber(1)
 	assert.Equal(t, coop.NodeDone, node.State)
+}
+
+func TestReviewDecisionNotifierRunsAfterConfirmedStateIsDurable(t *testing.T) {
+	store, err := coop.NewStoreAt(t.TempDir())
+	require.NoError(t, err)
+	m := readyModel()
+	m.store = store
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.selectionCursor = 0
+	require.NoError(t, store.Write(m.session))
+
+	var notifiedSession string
+	m.reviewDecisionNotifier = func(sessionID string) error {
+		notifiedSession = sessionID
+		loaded, err := store.Read(sessionID)
+		if err != nil {
+			return err
+		}
+		node, err := loaded.NodeByNumber(1)
+		if err != nil {
+			return err
+		}
+		if node.State != coop.NodeDone {
+			return errors.New("review decision was not durable before notification")
+		}
+		return nil
+	}
+
+	result, cmd := m.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	updated := result.(Model)
+	require.NotNil(t, cmd)
+	msg := cmd()
+	notified, ok := msg.(statusMsg)
+	require.True(t, ok)
+	assert.Contains(t, notified.message, "Waiting for agent")
+	assert.Equal(t, updated.session.ID, notifiedSession)
+}
+
+func TestReviewDecisionNotifierRunsAfterRequestedChanges(t *testing.T) {
+	store, err := coop.NewStoreAt(t.TempDir())
+	require.NoError(t, err)
+	m := readyModel()
+	m.store = store
+	m.session.Steps[0].Nodes[0].State = coop.NodeReview
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	m.selectionCursor = 0
+	require.NoError(t, store.Write(m.session))
+	target, ok := m.selectedReviewTarget()
+	require.True(t, ok)
+	m.rejectTarget = target
+
+	var notified bool
+	m.reviewDecisionNotifier = func(sessionID string) error {
+		notified = true
+		loaded, err := store.Read(sessionID)
+		if err != nil {
+			return err
+		}
+		node, err := loaded.NodeByNumber(1)
+		if err != nil {
+			return err
+		}
+		if node.State != coop.NodeActive {
+			return errors.New("requested changes were not durable before notification")
+		}
+		return nil
+	}
+
+	cmd := m.handleReject("Reuse the saved price")
+	require.NotNil(t, cmd)
+	msg := cmd()
+	notifiedMsg, ok := msg.(statusMsg)
+	require.True(t, ok)
+	assert.Contains(t, notifiedMsg.message, "Waiting for agent")
+	assert.True(t, notified)
+}
+
+func TestReviewDecisionNotificationFailureShowsExactManualResume(t *testing.T) {
+	m := readyModel()
+	m.session.ID = "coop_123"
+	m.reviewDecisionNotifier = func(string) error { return errors.New("tmux pane exited") }
+
+	cmd := m.notifyReviewDecision()
+	require.NotNil(t, cmd)
+	msg, ok := cmd().(statusMsg)
+	require.True(t, ok)
+	assert.Contains(t, msg.message, "stripe coop agent resume --session=coop_123")
 }
 
 func TestUpdateKeyConfirmIgnoresRepeat(t *testing.T) {

--- a/pkg/coop/workflow/resume.go
+++ b/pkg/coop/workflow/resume.go
@@ -1,0 +1,108 @@
+package workflow
+
+import (
+	"fmt"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+// Resume reports the current non-blocking lifecycle continuation. It is
+// read-only so duplicate wake-ups cannot advance the session twice.
+func (s *Service) Resume(sessionID string) (coop.CommandResponse, error) {
+	session, err := s.store.Read(sessionID)
+	if err != nil {
+		return sessionErrorResponse(err), nil
+	}
+	if session.Status == coop.SessionAborted {
+		return errorResponse(
+			fmt.Errorf("session %s is %s and cannot be resumed", session.ID, session.Status),
+			"Inspect the session before choosing a recovery action.",
+			coop.Continue(coop.StatusCommand(session.ID)),
+		), nil
+	}
+
+	if session.Status == coop.SessionCompleted || session.IsComplete() {
+		return nodeResponse(
+			session.ID,
+			session.TotalNodes(),
+			string(coop.SessionCompleted),
+			"Session work is complete. Continue with the exact next-action command.",
+			nextAfterNode(session, session.TotalNodes()),
+		), nil
+	}
+
+	if activeNode, nodeNumber := session.ActiveNode(); activeNode != nil {
+		if activeNode.RejectionNote != "" && activeNode.Activity == "" {
+			return rejectedResponse(session, nodeNumber, activeNode), nil
+		}
+		return nodeResponse(
+			session.ID,
+			nodeNumber,
+			string(coop.NodeActive),
+			fmt.Sprintf("Node %d is already active. Continue the current work; no resume command is needed.", nodeNumber),
+			coop.Continuation{},
+		), nil
+	}
+
+	nodeNumber := 0
+	for stepIndex := range session.Steps {
+		step := &session.Steps[stepIndex]
+		if session.StepReadyForReview(stepIndex) && session.StepHasReview(stepIndex) {
+			reviewNode := session.FirstReviewNodeInStep(stepIndex)
+			return nodeResponse(
+				session.ID,
+				reviewNode,
+				string(coop.NodeReview),
+				fmt.Sprintf("Step %q is waiting for human review.", step.TitleText()),
+				waitFor(coop.AwaitReviewCommand(session.ID, reviewNode), s.awaitTimeout),
+			), nil
+		}
+		for nodeIndex := range step.Nodes {
+			nodeNumber++
+			node := &step.Nodes[nodeIndex]
+			if node.State == coop.NodePending {
+				return nodeResponse(
+					session.ID,
+					nodeNumber,
+					string(coop.NodePending),
+					fmt.Sprintf("Resume with the next pending node: %s", node.TitleText()),
+					coop.Continue(coop.StartWorkCommand(session.ID, nodeNumber, "Beginning: "+node.TitleText())),
+				), nil
+			}
+		}
+	}
+
+	return errorResponse(
+		fmt.Errorf("session %s has no resumable lifecycle state", session.ID),
+		"Inspect the session before choosing a recovery action.",
+		coop.Continue(coop.StatusCommand(session.ID)),
+	), nil
+}
+
+func rejectedStepResponse(session *coop.Session, stepTitle string, nodeNumber int, node *coop.SessionNode) coop.CommandResponse {
+	response := rejectedResponse(session, nodeNumber, node)
+	response.Message = fmt.Sprintf("Step %q requested changes.", stepTitle)
+	if node != nil && node.RejectionNote != "" {
+		response.Message += fmt.Sprintf("\nFeedback: %s", node.RejectionNote)
+	}
+	response.Message += "\nRedo the step from the first affected node."
+	return response
+}
+
+func rejectedResponse(session *coop.Session, nodeNumber int, node *coop.SessionNode) coop.CommandResponse {
+	title := "affected node"
+	if node != nil && node.TitleText() != "" {
+		title = node.TitleText()
+	}
+	message := fmt.Sprintf("Node %d has requested changes. Redo the affected work.", nodeNumber)
+	if node != nil && node.RejectionNote != "" {
+		message += fmt.Sprintf("\nFeedback: %s", node.RejectionNote)
+	}
+	return nodeResponse(
+		session.ID,
+		nodeNumber,
+		"rejected",
+		message,
+		coop.Continue(coop.StartWorkCommand(session.ID, nodeNumber, "Redoing: "+title)),
+	)
+}

--- a/pkg/coop/workflow/resume_test.go
+++ b/pkg/coop/workflow/resume_test.go
@@ -1,0 +1,160 @@
+package workflow
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestStartWorkRetryIsConcurrentAndIdempotent(t *testing.T) {
+	store, session := twoStepResumeTestStore(t)
+	service := NewService(store)
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			response, err := service.StartWork(session.ID, 1, fmt.Sprintf("retry-%d", worker))
+			if err == nil && !response.OK {
+				err = fmt.Errorf("start-work response failed: %s", response.Error)
+			}
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	loaded, err := store.Read(session.ID)
+	require.NoError(t, err)
+	node, err := loaded.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodeActive, node.State)
+	assert.Contains(t, node.Activity, "retry-")
+}
+
+func TestLateReviewDecisionReleasesWaiterWithExactNextCommand(t *testing.T) {
+	store, session := twoStepResumeTestStore(t)
+	service := NewService(store, WithAwaitTimeout(3*time.Second))
+	_, err := service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go", Note: "Implemented server work"}, false)
+	require.NoError(t, err)
+
+	type awaitResult struct {
+		response coop.CommandResponse
+		err      error
+	}
+	done := make(chan awaitResult, 1)
+	go func() {
+		response, err := service.AwaitReview(session.ID, 1)
+		done <- awaitResult{response: response, err: err}
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		age, err := store.HeartbeatAge(session.ID)
+		require.NoError(t, err)
+		if age >= 0 {
+			break
+		}
+		require.True(t, time.Now().Before(deadline), "await-review did not publish its heartbeat")
+		time.Sleep(5 * time.Millisecond)
+	}
+	_, err = service.ConfirmReview(session.ID, []int{1})
+	require.NoError(t, err)
+
+	result := <-done
+	require.NoError(t, result.err)
+	require.True(t, result.response.OK)
+	assert.Equal(t, "confirmed", result.response.State)
+	assert.Equal(t, `stripe coop agent start-work --session=workflow_resume --step=2 --note="Beginning: Two"`, result.response.Next)
+}
+
+func TestResumeIsReadOnlyAndTracksCurrentLifecycleState(t *testing.T) {
+	store, session := twoStepResumeTestStore(t)
+	service := NewService(store)
+
+	response, err := service.Resume(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, `stripe coop agent start-work --session=workflow_resume --step=1 --note="Beginning: One"`, response.Next)
+
+	_, err = service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go", Note: "Implemented server work"}, false)
+	require.NoError(t, err)
+	response, err = service.Resume(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(coop.NodeReview), response.State)
+	assert.Equal(t, "stripe coop agent await-review --session=workflow_resume --step=1", response.Next)
+	assert.Equal(t, int(AwaitTimeout.Seconds()), response.WaitTimeoutSeconds)
+
+	_, err = service.RequestChanges(session.ID, []int{1}, "Reuse the saved price")
+	require.NoError(t, err)
+	response, err = service.Resume(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "rejected", response.State)
+	assert.Equal(t, `stripe coop agent start-work --session=workflow_resume --step=1 --note="Redoing: One"`, response.Next)
+
+	_, err = service.StartWork(session.ID, 1, "Redoing: One")
+	require.NoError(t, err)
+	response, err = service.Resume(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(coop.NodeActive), response.State)
+	assert.Empty(t, response.Next)
+
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go", Note: "Reworked server code"}, false)
+	require.NoError(t, err)
+	_, err = service.ConfirmReview(session.ID, []int{1})
+	require.NoError(t, err)
+	response, err = service.Resume(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, `stripe coop agent start-work --session=workflow_resume --step=2 --note="Beginning: Two"`, response.Next)
+
+	loaded, err := store.Read(session.ID)
+	require.NoError(t, err)
+	node, err := loaded.NodeByNumber(2)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodePending, node.State, "resume must not mutate session state")
+
+	_, err = service.StartWork(session.ID, 2, "Second")
+	require.NoError(t, err)
+	_, err = service.ReportWork(session.ID, 2, ReportWorkInput{File: "client.go", Note: "Implemented client work"}, false)
+	require.NoError(t, err)
+	_, err = service.ConfirmReview(session.ID, []int{2})
+	require.NoError(t, err)
+	response, err = service.Resume(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(coop.SessionCompleted), response.State)
+	assert.Equal(t, "stripe coop agent next-action --session=workflow_resume", response.Next)
+	require.NoError(t, response.Validate())
+}
+
+func twoStepResumeTestStore(t *testing.T) (*coop.Store, *coop.Session) {
+	t.Helper()
+	store, err := coop.NewStoreAt(t.TempDir())
+	require.NoError(t, err)
+	session := &coop.Session{
+		SchemaVersion: coop.CurrentSessionSchemaVersion,
+		ID:            "workflow_resume",
+		Blueprint:     "test",
+		Status:        coop.SessionActive,
+		Steps: []coop.SessionStep{
+			workflowStep("one", "One", workflowNode("one", "One", coop.NodePending)),
+			workflowStep("two", "Two", workflowNode("two", "Two", coop.NodePending)),
+		},
+	}
+	require.NoError(t, store.Write(session))
+	return store, session
+}

--- a/pkg/coop/workflow/review.go
+++ b/pkg/coop/workflow/review.go
@@ -132,15 +132,7 @@ func (s *Service) awaitStepReview(sessionID, stepTitle string, stepIndex, nodeNu
 		}
 		if activeNodeNumber := session.FirstActiveNodeInStep(stepIndex); activeNodeNumber > 0 {
 			activeNode, _ := session.NodeByNumber(activeNodeNumber)
-			msg := fmt.Sprintf("Step %q requested changes.", stepTitle)
-			if activeNode != nil && activeNode.RejectionNote != "" {
-				msg += fmt.Sprintf("\nFeedback: %s", activeNode.RejectionNote)
-			}
-			msg += "\nRedo the step from the first affected node."
-			return nodeResponse(
-				session.ID, activeNodeNumber, "rejected", msg,
-				coop.Continue(coop.StartWorkCommand(session.ID, activeNodeNumber, "Redoing: "+activeNode.TitleText())),
-			), nil
+			return rejectedStepResponse(session, stepTitle, activeNodeNumber, activeNode), nil
 		}
 		if session.StepHasReview(stepIndex) {
 			continue

--- a/pkg/coop/workflow/service.go
+++ b/pkg/coop/workflow/service.go
@@ -92,10 +92,18 @@ func (s *Service) StartWork(sessionID string, nodeNumber int, note string) (coop
 		if err != nil {
 			return err
 		}
-		if err := session.TransitionNode(nodeNumber, coop.NodeActive); err != nil {
+		node, err := session.NodeByNumber(nodeNumber)
+		if err != nil {
 			return err
 		}
-		node, _ := session.NodeByNumber(nodeNumber)
+		// A review decision can reach the agent through both the original waiter
+		// and a TUI wake-up. Replaying the returned command must be harmless.
+		if node.State != coop.NodeActive {
+			if err := session.TransitionNode(nodeNumber, coop.NodeActive); err != nil {
+				return err
+			}
+			node, _ = session.NodeByNumber(nodeNumber)
+		}
 		node.Activity = note
 		return nil
 	})


### PR DESCRIPTION
## Summary

- keep await-review bounded at its intentional ten-minute timeout
- tag the tmux agent pane and send one neutral resume prompt after a durable human review decision
- add a read-only agent resume command that returns the exact current lifecycle command or no next command when another handoff already advanced the session
- make duplicate start-work retries idempotent and document the lifecycle boundaries

## Reproduction and ownership

A real tmux/Codex run reproduced the gap: the shell tool returned while await-review remained in a background terminal, Codex completed its turn, and a later TUI confirmation released the waiter without causing Codex to consume the returned JSON. Co-op owns the fix at the tmux/TUI handoff layer; shell-tool cancellation and Codex turn completion remain agent-runtime behavior.

The post-fix tmux run automatically woke idle Codex, ran stripe coop agent resume, and advanced the next step exactly once. This adds no permanent poller or endless busy process.

## Test plan

- go test -race ./pkg/coop/... ./pkg/cmd/coop
- go vet ./pkg/coop/... ./pkg/cmd/coop
- golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...
- real tmux/Codex pre-fix reproduction and post-fix lifecycle verification

Repository-wide go test ./... passed all Co-op packages. The remaining failures were environmental and reproduced independently: the plugin manifest URL fails on the unchanged coop worktree, and stripeauth passes when Codex-specific user-agent environment variables are cleared.