### PR TITLE
Add autoupgrade-test workflow stub to master

### DIFF
--- a/.github/workflows/autoupgrade-test.yml
+++ b/.github/workflows/autoupgrade-test.yml
@@ -6,6 +6,9 @@ name: Auto-upgrade canary test
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   notice:
     runs-on: ubuntu-latest

--- a/.github/workflows/autoupgrade-test.yml
+++ b/.github/workflows/autoupgrade-test.yml
@@ -1,0 +1,16 @@
+# Stub: registers this workflow on the default branch so it can be dispatched
+# to v2 via `gh workflow run autoupgrade-test.yml --ref v2`.
+# The real implementation lives on the v2 branch.
+name: Auto-upgrade canary test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  notice:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "This workflow should be dispatched with --ref v2."
+          echo "The real implementation lives on the v2 branch."
+          exit 1


### PR DESCRIPTION
## Summary
- Adds a stub `autoupgrade-test.yml` on master so GitHub can discover the workflow
- The trigger workflow (`autoupgrade-test-trigger.yml`) dispatches this with `--ref v2`, but GitHub requires the workflow file to exist on the default branch to resolve it
- Without this stub, the dispatch fails with HTTP 404: `workflow autoupgrade-test.yml not found on the default branch` https://github.com/stripe/stripe-cli/actions/runs/30040283462
- The real implementation lives on v2; this stub just exits with a helpful message if accidentally run without `--ref v2`

## Test plan
- [ ] Merge this, then manually trigger `autoupgrade-test-trigger` and verify it successfully dispatches to v2