### PR TITLE
Include preferences as query parameters to docs.stripe.com requests

### DIFF
--- a/pkg/cmd/docs/prefs.go
+++ b/pkg/cmd/docs/prefs.go
@@ -185,6 +185,18 @@ func (r *RootCommand) renderPrefsList(w io.Writer, response *pkgdocs.PrefsRespon
 	return nil
 }
 
+// loadDocsPrefMap returns all stored docs preferences as a map suitable for passing to the client.
+func (r *RootCommand) loadDocsPrefMap() map[string]string {
+	if r.cfg == nil {
+		return nil
+	}
+	raw := viper.GetStringMapString(r.cfg.Profile.GetConfigField(docsPrefsConfigKey))
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
+}
+
 func (r *RootCommand) getDocsPref(id string) string {
 	if r.cfg == nil {
 		return ""

--- a/pkg/cmd/docs/root.go
+++ b/pkg/cmd/docs/root.go
@@ -195,6 +195,9 @@ func (r *RootCommand) initLogger() {
 func (r *RootCommand) preRun(_ *cobra.Command, _ []string) error {
 	r.initLogger()
 	r.initRenderer()
+	if r.client != nil {
+		r.client.WithOptions(pkgdocs.WithPrefs(r.loadDocsPrefMap()))
+	}
 	if r.logger != nil {
 		if a := useragent.DetectAIAgent(os.Getenv); a != "" {
 			r.logger.WithField("name", a).Debug("agent detected")

--- a/pkg/cmd/docs/root_test.go
+++ b/pkg/cmd/docs/root_test.go
@@ -269,6 +269,61 @@ func TestPreRun_LoggerRespectsConfiguredLevel(t *testing.T) {
 	assert.NotEmpty(t, logBuf.String(), "injected debug-level logger should capture log output")
 }
 
+func TestPrefsForwardedToPageFetch(t *testing.T) {
+	cfg, cleanup := setupPrefsTestConfig(t)
+	defer cleanup()
+	require.NoError(t, cfg.Profile.WriteConfigField("docs_prefs.lang", "ruby"))
+
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		fmt.Fprint(w, "# File Upload")
+	}))
+	defer server.Close()
+
+	renderer, err := markdown.NewRenderer()
+	require.NoError(t, err)
+
+	root := cmd.New().WithOptions(
+		cmd.WithConfig(&cliconfig.Config{Color: "off", Profile: cfg.Profile}),
+		cmd.WithClient(docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))),
+		cmd.WithRenderer(renderer),
+	).Root()
+	root.SetOut(new(bytes.Buffer))
+	root.SetArgs([]string{"--non-interactive", "/file-upload"})
+
+	require.NoError(t, root.ExecuteContext(context.Background()))
+	assert.Contains(t, gotQuery, "lang=ruby")
+}
+
+func TestPrefsNotOverriddenByExistingQueryParam(t *testing.T) {
+	cfg, cleanup := setupPrefsTestConfig(t)
+	defer cleanup()
+	require.NoError(t, cfg.Profile.WriteConfigField("docs_prefs.lang", "ruby"))
+
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		fmt.Fprint(w, "# Page")
+	}))
+	defer server.Close()
+
+	renderer, err := markdown.NewRenderer()
+	require.NoError(t, err)
+
+	root := cmd.New().WithOptions(
+		cmd.WithConfig(&cliconfig.Config{Color: "off", Profile: cfg.Profile}),
+		cmd.WithClient(docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))),
+		cmd.WithRenderer(renderer),
+	).Root()
+	root.SetOut(new(bytes.Buffer))
+	root.SetArgs([]string{"--non-interactive", "/page?lang=go"})
+
+	require.NoError(t, root.ExecuteContext(context.Background()))
+	assert.Contains(t, gotQuery, "lang=go")
+	assert.NotContains(t, gotQuery, "lang=ruby")
+}
+
 func TestRootCommand_NoTUI_RendersOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "# Payments\n\nAccept payments with Stripe.")

--- a/pkg/docs/client.go
+++ b/pkg/docs/client.go
@@ -47,6 +47,7 @@ type Client struct {
 	cacheKeyPrefix string
 	cache          Cache
 	logger         *log.Entry
+	prefs          map[string]string
 }
 
 // ClientOption configures a Client.
@@ -77,6 +78,12 @@ func WithCacheKeyPrefix(prefix string) ClientOption {
 	return func(c *Client) { c.cacheKeyPrefix = prefix }
 }
 
