### PR TITLE
coop: streamline agent prompt context

### DIFF
--- a/pkg/cmd/coop/coop_agent_test.go
+++ b/pkg/cmd/coop/coop_agent_test.go
@@ -148,17 +148,19 @@ func TestCoopAgentStartFollowupCreatesGuidedSession(t *testing.T) {
 		require.NoError(t, cmd.Execute())
 	})
 
-	var resp coopAgentRunResponse
+	var resp coop.CommandResponse
 	require.NoError(t, json.Unmarshal([]byte(output), &resp))
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(output), &fields))
 	require.True(t, resp.OK)
 	assert.Equal(t, 1, ensureCalls)
 	assert.Contains(t, stderr.String(), "unable to install the optional project-scoped Stripe skill; continuing without it")
 	assert.Contains(t, resp.Message, "Deploy your changes")
 	assert.Contains(t, resp.Next, "stripe coop agent start-work")
-	assert.Contains(t, resp.AgentInstructions, "guided co-op follow-up")
-	assert.Contains(t, resp.AgentInstructions, "Vercel")
-	require.Len(t, resp.Nodes, 3)
-	assert.Equal(t, "Inspect existing deploy config", resp.Nodes[0].Title)
+	assert.Contains(t, resp.AgentPrompt, "guided co-op follow-up")
+	assert.Contains(t, resp.AgentPrompt, "Vercel")
+	assert.NotContains(t, fields, "nodes")
+	assert.NotContains(t, fields, "agent_instructions")
 
 	ids, err := store.List()
 	require.NoError(t, err)

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -46,7 +46,7 @@ func TestNormalizeCoopTmuxSessionDimensionsFallsBack(t *testing.T) {
 	}
 }
 
