### PR TITLE
Only report errors and analytics on released builds

### DIFF
--- a/cmd/stripe/main.go
+++ b/cmd/stripe/main.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	goversion "github.com/hashicorp/go-version"
+
 	"github.com/stripe/stripe-cli/pkg/cmd"
 	"github.com/stripe/stripe-cli/pkg/reporting"
 	"github.com/stripe/stripe-cli/pkg/stripe"
@@ -20,6 +22,11 @@ func main() {
 
 	if stripe.TelemetryOptedOut(os.Getenv("STRIPE_CLI_TELEMETRY_OPTOUT")) || stripe.TelemetryOptedOut(os.Getenv("DO_NOT_TRACK")) {
 		// Proceed without telemetry or error reporting if the user opted out.
+		cmd.Execute(ctx)
+		return
+	}
+
+	if _, err := goversion.NewSemver(version.Version); err != nil {
 		cmd.Execute(ctx)
 		return
 	}


### PR DESCRIPTION
Only error reporting and analytics when the version is valid semver (i.e. skip dev builds where Version is "master"). This will help us avoid reporting too much noise.

Tested by simulating a real version in pkg/version/version.go:
```diff
- var Version = "master"
+ var Version = "1.0.0"
```