### PR TITLE
coop: formalize agent protocol contract

### DIFF
--- a/pkg/cmd/coop/coop.go
+++ b/pkg/cmd/coop/coop.go
@@ -48,8 +48,8 @@ The developer confirms each step before the agent moves on.`,
   1. stripe coop run <blueprint-id> — begin a session
   2. stripe coop agent start-work --session=<id> --step=<n> --note="..." — mark work active
   3. stripe coop agent report-check --session=<id> --step=<n> --check="..." --passed — add verification
-  4. stripe coop agent report-work --session=<id> --step=<n> --file=... --note="..." — report work complete
-  All commands output JSON with a "next" field suggesting the next command.
+  4. stripe coop agent report-work --session=<id> --step=<n> --note="..." — report work complete
+  Responses use "next" for exact commands or "next_template" plus "required_inputs" when values are needed.
   Run "stripe coop recommend --query=..." to discover available blueprints.`,
 		},
 	}
@@ -79,12 +79,6 @@ func coopSandboxClaimURL() string {
 		return ""
 	}
 	return options.SandboxClaimURL()
-}
-
-func mustMarkFlagRequired(cmd *cobra.Command, name string) {
-	if err := cmd.MarkFlagRequired(name); err != nil {
-		panic("marking required flag " + name + ": " + err.Error())
-	}
 }
 
 func mustMarkFlagHidden(cmd *cobra.Command, name string) {

--- a/pkg/cmd/coop/coop_agent.go
+++ b/pkg/cmd/coop/coop_agent.go
@@ -3,6 +3,8 @@ package coopcmd
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -40,6 +42,14 @@ func newCoopAgentCmd() *coopAgentCmd {
 		Use:   "agent",
 		Short: "Agent-facing co-op lifecycle commands",
 		Long:  "Typed commands used by agents to report co-op progress and wait for human review.",
+		Args:  agentNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return outputCoopError(
+				"stripe coop agent requires an action",
+				"Run the agent lifecycle action returned by the previous Co-op response.",
+				coop.Continue(coop.StatusCommand("")),
+			)
+		},
 	}
 	ac.cmd.AddCommand(newCoopAgentStartWorkCmd().cmd)
 	ac.cmd.AddCommand(newCoopAgentReportWorkCmd().cmd)
@@ -48,6 +58,7 @@ func newCoopAgentCmd() *coopAgentCmd {
 	ac.cmd.AddCommand(newCoopAgentAwaitReviewCmd().cmd)
 	ac.cmd.AddCommand(newCoopAgentNextActionCmd().cmd)
 	ac.cmd.AddCommand(newCoopAgentStartFollowupCmd().cmd)
+	configureAgentCommand(ac.cmd)
 	return ac
 }
 
