### PR TITLE
Scope docs cache by account and wire API key from CLI profile

### DIFF
--- a/pkg/cmd/docs/root.go
+++ b/pkg/cmd/docs/root.go
@@ -145,6 +145,12 @@ func (r *RootCommand) initClient() {
 		if cache, err := pkgdocs.NewFSCache(filepath.Join(configDir, "docs", "cache")); err == nil {
 			clientOpts = append(clientOpts, pkgdocs.WithCache(cache))
 		}
+		if accountID, err := r.cfg.Profile.GetAccountID(); err == nil {
+			clientOpts = append(clientOpts, pkgdocs.WithCacheKeyPrefix(accountID))
+		}
+		if apiKey, err := r.cfg.Profile.GetAPIKey(false); err == nil {
+			clientOpts = append(clientOpts, pkgdocs.WithAPIKey(apiKey))
+		}
 	}
 	if len(clientOpts) > 0 {
 		r.client.WithOptions(clientOpts...)

--- a/pkg/docs/client.go
+++ b/pkg/docs/client.go
@@ -40,11 +40,13 @@ type Hit struct {
 
 // Client fetches documentation pages and calls endpoints on docs.stripe.com.
 type Client struct {
-	http      *http.Client
-	baseURL   *url.URL
-	userAgent string
-	cache     Cache
-	logger    *log.Entry
+	http           *http.Client
+	baseURL        *url.URL
+	userAgent      string
+	apiKey         string
+	cacheKeyPrefix string
+	cache          Cache
+	logger         *log.Entry
 }
 
 // ClientOption configures a Client.
@@ -63,6 +65,17 @@ func WithCache(cache Cache) ClientOption { return func(c *Client) { c.cache = ca
 
 // WithLogger sets a custom logger.
 func WithLogger(logger *log.Entry) ClientOption { return func(c *Client) { c.logger = logger } }
+
+// WithAPIKey sets the Stripe API key sent as an Authorization header on every request.
+func WithAPIKey(key string) ClientOption { return func(c *Client) { c.apiKey = key } }
+
+// WithCacheKeyPrefix scopes the FetchPage cache to a specific account by prefixing
+// all cache keys with prefix. Pass the account ID (e.g. "acct_xxx") so that cached
+// entries from one account are never served to another. An empty prefix is a no-op,
+// which keeps unauthenticated usage working without changes.
+func WithCacheKeyPrefix(prefix string) ClientOption {
+	return func(c *Client) { c.cacheKeyPrefix = prefix }
+}
 
 // NewClient creates a Client configured to talk to docs.stripe.com.
 func NewClient(_ string) *Client {
@@ -94,9 +107,10 @@ func (c *Client) FetchPage(ctx context.Context, ref *url.URL) (Page, error) {
 	// a consistent cache key regardless of how callers construct RawQuery.
 	resolvedURL.RawQuery = resolvedURL.Query().Encode()
 	rawURL := resolvedURL.String()
+	cacheKey := c.cacheKey(rawURL)
 
 	if c.cache != nil {
-		if data, cachedAt, ok, err := c.cache.Get(rawURL); err != nil {
+		if data, cachedAt, ok, err := c.cache.Get(cacheKey); err != nil {
 			c.logger.WithFields(log.Fields{"url": rawURL}).WithError(err).Error("cache read failed")
 			return Page{}, fmt.Errorf("docs: cache read: %w", err)
 		} else if ok {
@@ -122,7 +136,7 @@ func (c *Client) FetchPage(ctx context.Context, ref *url.URL) (Page, error) {
 	}
 
 	if c.cache != nil {
-		if err := c.cache.Set(rawURL, res.body); err != nil {
+		if err := c.cache.Set(cacheKey, res.body); err != nil {
 			c.logger.WithField("url", rawURL).WithError(err).Error("cache write failed")
 			return Page{}, fmt.Errorf("docs: cache write: %w", err)
 		}
@@ -138,6 +152,15 @@ func (c *Client) FetchPage(ctx context.Context, ref *url.URL) (Page, error) {
 type response struct {
 	body     []byte
 	finalURL *url.URL
+}
+
+// cacheKey returns a cache key for a resolved URL, prefixed by the account ID
+// when one is configured so that entries are scoped per account.
+func (c *Client) cacheKey(rawURL string) string {
+	if c.cacheKeyPrefix == "" {
+		return rawURL
+	}
+	return c.cacheKeyPrefix + ":" + rawURL
 }
 
 func (c *Client) do(req *http.Request) (response, error) {

--- a/pkg/docs/client_test.go
+++ b/pkg/docs/client_test.go
@@ -101,6 +101,20 @@ func TestWithOptions(t *testing.T) {
 				assert.Equal(t, "https://second.com", c.baseURL.String())
 			},
 		},
+		{
+			name: "set API key",
+			opts: []ClientOption{WithAPIKey("sk_test_abc123")},
+			wantCheck: func(t *testing.T, c *Client) {
+				assert.Equal(t, "sk_test_abc123", c.apiKey)
+			},
+		},
+		{
+			name: "set cache key prefix",
+			opts: []ClientOption{WithCacheKeyPrefix("acct_123")},
+			wantCheck: func(t *testing.T, c *Client) {
+				assert.Equal(t, "acct_123", c.cacheKeyPrefix)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -503,6 +517,80 @@ func TestFetchPrefs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFetchPage_CacheKeyPrefix_ScopesByAccount(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		fmt.Fprintf(w, "response %d", calls)
+	}))
+	defer server.Close()
+
+	cache := newMockCache()
+	ref := &url.URL{Path: "/payments"}
+
+	acct1 := NewClient("0.1.0").WithOptions(WithBaseURL(server.URL), WithCache(cache), WithCacheKeyPrefix("acct_111"))
+	acct2 := NewClient("0.1.0").WithOptions(WithBaseURL(server.URL), WithCache(cache), WithCacheKeyPrefix("acct_222"))
+
+	got1, err := acct1.FetchPage(context.Background(), ref)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("response 1"), got1.Content)
+
+	// same URL, different prefix — must not hit acct1's cache entry
+	got2, err := acct2.FetchPage(context.Background(), ref)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("response 2"), got2.Content)
+
+	assert.Equal(t, 2, calls)
+	assert.Equal(t, 0, cache.hits)
+}
+
+func TestFetchPage_CacheKeyPrefix_HitsWithinSameAccount(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		fmt.Fprint(w, "content")
+	}))
+	defer server.Close()
+
+	cache := newMockCache()
+	ref := &url.URL{Path: "/payments"}
+
+	client := NewClient("0.1.0").WithOptions(WithBaseURL(server.URL), WithCache(cache), WithCacheKeyPrefix("acct_111"))
+
+	_, err := client.FetchPage(context.Background(), ref)
+	require.NoError(t, err)
+
+	_, err = client.FetchPage(context.Background(), ref)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, 1, cache.hits)
+}
+
+func TestFetchPage_EmptyCacheKeyPrefix_UsesRawURL(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		fmt.Fprint(w, "content")
+	}))
+	defer server.Close()
+
+	cache := newMockCache()
+	ref := &url.URL{Path: "/payments"}
+
+	// WithCacheKeyPrefix("") is a no-op — behaves identically to not setting a prefix
+	client := NewClient("0.1.0").WithOptions(WithBaseURL(server.URL), WithCache(cache), WithCacheKeyPrefix(""))
+
+	_, err := client.FetchPage(context.Background(), ref)
+	require.NoError(t, err)
+
+	_, err = client.FetchPage(context.Background(), ref)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, 1, cache.hits)
 }
 
 // evictingMockCache always returns a miss, simulating TTL expiry.


### PR DESCRIPTION
## Summary

The `stripe docs` command fetches pages from docs.stripe.com and caches them locally by URL. This PR wires up two new options on the docs HTTP client to prepare for authenticated requests:

- **`WithAPIKey`** stores a Stripe API key on the client. The key is populated from the CLI profile's test-mode key at startup but is not yet sent in requests; the transport layer is ready for when the correct auth scheme for docs.stripe.com is confirmed.

- **`WithCacheKeyPrefix`** prefixes all `FetchPage` cache keys with an arbitrary string. The CLI passes the account ID (`acct_xxx`) so that cached entries are scoped per account. This prevents pages fetched under one account from being returned to a different account if the docs endpoint ever returns personalized content. An empty prefix is a no-op, so unauthenticated usage is unchanged.

Both options are best-effort in `initClient`: if the user is logged out or has no test-mode key, the option is skipped and the client works as before.