+// WithPrefs sets documentation preferences to include as query parameters on page fetches.
+// A preference is only applied when the fetched URL does not already carry that parameter.
+func WithPrefs(prefs map[string]string) ClientOption {
+	return func(c *Client) { c.prefs = prefs }
+}
+
 // NewClient creates a Client configured to talk to docs.stripe.com.
 func NewClient(_ string) *Client {
 	base, _ := url.Parse(defaultBaseURL)
@@ -103,9 +110,15 @@ func (c *Client) WithOptions(opts ...ClientOption) *Client {
 //	page, err := c.FetchPage(ctx, &url.URL{Path: "/payments/accept-a-payment", RawQuery: "api_version=2024-06-30"})
 func (c *Client) FetchPage(ctx context.Context, ref *url.URL) (Page, error) {
 	resolvedURL := c.baseURL.ResolveReference(ref)
-	// url.Values.Encode() already sorts params, but we normalize here to ensure
-	// a consistent cache key regardless of how callers construct RawQuery.
-	resolvedURL.RawQuery = resolvedURL.Query().Encode()
+	// Merge stored prefs as query params, skipping any key already present in the ref.
+	// url.Values.Encode() sorts params, giving a consistent cache key.
+	q := resolvedURL.Query()
+	for k, v := range c.prefs {
+		if !q.Has(k) {
+			q.Set(k, v)
+		}
+	}
+	resolvedURL.RawQuery = q.Encode()
 	rawURL := resolvedURL.String()
 	cacheKey := c.cacheKey(rawURL)
 

--- a/pkg/docs/client_test.go
+++ b/pkg/docs/client_test.go
@@ -593,6 +593,64 @@ func TestFetchPage_EmptyCacheKeyPrefix_UsesRawURL(t *testing.T) {
 	assert.Equal(t, 1, cache.hits)
 }
 
+func TestFetchPageWithPrefs(t *testing.T) {
+	tests := []struct {
+		name       string
+		prefs      map[string]string
+		ref        *url.URL
+		wantParams map[string]string
+		wantAbsent []string
+	}{
+		{
+			name:       "prefs are added as query params",
+			prefs:      map[string]string{"lang": "go", "theme": "dark"},
+			ref:        &url.URL{Path: "/payments"},
+			wantParams: map[string]string{"lang": "go", "theme": "dark"},
+		},
+		{
+			name:       "existing param is not overridden",
+			prefs:      map[string]string{"lang": "go"},
+			ref:        &url.URL{Path: "/payments", RawQuery: "lang=ruby"},
+			wantParams: map[string]string{"lang": "ruby"},
+		},
+		{
+			name:       "prefs fill missing params but preserve existing ones",
+			prefs:      map[string]string{"lang": "go", "theme": "dark"},
+			ref:        &url.URL{Path: "/payments", RawQuery: "lang=ruby"},
+			wantParams: map[string]string{"lang": "ruby", "theme": "dark"},
+		},
+		{
+			name:       "no prefs adds no params",
+			prefs:      nil,
+			ref:        &url.URL{Path: "/payments"},
+			wantAbsent: []string{"lang", "theme"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotQuery url.Values
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotQuery = r.URL.Query()
+				w.Header().Set("Content-Type", "text/plain")
+				fmt.Fprint(w, "content")
+			}))
+			defer server.Close()
+
+			client := NewClient("test").WithOptions(WithBaseURL(server.URL), WithPrefs(tt.prefs))
+			_, err := client.FetchPage(context.Background(), tt.ref)
+			require.NoError(t, err)
+
+			for k, v := range tt.wantParams {
+				assert.Equal(t, v, gotQuery.Get(k))
+			}
+			for _, k := range tt.wantAbsent {
+				assert.Empty(t, gotQuery.Get(k))
+			}
+		})
+	}
+}
+
 // evictingMockCache always returns a miss, simulating TTL expiry.
 type evictingMockCache struct{}
 


### PR DESCRIPTION
### Summary and motivation

`stripe docs` now forwards stored documentation preferences (set via `stripe docs prefs set`) as query parameters when fetching pages.

Previously, preferences like language or theme were stored in the CLI config but had no effect on what content was returned. The docs page was always fetched without them. Now, each stored preference is automatically appended to the request URL as a query parameter, so the returned page reflects the user's saved settings. Preferences already present in the URL are left untouched.

### Test plan

- [X] Changes are covered by unit tests (including failures and edge cases)
- [X] Changes were tested manually

To test manually:
```bash
make
./stripe docs billing/subscriptions/cancel --no-pager --non-interactive --log-level debug

./stripe docs prefs set server go
./stripe docs billing/subscriptions/cancel --no-pager --non-interactive --log-level debug
```

with no pref set gets `curl` snippets:
<img width="1012" height="169" alt="CleanShot 2026-07-28 at 08 57 49" src="https://github.com/user-attachments/assets/19c51533-642b-4689-8819-fc88a4e6ec90" />
<img width="1012" height="104" alt="CleanShot 2026-07-28 at 08 58 23" src="https://github.com/user-attachments/assets/787cf95b-8581-46c8-ac53-3894c269e0ee" />

with go server set:
<img width="1012" height="111" alt="CleanShot 2026-07-28 at 08 56 35" src="https://github.com/user-attachments/assets/d8605670-66fc-4975-9f35-047c4c747685" />
<img width="1012" height="169" alt="CleanShot 2026-07-28 at 08 56 53" src="https://github.com/user-attachments/assets/f04e734c-e9c3-4d94-a02b-dc4403224b9d" />