@@ -56,7 +67,11 @@ func newCoopAgentStartWorkCmd() *coopAgentActionCmd {
 	c.cmd = &cobra.Command{
 		Use:   "start-work",
 		Short: "Mark a node as active",
+		Args:  agentNoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := c.validateSessionStep("start-work"); err != nil {
+				return err
+			}
 			service, err := newWorkflowService()
 			if err != nil {
 				return outputAgentError(err)
@@ -67,6 +82,7 @@ func newCoopAgentStartWorkCmd() *coopAgentActionCmd {
 	}
 	c.addSessionStepFlags()
 	c.cmd.Flags().StringVar(&c.note, "note", "", "Activity note")
+	configureAgentCommand(c.cmd)
 	return c
 }
 
@@ -75,7 +91,11 @@ func newCoopAgentReportWorkCmd() *coopAgentActionCmd {
 	c.cmd = &cobra.Command{
 		Use:   "report-work",
 		Short: "Report completed implementation work",
+		Args:  agentNoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := c.validateSessionStep("report-work"); err != nil {
+				return err
+			}
 			service, err := newWorkflowService()
 			if err != nil {
 				return outputAgentError(err)
@@ -94,6 +114,7 @@ func newCoopAgentReportWorkCmd() *coopAgentActionCmd {
 	c.cmd.Flags().StringVar(&c.lines, "lines", "", "Line range, e.g. 1-15")
 	c.cmd.Flags().StringVar(&c.snippet, "snippet", "", "Code snippet")
 	c.cmd.Flags().StringVar(&c.note, "note", "", "Implementation summary")
+	configureAgentCommand(c.cmd)
 	return c
 }
 
@@ -102,7 +123,11 @@ func newCoopAgentReportCheckCmd() *coopAgentActionCmd {
 	c.cmd = &cobra.Command{
 		Use:   "report-check",
 		Short: "Report a verification check",
+		Args:  agentNoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := c.validateSessionStep("report-check"); err != nil {
+				return err
+			}
 			service, err := newWorkflowService()
 			if err != nil {
 				return outputAgentError(err)
@@ -114,6 +139,7 @@ func newCoopAgentReportCheckCmd() *coopAgentActionCmd {
 	c.addSessionStepFlags()
 	c.cmd.Flags().StringVar(&c.check, "check", "", "Verification check label")
 	c.cmd.Flags().BoolVar(&c.passed, "passed", false, "Whether the verification passed")
+	configureAgentCommand(c.cmd)
 	return c
 }
 
@@ -122,7 +148,11 @@ func newCoopAgentSkipCmd() *coopAgentActionCmd {
 	c.cmd = &cobra.Command{
 		Use:   "skip",
 		Short: "Skip a node",
+		Args:  agentNoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := c.validateSessionStep("skip"); err != nil {
+				return err
+			}
 			service, err := newWorkflowService()
 			if err != nil {
 				return outputAgentError(err)
@@ -133,6 +163,7 @@ func newCoopAgentSkipCmd() *coopAgentActionCmd {
 	}
 	c.addSessionStepFlags()
 	c.cmd.Flags().StringVar(&c.note, "note", "", "Skip reason")
+	configureAgentCommand(c.cmd)
 	return c
 }
 
@@ -141,7 +172,11 @@ func newCoopAgentAwaitReviewCmd() *coopAgentActionCmd {
 	c.cmd = &cobra.Command{
 		Use:   "await-review",
 		Short: "Block until the developer confirms or requests changes",
+		Args:  agentNoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := c.validateSessionStep("await-review"); err != nil {
+				return err
+			}
 			service, err := newWorkflowService()
 			if err != nil {
 				return outputAgentError(err)
@@ -151,6 +186,7 @@ func newCoopAgentAwaitReviewCmd() *coopAgentActionCmd {
 		},
 	}
 	c.addSessionStepFlags()
+	configureAgentCommand(c.cmd)
 	return c
 }
 
@@ -159,13 +195,21 @@ func newCoopAgentNextActionCmd() *coopAgentActionCmd {
 	c.cmd = &cobra.Command{
 		Use:   "next-action",
 		Short: "Wait for or record the developer's next action",
+		Args:  agentNoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(c.session) == "" {
+				return outputCoopError(
+					"--session flag is required",
+					"Retry next-action with the intended session.",
+					coop.NextActionTemplate(),
+				)
+			}
 			return runCoopNextAction(c.session, c.completed)
 		},
 	}
 	c.cmd.Flags().StringVar(&c.session, "session", "", "Session ID")
 	c.cmd.Flags().StringVar(&c.completed, "completed", "", "Mark a next action as completed")
-	mustMarkFlagRequired(c.cmd, "session")
+	configureAgentCommand(c.cmd)
 	return c
 }
 
@@ -174,23 +218,62 @@ func newCoopAgentStartFollowupCmd() *coopAgentActionCmd {
 	c.cmd = &cobra.Command{
 		Use:   "start-followup",
 		Short: "Start an internal guided follow-up session",
+		Args:  agentNoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(c.session) == "" || strings.TrimSpace(c.action) == "" {
+				return outputCoopError(
+					"--session and --action flags are required",
+					"Provide the parent session and an offered follow-up action.",
+					coop.StartFollowupTemplate(""),
+				)
+			}
 			return runCoopStartFollowup(cmd, c.session, c.action, c.target, c.ensureSkill)
 		},
 	}
 	c.cmd.Flags().StringVar(&c.session, "session", "", "Parent session ID")
 	c.cmd.Flags().StringVar(&c.action, "action", "", "Follow-up action ID")
 	c.cmd.Flags().StringVar(&c.target, "target", "", "Detected deployment target")
-	mustMarkFlagRequired(c.cmd, "session")
-	mustMarkFlagRequired(c.cmd, "action")
+	configureAgentCommand(c.cmd)
 	return c
 }
 
 func (c *coopAgentActionCmd) addSessionStepFlags() {
 	c.cmd.Flags().StringVar(&c.session, "session", "", "Session ID")
 	c.cmd.Flags().IntVar(&c.step, "step", 0, "1-based node number")
-	mustMarkFlagRequired(c.cmd, "session")
-	mustMarkFlagRequired(c.cmd, "step")
+}
+
+func (c *coopAgentActionCmd) validateSessionStep(action string) error {
+	if strings.TrimSpace(c.session) != "" && c.step > 0 {
+		return nil
+	}
+	return outputCoopError(
+		"--session and a positive --step are required",
+		"Provide the Co-op session ID and 1-based node number.",
+		coop.SessionStepTemplate(action),
+	)
+}
+
+func configureAgentCommand(cmd *cobra.Command) {
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return outputCoopError(
+			err.Error(),
+			"Correct the command flags and retry.",
+			coop.Continue(coop.StatusCommand("")),
+		)
+	})
+}
+
+func agentNoArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	return outputCoopError(
+		fmt.Sprintf("%s does not accept positional arguments", cmd.CommandPath()),
+		"Remove the unexpected positional arguments and retry.",
+		coop.Continue(coop.StatusCommand("")),
+	)
 }
 
 func newWorkflowService() (*workflow.Service, error) {
@@ -204,7 +287,7 @@ func newWorkflowService() (*workflow.Service, error) {
 func runCoopNextAction(sessionID, completed string) error {
 	store, err := coop.NewStore(coopConfigFolder())
 	if err != nil {
-		return fmt.Errorf("creating store: %w", err)
+		return outputAgentError(fmt.Errorf("creating store: %w", err))
 	}
 	return runCoopNextActionWithStore(store, sessionID, completed)
 }
@@ -212,38 +295,51 @@ func runCoopNextAction(sessionID, completed string) error {
 func runCoopNextActionWithStore(store helpers.Store, sessionID, completed string) error {
 	resp, err := helpers.Run(store, helpers.Input{SessionID: sessionID, Completed: completed})
 	if errors.Is(err, helpers.ErrNoSession) {
-		return outputCoopError("No session found.", "stripe coop run <blueprint>")
+		return outputCoopError(
+			"No session found.",
+			"Start a Co-op session before requesting a next action.",
+			coop.RunTemplate(),
+		)
 	}
 	if err != nil {
-		return outputCoopError(err.Error(), nextActionHint(sessionID))
+		return outputCoopError(
+			err.Error(),
+			"Retry the next-action wait.",
+			coop.Continue(coop.NextActionCommand(sessionID, "")),
+		)
 	}
 	return outputJSON(resp)
-}
-
-func nextActionHint(sessionID string) string {
-	if sessionID == "" {
-		return "stripe coop agent next-action --session=<session>"
-	}
-	return fmt.Sprintf("stripe coop agent next-action --session=%s", sessionID)
 }
 
 func runCoopStartFollowup(cmd *cobra.Command, parentSessionID, actionID, target string, ensureSkill func() error) error {
 	store, err := coop.NewStore(coopConfigFolder())
 	if err != nil {
-		return fmt.Errorf("creating store: %w", err)
+		return outputAgentError(fmt.Errorf("creating store: %w", err))
 	}
 
 	parent, err := store.Read(parentSessionID)
 	if err != nil {
-		return outputCoopError(fmt.Sprintf("Parent session %q not found.", parentSessionID), "stripe coop agent next-action --session=<session>")
+		return outputCoopError(
+			fmt.Sprintf("Parent session %q not found.", parentSessionID),
+			"Inspect active and completed Co-op sessions.",
+			coop.Continue(coop.StatusCommand("")),
+		)
 	}
 
 	action, err := followups.GuidedActionByID(actionID, target)
 	if err != nil {
-		return outputCoopError(err.Error(), "stripe coop agent start-followup --session=<session> --action=deploy")
+		return outputCoopError(
+			err.Error(),
+			"Use an action offered by the parent session.",
+			coop.StartFollowupTemplate(parentSessionID),
+		)
 	}
 	if err := validateFollowupParent(parent, action.ID); err != nil {
-		return outputCoopError(err.Error(), "stripe coop agent next-action --session="+parent.ID)
+		return outputCoopError(
+			err.Error(),
+			"Return to the parent session's next-action selection.",
+			coop.Continue(coop.NextActionCommand(parent.ID, "")),
+		)
 	}
 	if ensureSkill != nil {
 		if err := ensureSkill(); err != nil {
@@ -267,7 +363,7 @@ func runCoopStartFollowup(cmd *cobra.Command, parentSessionID, actionID, target 
 		UsedSandbox:     parent.UsedSandbox || coopSandboxClaimURL() != "",
 	})
 	if err := store.Write(session); err != nil {
-		return fmt.Errorf("writing guided follow-up session: %w", err)
+		return outputAgentError(fmt.Errorf("writing guided follow-up session: %w", err))
 	}
 
 	return outputJSON(newCoopAgentGuidedActionResponse(action, session))
@@ -303,21 +399,32 @@ func outputAgentError(err error) error {
 
 func outputAgentResponse(resp coop.CommandResponse, err error) error {
 	if err != nil {
-		// Emit a structured ok:false response (on stdout, like every other agent
-		// command) so an agent parsing JSON always gets an error + recovery hint,
-		// even on infra failures (e.g. a heartbeat/store write error mid-await).
-		resp = coop.CommandResponse{
-			OK:    false,
-			Error: err.Error(),
-			Hint:  "stripe coop status",
-			Next:  "stripe coop status",
-		}
+		resp = protocolFailure(err.Error())
 	}
-	if outErr := outputJSON(resp); outErr != nil {
-		return outErr
+	if validationErr := resp.Validate(); validationErr != nil {
+		resp = protocolFailure("invalid Co-op protocol response: " + validationErr.Error())
 	}
 	if !resp.OK {
+		if resp.Recovery == nil {
+			resp.Recovery = defaultAgentRecovery()
+		}
+		if outErr := outputJSONTo(os.Stderr, resp); outErr != nil {
+			return outErr
+		}
 		return RenderedError{}
 	}
-	return nil
+	return outputJSON(resp)
+}
+
+func protocolFailure(message string) coop.CommandResponse {
+	return coop.CommandResponse{
+		OK:       false,
+		Error:    message,
+		Recovery: defaultAgentRecovery(),
+	}
+}
+
+func defaultAgentRecovery() *coop.Recovery {
+	return coop.Continue(coop.StatusCommand("")).
+		Recovery("Inspect the current Co-op session before retrying.")
 }

--- a/pkg/cmd/coop/coop_agent_test.go
+++ b/pkg/cmd/coop/coop_agent_test.go
@@ -57,7 +57,8 @@ func TestCoopAgentStartWorkCommand(t *testing.T) {
 	var resp coop.CommandResponse
 	require.NoError(t, json.Unmarshal([]byte(output), &resp))
 	require.True(t, resp.OK)
-	assert.Contains(t, resp.Next, "stripe coop agent report-work")
+	assert.Empty(t, resp.Next)
+	assert.Contains(t, resp.NextTemplate, "stripe coop agent report-work")
 
 	loaded, err := store.Read(session.ID)
 	require.NoError(t, err)
@@ -93,6 +94,64 @@ func TestCoopAgentReportCheckCommand(t *testing.T) {
 	assert.True(t, node.Verifications[0].Passed)
 }
 
+func TestCoopAgentMissingInputsReturnTemplateRecovery(t *testing.T) {
+	cmd := newCoopAgentStartWorkCmd().cmd
+	cmd.SetArgs(nil)
+
+	stderr := captureStderr(t, func() {
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.IsType(t, RenderedError{}, err)
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
+	assert.False(t, resp.OK)
+	assert.Empty(t, resp.Next)
+	require.NotNil(t, resp.Recovery)
+	assert.Contains(t, resp.Recovery.NextTemplate, `--session="<session>"`)
+	assert.Contains(t, resp.Recovery.NextTemplate, "--step=<step>")
+	require.Len(t, resp.Recovery.RequiredInputs, 2)
+	require.NoError(t, resp.Validate())
+}
+
+func TestCoopAgentFlagErrorsReturnStructuredRecovery(t *testing.T) {
+	cmd := newCoopAgentStartWorkCmd().cmd
+	cmd.SetArgs([]string{"--step", "not-a-number"})
+
+	stderr := captureStderr(t, func() {
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.IsType(t, RenderedError{}, err)
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
+	assert.False(t, resp.OK)
+	assert.Contains(t, resp.Error, "invalid argument")
+	require.NotNil(t, resp.Recovery)
+	assert.Equal(t, "stripe coop status", resp.Recovery.Next)
+	require.NoError(t, resp.Validate())
+}
+
+func TestCoopAgentRejectsPositionalArgumentsAsJSON(t *testing.T) {
+	cmd := newCoopAgentStartWorkCmd().cmd
+	cmd.SetArgs([]string{"unexpected"})
+
+	stderr := captureStderr(t, func() {
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.IsType(t, RenderedError{}, err)
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
+	assert.False(t, resp.OK)
+	assert.Contains(t, resp.Error, "does not accept positional arguments")
+	require.NotNil(t, resp.Recovery)
+	assert.Equal(t, "stripe coop status", resp.Recovery.Next)
+}
+
 func TestCoopAgentNextActionReturnsStructuredErrorForHelperFailure(t *testing.T) {
 	store := &nextActionErrorStore{
 		session: &coop.Session{
@@ -112,7 +171,9 @@ func TestCoopAgentNextActionReturnsStructuredErrorForHelperFailure(t *testing.T)
 	assert.False(t, resp.OK)
 	assert.Contains(t, resp.Error, "writing next-action suggestions")
 	assert.Contains(t, resp.Error, "disk full")
-	assert.Equal(t, "stripe coop agent next-action --session=agent_test_session", resp.Hint)
+	require.NotNil(t, resp.Recovery)
+	assert.Equal(t, "Retry the next-action wait.", resp.Recovery.Hint)
+	assert.Equal(t, "stripe coop agent next-action --session=agent_test_session", resp.Recovery.Next)
 }
 
 func TestCoopAgentStartFollowupCreatesGuidedSession(t *testing.T) {
@@ -310,7 +371,9 @@ func TestCoopAgentStartFollowupRejectsUnknownAction(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
 	assert.False(t, resp.OK)
 	assert.Contains(t, resp.Error, `guided action "unknown" not found`)
-	assert.Equal(t, "stripe coop agent start-followup --session=<session> --action=deploy", resp.Hint)
+	require.NotNil(t, resp.Recovery)
+	assert.Equal(t, "Use an action offered by the parent session.", resp.Recovery.Hint)
+	assert.Equal(t, `stripe coop agent start-followup --session=parent_session --action="<action>"`, resp.Recovery.NextTemplate)
 }
 
 type nextActionErrorStore struct {
@@ -332,8 +395,8 @@ func (s *nextActionErrorStore) Write(session *coop.Session) error {
 func TestOutputAgentErrorEmitsStructuredJSON(t *testing.T) {
 	// Failures before a workflow response exists (e.g. newWorkflowService/store
 	// creation in start-work, report-work, etc.) must still emit structured JSON,
-	// not a bare plain-text error, so an agent parsing stdout can recover.
-	output := captureStdout(t, func() {
+	// not a bare plain-text error, so an agent parsing stderr can recover.
+	output := captureStderr(t, func() {
 		err := outputAgentError(errors.New("creating store: disk full"))
 		require.Error(t, err)
 		assert.IsType(t, RenderedError{}, err)
@@ -343,5 +406,6 @@ func TestOutputAgentErrorEmitsStructuredJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(output), &resp))
 	assert.False(t, resp.OK)
 	assert.Contains(t, resp.Error, "creating store: disk full")
-	assert.NotEmpty(t, resp.Next)
+	require.NotNil(t, resp.Recovery)
+	assert.Equal(t, "stripe coop status", resp.Recovery.Next)
 }

--- a/pkg/cmd/coop/coop_run.go
+++ b/pkg/cmd/coop/coop_run.go
@@ -3,8 +3,8 @@ package coopcmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/workflow"
 )
 
 type coopAgentRunCmd struct {
@@ -36,7 +37,16 @@ This is the agent-facing command. Developers should use "stripe coop start" inst
 		Example: `  stripe coop run one-time-payment
   stripe coop run one-time-payment --language=node
   stripe coop run setup-future-payments --setting=framework=express --param=customer_type=existing`,
-		Args: cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				return nil
+			}
+			return outputCoopError(
+				"coop run requires exactly one blueprint ID",
+				"Choose a blueprint before starting a session.",
+				coop.Continue("stripe coop recommend"),
+			)
+		},
 		RunE: rc.runCmd,
 	}
 
@@ -45,6 +55,7 @@ This is the agent-facing command. Developers should use "stripe coop start" inst
 	rc.cmd.Flags().StringArrayVar(&rc.params, "param", nil, "Blueprint params as key=value pairs")
 	rc.cmd.Flags().StringVar(&rc.parentSession, "parent-session", "", "Parent co-op session ID for follow-up work")
 	rc.cmd.Flags().StringVar(&rc.parentStep, "parent-step", "", "Parent next-step ID this session fulfills")
+	configureAgentCommand(rc.cmd)
 
 	return rc
 }
@@ -56,26 +67,34 @@ func (rc *coopAgentRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		// Surface the specific error (e.g. an ambiguous prefix and its candidate
 		// list) rather than a generic "not found".
-		return outputCoopError(err.Error(), "stripe coop recommend")
+		return outputCoopError(
+			err.Error(),
+			"Choose an available blueprint ID.",
+			coop.Continue("stripe coop recommend"),
+		)
 	}
 
 	store, err := coop.NewStore(coopConfigFolder())
 	if err != nil {
-		return fmt.Errorf("creating store: %w", err)
+		return outputAgentError(fmt.Errorf("creating store: %w", err))
 	}
 
 	sessionID := "coop_" + uuid.New().String()[:8]
 
 	session, err := newCoopSession(bp, sessionID, rc.language, rc.settings, rc.params, rc.parentSession, rc.parentStep)
 	if err != nil {
-		return outputCoopError(err.Error(), "Use --setting key=value and --param key=value.")
+		return outputCoopError(
+			err.Error(),
+			"Retry without the malformed setting or parameter; optional values use key=value syntax.",
+			coop.Continue(coop.RunCommand(blueprintID)),
+		)
 	}
 	if err := rc.ensureStripeSkill(); err != nil {
 		warnRepoStripeBestPracticesSkill(cmd, err)
 	}
 
 	if err := store.Write(session); err != nil {
-		return fmt.Errorf("writing session: %w", err)
+		return outputAgentError(fmt.Errorf("writing session: %w", err))
 	}
 
 	resp := newCoopAgentRunResponse(bp, session)
@@ -100,13 +119,13 @@ func newCoopAgentGuidedActionResponse(action *coop.GuidedAction, session *coop.S
 
 func newCoopAgentSessionResponse(title string, session *coop.Session, instructions string) coop.CommandResponse {
 	return coop.CommandResponse{
-		OK:          true,
-		SessionID:   session.ID,
-		Node:        1,
-		State:       "created",
-		Message:     fmt.Sprintf("Session started: %s (%d nodes)", title, session.TotalNodes()),
-		Next:        fmt.Sprintf("stripe coop agent start-work --session=%s --step=1 --note=%s", session.ID, quoteArg("Beginning: "+session.Steps[0].Nodes[0].Title)),
-		AgentPrompt: instructions,
+		OK:           true,
+		SessionID:    session.ID,
+		Node:         1,
+		State:        "created",
+		Message:      fmt.Sprintf("Session started: %s (%d nodes)", title, session.TotalNodes()),
+		Continuation: coop.Continue(coop.StartWorkCommand(session.ID, 1, "Beginning: "+session.Steps[0].Nodes[0].Title)),
+		AgentPrompt:  instructions,
 	}
 }
 
@@ -207,33 +226,36 @@ For each node:
 4. Report the implementation with "stripe coop agent report-work".
 5. Continue with the response's next command. If a task does not apply, use "stripe coop agent skip" with a reason.
 
-Only await human review when the next command says to. Before awaiting, run the supplied review command, keep useful servers running, and give the developer concrete actions and expected results. Use a 5-minute shell timeout for await-review; re-run it if Co-op reports a timeout. If changes are requested, redo the affected node from the feedback. After the final confirmation, immediately run the returned next command.
+Only await human review when the next command says to. Before awaiting, run the supplied review command, keep useful servers running, and give the developer concrete actions and expected results. Co-op returns from await-review after %s; allow the shell command at least %s so the structured timeout response arrives. Re-run it if Co-op reports a timeout. If changes are requested, redo the affected node from the feedback. After the final confirmation, immediately run the returned next command.
 
-Never pass full card numbers to Stripe APIs or CLI commands. Collect card details only through hosted Checkout, Payment Element, or another official client-side integration. If an API needs a test payment method, use a supported test PaymentMethod ID such as pm_card_visa.`, preamble, coopAgentCoordinationInstructions(), stripeAgentGuidanceInstructions())
+Never pass full card numbers to Stripe APIs or CLI commands. Collect card details only through hosted Checkout, Payment Element, or another official client-side integration. If an API needs a test payment method, use a supported test PaymentMethod ID such as pm_card_visa.`,
+		preamble,
+		coopAgentCoordinationInstructions(),
+		stripeAgentGuidanceInstructions(),
+		workflow.AwaitTimeout,
+		workflow.AwaitHarnessTimeout,
+	)
 }
 
 func outputJSON(v interface{}) error {
+	return outputJSONTo(os.Stdout, v)
+}
+
+func outputJSONTo(w io.Writer, v interface{}) error {
 	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(data))
+	fmt.Fprintln(w, string(data))
 	return nil
 }
 
-func quoteArg(value string) string {
-	return strconv.Quote(value)
-}
-
-func outputCoopError(msg, hint string) error {
-	resp := coop.CommandResponse{
-		OK:    false,
-		Error: msg,
-		Hint:  hint,
-	}
-	data, _ := json.MarshalIndent(resp, "", "  ")
-	fmt.Fprintln(os.Stderr, string(data))
-	return RenderedError{}
+func outputCoopError(message, hint string, continuation coop.Continuation) error {
+	return outputAgentResponse(coop.CommandResponse{
+		OK:       false,
+		Error:    message,
+		Recovery: continuation.Recovery(hint),
+	}, nil)
 }
 
 type RenderedError struct{}

--- a/pkg/cmd/coop/coop_run_test.go
+++ b/pkg/cmd/coop/coop_run_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/workflow"
 )
 
 func TestNewCoopSessionAppliesSharedMetadata(t *testing.T) {
@@ -41,6 +42,14 @@ func TestNewCoopSessionAppliesSharedMetadata(t *testing.T) {
 	assert.Equal(t, "deploy", session.ParentStepID)
 	assert.True(t, session.UsedSandbox)
 	assert.False(t, session.CreatedAt.IsZero())
+}
+
+func TestAgentInstructionsAdvertiseAwaitTimeoutWithHarnessHeadroom(t *testing.T) {
+	instructions := sessionLifecycleInstructions("Build an integration.")
+
+	assert.Contains(t, instructions, "Co-op returns from await-review after "+workflow.AwaitTimeout.String())
+	assert.Contains(t, instructions, "allow the shell command at least "+workflow.AwaitHarnessTimeout.String())
+	assert.NotContains(t, instructions, "Set a 5-minute timeout")
 }
 
 func TestNewCoopSessionRejectsMalformedKeyValues(t *testing.T) {
@@ -279,7 +288,9 @@ func TestCoopRunReturnsStructuredErrorForMalformedSetting(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
 	assert.False(t, resp.OK)
 	assert.Contains(t, resp.Error, "--setting must be in key=value format")
-	assert.Equal(t, "Use --setting key=value and --param key=value.", resp.Hint)
+	require.NotNil(t, resp.Recovery)
+	assert.Contains(t, resp.Recovery.Hint, "malformed setting or parameter")
+	assert.Equal(t, `stripe coop run "one-time-payment"`, resp.Recovery.Next)
 
 	store, err := coop.NewStore(coopConfigFolder())
 	require.NoError(t, err)
@@ -313,6 +324,24 @@ func TestCoopRunReturnsCompactBootstrapWithoutBlueprintNodes(t *testing.T) {
 	assert.Less(t, len(output), 10000)
 }
 
+func TestCoopRunMissingBlueprintReturnsStructuredRecovery(t *testing.T) {
+	cmd := newCoopAgentRunCmd().cmd
+	cmd.SetArgs(nil)
+
+	stderr := captureStderr(t, func() {
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.IsType(t, RenderedError{}, err)
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
+	assert.False(t, resp.OK)
+	require.NotNil(t, resp.Recovery)
+	assert.Equal(t, "stripe coop recommend", resp.Recovery.Next)
+	require.NoError(t, resp.Validate())
+}
+
 func TestCoopRunReturnsStructuredErrorForMalformedParam(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	cmd := newCoopAgentRunCmd().cmd
@@ -329,7 +358,9 @@ func TestCoopRunReturnsStructuredErrorForMalformedParam(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
 	assert.False(t, resp.OK)
 	assert.Contains(t, resp.Error, "--param key cannot be empty")
-	assert.Equal(t, "Use --setting key=value and --param key=value.", resp.Hint)
+	require.NotNil(t, resp.Recovery)
+	assert.Contains(t, resp.Recovery.Hint, "malformed setting or parameter")
+	assert.Equal(t, `stripe coop run "one-time-payment"`, resp.Recovery.Next)
 
 	store, err := coop.NewStore(coopConfigFolder())
 	require.NoError(t, err)
@@ -354,7 +385,8 @@ func TestCoopRunPreservesBlueprintLoadError(t *testing.T) {
 	assert.False(t, resp.OK)
 	assert.Contains(t, resp.Error, "ambiguous blueprint prefix")
 	assert.NotContains(t, resp.Error, "not found")
-	assert.Equal(t, "stripe coop recommend", resp.Hint)
+	require.NotNil(t, resp.Recovery)
+	assert.Equal(t, "stripe coop recommend", resp.Recovery.Next)
 }
 
 func TestCoopRunKeepsNotFoundGuidance(t *testing.T) {
@@ -371,7 +403,8 @@ func TestCoopRunKeepsNotFoundGuidance(t *testing.T) {
 	var resp coop.CommandResponse
 	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
 	assert.Contains(t, resp.Error, "not found")
-	assert.Equal(t, "stripe coop recommend", resp.Hint)
+	require.NotNil(t, resp.Recovery)
+	assert.Equal(t, "stripe coop recommend", resp.Recovery.Next)
 }
 
 func TestCoopStartPreservesBlueprintLoadError(t *testing.T) {

--- a/pkg/cmd/coop/coop_status.go
+++ b/pkg/cmd/coop/coop_status.go
@@ -42,7 +42,11 @@ func (sc *coopStatusCmd) runStatusCmd(cmd *cobra.Command, args []string) error {
 		session, err = store.LatestSession()
 	}
 	if err != nil {
-		return outputCoopError("No active session found. Start one with 'stripe coop start <blueprint>'.", "stripe coop start one-time-payment")
+		return outputCoopError(
+			"No active session found.",
+			"Choose a blueprint before starting a Co-op session.",
+			coop.Continue("stripe coop recommend"),
+		)
 	}
 
 	if sc.asJSON {

--- a/pkg/cmd/coop/coop_status_test.go
+++ b/pkg/cmd/coop/coop_status_test.go
@@ -1,0 +1,30 @@
+package coopcmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+)
+
+func TestCoopStatusWithoutSessionRecommendsBlueprint(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cmd := newCoopStatusCmd().cmd
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	stderr := captureStderr(t, func() {
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.IsType(t, RenderedError{}, err)
+	})
+
+	var resp coop.CommandResponse
+	require.NoError(t, json.Unmarshal([]byte(stderr), &resp))
+	require.NotNil(t, resp.Recovery)
+	assert.Equal(t, "stripe coop recommend", resp.Recovery.Next)
+	require.NoError(t, resp.Validate())
+}

--- a/pkg/cmd/coop/coop_stop.go
+++ b/pkg/cmd/coop/coop_stop.go
@@ -46,7 +46,17 @@ func (sc *coopStopCmd) runStopCmd(cmd *cobra.Command, args []string) error {
 		session, err = store.LatestActiveSession()
 	}
 	if err != nil {
-		return outputCoopError("No active session found.", "stripe coop start <blueprint>")
+		return outputCoopError(
+			"No active session found.",
+			"Start a Co-op session before stopping one.",
+			coop.Continuation{
+				NextTemplate: "stripe coop start \"<blueprint>\"",
+				RequiredInputs: []coop.CommandInput{{
+					Name:        "blueprint",
+					Description: "Blueprint ID returned by stripe coop recommend.",
+				}},
+			},
+		)
 	}
 
 	if sc.abort {

--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -74,7 +74,7 @@ active ──→ completed    (all nodes done/skipped, or "stripe coop stop")
 | `stripe coop agent next-action` | Show post-completion options (blocks until selection) |
 | `stripe coop agent start-followup` | Start an internal guided follow-up session selected from next actions |
 
-All agent commands output JSON with an `ok` field and a `next` field suggesting the next command. Agents replace any `<...>` placeholders in a suggested command with real values before running it. Session creation does not front-load the full blueprint: each successful `start-work` response returns an `agent_prompt` for only the current node, plus any relevant `api_request`, `test_requests`, `events`, and SDK example. The `--step` flag name is retained for the CLI, but its value is the 1-based node number across the session.
+Agent commands return `next` only when the value is immediately executable. Commands that still need values return `next_template` with `required_inputs`. Failures use a single `recovery` object containing a hint and one of those continuation forms. Session creation does not front-load the full blueprint: each successful `start-work` response returns an `agent_prompt` for only the current node, plus any relevant `api_request`, `test_requests`, `events`, and SDK example. The `--step` flag name is retained for the CLI, but its value is the 1-based node number across the session.
 
 ## TUI Keybindings
 
@@ -158,7 +158,7 @@ When the agent runs `stripe coop agent await-review`, it writes a `.heartbeat` f
 - **Fresh heartbeat (< 5s old):** Agent is actively waiting for confirmation
 - **No heartbeat + no session update in 2min:** Show idle warning
 
-The heartbeat file is cleaned up when `await` exits.
+The heartbeat file is cleaned up when `await` exits. The command advertises its five-minute wait as `wait_timeout_seconds`; agent harnesses should allow at least six minutes so the structured timeout response can arrive.
 
 ## Resuming
 
@@ -216,7 +216,7 @@ After syncing, test with `go run ./cmd/stripe coop run <blueprint-id>`. Prefix m
 | "timed out waiting for session lock" | A previous writer left a `.lock` file behind | If no `stripe coop` command is running, remove the named lock file and retry |
 | TUI shows wrong session | Multiple sessions exist | Use `stripe coop join <session-id>` with the correct ID |
 | Steps not updating in TUI | Agent created a duplicate session | Check `stripe coop status` for the correct session ID |
-| Agent ignores "next" hint | LLM didn't follow instructions | Copy the `next` value and run it manually, or restart |
+| Agent ignores its continuation | LLM didn't follow instructions | Run `next` exactly, or fill every `required_inputs` value in `next_template` |
 | Double footer / layout broken | Terminal resize not detected | Resize the terminal window (triggers recalculation) |
 | "Blueprint not found" | Typo in blueprint ID | Run `stripe coop recommend` to see available IDs |
 

--- a/pkg/coop/commands.go
+++ b/pkg/coop/commands.go
@@ -1,0 +1,129 @@
+package coop
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// StatusCommand returns the exact command for inspecting Co-op state.
+func StatusCommand(sessionID string) string {
+	if sessionID == "" {
+		return "stripe coop status"
+	}
+	return fmt.Sprintf("stripe coop status --session=%s", sessionID)
+}
+
+// RunCommand returns the exact command for starting a blueprint session.
+func RunCommand(blueprintID string) string {
+	return fmt.Sprintf("stripe coop run %s", strconv.Quote(blueprintID))
+}
+
+// RunTemplate returns the continuation for a missing blueprint ID.
+func RunTemplate() Continuation {
+	return commandTemplate(
+		"stripe coop run \"<blueprint>\"",
+		commandInput("blueprint", "", "Blueprint ID returned by stripe coop recommend."),
+	)
+}
+
+// StopCommand returns the exact command for ending Co-op state.
+func StopCommand(sessionID string) string {
+	if sessionID == "" {
+		return "stripe coop stop"
+	}
+	return fmt.Sprintf("stripe coop stop --session=%s", sessionID)
+}
+
+// StartWorkCommand returns the exact command for activating a node.
+func StartWorkCommand(sessionID string, nodeNumber int, note string) string {
+	return fmt.Sprintf(
+		"stripe coop agent start-work --session=%s --step=%d --note=%s",
+		sessionID,
+		nodeNumber,
+		strconv.Quote(note),
+	)
+}
+
+// AwaitReviewCommand returns the exact command for waiting on a node review.
+func AwaitReviewCommand(sessionID string, nodeNumber int) string {
+	return fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", sessionID, nodeNumber)
+}
+
+// NextActionCommand returns the exact command for waiting on or completing a
+// post-session action.
+func NextActionCommand(sessionID, completed string) string {
+	command := fmt.Sprintf("stripe coop agent next-action --session=%s", sessionID)
+	if completed != "" {
+		command += " --completed=" + completed
+	}
+	return command
+}
+
+// StartFollowupCommand returns the exact command for starting a guided follow-up.
+func StartFollowupCommand(sessionID, action, target string) string {
+	command := fmt.Sprintf(
+		"stripe coop agent start-followup --session=%s --action=%s",
+		strconv.Quote(sessionID),
+		strconv.Quote(action),
+	)
+	if target != "" {
+		command += " --target=" + strconv.Quote(target)
+	}
+	return command
+}
+
+// SessionStepTemplate returns the common session/node continuation.
+func SessionStepTemplate(action string) Continuation {
+	return commandTemplate(
+		fmt.Sprintf("stripe coop agent %s --session=\"<session>\" --step=<step>", action),
+		commandInput("session", "--session", "Co-op session ID."),
+		commandInput("step", "--step", "Positive 1-based node number."),
+	)
+}
+
+// NextActionTemplate returns the continuation for a missing session ID.
+func NextActionTemplate() Continuation {
+	return commandTemplate(
+		"stripe coop agent next-action --session=\"<session>\"",
+		commandInput("session", "--session", "Co-op session ID."),
+	)
+}
+
+// StartFollowupTemplate returns the continuation for missing follow-up inputs.
+func StartFollowupTemplate(sessionID string) Continuation {
+	if sessionID == "" {
+		return commandTemplate(
+			"stripe coop agent start-followup --session=\"<session>\" --action=\"<action>\"",
+			commandInput("session", "--session", "Completed parent Co-op session ID."),
+			commandInput("action", "--action", "Follow-up action offered by next-action."),
+		)
+	}
+	return commandTemplate(
+		fmt.Sprintf("stripe coop agent start-followup --session=%s --action=\"<action>\"", sessionID),
+		commandInput("action", "--action", "Available follow-up action ID."),
+	)
+}
+
+// ReportCheckTemplate returns the continuation for a missing check.
+func ReportCheckTemplate(sessionID string, nodeNumber int) Continuation {
+	return commandTemplate(
+		fmt.Sprintf("stripe coop agent report-check --session=%s --step=%d --check=\"<what you verified>\" --passed", sessionID, nodeNumber),
+		commandInput("check", "--check", "Concrete verification and its observed result."),
+	)
+}
+
+// ReportWorkTemplate returns the continuation for reporting implementation.
+func ReportWorkTemplate(sessionID string, nodeNumber int) Continuation {
+	return commandTemplate(
+		fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --note=\"<what you did>\"", sessionID, nodeNumber),
+		commandInput("note", "--note", "Concrete summary of the completed implementation."),
+	)
+}
+
+func commandTemplate(command string, inputs ...CommandInput) Continuation {
+	return Continuation{NextTemplate: command, RequiredInputs: inputs}
+}
+
+func commandInput(name, flag, description string) CommandInput {
+	return CommandInput{Name: name, Flag: flag, Description: description}
+}

--- a/pkg/coop/commands_test.go
+++ b/pkg/coop/commands_test.go
@@ -1,0 +1,19 @@
+package coop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExactCoopCommands(t *testing.T) {
+	assert.Equal(t, "stripe coop status", StatusCommand(""))
+	assert.Equal(t, "stripe coop status --session=coop_123", StatusCommand("coop_123"))
+	assert.Equal(t, `stripe coop run "one-time-payment"`, RunCommand("one-time-payment"))
+	assert.Equal(t, "stripe coop stop --session=coop_123", StopCommand("coop_123"))
+	assert.Equal(t, `stripe coop agent start-work --session=coop_123 --step=2 --note="Beginning: Product"`, StartWorkCommand("coop_123", 2, "Beginning: Product"))
+	assert.Equal(t, "stripe coop agent await-review --session=coop_123 --step=2", AwaitReviewCommand("coop_123", 2))
+	assert.Equal(t, "stripe coop agent next-action --session=coop_123", NextActionCommand("coop_123", ""))
+	assert.Equal(t, "stripe coop agent next-action --session=coop_123 --completed=deploy", NextActionCommand("coop_123", "deploy"))
+	assert.Equal(t, `stripe coop agent start-followup --session="coop_123" --action="deploy" --target="Vercel"`, StartFollowupCommand("coop_123", "deploy", "Vercel"))
+}

--- a/pkg/coop/helpers/nextaction.go
+++ b/pkg/coop/helpers/nextaction.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -42,7 +41,7 @@ type Response struct {
 	Completed   string       `json:"completed"`
 	Suggestions []Suggestion `json:"suggestions"`
 	AgentPrompt string       `json:"agent_prompt"`
-	Next        string       `json:"next"`
+	coop.Continuation
 }
 
 type Environment struct {
@@ -238,7 +237,9 @@ func BuildResponse(session *coop.Session, suggestions []Suggestion, selected str
 			Completed:   session.Blueprint,
 			Suggestions: suggestions,
 			AgentPrompt: BuildSummarizePrompt(session),
-			Next:        fmt.Sprintf("Write STRIPE.md, then run: stripe coop agent next-action --session=%s --completed=summarize", session.ID),
+			Continuation: coop.Continue(
+				coop.NextActionCommand(session.ID, "summarize"),
+			),
 		}
 	case "deploy":
 		return Response{
@@ -247,7 +248,9 @@ func BuildResponse(session *coop.Session, suggestions []Suggestion, selected str
 			Completed:   session.Blueprint,
 			Suggestions: suggestions,
 			AgentPrompt: BuildDeployPrompt(session),
-			Next:        followupCommand(session.ID, "deploy", ""),
+			Continuation: coop.Continue(
+				coop.StartFollowupCommand(session.ID, "deploy", ""),
+			),
 		}
 	case "deploy-update":
 		target := deployTargetFromSuggestion(suggestions, selected)
@@ -257,7 +260,9 @@ func BuildResponse(session *coop.Session, suggestions []Suggestion, selected str
 			Completed:   session.Blueprint,
 			Suggestions: suggestions,
 			AgentPrompt: BuildDeployUpdatePrompt(session, target),
-			Next:        followupCommand(session.ID, "deploy-update", target),
+			Continuation: coop.Continue(
+				coop.StartFollowupCommand(session.ID, "deploy-update", target),
+			),
 		}
 	case "add-integration":
 		return Response{
@@ -266,7 +271,9 @@ func BuildResponse(session *coop.Session, suggestions []Suggestion, selected str
 			Completed:   session.Blueprint,
 			Suggestions: suggestions,
 			AgentPrompt: fmt.Sprintf("The developer wants to add another Stripe feature. Run 'stripe coop recommend' and ask what they need, then start a new session with --parent-session=%s --parent-step=add-integration.", session.ID),
-			Next:        "stripe coop recommend",
+			Continuation: coop.Continue(
+				"stripe coop recommend",
+			),
 		}
 	case "done":
 		return Response{
@@ -274,7 +281,9 @@ func BuildResponse(session *coop.Session, suggestions []Suggestion, selected str
 			SessionID:   session.ID,
 			Completed:   session.Blueprint,
 			AgentPrompt: "The developer is done. End the session.",
-			Next:        fmt.Sprintf("stripe coop stop --session=%s", session.ID),
+			Continuation: coop.Continue(
+				coop.StopCommand(session.ID),
+			),
 		}
 	default:
 		return Response{
@@ -282,7 +291,9 @@ func BuildResponse(session *coop.Session, suggestions []Suggestion, selected str
 			SessionID:   session.ID,
 			Completed:   session.Blueprint,
 			AgentPrompt: fmt.Sprintf("The developer selected: %s", selected),
-			Next:        "stripe coop stop",
+			Continuation: coop.Continue(
+				coop.StopCommand(""),
+			),
 		}
 	}
 }
@@ -302,14 +313,6 @@ func deployTargetFromSuggestion(suggestions []Suggestion, selected string) strin
 		}
 	}
 	return "the detected deployment target"
-}
-
-func followupCommand(sessionID, action, target string) string {
-	cmd := fmt.Sprintf("stripe coop agent start-followup --session=%s --action=%s", strconv.Quote(sessionID), strconv.Quote(action))
-	if target != "" {
-		cmd += fmt.Sprintf(" --target=%s", strconv.Quote(target))
-	}
-	return cmd
 }
 
 func BuildDeployPrompt(session *coop.Session) string {

--- a/pkg/coop/helpers/nextaction_test.go
+++ b/pkg/coop/helpers/nextaction_test.go
@@ -91,6 +91,18 @@ func TestBuildResponseForDeployStartsGuidedFollowup(t *testing.T) {
 	assert.NotContains(t, resp.Next, "stripe coop run")
 }
 
+func TestBuildResponseForSummarizeReturnsExecutableNext(t *testing.T) {
+	session := &coop.Session{
+		ID:        "sess_123",
+		Blueprint: "one-time-payment",
+	}
+
+	resp := BuildResponse(session, nil, "summarize")
+
+	assert.Equal(t, "stripe coop agent next-action --session=sess_123 --completed=summarize", resp.Next)
+	assert.NotContains(t, resp.Next, "Write STRIPE.md")
+}
+
 func TestBuildResponseForDeployUpdateStartsGuidedFollowupWithDetectedTarget(t *testing.T) {
 	session := &coop.Session{
 		ID:        "sess_123",

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -2,7 +2,14 @@
 // AI agent + human developer Stripe integration building.
 package coop
 
-import "time"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var commandTemplatePlaceholder = regexp.MustCompile(`<[^>]+>`)
 
 // NodeState represents the lifecycle state of a single blueprint node.
 type NodeState string
@@ -141,19 +148,120 @@ type NextStepSuggestion struct {
 	Reason      string `json:"reason,omitempty"`
 }
 
+// CommandInput describes a value an agent must provide before executing a
+// command template.
+type CommandInput struct {
+	Name        string `json:"name"`
+	Flag        string `json:"flag,omitempty"`
+	Description string `json:"description"`
+}
+
+// Continuation tells an agent either what to run next or what inputs are
+// needed to complete a command template.
+type Continuation struct {
+	Next               string         `json:"next,omitempty"`
+	NextTemplate       string         `json:"next_template,omitempty"`
+	RequiredInputs     []CommandInput `json:"required_inputs,omitempty"`
+	WaitTimeoutSeconds int            `json:"wait_timeout_seconds,omitempty"`
+}
+
+// Continue returns a continuation for an immediately executable command.
+func Continue(next string) Continuation {
+	return Continuation{Next: next}
+}
+
+// WithWaitTimeout returns a continuation with its advertised shell timeout.
+func (c Continuation) WithWaitTimeout(seconds int) Continuation {
+	c.WaitTimeoutSeconds = seconds
+	return c
+}
+
+// Recovery turns a continuation into the common agent failure contract.
+func (c Continuation) Recovery(hint string) *Recovery {
+	return &Recovery{Hint: hint, Continuation: c}
+}
+
+// Recovery is the single recovery contract for all agent-facing failures.
+type Recovery struct {
+	Hint string `json:"hint"`
+	Continuation
+}
+
 // CommandResponse is the JSON output format for agent-facing commands.
 type CommandResponse struct {
-	OK           bool                `json:"ok"`
-	SessionID    string              `json:"session_id,omitempty"`
-	Node         int                 `json:"node,omitempty"`
-	State        string              `json:"state,omitempty"`
-	Message      string              `json:"message,omitempty"`
-	Next         string              `json:"next,omitempty"`
+	OK        bool   `json:"ok"`
+	SessionID string `json:"session_id,omitempty"`
+	Node      int    `json:"node,omitempty"`
+	State     string `json:"state,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Continuation
 	AgentPrompt  string              `json:"agent_prompt,omitempty"`
 	APIRequest   *APIRequest         `json:"api_request,omitempty"`
 	TestRequests []TestHelperRequest `json:"test_requests,omitempty"`
 	Events       []string            `json:"events,omitempty"`
 	SDKExample   string              `json:"sdk_example,omitempty"`
 	Error        string              `json:"error,omitempty"`
-	Hint         string              `json:"hint,omitempty"`
+	Recovery     *Recovery           `json:"recovery,omitempty"`
+}
+
+// Validate checks the invariants agents rely on when interpreting a response.
+func (r CommandResponse) Validate() error {
+	if r.OK {
+		if r.Error != "" || r.Recovery != nil {
+			return fmt.Errorf("successful response cannot contain error recovery")
+		}
+		return r.validate(true)
+	}
+	if strings.TrimSpace(r.Error) == "" {
+		return fmt.Errorf("failed response must contain error")
+	}
+	if r.Next != "" || r.NextTemplate != "" || len(r.RequiredInputs) > 0 || r.WaitTimeoutSeconds != 0 {
+		return fmt.Errorf("failed response must put continuation data inside recovery")
+	}
+	if r.Recovery == nil {
+		return fmt.Errorf("failed response must contain recovery")
+	}
+	if strings.TrimSpace(r.Recovery.Hint) == "" {
+		return fmt.Errorf("recovery must contain hint")
+	}
+	return r.Recovery.validate(false)
+}
+
+func (c Continuation) validate(allowEmpty bool) error {
+	if c.WaitTimeoutSeconds < 0 {
+		return fmt.Errorf("wait_timeout_seconds cannot be negative")
+	}
+	if c.Next != "" && c.NextTemplate != "" {
+		return fmt.Errorf("response cannot contain both next and next_template")
+	}
+	if c.Next == "" && c.NextTemplate == "" {
+		if c.WaitTimeoutSeconds != 0 {
+			return fmt.Errorf("wait_timeout_seconds requires a continuation")
+		}
+		if allowEmpty {
+			return nil
+		}
+		return fmt.Errorf("recovery must contain next or next_template")
+	}
+	if c.Next != "" {
+		if len(c.RequiredInputs) > 0 {
+			return fmt.Errorf("exact next command cannot require inputs")
+		}
+		if commandTemplatePlaceholder.MatchString(c.Next) {
+			return fmt.Errorf("exact next command contains a template placeholder")
+		}
+		return nil
+	}
+	if len(c.RequiredInputs) == 0 {
+		return fmt.Errorf("next_template must describe required_inputs")
+	}
+	if !commandTemplatePlaceholder.MatchString(c.NextTemplate) {
+		return fmt.Errorf("next_template must contain a placeholder")
+	}
+	for _, input := range c.RequiredInputs {
+		if strings.TrimSpace(input.Name) == "" || strings.TrimSpace(input.Description) == "" {
+			return fmt.Errorf("required_inputs must contain name and description")
+		}
+	}
+	return nil
 }

--- a/pkg/coop/types_test.go
+++ b/pkg/coop/types_test.go
@@ -1,0 +1,106 @@
+package coop
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandResponseValidate(t *testing.T) {
+	input := []CommandInput{{Name: "note", Flag: "--note", Description: "Work summary."}}
+	tests := []struct {
+		name    string
+		resp    CommandResponse
+		wantErr string
+	}{
+		{name: "exact success", resp: CommandResponse{OK: true, Continuation: Continue("stripe coop status")}},
+		{
+			name: "template success",
+			resp: CommandResponse{OK: true, Continuation: Continuation{
+				NextTemplate: `stripe coop agent report-work --note="<note>"`, RequiredInputs: input,
+			}},
+		},
+		{name: "terminal success", resp: CommandResponse{OK: true, State: "completed"}},
+		{
+			name: "exact recovery",
+			resp: CommandResponse{
+				OK: false, Error: "disk full",
+				Recovery: Continue("stripe coop status").Recovery("Inspect the session."),
+			},
+		},
+		{
+			name: "template recovery",
+			resp: CommandResponse{OK: false, Error: "missing note", Recovery: Continuation{
+				NextTemplate: `stripe coop agent report-work --note="<note>"`, RequiredInputs: input,
+			}.Recovery("Supply a note.")},
+		},
+		{
+			name:    "placeholder in exact next",
+			resp:    CommandResponse{OK: true, Continuation: Continue("stripe coop run <blueprint>")},
+			wantErr: "template placeholder",
+		},
+		{
+			name: "both continuation forms",
+			resp: CommandResponse{OK: true, Continuation: Continuation{
+				Next: "stripe coop status", NextTemplate: "stripe coop status", RequiredInputs: input,
+			}},
+			wantErr: "both next",
+		},
+		{
+			name:    "template without inputs",
+			resp:    CommandResponse{OK: true, Continuation: Continuation{NextTemplate: "stripe coop run <blueprint>"}},
+			wantErr: "required_inputs",
+		},
+		{
+			name:    "timeout without continuation",
+			resp:    CommandResponse{OK: true, Continuation: Continuation{WaitTimeoutSeconds: 300}},
+			wantErr: "requires a continuation",
+		},
+		{
+			name:    "failure without recovery",
+			resp:    CommandResponse{OK: false, Error: "failed"},
+			wantErr: "recovery",
+		},
+		{
+			name: "failure with top-level next",
+			resp: CommandResponse{
+				OK: false, Error: "failed", Continuation: Continue("stripe coop status"),
+				Recovery: Continue("stripe coop status").Recovery("Inspect."),
+			},
+			wantErr: "inside recovery",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.resp.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestCommandResponseJSONKeepsContinuationFieldsFlat(t *testing.T) {
+	resp := CommandResponse{
+		OK: true,
+		Continuation: Continuation{
+			NextTemplate:       `stripe coop run "<blueprint>"`,
+			RequiredInputs:     []CommandInput{{Name: "blueprint", Description: "Blueprint ID."}},
+			WaitTimeoutSeconds: 300,
+		},
+	}
+
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"ok": true,
+		"next_template": "stripe coop run \"<blueprint>\"",
+		"required_inputs": [{"name": "blueprint", "description": "Blueprint ID."}],
+		"wait_timeout_seconds": 300
+	}`, string(data))
+}

--- a/pkg/coop/workflow/service.go
+++ b/pkg/coop/workflow/service.go
@@ -10,7 +10,10 @@ import (
 	"github.com/stripe/stripe-cli/pkg/coop/helpers"
 )
 
-const AwaitTimeout = 10 * time.Minute
+const (
+	AwaitTimeout        = 5 * time.Minute
+	AwaitHarnessTimeout = 6 * time.Minute
+)
 
 type Store interface {
 	Read(id string) (*coop.Session, error)
@@ -86,7 +89,7 @@ func (s *Service) StartWork(sessionID string, nodeNumber int, note string) (coop
 		return nil
 	})
 	if err != nil {
-		return errorResponse(err, "stripe coop status"), nil
+		return sessionErrorResponse(err), nil
 	}
 
 	node, _ := session.NodeByNumber(nodeNumber)
@@ -96,7 +99,7 @@ func (s *Service) StartWork(sessionID string, nodeNumber int, note string) (coop
 		Node:         nodeNumber,
 		State:        string(coop.NodeActive),
 		Message:      fmt.Sprintf("Started: %s", node.Title),
-		Next:         fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --file=<path> --note=\"<what you did>\"", session.ID, nodeNumber),
+		Continuation: coop.ReportWorkTemplate(session.ID, nodeNumber),
 		AgentPrompt:  nodeAgentPrompt(session, node, nodeNumber),
 		TestRequests: node.TestRequests,
 		Events:       node.Events,
@@ -178,6 +181,13 @@ func nodeTypeGuidance(node *coop.SessionNode) string {
 }
 
 func (s *Service) ReportWork(sessionID string, nodeNumber int, input ReportWorkInput, autoConfirm bool) (coop.CommandResponse, error) {
+	if strings.TrimSpace(input.Note) == "" {
+		return errorResponse(
+			fmt.Errorf("--note flag is required"),
+			"Describe the completed implementation.",
+			coop.ReportWorkTemplate(sessionID, nodeNumber),
+		), nil
+	}
 	var targetState coop.NodeState
 	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
 		if err := requireActiveSession(session); err != nil {
@@ -210,7 +220,7 @@ func (s *Service) ReportWork(sessionID string, nodeNumber int, input ReportWorkI
 		return nil
 	})
 	if err != nil {
-		return errorResponse(err, fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d", sessionID, nodeNumber)), nil
+		return sessionErrorResponse(err), nil
 	}
 	node, _ := session.NodeByNumber(nodeNumber)
 	return s.reportWorkResponse(session, node, nodeNumber, targetState), nil
@@ -218,7 +228,11 @@ func (s *Service) ReportWork(sessionID string, nodeNumber int, input ReportWorkI
 
 func (s *Service) ReportCheck(sessionID string, nodeNumber int, check string, passed bool) (coop.CommandResponse, error) {
 	if strings.TrimSpace(check) == "" {
-		return errorResponse(fmt.Errorf("--check flag is required"), fmt.Sprintf("stripe coop agent report-check --session=%s --step=%d --check=\"<label>\" --passed", sessionID, nodeNumber)), nil
+		return errorResponse(
+			fmt.Errorf("--check flag is required"),
+			"Describe the verification that was performed.",
+			coop.ReportCheckTemplate(sessionID, nodeNumber),
+		), nil
 	}
 	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
 		if err := requireActiveSession(session); err != nil {
@@ -232,7 +246,7 @@ func (s *Service) ReportCheck(sessionID string, nodeNumber int, check string, pa
 		return nil
 	})
 	if err != nil {
-		return errorResponse(err, "stripe coop status"), nil
+		return sessionErrorResponse(err), nil
 	}
 	node, _ := session.NodeByNumber(nodeNumber)
 	status := "failed"
@@ -240,12 +254,12 @@ func (s *Service) ReportCheck(sessionID string, nodeNumber int, check string, pa
 		status = "passed"
 	}
 	return coop.CommandResponse{
-		OK:        true,
-		SessionID: session.ID,
-		Node:      nodeNumber,
-		State:     string(node.State),
-		Message:   fmt.Sprintf("Verification %s: %s", status, check),
-		Next:      fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --file=<path> --note=\"<what you did>\"", session.ID, nodeNumber),
+		OK:           true,
+		SessionID:    session.ID,
+		Node:         nodeNumber,
+		State:        string(node.State),
+		Message:      fmt.Sprintf("Verification %s: %s", status, check),
+		Continuation: coop.ReportWorkTemplate(session.ID, nodeNumber),
 	}, nil
 }
 
@@ -265,16 +279,16 @@ func (s *Service) Skip(sessionID string, nodeNumber int, note string) (coop.Comm
 		return nil
 	})
 	if err != nil {
-		return errorResponse(err, "stripe coop status"), nil
+		return sessionErrorResponse(err), nil
 	}
 	node, _ := session.NodeByNumber(nodeNumber)
 	return coop.CommandResponse{
-		OK:        true,
-		SessionID: session.ID,
-		Node:      nodeNumber,
-		State:     string(coop.NodeSkipped),
-		Message:   fmt.Sprintf("Skipped: %s", node.Title),
-		Next:      nextAfterNode(session, nodeNumber),
+		OK:           true,
+		SessionID:    session.ID,
+		Node:         nodeNumber,
+		State:        string(coop.NodeSkipped),
+		Message:      fmt.Sprintf("Skipped: %s", node.Title),
+		Continuation: nextAfterNode(session, nodeNumber),
 	}, nil
 }
 
@@ -332,14 +346,14 @@ func (s *Service) RequestChanges(sessionID string, nodeNumbers []int, note strin
 func (s *Service) AwaitReview(sessionID string, nodeNumber int) (coop.CommandResponse, error) {
 	session, err := s.store.Read(sessionID)
 	if err != nil {
-		return errorResponse(err, "stripe coop status"), nil
+		return sessionErrorResponse(err), nil
 	}
 	if err := requireActiveSession(session); err != nil {
-		return errorResponse(err, "stripe coop status"), nil
+		return sessionErrorResponse(err), nil
 	}
 	node, err := session.NodeByNumber(nodeNumber)
 	if err != nil {
-		return errorResponse(err, "stripe coop status"), nil
+		return sessionErrorResponse(err), nil
 	}
 
 	if node.AutoConfirm && node.State == coop.NodeReview {
@@ -348,16 +362,16 @@ func (s *Service) AwaitReview(sessionID string, nodeNumber int) (coop.CommandRes
 	if node.State == coop.NodeReview {
 		step, stepIndex, _, err := session.StepByNodeNumber(nodeNumber)
 		if err != nil {
-			return errorResponse(err, "stripe coop status"), nil
+			return sessionErrorResponse(err), nil
 		}
 		if !session.StepReadyForReview(stepIndex) {
 			return coop.CommandResponse{
-				OK:        true,
-				SessionID: session.ID,
-				Node:      nodeNumber,
-				State:     string(coop.NodeReview),
-				Message:   fmt.Sprintf("Node %d is ready. Continue the step before asking for human review.", nodeNumber),
-				Next:      nextInStepOrStatus(session, stepIndex, nodeNumber),
+				OK:           true,
+				SessionID:    session.ID,
+				Node:         nodeNumber,
+				State:        string(coop.NodeReview),
+				Message:      fmt.Sprintf("Node %d is ready. Continue the step before asking for human review.", nodeNumber),
+				Continuation: coop.Continue(nextInStepOrStatus(session, stepIndex, nodeNumber)),
 			}, nil
 		}
 		return s.awaitStepReview(session.ID, step.Title, stepIndex, nodeNumber)
@@ -371,15 +385,15 @@ func (s *Service) AwaitReview(sessionID string, nodeNumber int) (coop.CommandRes
 func (s *Service) autoConfirm(sessionID string, nodeNumber int) (coop.CommandResponse, error) {
 	session, err := s.ConfirmReview(sessionID, []int{nodeNumber})
 	if err != nil {
-		return errorResponse(err, "stripe coop status"), nil
+		return sessionErrorResponse(err), nil
 	}
 	return coop.CommandResponse{
-		OK:        true,
-		SessionID: session.ID,
-		Node:      nodeNumber,
-		State:     "confirmed",
-		Message:   fmt.Sprintf("Node %d auto-confirmed. Proceed to next node.", nodeNumber),
-		Next:      nextAfterNode(session, nodeNumber),
+		OK:           true,
+		SessionID:    session.ID,
+		Node:         nodeNumber,
+		State:        "confirmed",
+		Message:      fmt.Sprintf("Node %d auto-confirmed. Proceed to next node.", nodeNumber),
+		Continuation: nextAfterNode(session, nodeNumber),
 	}, nil
 }
 
@@ -394,7 +408,7 @@ func (s *Service) awaitStepReview(sessionID, stepTitle string, stepIndex, nodeNu
 	deadline := s.now().Add(s.awaitTimeout)
 	for {
 		if s.now().After(deadline) {
-			return timeoutResponse(sessionID, nodeNumber), nil
+			return timeoutResponse(sessionID, nodeNumber, s.awaitTimeout), nil
 		}
 		s.sleep(500 * time.Millisecond)
 		if err := s.store.WriteHeartbeat(sessionID); err != nil {
@@ -413,12 +427,12 @@ func (s *Service) awaitStepReview(sessionID, stepTitle string, stepIndex, nodeNu
 			}
 			msg += "\nRedo the step from the first affected node."
 			return coop.CommandResponse{
-				OK:        true,
-				SessionID: session.ID,
-				Node:      activeNodeNumber,
-				State:     "rejected",
-				Message:   msg,
-				Next:      fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d --note=%s", session.ID, activeNodeNumber, quoteArg("Redoing: "+activeNode.Title)),
+				OK:           true,
+				SessionID:    session.ID,
+				Node:         activeNodeNumber,
+				State:        "rejected",
+				Message:      msg,
+				Continuation: coop.Continue(coop.StartWorkCommand(session.ID, activeNodeNumber, "Redoing: "+activeNode.Title)),
 			}, nil
 		}
 		if session.StepHasReview(stepIndex) {
@@ -433,12 +447,12 @@ func (s *Service) reportWorkResponse(session *coop.Session, node *coop.SessionNo
 		step, stepIndex, _, err := session.StepByNodeNumber(nodeNumber)
 		if err == nil && !session.StepReadyForReview(stepIndex) {
 			return coop.CommandResponse{
-				OK:        true,
-				SessionID: session.ID,
-				Node:      nodeNumber,
-				State:     string(coop.NodeReview),
-				Message:   fmt.Sprintf("Ready: %s. Continue the step before asking for human review.", node.Title),
-				Next:      nextInStepOrStatus(session, stepIndex, nodeNumber),
+				OK:           true,
+				SessionID:    session.ID,
+				Node:         nodeNumber,
+				State:        string(coop.NodeReview),
+				Message:      fmt.Sprintf("Ready: %s. Continue the step before asking for human review.", node.Title),
+				Continuation: coop.Continue(nextInStepOrStatus(session, stepIndex, nodeNumber)),
 			}
 		}
 		if err == nil {
@@ -448,7 +462,8 @@ func (s *Service) reportWorkResponse(session *coop.Session, node *coop.SessionNo
 				Node:      nodeNumber,
 				State:     string(coop.NodeReview),
 				Message:   fmt.Sprintf("Step ready for review: %s. Run relevant checks, keep useful servers running, share local URLs or test data, then await review.", step.Title),
-				Next:      fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", session.ID, nodeNumber),
+				Continuation: coop.Continue(coop.AwaitReviewCommand(session.ID, nodeNumber)).
+					WithWaitTimeout(int(s.awaitTimeout.Seconds())),
 			}
 		}
 		return coop.CommandResponse{
@@ -457,7 +472,8 @@ func (s *Service) reportWorkResponse(session *coop.Session, node *coop.SessionNo
 			Node:      nodeNumber,
 			State:     string(coop.NodeReview),
 			Message:   fmt.Sprintf("Ready for review: %s", node.Title),
-			Next:      fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", session.ID, nodeNumber),
+			Continuation: coop.Continue(coop.AwaitReviewCommand(session.ID, nodeNumber)).
+				WithWaitTimeout(int(s.awaitTimeout.Seconds())),
 		}
 	}
 
@@ -467,35 +483,39 @@ func (s *Service) reportWorkResponse(session *coop.Session, node *coop.SessionNo
 		msg += " All nodes complete. Run next-action so the developer can choose what happens next."
 	}
 	return coop.CommandResponse{
-		OK:        true,
-		SessionID: session.ID,
-		Node:      nodeNumber,
-		State:     string(targetState),
-		Message:   msg,
-		Next:      next,
+		OK:           true,
+		SessionID:    session.ID,
+		Node:         nodeNumber,
+		State:        string(targetState),
+		Message:      msg,
+		Continuation: next,
 	}
 }
 
-func nextAfterNode(session *coop.Session, nodeNumber int) string {
+func nextAfterNode(session *coop.Session, nodeNumber int) coop.Continuation {
 	if nextNodeNumber := session.NextPendingNode(nodeNumber); nextNodeNumber > 0 {
 		nextNode, _ := session.NodeByNumber(nextNodeNumber)
-		return fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d --note=%s", session.ID, nextNodeNumber, quoteArg("Beginning: "+nextNode.Title))
+		return coop.Continue(coop.StartWorkCommand(session.ID, nextNodeNumber, "Beginning: "+nextNode.Title))
 	}
 	if session.IsComplete() {
+		var command string
 		if session.ParentSessionID != "" && session.ParentStepID != "" {
-			return fmt.Sprintf("stripe coop agent next-action --session=%s --completed=%s", session.ParentSessionID, session.ParentStepID)
+			command = coop.NextActionCommand(session.ParentSessionID, session.ParentStepID)
+		} else {
+			command = coop.NextActionCommand(session.ID, "")
 		}
-		return fmt.Sprintf("stripe coop agent next-action --session=%s", session.ID)
+		return coop.Continue(command).
+			WithWaitTimeout(int(helpers.NextActionSelectionTimeout.Seconds()))
 	}
-	return fmt.Sprintf("stripe coop status --session=%s", session.ID)
+	return coop.Continue(coop.StatusCommand(session.ID))
 }
 
 func nextInStepOrStatus(session *coop.Session, stepIndex, afterNode int) string {
 	if nextNodeNumber := helpers.NextPendingNodeInStep(session, stepIndex+1, afterNode); nextNodeNumber > 0 {
 		nextNode, _ := session.NodeByNumber(nextNodeNumber)
-		return fmt.Sprintf("stripe coop agent start-work --session=%s --step=%d --note=%s", session.ID, nextNodeNumber, quoteArg("Beginning: "+nextNode.Title))
+		return coop.StartWorkCommand(session.ID, nextNodeNumber, "Beginning: "+nextNode.Title)
 	}
-	return fmt.Sprintf("stripe coop status --session=%s", session.ID)
+	return coop.StatusCommand(session.ID)
 }
 
 func alreadyMovedResponse(session *coop.Session, nodeNumber int, state coop.NodeState) coop.CommandResponse {
@@ -504,39 +524,52 @@ func alreadyMovedResponse(session *coop.Session, nodeNumber int, state coop.Node
 		msg = fmt.Sprintf("Node %d confirmed. All nodes done. Run next-action now.", nodeNumber)
 	}
 	return coop.CommandResponse{
-		OK:        true,
-		SessionID: session.ID,
-		Node:      nodeNumber,
-		State:     string(state),
-		Message:   msg,
-		Next:      nextAfterNode(session, nodeNumber),
+		OK:           true,
+		SessionID:    session.ID,
+		Node:         nodeNumber,
+		State:        string(state),
+		Message:      msg,
+		Continuation: nextAfterNode(session, nodeNumber),
 	}
 }
 
 func confirmedResponse(session *coop.Session, nodeNumber int) coop.CommandResponse {
 	return coop.CommandResponse{
-		OK:        true,
-		SessionID: session.ID,
-		Node:      nodeNumber,
-		State:     "confirmed",
-		Message:   fmt.Sprintf("Node %d confirmed by developer. Proceed to next node.", nodeNumber),
-		Next:      nextAfterNode(session, nodeNumber),
+		OK:           true,
+		SessionID:    session.ID,
+		Node:         nodeNumber,
+		State:        "confirmed",
+		Message:      fmt.Sprintf("Node %d confirmed by developer. Proceed to next node.", nodeNumber),
+		Continuation: nextAfterNode(session, nodeNumber),
 	}
 }
 
-func timeoutResponse(sessionID string, nodeNumber int) coop.CommandResponse {
+func timeoutResponse(sessionID string, nodeNumber int, timeout time.Duration) coop.CommandResponse {
 	return coop.CommandResponse{
 		OK:        true,
 		SessionID: sessionID,
 		Node:      nodeNumber,
 		State:     "timeout",
-		Message:   "Timed out waiting for developer confirmation. Re-run await-review to wait again.",
-		Next:      fmt.Sprintf("stripe coop agent await-review --session=%s --step=%d", sessionID, nodeNumber),
+		Message:   fmt.Sprintf("Timed out after %s waiting for developer confirmation. Re-run await-review to wait again.", timeout),
+		Continuation: coop.Continue(coop.AwaitReviewCommand(sessionID, nodeNumber)).
+			WithWaitTimeout(int(timeout.Seconds())),
 	}
 }
 
-func errorResponse(err error, hint string) coop.CommandResponse {
-	return coop.CommandResponse{OK: false, Error: err.Error(), Hint: hint}
+func sessionErrorResponse(err error) coop.CommandResponse {
+	return errorResponse(
+		err,
+		"Inspect the current Co-op session before retrying.",
+		coop.Continue(coop.StatusCommand("")),
+	)
+}
+
+func errorResponse(err error, hint string, continuation coop.Continuation) coop.CommandResponse {
+	return coop.CommandResponse{
+		OK:       false,
+		Error:    err.Error(),
+		Recovery: continuation.Recovery(hint),
+	}
 }
 
 func requireActiveSession(session *coop.Session) error {
@@ -551,8 +584,4 @@ func language(session *coop.Session) string {
 		return session.Settings["language"]
 	}
 	return "node"
-}
-
-func quoteArg(value string) string {
-	return fmt.Sprintf("%q", value)
 }

--- a/pkg/coop/workflow/service_test.go
+++ b/pkg/coop/workflow/service_test.go
@@ -2,11 +2,13 @@ package workflow
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/helpers"
 )
 
 func TestStartWorkTransitionsNodeAndReturnsTypedNextCommand(t *testing.T) {
@@ -19,7 +21,9 @@ func TestStartWorkTransitionsNodeAndReturnsTypedNextCommand(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, resp.OK)
 	assert.Equal(t, "active", resp.State)
-	assert.Contains(t, resp.Next, "stripe coop agent report-work")
+	assert.Empty(t, resp.Next)
+	assert.Contains(t, resp.NextTemplate, "stripe coop agent report-work")
+	require.NotEmpty(t, resp.RequiredInputs)
 
 	loaded, err := store.Read(session.ID)
 	require.NoError(t, err)
@@ -114,15 +118,66 @@ func TestReportWorkRoutesToAwaitReviewWhenStepReady(t *testing.T) {
 
 	_, err := service.StartWork(session.ID, 1, "First")
 	require.NoError(t, err)
-	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go"}, false)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go", Note: "Implemented server work"}, false)
 	require.NoError(t, err)
 	_, err = service.StartWork(session.ID, 2, "Second")
 	require.NoError(t, err)
-	resp, err := service.ReportWork(session.ID, 2, ReportWorkInput{File: "client.go"}, false)
+	resp, err := service.ReportWork(session.ID, 2, ReportWorkInput{File: "client.go", Note: "Implemented client work"}, false)
 	require.NoError(t, err)
 	require.True(t, resp.OK)
 	assert.Contains(t, resp.Message, "Step ready for review")
 	assert.Contains(t, resp.Next, "stripe coop agent await-review")
+	assert.Equal(t, int(AwaitTimeout.Seconds()), resp.WaitTimeoutSeconds)
+}
+
+func TestAwaitTimeoutContractLeavesHarnessHeadroom(t *testing.T) {
+	assert.Equal(t, 5*time.Minute, AwaitTimeout)
+	assert.Greater(t, AwaitHarnessTimeout, AwaitTimeout)
+
+	resp := timeoutResponse("session_123", 4, AwaitTimeout)
+	require.NoError(t, resp.Validate())
+	assert.Equal(t, int(AwaitTimeout.Seconds()), resp.WaitTimeoutSeconds)
+	assert.Contains(t, resp.Message, AwaitTimeout.String())
+}
+
+func TestConfiguredAwaitTimeoutIsAdvertised(t *testing.T) {
+	store, session := workflowTestStore(t)
+	timeout := 45 * time.Second
+	service := NewService(store, WithAwaitTimeout(timeout))
+
+	_, err := service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{Note: "First done"}, false)
+	require.NoError(t, err)
+	_, err = service.StartWork(session.ID, 2, "Second")
+	require.NoError(t, err)
+	resp, err := service.ReportWork(session.ID, 2, ReportWorkInput{Note: "Second done"}, false)
+	require.NoError(t, err)
+
+	require.True(t, resp.OK)
+	assert.Contains(t, resp.Next, "stripe coop agent await-review")
+	assert.Equal(t, int(timeout.Seconds()), resp.WaitTimeoutSeconds)
+
+	timedOut := timeoutResponse(session.ID, 2, timeout)
+	assert.Equal(t, int(timeout.Seconds()), timedOut.WaitTimeoutSeconds)
+	assert.Contains(t, timedOut.Message, timeout.String())
+}
+
+func TestReportWorkRequiresNoteWithTemplateRecovery(t *testing.T) {
+	store, session := workflowTestStore(t)
+	service := NewService(store)
+
+	_, err := service.StartWork(session.ID, 1, "First")
+	require.NoError(t, err)
+	resp, err := service.ReportWork(session.ID, 1, ReportWorkInput{}, false)
+	require.NoError(t, err)
+
+	assert.False(t, resp.OK)
+	assert.Empty(t, resp.Next)
+	require.NotNil(t, resp.Recovery)
+	assert.Contains(t, resp.Recovery.NextTemplate, `--note="<what you did>"`)
+	require.Len(t, resp.Recovery.RequiredInputs, 1)
+	require.NoError(t, resp.Validate())
 }
 
 func TestConfirmAndRequestChangesUseCentralWorkflow(t *testing.T) {
@@ -131,7 +186,7 @@ func TestConfirmAndRequestChangesUseCentralWorkflow(t *testing.T) {
 
 	_, err := service.StartWork(session.ID, 1, "First")
 	require.NoError(t, err)
-	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go"}, false)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go", Note: "Implemented server work"}, false)
 	require.NoError(t, err)
 
 	updated, err := service.ConfirmReview(session.ID, []int{1})
@@ -161,7 +216,7 @@ func TestRequestChangesMovesReviewNodeBackToActive(t *testing.T) {
 
 	_, err := service.StartWork(session.ID, 1, "First")
 	require.NoError(t, err)
-	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go"}, false)
+	_, err = service.ReportWork(session.ID, 1, ReportWorkInput{File: "server.go", Note: "Implemented server work"}, false)
 	require.NoError(t, err)
 	updated, err := service.RequestChanges(session.ID, []int{1}, "Needs tests")
 	require.NoError(t, err)
@@ -186,7 +241,7 @@ func TestAgentWorkflowRejectsInactiveSessions(t *testing.T) {
 		{
 			name: "report work",
 			run: func(service *Service, sessionID string) (coop.CommandResponse, error) {
-				return service.ReportWork(sessionID, 1, ReportWorkInput{File: "server.go"}, false)
+				return service.ReportWork(sessionID, 1, ReportWorkInput{File: "server.go", Note: "Implemented server work"}, false)
 			},
 		},
 		{
@@ -312,6 +367,7 @@ func TestCompletedParentedSessionRoutesNextActionToParent(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, resp.OK)
 	assert.Equal(t, "stripe coop agent next-action --session=parent_session --completed=add-integration", resp.Next)
+	assert.Equal(t, int(helpers.NextActionSelectionTimeout.Seconds()), resp.WaitTimeoutSeconds)
 }
 
 func workflowTestStore(t *testing.T) (*coop.Store, *coop.Session) {


### PR DESCRIPTION
## Summary

- distinguish executable `next` commands from `next_template` continuations with declared inputs
- normalize agent failures under one structured `recovery` contract on stderr
- advertise blocking command timeouts and align the five-minute await with six-minute harness headroom
- centralize Co-op command formatting so protocol responses cannot drift

## Scope

This is the first PR in a planned stack. It intentionally excludes persisted node outputs and reference resolution, plus the later file-organization cleanup.

## Testing

- `go test -race -count=1 ./pkg/coop/... ./pkg/cmd/coop`
- `go test -count=1 ./pkg/cmd ./pkg/coop/...`
- `go vet ./pkg/coop/... ./pkg/cmd/coop`
- built CLI smoke tests for structured agent failures
- repository-wide `go test -count=1 ./...` passed all touched packages; `pkg/plugins` remains blocked by a private JFrog manifest lookup in this environment