-func TestExplicitBlueprintPromptIncludesSessionProtocol(t *testing.T) {
+func TestExplicitBlueprintPromptIsCompactBootstrap(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	rc := &coopRunCmd{language: "node"}
@@ -59,20 +59,24 @@ func TestExplicitBlueprintPromptIncludesSessionProtocol(t *testing.T) {
 	assert.Contains(t, prompt, "cheaper subagents wherever possible, using your best judgment")
 
 	assert.Contains(t, prompt, session.ID)
-	assert.Contains(t, prompt, `"agent_instructions"`)
-	assert.Contains(t, prompt, `"nodes"`)
-	assert.Contains(t, prompt, `"next": "stripe coop agent start-work --session=`+session.ID+` --step=1`)
-	assert.Contains(t, prompt, "Understand the project")
-	assert.Contains(t, prompt, "Start by running the \"next\" command exactly as written")
+	assert.Contains(t, prompt, "stripe coop agent start-work --session="+session.ID+" --step=1")
+	assert.Contains(t, prompt, "agent_prompt and next fields")
+	assert.Contains(t, prompt, "production-grade Stripe integration")
+	assert.Contains(t, prompt, "context from the current app or codebase")
+	assert.NotContains(t, prompt, `"ok": true`)
+	assert.NotContains(t, prompt, `"agent_instructions"`)
+	assert.NotContains(t, prompt, `"nodes"`)
+	assert.NotContains(t, prompt, "Create a Stripe Product with inline default_price_data")
 	assert.Equal(t, 1, strings.Count(prompt, stripeAgentGuidanceStart))
 	assert.Equal(t, 1, strings.Count(prompt, stripeAgentGuidanceEnd))
 	assert.Contains(t, prompt, "Co-op is responsible for selecting the integration and API family through its recommender and blueprint")
 	assert.Contains(t, prompt, "stripe docs search")
 	assert.Contains(t, prompt, "Documentation lookup is optional, not a mandatory preflight or ceremony")
 	assert.NotContains(t, prompt, "Open at least one relevant result")
-	assert.Contains(t, prompt, `stripe docs \u003cresult-path\u003e --non-interactive --no-pager`)
-	assert.Contains(t, prompt, `stripe docs api \u003cresource-or-event\u003e --non-interactive --no-pager`)
-	assert.Contains(t, prompt, `stripe docs api \u003cHTTP-method\u003e \u003cendpoint\u003e --non-interactive --no-pager`)
+	assert.Contains(t, prompt, `stripe docs <result-path> --non-interactive --no-pager`)
+	assert.Contains(t, prompt, `stripe docs api <resource-or-event> --non-interactive --no-pager`)
+	assert.Contains(t, prompt, `stripe docs api <HTTP-method> <endpoint> --non-interactive --no-pager`)
+	assert.Less(t, len(prompt), 10000)
 }
 
 func TestDiscoveryPromptKeepsCoopAsIntegrationAuthority(t *testing.T) {
@@ -80,6 +84,10 @@ func TestDiscoveryPromptKeepsCoopAsIntegrationAuthority(t *testing.T) {
 	assert.Contains(t, prompt, "We will handle coordination and orchestration with you")
 	assert.Contains(t, prompt, "cheaper subagents wherever possible, using your best judgment")
 
+	assert.Contains(t, prompt, "production-grade Stripe integration")
+	assert.Contains(t, prompt, "context from the current app or codebase")
+	assert.Contains(t, prompt, "architecture, language, framework, conventions, dependencies, and existing Stripe code")
+	assert.Contains(t, prompt, "The developer is working in go")
 	assert.Contains(t, prompt, "Your first job is to understand what they're building and what they need from Stripe")
 	assert.Contains(t, prompt, `run "stripe coop recommend --query=<description of what they need>"`)
 	assert.Contains(t, prompt, "Co-op is responsible for selecting the integration and API family through its recommender and blueprint")

--- a/pkg/cmd/coop/coop_run.go
+++ b/pkg/cmd/coop/coop_run.go
@@ -90,45 +90,24 @@ func (rc *coopAgentRunCmd) ensureStripeSkill() error {
 	return ensureRepoStripeBestPracticesSkill()
 }
 
-func newCoopAgentRunResponse(bp *coop.Blueprint, session *coop.Session) coopAgentRunResponse {
-	return newCoopAgentSessionResponse(bp.Title, session, agentInstructions(bp, session))
+func newCoopAgentRunResponse(bp *coop.Blueprint, session *coop.Session) coop.CommandResponse {
+	return newCoopAgentSessionResponse(bp.Title, session, agentInstructions(bp))
 }
 
-func newCoopAgentGuidedActionResponse(action *coop.GuidedAction, session *coop.Session) coopAgentRunResponse {
-	return newCoopAgentSessionResponse(action.Title, session, guidedActionAgentInstructions(action, session))
+func newCoopAgentGuidedActionResponse(action *coop.GuidedAction, session *coop.Session) coop.CommandResponse {
+	return newCoopAgentSessionResponse(action.Title, session, guidedActionAgentInstructions(action))
 }
 
-func newCoopAgentSessionResponse(title string, session *coop.Session, instructions string) coopAgentRunResponse {
-	var nodes []nodeBrief
-	nodeNumber := 0
-	for _, step := range session.Steps {
-		for _, n := range step.Nodes {
-			nodeNumber++
-			nodes = append(nodes, nodeBrief{
-				Number:        nodeNumber,
-				Title:         n.Title,
-				Type:          string(n.Type),
-				Description:   n.Description,
-				ReviewPrompt:  n.ReviewPrompt,
-				ReviewCommand: n.ReviewCommand,
-				AutoConfirm:   n.AutoConfirm,
-			})
-		}
+func newCoopAgentSessionResponse(title string, session *coop.Session, instructions string) coop.CommandResponse {
+	return coop.CommandResponse{
+		OK:          true,
+		SessionID:   session.ID,
+		Node:        1,
+		State:       "created",
+		Message:     fmt.Sprintf("Session started: %s (%d nodes)", title, session.TotalNodes()),
+		Next:        fmt.Sprintf("stripe coop agent start-work --session=%s --step=1 --note=%s", session.ID, quoteArg("Beginning: "+session.Steps[0].Nodes[0].Title)),
+		AgentPrompt: instructions,
 	}
-
-	resp := coopAgentRunResponse{
-		CommandResponse: coop.CommandResponse{
-			OK:        true,
-			SessionID: session.ID,
-			Node:      1,
-			State:     "created",
-			Message:   fmt.Sprintf("Session started: %s (%d nodes)", title, session.TotalNodes()),
-			Next:      fmt.Sprintf("stripe coop agent start-work --session=%s --step=1 --note=%s", session.ID, quoteArg("Beginning: "+session.Steps[0].Nodes[0].Title)),
-		},
-		AgentInstructions: instructions,
-		Nodes:             nodes,
-	}
-	return resp
 }
 
 func newCoopSession(bp *coop.Blueprint, sessionID, language string, rawSettings, rawParams []string, parentSession, parentStep string) (*coop.Session, error) {
@@ -168,33 +147,17 @@ func mergeKeyValues(dst map[string]string, flag string, values []string) error {
 	return nil
 }
 
-type coopAgentRunResponse struct {
-	coop.CommandResponse
-	AgentInstructions string      `json:"agent_instructions"`
-	Nodes             []nodeBrief `json:"nodes"`
+func agentInstructions(bp *coop.Blueprint) string {
+	preamble := fmt.Sprintf("You are building a production-grade Stripe integration: %q", bp.Title)
+	return sessionLifecycleInstructions(preamble)
 }
 
-type nodeBrief struct {
-	Number        int    `json:"number"`
-	Title         string `json:"title"`
-	Type          string `json:"type"`
-	Description   string `json:"description,omitempty"`
-	ReviewPrompt  string `json:"review_prompt,omitempty"`
-	ReviewCommand string `json:"review_command,omitempty"`
-	AutoConfirm   bool   `json:"auto_confirm,omitempty"`
-}
-
-func agentInstructions(bp *coop.Blueprint, session *coop.Session) string {
-	preamble := fmt.Sprintf("You are building a working Stripe integration: %q", bp.Title)
-	return sessionLifecycleInstructions(preamble, session)
-}
-
-func guidedActionAgentInstructions(action *coop.GuidedAction, session *coop.Session) string {
+func guidedActionAgentInstructions(action *coop.GuidedAction) string {
 	preamble := fmt.Sprintf("You are completing a guided co-op follow-up: %q.\n\n%s", action.Title, action.AgentContext)
-	return sessionLifecycleInstructions(preamble, session)
+	return sessionLifecycleInstructions(preamble)
 }
 
-func sessionLifecycleInstructions(preamble string, session *coop.Session) string {
+func sessionLifecycleInstructions(preamble string) string {
 	return fmt.Sprintf(`%s
 
 The blueprint describes the Stripe flow the developer wants in their app. Your deliverable is the user's app implementing that flow. Stripe CLI commands are useful for setup and verification, but they are not the implementation unless a node is explicitly a cliCommand.
@@ -231,35 +194,22 @@ Run at least one meaningful report-check before report-work for every non-skippe
 
 %s
 
-If a node includes review_prompt, that is the baseline acceptance check shown to the human. If it includes review_command, run that exact command when verifying or explain why it does not apply. Make your implementation note and verifications directly answer these fields. When you add verification checks, write them as useful confirmation guidance for the human too: include concrete actions and expected results, such as "Visit http://localhost:3000/checkout, click Pay, and confirm the browser redirects to Stripe Checkout" rather than vague labels like "manual test passed".
+Use context from the current app or codebase, if one exists, to inform your decisions. Inspect its architecture, language, framework, conventions, dependencies, and existing Stripe code so the integration fits the project naturally.
 
-If a node asks you to understand the project, scan files, identify the tech stack, and summarize what you found. This helps you adapt the remaining nodes to the developer's actual setup. Don't ask the developer questions you can answer by reading the code.
+Work through one node at a time. Every start-work response includes an agent_prompt with the current task and acceptance criteria; do not work ahead. Write working code, run it, and report concrete file paths and test results. Use the latest Stripe SDK.
 
-Agent lifecycle commands (use this session id: %s):
-1. stripe coop agent start-work --session=%s --step=<n> --note="<what you're about to do>"
-2. Write the code and run it to verify it works
-3. stripe coop agent report-check --session=%s --step=<n> --check="<what you verified>" --passed
-4. stripe coop agent report-work --session=%s --step=<n> --file=<main file> --lines=<range> --snippet="<key code>" --note="<summary>"
-5. Follow the JSON response's next command. Most nodes continue to the next node in the same step.
-6. Only run stripe coop agent await-review --session=%s --step=<n> when the response says the step is ready for review. Await blocks until the human confirms the step or requests changes.
-7. If confirmed: move to next node. If rejected: redo the affected node (check the message for feedback).
-8. When the final node is confirmed: IMMEDIATELY run the JSON response's next command. Do not stop or ask. It will return to the parent session for follow-up work or show the developer their options in the TUI.
+Before starting, run "stripe whoami". If you are not authenticated or it says "Test mode key: not available", run "stripe sandbox create --from-git"; the claim URL will appear in the developer's TUI.
 
-Steps are the default human-review unit. Build and verify each node one at a time, but do not interrupt the developer for every node. At the end of each step, before running await, help the developer verify the step: run relevant review_command values, start any needed app/server, keep useful processes running, share the local URL or command to open it, create or identify test data, and explain exactly what observable result they should confirm. Add these concrete user-facing checks with stripe coop agent report-check --session=%s --step=<n> --check="..." --passed so the review card has useful evidence.
+For each node:
+1. Run the next command returned by Co-op. Replace any <...> placeholders with real values before running it.
+2. Follow that response's agent_prompt as the source of truth.
+3. Verify the result and report each useful check with "stripe coop agent report-check".
+4. Report the implementation with "stripe coop agent report-work".
+5. Continue with the response's next command. If a task does not apply, use "stripe coop agent skip" with a reason.
 
-The "await" command is critical at step boundaries — it blocks until the developer acts. Do NOT proceed to the next step without running await when the node response tells you the step is ready. Set a 5-minute timeout on the shell command (it will re-prompt you if it times out). If changes are requested, ask the developer what they'd like you to change before redoing the affected node.
+Only await human review when the next command says to. Before awaiting, run the supplied review command, keep useful servers running, and give the developer concrete actions and expected results. Use a 5-minute shell timeout for await-review; re-run it if Co-op reports a timeout. If changes are requested, redo the affected node from the feedback. After the final confirmation, immediately run the returned next command.
 
-Some nodes are marked auto_confirm — these do not require human review. Continue following the next command returned by the CLI.
-
-Important:
-- The human is watching your progress live in a terminal UI.
-- Write working code, not stubs. Run it. Verify it actually works.
-- Report what you did concretely (file paths, line numbers, test results).
-- Never pass full card numbers to Stripe APIs or CLI commands. Collect card details only through hosted Checkout, Payment Element, or another official client-side integration. If an API needs a test payment method, use supported test PaymentMethod IDs such as pm_card_visa instead of card[number].
-- If a node doesn't apply to the user's setup, skip it: stripe coop agent skip --session=%s --step=<n> --note="<reason>"
-- Always install the LATEST version of the Stripe SDK for the language in use. Do not pin to old versions.
-  Examples: "npm install stripe@latest", "pip install --upgrade stripe", "gem install stripe"
-  Check https://docs.stripe.com/libraries for current versions if unsure.`, preamble, coopAgentCoordinationInstructions(), stripeAgentGuidanceInstructions(), session.ID, session.ID, session.ID, session.ID, session.ID, session.ID, session.ID)
+Never pass full card numbers to Stripe APIs or CLI commands. Collect card details only through hosted Checkout, Payment Element, or another official client-side integration. If an API needs a test payment method, use a supported test PaymentMethod ID such as pm_card_visa.`, preamble, coopAgentCoordinationInstructions(), stripeAgentGuidanceInstructions())
 }
 
 func outputJSON(v interface{}) error {

--- a/pkg/cmd/coop/coop_run_test.go
+++ b/pkg/cmd/coop/coop_run_test.go
@@ -98,8 +98,8 @@ func TestAgentInstructionsIncludeOptionalStripeDocsGuidanceExactlyOnce(t *testin
 		name         string
 		instructions string
 	}{
-		{name: "normal blueprint", instructions: newCoopAgentRunResponse(bp, normalSession).AgentInstructions},
-		{name: "guided follow-up", instructions: newCoopAgentGuidedActionResponse(guidedAction, guidedSession).AgentInstructions},
+		{name: "normal blueprint", instructions: newCoopAgentRunResponse(bp, normalSession).AgentPrompt},
+		{name: "guided follow-up", instructions: newCoopAgentGuidedActionResponse(guidedAction, guidedSession).AgentPrompt},
 	}
 
 	for _, tt := range tests {
@@ -126,8 +126,9 @@ func TestAgentInstructionsIncludeOptionalStripeDocsGuidanceExactlyOnce(t *testin
 			assert.NotContains(t, tt.instructions, "Search again when moving into a materially different Stripe domain")
 			assert.NotContains(t, tt.instructions, "Latest Stripe API version: **2026-06-24.dahlia**")
 			assert.Contains(t, tt.instructions, "BEFORE YOU START — ensure you have API access")
-			assert.Contains(t, tt.instructions, "Agent lifecycle commands")
-			assert.Contains(t, tt.instructions, `The "await" command is critical at step boundaries`)
+			assert.Contains(t, tt.instructions, "Work through one node at a time")
+			assert.Contains(t, tt.instructions, "Only await human review when the next command says to")
+			assert.NotContains(t, tt.instructions, "Agent lifecycle commands (use this session id")
 		})
 	}
 }
@@ -287,6 +288,31 @@ func TestCoopRunReturnsStructuredErrorForMalformedSetting(t *testing.T) {
 	assert.Empty(t, ids)
 }
 
+func TestCoopRunReturnsCompactBootstrapWithoutBlueprintNodes(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	rc := newCoopAgentRunCmd()
+	rc.ensureSkill = func() error { return nil }
+	cmd := rc.cmd
+	cmd.SetArgs([]string{"one-time-payment", "--language", "node"})
+
+	output := captureStdout(t, func() {
+		require.NoError(t, cmd.Execute())
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(output), &resp))
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(output), &fields))
+	require.True(t, resp.OK)
+	assert.Contains(t, resp.AgentPrompt, "one node at a time")
+	assert.Contains(t, resp.AgentPrompt, "Replace any <...> placeholders with real values")
+	assert.Contains(t, resp.Next, "stripe coop agent start-work")
+	assert.NotContains(t, fields, "agent_instructions")
+	assert.NotContains(t, fields, "nodes")
+	assert.NotContains(t, output, "Create a Stripe Product with inline default_price_data")
+	assert.Less(t, len(output), 10000)
+}
+
 func TestCoopRunReturnsStructuredErrorForMalformedParam(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	cmd := newCoopAgentRunCmd().cmd
@@ -367,9 +393,8 @@ func TestCoopStartKeepsNotFoundGuidance(t *testing.T) {
 
 func TestAgentInstructionsFrameBlueprintAsAppImplementation(t *testing.T) {
 	bp := &coop.Blueprint{Title: "Metered subscription"}
-	session := &coop.Session{ID: "coop_123"}
 
-	instructions := agentInstructions(bp, session)
+	instructions := agentInstructions(bp)
 
 	assert.Contains(t, instructions, "The blueprint describes the Stripe flow the developer wants in their app")
 	assert.Contains(t, instructions, "Stripe CLI commands are useful for setup and verification, but they are not the implementation")
@@ -383,7 +408,7 @@ func TestAgentInstructionsFrameBlueprintAsAppImplementation(t *testing.T) {
 	assert.Contains(t, instructions, "Never pass full card numbers to Stripe APIs or CLI commands")
 }
 
-func TestCoopAgentRunResponsePreservesNodesWireKey(t *testing.T) {
+func TestCoopAgentRunResponseOmitsBlueprintNodes(t *testing.T) {
 	bp, err := coop.LoadBlueprint("one-time-payment")
 	require.NoError(t, err)
 	session := coop.NewSessionFromBlueprint(bp, "coop_123", nil, nil)
@@ -393,6 +418,9 @@ func TestCoopAgentRunResponsePreservesNodesWireKey(t *testing.T) {
 
 	var payload map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(data, &payload))
-	assert.Contains(t, payload, "nodes")
+	assert.Contains(t, payload, "agent_prompt")
+	assert.Contains(t, payload, "next")
+	assert.NotContains(t, payload, "agent_instructions")
+	assert.NotContains(t, payload, "nodes")
 	assert.NotContains(t, payload, "steps")
 }

--- a/pkg/cmd/coop/coop_start.go
+++ b/pkg/cmd/coop/coop_start.go
@@ -1,7 +1,6 @@
 package coopcmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -137,11 +136,13 @@ func (rc *coopRunCmd) buildAgentPrompt(blueprintID string) string {
 		langHint = fmt.Sprintf("\nThe developer is working in %s.", rc.language)
 	}
 
-	return fmt.Sprintf(`You are helping a developer add Stripe to their project.
+	return fmt.Sprintf(`You are helping a developer build a production-grade Stripe integration.
 
 A developer is watching your progress in a live terminal UI (the other pane).%s
 
 %s
+
+Use context from the current app or codebase, if one exists, to inform your recommendations and decisions. Inspect its architecture, language, framework, conventions, dependencies, and existing Stripe code so the integration fits the project naturally.
 
 Your first job is to understand what they're building and what they need from Stripe. Do NOT assume they know Stripe product names.
 
@@ -171,22 +172,16 @@ func (rc *coopRunCmd) buildAgentPromptForSession(session *coop.Session) (string,
 		return "", err
 	}
 	resp := newCoopAgentRunResponse(bp, session)
-	data, err := json.MarshalIndent(resp, "", "  ")
-	if err != nil {
-		return "", err
-	}
 
-	return fmt.Sprintf(`You are running a Stripe co-op integration session.
-
-A developer is watching your progress in a live terminal UI (the other pane).
-
-The session is already created. Use this structured start response as the protocol source of truth:
+	return fmt.Sprintf(`You are running a Stripe co-op integration session. A developer is watching your progress in a live terminal UI.
 
 %s
 
-Start by running the "next" command exactly as written. Then follow agent_instructions and continue using the JSON responses from the typed co-op agent commands.
+The session is already created. After the authentication check above, begin by running this command exactly:
 
-Important: Run "stripe whoami" first to check auth. If not logged in OR if it shows "Test mode key: not available", run "stripe sandbox create --from-git" to provision a sandbox. The claim URL will appear automatically in the TUI.`, string(data)), nil
+%s
+
+Continue using the agent_prompt and next fields returned by the typed Co-op commands.`, resp.AgentPrompt, resp.Next), nil
 }
 
 func (rc *coopRunCmd) startSessionQuietly(blueprintID string) (*coop.Session, error) {

--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -65,8 +65,8 @@ active ──→ completed    (all nodes done/skipped, or "stripe coop stop")
 ### Agent-facing (AI agent runs these)
 | Command | Purpose |
 |---------|---------|
-| `stripe coop run <blueprint>` | Create a session (outputs JSON with instructions) |
-| `stripe coop agent start-work --step <n>` | Mark a node as active |
+| `stripe coop run <blueprint>` | Create a session (outputs a compact JSON bootstrap) |
+| `stripe coop agent start-work --step <n>` | Mark a node active and return its task context |
 | `stripe coop agent report-work --step <n>` | Mark a node complete (→ review or → done if auto_confirm) |
 | `stripe coop agent report-check --step <n>` | Add a verification check |
 | `stripe coop agent skip --step <n>` | Skip a node |
@@ -74,7 +74,7 @@ active ──→ completed    (all nodes done/skipped, or "stripe coop stop")
 | `stripe coop agent next-action` | Show post-completion options (blocks until selection) |
 | `stripe coop agent start-followup` | Start an internal guided follow-up session selected from next actions |
 
-All agent commands output JSON with an `ok` field and a `next` field suggesting the next command. The `--step` flag name is retained for the CLI, but its value is the 1-based node number across the session.
+All agent commands output JSON with an `ok` field and a `next` field suggesting the next command. Agents replace any `<...>` placeholders in a suggested command with real values before running it. Session creation does not front-load the full blueprint: each successful `start-work` response returns an `agent_prompt` for only the current node, plus any relevant `api_request`, `test_requests`, `events`, and SDK example. The `--step` flag name is retained for the CLI, but its value is the 1-based node number across the session.
 
 ## TUI Keybindings
 
@@ -114,10 +114,11 @@ In the completion view:
 $ stripe coop start one-time-payment --language=node
 
 # What happens behind the scenes:
-# 1. CLI creates the session and gives the agent the exact session protocol
+# 1. CLI creates the session and gives the agent a compact protocol bootstrap
 # 2. Agent (Claude/Codex) is launched in right pane
 # 3. TUI appears in left pane showing step progress
-# 4. Agent starts from the provided next command:
+# 4. Agent starts from the provided next command; its response supplies the
+#    current node's task and acceptance criteria:
 #      stripe coop agent start-work --session=coop_abc123 --step=1 --note="Beginning: Understand the project"
 # 5. Agent works through steps, calling:
 #      stripe coop agent start-work --session=coop_abc123 --step=1 --note="Scanning project"

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -143,15 +143,17 @@ type NextStepSuggestion struct {
 
 // CommandResponse is the JSON output format for agent-facing commands.
 type CommandResponse struct {
-	OK          bool        `json:"ok"`
-	SessionID   string      `json:"session_id,omitempty"`
-	Node        int         `json:"node,omitempty"`
-	State       string      `json:"state,omitempty"`
-	Message     string      `json:"message,omitempty"`
-	Next        string      `json:"next,omitempty"`
-	AgentPrompt string      `json:"agent_prompt,omitempty"`
-	APIRequest  *APIRequest `json:"api_request,omitempty"`
-	SDKExample  string      `json:"sdk_example,omitempty"`
-	Error       string      `json:"error,omitempty"`
-	Hint        string      `json:"hint,omitempty"`
+	OK           bool                `json:"ok"`
+	SessionID    string              `json:"session_id,omitempty"`
+	Node         int                 `json:"node,omitempty"`
+	State        string              `json:"state,omitempty"`
+	Message      string              `json:"message,omitempty"`
+	Next         string              `json:"next,omitempty"`
+	AgentPrompt  string              `json:"agent_prompt,omitempty"`
+	APIRequest   *APIRequest         `json:"api_request,omitempty"`
+	TestRequests []TestHelperRequest `json:"test_requests,omitempty"`
+	Events       []string            `json:"events,omitempty"`
+	SDKExample   string              `json:"sdk_example,omitempty"`
+	Error        string              `json:"error,omitempty"`
+	Hint         string              `json:"hint,omitempty"`
 }

--- a/pkg/coop/workflow/service.go
+++ b/pkg/coop/workflow/service.go
@@ -91,12 +91,15 @@ func (s *Service) StartWork(sessionID string, nodeNumber int, note string) (coop
 
 	node, _ := session.NodeByNumber(nodeNumber)
 	resp := coop.CommandResponse{
-		OK:        true,
-		SessionID: session.ID,
-		Node:      nodeNumber,
-		State:     string(coop.NodeActive),
-		Message:   fmt.Sprintf("Started: %s", node.Title),
-		Next:      fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --file=<path> --note=\"<what you did>\"", session.ID, nodeNumber),
+		OK:           true,
+		SessionID:    session.ID,
+		Node:         nodeNumber,
+		State:        string(coop.NodeActive),
+		Message:      fmt.Sprintf("Started: %s", node.Title),
+		Next:         fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --file=<path> --note=\"<what you did>\"", session.ID, nodeNumber),
+		AgentPrompt:  nodeAgentPrompt(session, node, nodeNumber),
+		TestRequests: node.TestRequests,
+		Events:       node.Events,
 	}
 	if node.Type == coop.NodeAPIRequest && node.Request != nil {
 		resp.APIRequest = node.Request
@@ -105,6 +108,73 @@ func (s *Service) StartWork(sessionID string, nodeNumber int, note string) (coop
 		}
 	}
 	return resp, nil
+}
+
+func nodeAgentPrompt(session *coop.Session, node *coop.SessionNode, nodeNumber int) string {
+	stepTitle := ""
+	if step, _, _, err := session.StepByNodeNumber(nodeNumber); err == nil {
+		stepTitle = step.Title
+	}
+
+	var prompt strings.Builder
+	fmt.Fprintf(&prompt, "Current node %d of %d", nodeNumber, session.TotalNodes())
+	if stepTitle != "" {
+		fmt.Fprintf(&prompt, " in step %q", stepTitle)
+	}
+	fmt.Fprintf(&prompt, ": %s\n\n", node.Title)
+
+	if node.Type != "" {
+		fmt.Fprintf(&prompt, "Node type: %s\n\n", node.Type)
+	}
+	if node.Description != "" {
+		fmt.Fprintf(&prompt, "Task (source of truth): %s\n\n", node.Description)
+	}
+	if guidance := nodeTypeGuidance(node); guidance != "" {
+		fmt.Fprintf(&prompt, "How to approach it: %s\n\n", guidance)
+	}
+	if node.ReviewPrompt != "" {
+		fmt.Fprintf(&prompt, "Acceptance check: %s\n", node.ReviewPrompt)
+	}
+	if node.ReviewCommand != "" {
+		fmt.Fprintf(&prompt, "Verification command: run %q exactly, or explain concretely why it does not apply.\n", node.ReviewCommand)
+	}
+	if node.AutoConfirm {
+		prompt.WriteString("This node is auto-confirmed, so continue immediately after reporting the work.\n")
+	}
+
+	prompt.WriteString("\nWork only on this node. Inspect the existing project before changing it, implement a working result, and verify it. Make your report-work note and report-check evidence directly address the task")
+	if node.ReviewPrompt != "" {
+		prompt.WriteString(" and acceptance check")
+	}
+	prompt.WriteString(". Give the developer concrete actions and expected results for any manual verification.")
+	fmt.Fprintf(&prompt, "\n\nBefore running the next command, report each passed verification with:\nstripe coop agent report-check --session=%s --step=%d --check=\"<what you verified>\" --passed", session.ID, nodeNumber)
+	fmt.Fprintf(&prompt, "\nIf this node does not apply, use:\nstripe coop agent skip --session=%s --step=%d --note=\"<reason>\"", session.ID, nodeNumber)
+	return prompt.String()
+}
+
+func nodeTypeGuidance(node *coop.SessionNode) string {
+	if node.Key == "scan-project" {
+		return "Read the project files, identify the stack and existing Stripe integration points, and summarize what you find. Do not ask the developer questions you can answer from the code."
+	}
+
+	switch node.Type {
+	case coop.NodeAPIRequest:
+		return "Use api_request and, when present, sdk_example as the technical starting point. Based on the task and existing project, decide whether the call belongs in runtime application code, a setup or seed script, or one-time provisioning; do not add a runtime endpoint for one-time provisioning unless the task requires one. Run and verify the call, and reuse returned IDs where later work needs them."
+	case coop.NodeAsyncHandler:
+		return `Implement and run the webhook handler. Test it with "stripe listen --forward-to localhost:<port>/webhook" and verify Stripe signatures before acting on events.`
+	case coop.NodeUIComponent:
+		return "Build the user-facing flow and exercise it in the running application."
+	case coop.NodeCLICommand:
+		return "Run the requested CLI operation and report its concrete result."
+	case coop.NodeTestHelper:
+		return "Verify the integration end to end. Any test_requests advance Stripe test state and should be run as test setup, not implemented in the application."
+	case coop.NodeDashboard:
+		return "Complete the requested Stripe Dashboard configuration and verify the resulting state."
+	case coop.NodeSetUpWebhooks:
+		return "Configure the requested webhook destination and verify that the application receives the listed events."
+	default:
+		return ""
+	}
 }
 
 func (s *Service) ReportWork(sessionID string, nodeNumber int, input ReportWorkInput, autoConfirm bool) (coop.CommandResponse, error) {

--- a/pkg/coop/workflow/service_test.go
+++ b/pkg/coop/workflow/service_test.go
@@ -29,6 +29,71 @@ func TestStartWorkTransitionsNodeAndReturnsTypedNextCommand(t *testing.T) {
 	assert.Equal(t, "Scanning", node.Activity)
 }
 
+func TestStartWorkReturnsOnlyCurrentNodeContext(t *testing.T) {
+	store, session := workflowTestStore(t)
+	_, err := store.Update(session.ID, func(session *coop.Session) error {
+		current := &session.Steps[0].Nodes[0]
+		current.Type = coop.NodeTestHelper
+		current.Description = "Advance the test clock and confirm an invoice is created."
+		current.ReviewPrompt = "Confirm the new invoice appears."
+		current.ReviewCommand = "stripe invoices list --limit=1"
+		current.TestRequests = []coop.TestHelperRequest{{
+			Key: "advance-clock",
+			APIRequest: coop.APIRequest{
+				Path:   "/v1/test_helpers/test_clocks/clock_123/advance",
+				Method: "post",
+			},
+		}}
+		current.Events = []string{"invoice.created"}
+		session.Steps[0].Nodes[1].Description = "FUTURE NODE DETAILS MUST NOT LEAK"
+		return nil
+	})
+	require.NoError(t, err)
+
+	resp, err := NewService(store).StartWork(session.ID, 1, "Starting")
+	require.NoError(t, err)
+	require.True(t, resp.OK)
+
+	assert.Contains(t, resp.AgentPrompt, "Current node 1 of 2")
+	assert.Contains(t, resp.AgentPrompt, "Advance the test clock")
+	assert.Contains(t, resp.AgentPrompt, "Confirm the new invoice appears")
+	assert.Contains(t, resp.AgentPrompt, `stripe invoices list --limit=1`)
+	assert.Contains(t, resp.AgentPrompt, `stripe coop agent report-check --session=workflow_test --step=1 --check="<what you verified>" --passed`)
+	assert.Contains(t, resp.AgentPrompt, `stripe coop agent skip --session=workflow_test --step=1 --note="<reason>"`)
+	assert.NotContains(t, resp.AgentPrompt, "FUTURE NODE DETAILS MUST NOT LEAK")
+	require.Len(t, resp.TestRequests, 1)
+	assert.Equal(t, "advance-clock", resp.TestRequests[0].Key)
+	assert.Equal(t, []string{"invoice.created"}, resp.Events)
+}
+
+func TestStartWorkAPIRequestGuidanceDefersPlacementToProjectContext(t *testing.T) {
+	store, session := workflowTestStore(t)
+	_, err := store.Update(session.ID, func(session *coop.Session) error {
+		current := &session.Steps[0].Nodes[0]
+		current.Type = coop.NodeAPIRequest
+		current.Description = "Create a product during integration setup."
+		current.Request = &coop.APIRequest{Path: "/v1/products", Method: "post"}
+		return nil
+	})
+	require.NoError(t, err)
+
+	service := NewService(store, WithSnippetFetcher(func(path, method string, params interface{}, language string) (string, error) {
+		return "stripe.products.create(...)", nil
+	}))
+	resp, err := service.StartWork(session.ID, 1, "Starting")
+	require.NoError(t, err)
+	require.True(t, resp.OK)
+
+	require.NotNil(t, resp.APIRequest)
+	assert.Equal(t, "/v1/products", resp.APIRequest.Path)
+	assert.Equal(t, "stripe.products.create(...)", resp.SDKExample)
+	assert.Contains(t, resp.AgentPrompt, "Based on the task and existing project")
+	assert.Contains(t, resp.AgentPrompt, "runtime application code")
+	assert.Contains(t, resp.AgentPrompt, "setup or seed script")
+	assert.Contains(t, resp.AgentPrompt, "one-time provisioning")
+	assert.NotContains(t, resp.AgentPrompt, "Implement the Stripe call in api_request in the application")
+}
+
 func TestReportWorkContinuesStepBeforeReview(t *testing.T) {
 	store, session := workflowTestStore(t)
 	service := NewService(store)


### PR DESCRIPTION
## Summary

- replace the full session JSON embedded in the initial co-op prompt with a compact protocol bootstrap
- deliver task, acceptance, API, test-helper, and event context only when the current node starts
- make production-grade quality and existing-project context explicit in both launch paths
- clarify command placeholder handling and provide node-local reporting templates
- preserve guided follow-up context while removing future-node front-loading

## Testing

- `go vet ./pkg/cmd/coop ./pkg/coop/...`
- `go test -count=1 ./pkg/cmd/coop ./pkg/coop/...`