### PR TITLE
coop: support Cursor, Gemini, Goose, opencode, and Pi agents

### DIFF
--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -17,8 +17,8 @@ import (
 )
 
 type agentInfo struct {
-	name string // "claude" or "codex"
-	path string
+	harness harness
+	path    string
 }
 
 // shellQuote wraps s in POSIX single quotes so it is safe to interpolate into a
@@ -44,66 +44,72 @@ const (
 	defaultCoopTmuxSessionHeight = 50
 )
 
+// lookPath is indirected so tests can control which harnesses appear installed.
+var lookPath = exec.LookPath
+
 func (rc *coopRunCmd) detectAgent() (*agentInfo, error) {
 	if rc.agent != "" {
-		path, err := exec.LookPath(rc.agent)
+		path, err := lookPath(rc.agent)
 		if err != nil {
 			return nil, fmt.Errorf("agent %q not found in PATH", rc.agent)
 		}
-		name := rc.agent
-		if strings.Contains(path, "claude") {
-			name = "claude"
-		} else if strings.Contains(path, "codex") {
-			name = "codex"
+		h, ok := harnessFor(rc.agent, path)
+		if !ok {
+			h = customHarness(rc.agent)
 		}
-		return &agentInfo{name: name, path: path}, nil
+		return &agentInfo{harness: h, path: path}, nil
 	}
 
-	claudePath, claudeErr := exec.LookPath("claude")
-	codexPath, codexErr := exec.LookPath("codex")
+	installed := installedHarnesses()
 
-	hasClaude := claudeErr == nil
-	hasCodex := codexErr == nil
+	switch len(installed) {
+	case 0:
+		return nil, noAgentFoundError()
+	case 1:
+		return &installed[0], nil
+	}
 
-	switch {
-	case hasClaude && hasCodex:
-		var choice string
-		err := selectString("Multiple agents detected. Which would you like to use?",
-			[]huh.Option[string]{
-				huh.NewOption("Claude Code", "claude"),
-				huh.NewOption("Codex", "codex"),
-			},
-			&choice,
-		)
+	options := make([]huh.Option[string], 0, len(installed))
+	for _, agent := range installed {
+		options = append(options, huh.NewOption(agent.harness.displayName, agent.harness.id))
+	}
+
+	var choice string
+	if err := selectString("Multiple agents detected. Which would you like to use?", options, &choice); err != nil {
+		return nil, err
+	}
+	for _, agent := range installed {
+		if agent.harness.id == choice {
+			return &agent, nil
+		}
+	}
+	// The picker only offers ids drawn from installed, so this is unreachable
+	// unless the prompt is stubbed out; fall back to the first detected agent
+	// rather than returning a nil agent to the caller.
+	return &installed[0], nil
+}
+
+// installedHarnesses returns the registry entries whose binary is on PATH, in
+// registry order.
+func installedHarnesses() []agentInfo {
+	var found []agentInfo
+	for _, h := range supportedHarnesses {
+		path, err := lookPath(h.binary)
 		if err != nil {
-			return nil, err
+			continue
 		}
-		if choice == "codex" {
-			return &agentInfo{name: "codex", path: codexPath}, nil
-		}
-		return &agentInfo{name: "claude", path: claudePath}, nil
-
-	case hasClaude:
-		return &agentInfo{name: "claude", path: claudePath}, nil
-	case hasCodex:
-		return &agentInfo{name: "codex", path: codexPath}, nil
-	default:
-		return nil, fmt.Errorf("no AI agent found in PATH.\n  Install Claude Code: https://docs.anthropic.com/en/docs/claude-code\n  Or specify a custom agent: --agent=<command>")
+		found = append(found, agentInfo{harness: h, path: path})
 	}
+	return found
 }
 
 func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) (bool, error) {
-	var choice string
-
-	var title string
-	switch agent.name {
-	case "claude":
-		title = "Permission mode for Claude Code:"
-	case "codex":
-		title = "Permission mode for Codex:"
-	default:
+	if !agent.harness.offersAutoApprove() {
 		return false, nil
 	}
+
+	var choice string
+	title := fmt.Sprintf("Permission mode for %s:", agent.harness.displayName)
 
 	err := selectString(title,
 		[]huh.Option[string]{
@@ -120,29 +126,26 @@ func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) (bool, error) {
 
 func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApprove bool) (string, error) {
 	launcherPath := promptPath + ".sh"
-	var script string
 
-	switch agent.name {
-	case "claude":
-		flags := ""
-		if autoApprove {
-			flags = " --dangerously-skip-permissions"
-		}
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path), flags)
-
-	case "codex":
-		flags := ""
-		if autoApprove {
-			flags = " --dangerously-bypass-approvals-and-sandbox"
-		}
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path), flags)
-
-	default:
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path))
+	// The agent path is user-controlled and must be quoted. Everything else is a
+	// compile-time constant from the registry, so it is interpolated as-is.
+	argv := []string{shellQuote(agent.path)}
+	argv = append(argv, agent.harness.args...)
+	if autoApprove && agent.harness.autoApproveFlag != "" {
+		argv = append(argv, agent.harness.autoApproveFlag)
 	}
+	if agent.harness.promptFlag != "" {
+		argv = append(argv, agent.harness.promptFlag)
+	}
+	argv = append(argv, `"$prompt"`)
+
+	env := ""
+	if autoApprove && agent.harness.autoApproveEnv != "" {
+		env = fmt.Sprintf("export %s\n", agent.harness.autoApproveEnv)
+	}
+
+	script := fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\n%sexec %s\n",
+		shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), env, strings.Join(argv, " "))
 
 	if err := os.WriteFile(launcherPath, []byte(script), 0700); err != nil {
 		return "", fmt.Errorf("creating agent launcher: %w", err)

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -17,8 +17,8 @@ import (
 )
 
 type agentInfo struct {
-	name string // "claude" or "codex"
-	path string
+	harness harness
+	path    string
 }
 
 // shellQuote wraps s in POSIX single quotes so it is safe to interpolate into a
@@ -45,74 +45,77 @@ const (
 	claudeCoopAgents             = `{"coop-cost-effective-worker":{"description":"Use proactively for well-bounded, self-contained exploration, documentation research, test execution, log analysis, and verification tasks when delegation saves main-session context and cost.","prompt":"Work as a focused cost-effective Co-op subagent. Complete only the bounded task you receive, verify your result, and return concise evidence to the main agent. Find and honor applicable repository guidance, including AGENTS.md and CLAUDE.md, before acting. Do not choose or change the Stripe integration or run Co-op lifecycle commands.","model":"haiku"}}`
 )
 
+// lookPath is indirected so tests can control which harnesses appear installed.
+var lookPath = exec.LookPath
+
 func (rc *coopRunCmd) detectAgent() (*agentInfo, error) {
 	if rc.agent != "" {
-		path, err := exec.LookPath(rc.agent)
+		path, err := lookPath(rc.agent)
 		if err != nil {
 			return nil, fmt.Errorf("agent %q not found in PATH", rc.agent)
 		}
-		name := rc.agent
-		if strings.Contains(path, "claude") {
-			name = "claude"
-		} else if strings.Contains(path, "codex") {
-			name = "codex"
+		h, ok := harnessFor(rc.agent, path)
+		if !ok {
+			h = customHarness(rc.agent)
 		}
-		return &agentInfo{name: name, path: path}, nil
+		return &agentInfo{harness: h, path: path}, nil
 	}
 
-	claudePath, claudeErr := exec.LookPath("claude")
-	codexPath, codexErr := exec.LookPath("codex")
+	installed := installedHarnesses()
 
-	hasClaude := claudeErr == nil
-	hasCodex := codexErr == nil
+	switch len(installed) {
+	case 0:
+		return nil, noAgentFoundError()
+	case 1:
+		return &installed[0], nil
+	}
 
-	switch {
-	case hasClaude && hasCodex:
-		var choice string
-		err := selectString("Multiple agents detected. Which would you like to use?",
-			[]huh.Option[string]{
-				huh.NewOption("Claude Code", "claude"),
-				huh.NewOption("Codex", "codex"),
-			},
-			&choice,
-		)
+	options := make([]huh.Option[string], 0, len(installed))
+	for _, agent := range installed {
+		options = append(options, huh.NewOption(agent.harness.displayName, agent.harness.id))
+	}
+
+	var choice string
+	if err := selectString("Multiple agents detected. Which would you like to use?", options, &choice); err != nil {
+		return nil, err
+	}
+	for _, agent := range installed {
+		if agent.harness.id == choice {
+			return &agent, nil
+		}
+	}
+	// The picker only offers ids drawn from installed, so this is unreachable
+	// unless the prompt is stubbed out; fall back to the first detected agent
+	// rather than returning a nil agent to the caller.
+	return &installed[0], nil
+}
+
+// installedHarnesses returns the registry entries whose binary is on PATH, in
+// registry order.
+func installedHarnesses() []agentInfo {
+	var found []agentInfo
+	for _, h := range supportedHarnesses {
+		path, err := lookPath(h.binary)
 		if err != nil {
-			return nil, err
+			continue
 		}
-		if choice == "codex" {
-			return &agentInfo{name: "codex", path: codexPath}, nil
-		}
-		return &agentInfo{name: "claude", path: claudePath}, nil
-
-	case hasClaude:
-		return &agentInfo{name: "claude", path: claudePath}, nil
-	case hasCodex:
-		return &agentInfo{name: "codex", path: codexPath}, nil
-	default:
-		return nil, fmt.Errorf("no AI agent found in PATH.\n  Install Claude Code: https://docs.anthropic.com/en/docs/claude-code\n  Or specify a custom agent: --agent=<command>")
+		found = append(found, agentInfo{harness: h, path: path})
 	}
+	return found
 }
 
 func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) (bool, error) {
-	var choice string
-
-	var title string
-	var bypassLabel string
-	switch agent.name {
-	case "claude":
-		title = "Permission mode for Claude Code:"
-		bypassLabel = "Bypass permissions — skip safety checks (isolated environments only)"
-	case "codex":
-		title = "Permission mode for Codex:"
-		bypassLabel = "Bypass approvals and sandbox — skip safety checks (isolated environments only)"
-	default:
+	if !agent.harness.offersAutoApprove() {
 		return false, nil
 	}
+
+	var choice string
+	title := fmt.Sprintf("Permission mode for %s:", agent.harness.displayName)
 
 	err := selectString(title,
 		[]huh.Option[string]{
 			huh.NewOption("Normal — agent asks before running commands", "normal"),
-			huh.NewOption(bypassLabel, "bypass"),
+			huh.NewOption(agent.harness.bypassOption(), "bypass"),
 		},
 		&choice,
 	)
@@ -124,29 +127,26 @@ func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) (bool, error) {
 
 func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApprove bool) (string, error) {
 	launcherPath := promptPath + ".sh"
-	var script string
 
-	switch agent.name {
-	case "claude":
-		flags := " --agents " + shellQuote(claudeCoopAgents)
-		if autoApprove {
-			flags += " --dangerously-skip-permissions"
-		}
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path), flags)
-
-	case "codex":
-		flags := ""
-		if autoApprove {
-			flags = " --dangerously-bypass-approvals-and-sandbox"
-		}
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path), flags)
-
-	default:
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path))
+	// The agent path is user-controlled and must be quoted. Everything else is a
+	// compile-time constant from the registry, so it is interpolated as-is.
+	argv := []string{shellQuote(agent.path)}
+	argv = append(argv, agent.harness.args...)
+	if autoApprove && agent.harness.autoApproveFlag != "" {
+		argv = append(argv, agent.harness.autoApproveFlag)
 	}
+	if agent.harness.promptFlag != "" {
+		argv = append(argv, agent.harness.promptFlag)
+	}
+	argv = append(argv, `"$prompt"`)
+
+	env := ""
+	if autoApprove && agent.harness.autoApproveEnv != "" {
+		env = fmt.Sprintf("export %s\n", agent.harness.autoApproveEnv)
+	}
+
+	script := fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\n%sexec %s\n",
+		shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), env, strings.Join(argv, " "))
 
 	if err := os.WriteFile(launcherPath, []byte(script), 0700); err != nil {
 		return "", fmt.Errorf("creating agent launcher: %w", err)

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -72,7 +72,7 @@ func TestPromptAutoApproveReturnsPromptErrors(t *testing.T) {
 		selectString = originalSelectString
 	})
 
-	autoApprove, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{name: "claude"})
+	autoApprove, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{harness: mustHarness(t, "claude")})
 
 	require.ErrorIs(t, err, promptErr)
 	assert.False(t, autoApprove)
@@ -246,7 +246,7 @@ func TestAgentPaneCommandShellQuotesLauncherPath(t *testing.T) {
 	t.Setenv("TEMP", tmp)
 
 	rc := &coopRunCmd{}
-	build := rc.agentPaneCommandBuilder(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, "discovery prompt", false)
+	build := rc.agentPaneCommandBuilder(&agentInfo{harness: mustHarness(t, "claude"), path: "/usr/local/bin/claude"}, "discovery prompt", false)
 	paneCmd, cleanup, err := build(nil)
 	require.NoError(t, err)
 	require.NotNil(t, cleanup)

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -108,7 +108,7 @@ func TestPromptAutoApproveReturnsPromptErrors(t *testing.T) {
 		selectString = originalSelectString
 	})
 
-	autoApprove, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{name: "claude"})
+	autoApprove, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{harness: mustHarness(t, "claude")})
 
 	require.ErrorIs(t, err, promptErr)
 	assert.False(t, autoApprove)
@@ -137,7 +137,7 @@ func TestPromptAutoApproveLabelsBypassModeAccurately(t *testing.T) {
 			}
 			t.Cleanup(func() { selectString = originalSelectString })
 
-			bypass, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{name: tt.agent})
+			bypass, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{harness: mustHarness(t, tt.agent)})
 
 			require.NoError(t, err)
 			assert.True(t, bypass)
@@ -161,7 +161,7 @@ func TestClaudeLauncherConfiguresCostEffectiveWorkerAndInteractivePrompt(t *test
 	require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
 	rc := &coopRunCmd{}
 
-	launcherPath, err := rc.buildAgentCmd(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, promptPath, true)
+	launcherPath, err := rc.buildAgentCmd(&agentInfo{harness: mustHarness(t, "claude"), path: "/usr/local/bin/claude"}, promptPath, true)
 	require.NoError(t, err)
 	launcher, err := os.ReadFile(launcherPath)
 	require.NoError(t, err)
@@ -180,7 +180,7 @@ func TestClaudeLauncherNormalModeDoesNotBypassPermissions(t *testing.T) {
 	promptPath := filepath.Join(t.TempDir(), "prompt")
 	require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
 
-	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, promptPath, false)
+	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(&agentInfo{harness: mustHarness(t, "claude"), path: "/usr/local/bin/claude"}, promptPath, false)
 	require.NoError(t, err)
 	launcher, err := os.ReadFile(launcherPath)
 	require.NoError(t, err)
@@ -194,7 +194,7 @@ func TestCodexLauncherDoesNotReceiveClaudeAgents(t *testing.T) {
 	promptPath := filepath.Join(t.TempDir(), "prompt")
 	require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
 
-	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(&agentInfo{name: "codex", path: "/usr/local/bin/codex"}, promptPath, true)
+	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(&agentInfo{harness: mustHarness(t, "codex"), path: "/usr/local/bin/codex"}, promptPath, true)
 	require.NoError(t, err)
 	launcher, err := os.ReadFile(launcherPath)
 	require.NoError(t, err)
@@ -380,7 +380,7 @@ func TestAgentPaneCommandShellQuotesLauncherPath(t *testing.T) {
 	t.Setenv("TEMP", tmp)
 
 	rc := &coopRunCmd{}
-	build := rc.agentPaneCommandBuilder(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, "discovery prompt", false)
+	build := rc.agentPaneCommandBuilder(&agentInfo{harness: mustHarness(t, "claude"), path: "/usr/local/bin/claude"}, "discovery prompt", false)
 	paneCmd, cleanup, err := build(nil)
 	require.NoError(t, err)
 	require.NotNil(t, cleanup)

--- a/pkg/cmd/coop/coop_start.go
+++ b/pkg/cmd/coop/coop_start.go
@@ -23,14 +23,20 @@ func newCoopRunCmd() *coopRunCmd {
 	rc.cmd = &cobra.Command{
 		Use:   "start [blueprint-id]",
 		Short: "Launch a co-op session with an AI agent in split-screen",
-		Long: `Starts a co-op session and launches an AI agent (Claude Code) in a
-split terminal view. The TUI shows on one side, the agent works on the other.
+		Long: fmt.Sprintf(`Starts a co-op session and launches an AI agent in a split
+terminal view. The TUI shows on one side, the agent works on the other.
+
+Supported agents, auto-detected on PATH:
+  %s
+
+When more than one is installed, co-op asks which to use. Use --agent to
+force a specific one, or to run an agent co-op does not know about.
 
 If no blueprint is provided, the agent will explore your codebase,
 understand your needs, and pick the right integration via the recommender.
 
 Requires tmux (detected automatically). If already in a tmux session,
-splits the current window. Otherwise creates a new tmux session.`,
+splits the current window. Otherwise creates a new tmux session.`, supportedHarnessList()),
 		Example: `  stripe coop start
   stripe coop start one-time-payment --language=node
   stripe coop start --language=python`,
@@ -40,7 +46,7 @@ splits the current window. Otherwise creates a new tmux session.`,
 
 	rc.cmd.Flags().StringVar(&rc.language, "language", "", "Programming language for the integration")
 	rc.cmd.Flags().StringArrayVar(&rc.settings, "setting", nil, "Blueprint settings as key=value pairs")
-	rc.cmd.Flags().StringVar(&rc.agent, "agent", "", "Agent to use (default: auto-detect claude/codex)")
+	rc.cmd.Flags().StringVar(&rc.agent, "agent", "", fmt.Sprintf("Agent to use: %s, or a custom command (default: auto-detect)", supportedHarnessList()))
 	rc.cmd.Flags().BoolVar(&rc.debugAgent, "debug-agent", false, "Use a deterministic fake agent for local TUI debugging")
 	mustMarkFlagHidden(rc.cmd, "debug-agent")
 

--- a/pkg/cmd/coop/coop_start.go
+++ b/pkg/cmd/coop/coop_start.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/coop"
 )
 
@@ -82,6 +83,10 @@ func (rc *coopRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 	agent, err := rc.detectAgent()
 	if err != nil {
 		return err
+	}
+
+	if notice := agent.harness.permissionNotice(); notice != "" {
+		fmt.Println(ansi.Bold("Warning: ") + notice)
 	}
 
 	autoApprove, err := rc.promptAutoApprove(agent)

--- a/pkg/cmd/coop/coop_start.go
+++ b/pkg/cmd/coop/coop_start.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/coop"
 )
 
@@ -99,6 +100,10 @@ func (rc *coopRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 	agent, err := rc.detectAgent()
 	if err != nil {
 		return err
+	}
+
+	if notice := agent.harness.permissionNotice(); notice != "" {
+		fmt.Println(ansi.Bold("Warning: ") + notice)
 	}
 
 	autoApprove, err := rc.promptAutoApprove(agent)

--- a/pkg/cmd/coop/coop_start.go
+++ b/pkg/cmd/coop/coop_start.go
@@ -30,14 +30,20 @@ func newCoopRunCmd() *coopRunCmd {
 	rc.cmd = &cobra.Command{
 		Use:   "start [blueprint-id]",
 		Short: "Launch a co-op session with an AI agent in split-screen",
-		Long: `Starts a co-op session and launches an AI agent (Claude Code) in a
-split terminal view. The TUI shows on one side, the agent works on the other.
+		Long: fmt.Sprintf(`Starts a co-op session and launches an AI agent in a split
+terminal view. The TUI shows on one side, the agent works on the other.
+
+Supported agents, auto-detected on PATH:
+  %s
+
+When more than one is installed, co-op asks which to use. Use --agent to
+force a specific one, or to run an agent co-op does not know about.
 
 If no blueprint is provided, the agent will explore your codebase,
 understand your needs, and pick the right integration via the recommender.
 
 Requires tmux (detected automatically). If already in a tmux session,
-splits the current window. Otherwise creates a new tmux session.`,
+splits the current window. Otherwise creates a new tmux session.`, supportedHarnessList()),
 		Example: `  stripe coop start
   stripe coop start one-time-payment --language=node
   stripe coop start --language=python`,
@@ -47,7 +53,7 @@ splits the current window. Otherwise creates a new tmux session.`,
 
 	rc.cmd.Flags().StringVar(&rc.language, "language", "", "Programming language for the integration")
 	rc.cmd.Flags().StringArrayVar(&rc.settings, "setting", nil, "Blueprint settings as key=value pairs")
-	rc.cmd.Flags().StringVar(&rc.agent, "agent", "", "Agent to use (default: auto-detect claude/codex)")
+	rc.cmd.Flags().StringVar(&rc.agent, "agent", "", fmt.Sprintf("Agent to use: %s, or a custom command (default: auto-detect)", supportedHarnessList()))
 	rc.cmd.Flags().BoolVar(&rc.debugAgent, "debug-agent", false, "Use a deterministic fake agent for local TUI debugging")
 	mustMarkFlagHidden(rc.cmd, "debug-agent")
 
@@ -103,7 +109,7 @@ func (rc *coopRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 		if err := rc.ensureStripeSkill(); err != nil {
 			warnRepoStripeBestPracticesSkill(cmd, err)
 		}
-	} else if agent.name == "claude" {
+	} else if agent.harness.id == "claude" {
 		if err := rc.prepareAgentSkillDiscovery(); err != nil {
 			warnRepoClaudeSkillsDiscovery(cmd, err)
 		}

--- a/pkg/cmd/coop/harness.go
+++ b/pkg/cmd/coop/harness.go
@@ -37,6 +37,25 @@ type harness struct {
 	// autoApproveEnv is a KEY=value pair exported before exec, for harnesses
 	// that control approvals through the environment instead of a flag.
 	autoApproveEnv string
+	// noPermissionGate marks a harness that never prompts before acting. Co-op
+	// warns instead of simply omitting the permission-mode question, so the
+	// missing prompt is not read as "the safe default applied".
+	noPermissionGate bool
+}
+
+// permissionNotice returns a warning to print before launching, or "" when the
+// harness gates tool use normally.
+//
+// This covers only harnesses known to have no gate. A custom --agent binary
+// also has no autoApproveFlag, but that reflects co-op not knowing its
+// permission model rather than knowing it has none.
+func (h harness) permissionNotice() string {
+	if !h.noPermissionGate {
+		return ""
+	}
+	return fmt.Sprintf("%s has no permission prompts: it reads, writes, and runs commands "+
+		"without asking. Co-op cannot gate it, so there is no permission mode to choose.",
+		h.displayName)
 }
 
 // offersAutoApprove reports whether co-op can skip this harness's permission
@@ -106,7 +125,7 @@ var supportedHarnesses = []harness{
 		// Pi ships no permission system and no sandbox: it runs with the
 		// privileges of the launching process and never prompts, so there is
 		// nothing for co-op's auto-approve choice to skip.
-		autoApproveFlag: "",
+		noPermissionGate: true,
 	},
 }
 

--- a/pkg/cmd/coop/harness.go
+++ b/pkg/cmd/coop/harness.go
@@ -1,0 +1,192 @@
+package coopcmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// harness describes a terminal AI coding agent that co-op can launch in the
+// agent pane.
+//
+// Co-op drives the agent through a single generated launcher script of the form
+// `exec <path> [autoApproveFlag] [promptFlag] "$prompt"`, so every harness here
+// must accept an initial prompt that leaves an *interactive* session running.
+// Harnesses whose prompt flag forces a headless one-shot run (the agent answers
+// and exits) are not usable: co-op's review loop depends on the agent process
+// staying alive across `stripe coop agent await-review`.
+type harness struct {
+	// id is the stable identifier accepted by --agent.
+	id string
+	// displayName labels the harness in the picker and permission prompt.
+	displayName string
+	// binary is the executable looked up on PATH.
+	binary string
+	// args are fixed arguments placed before any flags, for harnesses whose
+	// seeded-interactive mode lives behind a subcommand.
+	args []string
+	// promptFlag carries the initial prompt for harnesses that do not accept it
+	// as a positional argument. Empty means the prompt is positional.
+	//
+	// Note that the flag spelling matters: on several harnesses a bare
+	// -p/--prompt means "run headless and exit" while a different flag seeds an
+	// interactive session. Only the interactive spelling belongs here.
+	promptFlag string
+	// autoApproveFlag skips all permission prompts.
+	autoApproveFlag string
+	// autoApproveEnv is a KEY=value pair exported before exec, for harnesses
+	// that control approvals through the environment instead of a flag.
+	autoApproveEnv string
+}
+
+// offersAutoApprove reports whether co-op can skip this harness's permission
+// prompts. When false, co-op does not ask the developer to choose a permission
+// mode — either the harness has no such control, or it has no prompts at all.
+func (h harness) offersAutoApprove() bool {
+	return h.autoApproveFlag != "" || h.autoApproveEnv != ""
+}
+
+// supportedHarnesses is the canonical registry, in picker order. Claude Code and
+// Codex lead because they were the original two supported agents; the rest
+// follow alphabetically.
+var supportedHarnesses = []harness{
+	{
+		id:              "claude",
+		displayName:     "Claude Code",
+		binary:          "claude",
+		autoApproveFlag: "--dangerously-skip-permissions",
+	},
+	{
+		id:              "codex",
+		displayName:     "Codex",
+		binary:          "codex",
+		autoApproveFlag: "--dangerously-bypass-approvals-and-sandbox",
+	},
+	{
+		id:              "cursor",
+		displayName:     "Cursor CLI",
+		binary:          "cursor-agent",
+		autoApproveFlag: "--force",
+	},
+	{
+		id:          "gemini",
+		displayName: "Gemini CLI",
+		binary:      "gemini",
+		// -i/--prompt-interactive seeds the session and stays interactive;
+		// -p/--prompt would run headless and exit.
+		promptFlag:      "-i",
+		autoApproveFlag: "--approval-mode=yolo",
+	},
+	{
+		id:          "goose",
+		displayName: "Goose",
+		binary:      "goose",
+		// `goose session` cannot be seeded; only `goose run` accepts input, and
+		// -s/--interactive is what keeps it interactive afterward.
+		args:       []string{"run", "-s"},
+		promptFlag: "-t",
+		// Goose has no auto-approve flag; GOOSE_MODE selects the approval
+		// policy. Co-op sets it only when the developer opts into auto-approve,
+		// so declining leaves any configured mode untouched.
+		autoApproveEnv: "GOOSE_MODE=auto",
+	},
+	{
+		id:          "opencode",
+		displayName: "opencode",
+		binary:      "opencode",
+		// opencode inverts the usual convention: --prompt seeds the TUI, while
+		// `opencode run <message>` is the headless one-shot form.
+		promptFlag:      "--prompt",
+		autoApproveFlag: "--auto",
+	},
+	{
+		id:          "pi",
+		displayName: "Pi",
+		binary:      "pi",
+		// Pi ships no permission system and no sandbox: it runs with the
+		// privileges of the launching process and never prompts, so there is
+		// nothing for co-op's auto-approve choice to skip.
+		autoApproveFlag: "",
+	},
+}
+
+// customHarness describes an agent supplied via --agent that is not in the
+// registry. Co-op passes the prompt positionally and adds no flags, since it
+// cannot know the binary's permission model.
+func customHarness(name string) harness {
+	return harness{id: name, displayName: name, binary: name}
+}
+
+// harnessByID returns the registry entry with the given id.
+func harnessByID(id string) (harness, bool) {
+	for _, h := range supportedHarnesses {
+		if h.id == id {
+			return h, true
+		}
+	}
+	return harness{}, false
+}
+
+// harnessFor resolves a --agent value to a registry entry. It matches the value
+// against harness ids and binary names, then falls back to the resolved
+// executable's base name so that an absolute path (or a shell alias resolving to
+// one) still picks up the right flags.
+//
+// Matching is deliberately exact rather than substring-based: a path such as
+// /home/claude-vm/bin/myagent must not be mistaken for Claude Code.
+func harnessFor(name, path string) (harness, bool) {
+	candidates := []string{name, executableName(name), executableName(path)}
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		for _, h := range supportedHarnesses {
+			if h.id == candidate || h.binary == candidate {
+				return h, true
+			}
+		}
+	}
+	return harness{}, false
+}
+
+// windowsExecExtensions are stripped when deriving a binary name, so a Windows
+// lookup resolving to cursor-agent.exe still matches the registry.
+var windowsExecExtensions = []string{".exe", ".bat", ".cmd", ".com"}
+
+// executableName returns the base name of path with any Windows executable
+// extension removed.
+//
+// Both separators are handled explicitly rather than via filepath.Base, which
+// only treats "\" as a separator when GOOS is windows — exec.LookPath returns
+// backslash paths there, and this must resolve identically wherever it runs.
+// Only executable extensions are stripped: a wrapper script named claude.sh is
+// a different program from Claude Code and must not inherit its flags.
+func executableName(path string) string {
+	base := path
+	if i := strings.LastIndexAny(base, `/\`); i >= 0 {
+		base = base[i+1:]
+	}
+	for _, ext := range windowsExecExtensions {
+		if strings.EqualFold(filepath.Ext(base), ext) {
+			return base[:len(base)-len(ext)]
+		}
+	}
+	return base
+}
+
+// supportedHarnessList renders the registry for error messages.
+func supportedHarnessList() string {
+	ids := make([]string, 0, len(supportedHarnesses))
+	for _, h := range supportedHarnesses {
+		ids = append(ids, h.id)
+	}
+	return strings.Join(ids, ", ")
+}
+
+// noAgentFoundError explains that no supported harness is installed.
+func noAgentFoundError() error {
+	return fmt.Errorf(`no AI agent found in PATH.
+  Co-op supports: %s
+  Install Claude Code: https://docs.anthropic.com/en/docs/claude-code
+  Or specify a custom agent: --agent=<command>`, supportedHarnessList())
+}

--- a/pkg/cmd/coop/harness.go
+++ b/pkg/cmd/coop/harness.go
@@ -1,0 +1,216 @@
+package coopcmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// harness describes a terminal AI coding agent that co-op can launch in the
+// agent pane.
+//
+// Co-op drives the agent through a single generated launcher script of the form
+// `exec <path> [autoApproveFlag] [promptFlag] "$prompt"`, so every harness here
+// must accept an initial prompt that leaves an *interactive* session running.
+// Harnesses whose prompt flag forces a headless one-shot run (the agent answers
+// and exits) are not usable: co-op's review loop depends on the agent process
+// staying alive across `stripe coop agent await-review`.
+type harness struct {
+	// id is the stable identifier accepted by --agent.
+	id string
+	// displayName labels the harness in the picker and permission prompt.
+	displayName string
+	// binary is the executable looked up on PATH.
+	binary string
+	// args are fixed arguments placed after the binary and before any flags,
+	// whether the agent needs them (goose's `run -s` subcommand) or the harness
+	// always passes them (Claude's `--agents <defs>`). Each element is emitted
+	// verbatim, so any value containing shell metacharacters must already be
+	// quoted with shellQuote.
+	args []string
+	// promptFlag carries the initial prompt for harnesses that do not accept it
+	// as a positional argument. Empty means the prompt is positional.
+	//
+	// Note that the flag spelling matters: on several harnesses a bare
+	// -p/--prompt means "run headless and exit" while a different flag seeds an
+	// interactive session. Only the interactive spelling belongs here.
+	promptFlag string
+	// autoApproveFlag skips all permission prompts.
+	autoApproveFlag string
+	// autoApproveEnv is a KEY=value pair exported before exec, for harnesses
+	// that control approvals through the environment instead of a flag.
+	autoApproveEnv string
+	// bypassLabel is the picker option that turns auto-approve on. It names the
+	// specific safety control being skipped, which differs per harness (Claude
+	// skips permissions; Codex skips approvals and its sandbox). Required when
+	// the harness offers auto-approve; bypassOption falls back to a generic
+	// label otherwise.
+	bypassLabel string
+}
+
+// bypassOption returns the picker label for turning auto-approve on.
+func (h harness) bypassOption() string {
+	if h.bypassLabel != "" {
+		return h.bypassLabel
+	}
+	return "Bypass permissions — skip safety checks (isolated environments only)"
+}
+
+// offersAutoApprove reports whether co-op can skip this harness's permission
+// prompts. When false, co-op does not ask the developer to choose a permission
+// mode — either the harness has no such control, or it has no prompts at all.
+func (h harness) offersAutoApprove() bool {
+	return h.autoApproveFlag != "" || h.autoApproveEnv != ""
+}
+
+// supportedHarnesses is the canonical registry, in picker order. Claude Code and
+// Codex lead because they were the original two supported agents; the rest
+// follow alphabetically.
+var supportedHarnesses = []harness{
+	{
+		id:          "claude",
+		displayName: "Claude Code",
+		binary:      "claude",
+		// Register a bounded, cost-effective Co-op subagent so Claude can
+		// delegate exploration and verification without spending main-session
+		// context. Always passed, so it lives in args rather than behind
+		// auto-approve. The JSON carries quotes and spaces, so it is quoted here.
+		args:            []string{"--agents", shellQuote(claudeCoopAgents)},
+		autoApproveFlag: "--dangerously-skip-permissions",
+		bypassLabel:     "Bypass permissions — skip safety checks (isolated environments only)",
+	},
+	{
+		id:              "codex",
+		displayName:     "Codex",
+		binary:          "codex",
+		autoApproveFlag: "--dangerously-bypass-approvals-and-sandbox",
+		bypassLabel:     "Bypass approvals and sandbox — skip safety checks (isolated environments only)",
+	},
+	{
+		id:              "cursor",
+		displayName:     "Cursor CLI",
+		binary:          "cursor-agent",
+		autoApproveFlag: "--force",
+	},
+	{
+		id:          "gemini",
+		displayName: "Gemini CLI",
+		binary:      "gemini",
+		// -i/--prompt-interactive seeds the session and stays interactive;
+		// -p/--prompt would run headless and exit.
+		promptFlag:      "-i",
+		autoApproveFlag: "--approval-mode=yolo",
+	},
+	{
+		id:          "goose",
+		displayName: "Goose",
+		binary:      "goose",
+		// `goose session` cannot be seeded; only `goose run` accepts input, and
+		// -s/--interactive is what keeps it interactive afterward.
+		args:       []string{"run", "-s"},
+		promptFlag: "-t",
+		// Goose has no auto-approve flag; GOOSE_MODE selects the approval
+		// policy. Co-op sets it only when the developer opts into auto-approve,
+		// so declining leaves any configured mode untouched.
+		autoApproveEnv: "GOOSE_MODE=auto",
+	},
+	{
+		id:          "opencode",
+		displayName: "opencode",
+		binary:      "opencode",
+		// opencode inverts the usual convention: --prompt seeds the TUI, while
+		// `opencode run <message>` is the headless one-shot form.
+		promptFlag:      "--prompt",
+		autoApproveFlag: "--auto",
+	},
+	{
+		id:          "pi",
+		displayName: "Pi",
+		binary:      "pi",
+		// Pi ships no permission system and no sandbox: it runs with the
+		// privileges of the launching process and never prompts, so there is
+		// nothing for co-op's auto-approve choice to skip.
+		autoApproveFlag: "",
+	},
+}
+
+// customHarness describes an agent supplied via --agent that is not in the
+// registry. Co-op passes the prompt positionally and adds no flags, since it
+// cannot know the binary's permission model.
+func customHarness(name string) harness {
+	return harness{id: name, displayName: name, binary: name}
+}
+
+// harnessByID returns the registry entry with the given id.
+func harnessByID(id string) (harness, bool) {
+	for _, h := range supportedHarnesses {
+		if h.id == id {
+			return h, true
+		}
+	}
+	return harness{}, false
+}
+
+// harnessFor resolves a --agent value to a registry entry. It matches the value
+// against harness ids and binary names, then falls back to the resolved
+// executable's base name so that an absolute path (or a shell alias resolving to
+// one) still picks up the right flags.
+//
+// Matching is deliberately exact rather than substring-based: a path such as
+// /home/claude-vm/bin/myagent must not be mistaken for Claude Code.
+func harnessFor(name, path string) (harness, bool) {
+	candidates := []string{name, executableName(name), executableName(path)}
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		for _, h := range supportedHarnesses {
+			if h.id == candidate || h.binary == candidate {
+				return h, true
+			}
+		}
+	}
+	return harness{}, false
+}
+
+// windowsExecExtensions are stripped when deriving a binary name, so a Windows
+// lookup resolving to cursor-agent.exe still matches the registry.
+var windowsExecExtensions = []string{".exe", ".bat", ".cmd", ".com"}
+
+// executableName returns the base name of path with any Windows executable
+// extension removed.
+//
+// Both separators are handled explicitly rather than via filepath.Base, which
+// only treats "\" as a separator when GOOS is windows — exec.LookPath returns
+// backslash paths there, and this must resolve identically wherever it runs.
+// Only executable extensions are stripped: a wrapper script named claude.sh is
+// a different program from Claude Code and must not inherit its flags.
+func executableName(path string) string {
+	base := path
+	if i := strings.LastIndexAny(base, `/\`); i >= 0 {
+		base = base[i+1:]
+	}
+	for _, ext := range windowsExecExtensions {
+		if strings.EqualFold(filepath.Ext(base), ext) {
+			return base[:len(base)-len(ext)]
+		}
+	}
+	return base
+}
+
+// supportedHarnessList renders the registry for error messages.
+func supportedHarnessList() string {
+	ids := make([]string, 0, len(supportedHarnesses))
+	for _, h := range supportedHarnesses {
+		ids = append(ids, h.id)
+	}
+	return strings.Join(ids, ", ")
+}
+
+// noAgentFoundError explains that no supported harness is installed.
+func noAgentFoundError() error {
+	return fmt.Errorf(`no AI agent found in PATH.
+  Co-op supports: %s
+  Install Claude Code: https://docs.anthropic.com/en/docs/claude-code
+  Or specify a custom agent: --agent=<command>`, supportedHarnessList())
+}

--- a/pkg/cmd/coop/harness.go
+++ b/pkg/cmd/coop/harness.go
@@ -46,6 +46,10 @@ type harness struct {
 	// the harness offers auto-approve; bypassOption falls back to a generic
 	// label otherwise.
 	bypassLabel string
+	// noPermissionGate marks a harness that never prompts before acting. Co-op
+	// warns instead of simply omitting the permission-mode question, so the
+	// missing prompt is not read as "the safe default applied".
+	noPermissionGate bool
 }
 
 // bypassOption returns the picker label for turning auto-approve on.
@@ -54,6 +58,21 @@ func (h harness) bypassOption() string {
 		return h.bypassLabel
 	}
 	return "Bypass permissions — skip safety checks (isolated environments only)"
+}
+
+// permissionNotice returns a warning to print before launching, or "" when the
+// harness gates tool use normally.
+//
+// This covers only harnesses known to have no gate. A custom --agent binary
+// also has no autoApproveFlag, but that reflects co-op not knowing its
+// permission model rather than knowing it has none.
+func (h harness) permissionNotice() string {
+	if !h.noPermissionGate {
+		return ""
+	}
+	return fmt.Sprintf("%s has no permission prompts: it reads, writes, and runs commands "+
+		"without asking. Co-op cannot gate it, so there is no permission mode to choose.",
+		h.displayName)
 }
 
 // offersAutoApprove reports whether co-op can skip this harness's permission
@@ -130,7 +149,7 @@ var supportedHarnesses = []harness{
 		// Pi ships no permission system and no sandbox: it runs with the
 		// privileges of the launching process and never prompts, so there is
 		// nothing for co-op's auto-approve choice to skip.
-		autoApproveFlag: "",
+		noPermissionGate: true,
 	},
 }
 

--- a/pkg/cmd/coop/harness_test.go
+++ b/pkg/cmd/coop/harness_test.go
@@ -1,0 +1,371 @@
+package coopcmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"charm.land/huh/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mustHarness returns the registry entry for id, failing the test if absent.
+func mustHarness(t *testing.T, id string) harness {
+	t.Helper()
+	h, ok := harnessByID(id)
+	require.True(t, ok, "harness %q not in registry", id)
+	return h
+}
+
+// stubLookPath makes exactly the named binaries appear installed, at a
+// synthetic path, for the duration of the test.
+func stubLookPath(t *testing.T, installed ...string) {
+	t.Helper()
+	present := make(map[string]bool, len(installed))
+	for _, name := range installed {
+		present[name] = true
+	}
+	original := lookPath
+	lookPath = func(file string) (string, error) {
+		if present[file] {
+			return "/usr/local/bin/" + file, nil
+		}
+		return "", errors.New("not found")
+	}
+	t.Cleanup(func() { lookPath = original })
+}
+
+// stubSelect answers the harness picker with choice and records the options it
+// was offered.
+func stubSelect(t *testing.T, choice string) *[]huh.Option[string] {
+	t.Helper()
+	var offered []huh.Option[string]
+	original := selectString
+	selectString = func(title string, options []huh.Option[string], value *string) error {
+		offered = options
+		*value = choice
+		return nil
+	}
+	t.Cleanup(func() { selectString = original })
+	return &offered
+}
+
+func TestRegistryEntriesAreWellFormed(t *testing.T) {
+	seenIDs := map[string]bool{}
+	seenBinaries := map[string]bool{}
+
+	for _, h := range supportedHarnesses {
+		t.Run(h.id, func(t *testing.T) {
+			assert.NotEmpty(t, h.id)
+			assert.NotEmpty(t, h.displayName)
+			assert.NotEmpty(t, h.binary)
+			assert.False(t, seenIDs[h.id], "duplicate harness id %q", h.id)
+			assert.False(t, seenBinaries[h.binary], "duplicate harness binary %q", h.binary)
+			seenIDs[h.id] = true
+			seenBinaries[h.binary] = true
+		})
+	}
+}
+
+func TestHarnessForMatchesIDBinaryAndPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		agent   string
+		path    string
+		wantID  string
+		wantHit bool
+	}{
+		{name: "by id", agent: "cursor", path: "/usr/local/bin/cursor-agent", wantID: "cursor", wantHit: true},
+		{name: "by binary", agent: "cursor-agent", path: "/usr/local/bin/cursor-agent", wantID: "cursor", wantHit: true},
+		{name: "by absolute path", agent: "/opt/homebrew/bin/gemini", path: "/opt/homebrew/bin/gemini", wantID: "gemini", wantHit: true},
+		{name: "windows extension", agent: "cursor-agent.exe", path: `C:\tools\cursor-agent.exe`, wantID: "cursor", wantHit: true},
+		{name: "unknown binary", agent: "mycoder", path: "/usr/local/bin/mycoder", wantHit: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, ok := harnessFor(tt.agent, tt.path)
+
+			assert.Equal(t, tt.wantHit, ok)
+			if tt.wantHit {
+				assert.Equal(t, tt.wantID, h.id)
+			}
+		})
+	}
+}
+
+// TestHarnessForRejectsLookalikePaths guards the substring-matching bug the
+// registry replaced: a custom binary living under a directory whose name merely
+// contains "claude" must not inherit Claude Code's flags.
+func TestHarnessForRejectsLookalikePaths(t *testing.T) {
+	lookalikes := []struct{ agent, path string }{
+		{agent: "mycoder", path: "/home/claude-vm/bin/mycoder"},
+		{agent: "mycoder", path: "/opt/codex-tools/bin/mycoder"},
+		{agent: "claude-wrapper", path: "/usr/local/bin/claude-wrapper"},
+		// A wrapper script is a different program from the harness it shares a
+		// stem with; only Windows executable extensions are stripped.
+		{agent: "claude.sh", path: "/usr/local/bin/claude.sh"},
+	}
+
+	for _, tt := range lookalikes {
+		t.Run(tt.path, func(t *testing.T) {
+			_, ok := harnessFor(tt.agent, tt.path)
+
+			assert.False(t, ok, "%s must not resolve to a registry harness", tt.path)
+		})
+	}
+}
+
+func TestDetectAgentReturnsSoleInstalledHarness(t *testing.T) {
+	stubLookPath(t, "gemini")
+
+	agent, err := (&coopRunCmd{}).detectAgent()
+
+	require.NoError(t, err)
+	assert.Equal(t, "gemini", agent.harness.id)
+	assert.Equal(t, "/usr/local/bin/gemini", agent.path)
+}
+
+func TestDetectAgentPromptsWhenMultipleInstalled(t *testing.T) {
+	stubLookPath(t, "claude", "opencode", "cursor-agent")
+	offered := stubSelect(t, "opencode")
+
+	agent, err := (&coopRunCmd{}).detectAgent()
+
+	require.NoError(t, err)
+	assert.Equal(t, "opencode", agent.harness.id)
+
+	// Every installed harness is offered, in registry order, and nothing else.
+	var labels, values []string
+	for _, option := range *offered {
+		labels = append(labels, option.Key)
+		values = append(values, option.Value)
+	}
+	assert.Equal(t, []string{"claude", "cursor", "opencode"}, values)
+	assert.Equal(t, []string{"Claude Code", "Cursor CLI", "opencode"}, labels)
+}
+
+func TestDetectAgentPropagatesPickerError(t *testing.T) {
+	stubLookPath(t, "claude", "codex")
+	pickerErr := errors.New("picker canceled")
+	original := selectString
+	selectString = func(string, []huh.Option[string], *string) error { return pickerErr }
+	t.Cleanup(func() { selectString = original })
+
+	agent, err := (&coopRunCmd{}).detectAgent()
+
+	require.ErrorIs(t, err, pickerErr)
+	assert.Nil(t, agent)
+}
+
+func TestDetectAgentErrorListsSupportedHarnesses(t *testing.T) {
+	stubLookPath(t)
+
+	_, err := (&coopRunCmd{}).detectAgent()
+
+	require.Error(t, err)
+	for _, h := range supportedHarnesses {
+		assert.Contains(t, err.Error(), h.id)
+	}
+}
+
+func TestDetectAgentResolvesExplicitAgentFlag(t *testing.T) {
+	// --agent names a harness whose binary is installed but which is not the
+	// first in registry order.
+	stubLookPath(t, "claude", "cursor-agent")
+
+	agent, err := (&coopRunCmd{agent: "cursor-agent"}).detectAgent()
+
+	require.NoError(t, err)
+	assert.Equal(t, "cursor", agent.harness.id)
+	assert.Equal(t, "--force", agent.harness.autoApproveFlag)
+}
+
+func TestDetectAgentFallsBackToCustomHarness(t *testing.T) {
+	stubLookPath(t, "mycoder")
+
+	agent, err := (&coopRunCmd{agent: "mycoder"}).detectAgent()
+
+	require.NoError(t, err)
+	assert.Equal(t, "mycoder", agent.harness.id)
+	// A custom binary gets no flags: co-op cannot know its permission model or
+	// whether it seeds an interactive session from a flag.
+	assert.Empty(t, agent.harness.autoApproveFlag)
+	assert.Empty(t, agent.harness.promptFlag)
+}
+
+func TestDetectAgentErrorsWhenExplicitAgentMissing(t *testing.T) {
+	stubLookPath(t)
+
+	_, err := (&coopRunCmd{agent: "mycoder"}).detectAgent()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `agent "mycoder" not found in PATH`)
+}
+
+func TestPromptAutoApproveSkippedWithoutAutoApproveFlag(t *testing.T) {
+	original := selectString
+	selectString = func(string, []huh.Option[string], *string) error {
+		t.Fatal("permission prompt shown for a harness with no auto-approve flag")
+		return nil
+	}
+	t.Cleanup(func() { selectString = original })
+
+	autoApprove, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{harness: customHarness("mycoder")})
+
+	require.NoError(t, err)
+	assert.False(t, autoApprove)
+}
+
+func TestPromptAutoApproveTitleNamesHarness(t *testing.T) {
+	var title string
+	original := selectString
+	selectString = func(t string, _ []huh.Option[string], value *string) error {
+		title = t
+		*value = "auto"
+		return nil
+	}
+	t.Cleanup(func() { selectString = original })
+
+	autoApprove, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{harness: mustHarness(t, "opencode")})
+
+	require.NoError(t, err)
+	assert.True(t, autoApprove)
+	assert.Equal(t, "Permission mode for opencode:", title)
+}
+
+func TestBuildAgentCmdRendersHarnessInvocation(t *testing.T) {
+	tests := []struct {
+		name        string
+		harness     harness
+		autoApprove bool
+		wantExec    string
+	}{
+		{
+			name:     "positional prompt",
+			harness:  mustHarness(t, "claude"),
+			wantExec: `exec '/usr/local/bin/claude' "$prompt"`,
+		},
+		{
+			name:        "positional prompt with auto approve",
+			harness:     mustHarness(t, "claude"),
+			autoApprove: true,
+			wantExec:    `exec '/usr/local/bin/claude' --dangerously-skip-permissions "$prompt"`,
+		},
+		{
+			name:     "interactive prompt flag",
+			harness:  mustHarness(t, "gemini"),
+			wantExec: `exec '/usr/local/bin/gemini' -i "$prompt"`,
+		},
+		{
+			name:        "interactive prompt flag with auto approve",
+			harness:     mustHarness(t, "gemini"),
+			autoApprove: true,
+			wantExec:    `exec '/usr/local/bin/gemini' --approval-mode=yolo -i "$prompt"`,
+		},
+		{
+			name:        "opencode seeds the tui with --prompt",
+			harness:     mustHarness(t, "opencode"),
+			autoApprove: true,
+			wantExec:    `exec '/usr/local/bin/opencode' --auto --prompt "$prompt"`,
+		},
+		{
+			name:     "subcommand args precede flags",
+			harness:  mustHarness(t, "goose"),
+			wantExec: `exec '/usr/local/bin/goose' run -s -t "$prompt"`,
+		},
+		{
+			name:     "pi takes a bare positional prompt",
+			harness:  mustHarness(t, "pi"),
+			wantExec: `exec '/usr/local/bin/pi' "$prompt"`,
+		},
+		{
+			name:        "custom agent never gets flags",
+			harness:     customHarness("mycoder"),
+			autoApprove: true,
+			wantExec:    `exec '/usr/local/bin/mycoder' "$prompt"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			promptPath := filepath.Join(t.TempDir(), "prompt.txt")
+			require.NoError(t, os.WriteFile(promptPath, []byte("do the thing"), 0o600))
+			agent := &agentInfo{harness: tt.harness, path: "/usr/local/bin/" + tt.harness.binary}
+
+			launcherPath, err := (&coopRunCmd{}).buildAgentCmd(agent, promptPath, tt.autoApprove)
+			require.NoError(t, err)
+
+			script, err := os.ReadFile(launcherPath)
+			require.NoError(t, err)
+			assert.Contains(t, string(script), tt.wantExec+"\n")
+			// The launcher removes the prompt file and itself before exec'ing,
+			// so a stale prompt is never left behind in TMPDIR.
+			assert.Contains(t, string(script), "rm -f "+shellQuote(promptPath)+" "+shellQuote(launcherPath))
+		})
+	}
+}
+
+// TestBuildAgentCmdExportsAutoApproveEnv covers Goose, whose approval policy is
+// an environment variable rather than a flag.
+func TestBuildAgentCmdExportsAutoApproveEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		autoApprove bool
+		wantEnv     bool
+	}{
+		{name: "auto approve exports GOOSE_MODE", autoApprove: true, wantEnv: true},
+		// Declining must not export anything: GOOSE_MODE already defaults to
+		// auto, and overriding it would silently discard a developer's
+		// configured approval mode.
+		{name: "normal mode leaves env untouched", autoApprove: false, wantEnv: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			promptPath := filepath.Join(t.TempDir(), "prompt.txt")
+			require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
+			agent := &agentInfo{harness: mustHarness(t, "goose"), path: "/usr/local/bin/goose"}
+
+			launcherPath, err := (&coopRunCmd{}).buildAgentCmd(agent, promptPath, tt.autoApprove)
+			require.NoError(t, err)
+
+			script, err := os.ReadFile(launcherPath)
+			require.NoError(t, err)
+			if tt.wantEnv {
+				assert.Contains(t, string(script), "export GOOSE_MODE=auto\n")
+			} else {
+				assert.NotContains(t, string(script), "GOOSE_MODE")
+			}
+			// The export must precede exec, or it never reaches the agent.
+			assert.Contains(t, string(script), `exec '/usr/local/bin/goose' run -s -t "$prompt"`)
+		})
+	}
+}
+
+// TestHarnessesWithoutApprovalControlSkipThePrompt documents the harnesses where
+// co-op deliberately shows no permission-mode choice.
+func TestHarnessesWithoutApprovalControlSkipThePrompt(t *testing.T) {
+	// Pi has no permission system at all, so there is nothing to auto-approve.
+	assert.False(t, mustHarness(t, "pi").offersAutoApprove())
+	// Goose controls approvals via the environment, which still counts.
+	assert.True(t, mustHarness(t, "goose").offersAutoApprove())
+	assert.True(t, mustHarness(t, "claude").offersAutoApprove())
+}
+
+// TestBuildAgentCmdQuotesAgentPath keeps the shell-injection guard in place for
+// the registry-driven argv construction.
+func TestBuildAgentCmdQuotesAgentPath(t *testing.T) {
+	promptPath := filepath.Join(t.TempDir(), "prompt.txt")
+	require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
+	agent := &agentInfo{harness: mustHarness(t, "claude"), path: "/tmp/a$(touch pwned)/claude"}
+
+	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(agent, promptPath, false)
+	require.NoError(t, err)
+
+	script, err := os.ReadFile(launcherPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(script), `exec '/tmp/a$(touch pwned)/claude' "$prompt"`)
+}

--- a/pkg/cmd/coop/harness_test.go
+++ b/pkg/cmd/coop/harness_test.go
@@ -355,6 +355,32 @@ func TestHarnessesWithoutApprovalControlSkipThePrompt(t *testing.T) {
 	assert.True(t, mustHarness(t, "claude").offersAutoApprove())
 }
 
+// TestPermissionNoticeWarnsWhenNoGateExists guards against the missing
+// permission-mode prompt reading as "the safe default applied". Every harness
+// that offers no permission choice must either say why, or be a custom binary
+// whose permission model co-op cannot know.
+func TestPermissionNoticeWarnsWhenNoGateExists(t *testing.T) {
+	for _, h := range supportedHarnesses {
+		t.Run(h.id, func(t *testing.T) {
+			if h.offersAutoApprove() {
+				assert.Empty(t, h.permissionNotice(), "harness with a permission gate must not warn")
+				return
+			}
+			assert.NotEmpty(t, h.permissionNotice(),
+				"harness %q shows no permission prompt and no warning, so users cannot tell it is ungated", h.id)
+		})
+	}
+}
+
+// TestCustomHarnessDoesNotClaimToBeUngated separates "known to have no gate"
+// from "co-op does not know", which must not produce the same warning.
+func TestCustomHarnessDoesNotClaimToBeUngated(t *testing.T) {
+	custom := customHarness("mycoder")
+
+	assert.False(t, custom.offersAutoApprove())
+	assert.Empty(t, custom.permissionNotice())
+}
+
 // TestBuildAgentCmdQuotesAgentPath keeps the shell-injection guard in place for
 // the registry-driven argv construction.
 func TestBuildAgentCmdQuotesAgentPath(t *testing.T) {

--- a/pkg/cmd/coop/harness_test.go
+++ b/pkg/cmd/coop/harness_test.go
@@ -1,0 +1,375 @@
+package coopcmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"charm.land/huh/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mustHarness returns the registry entry for id, failing the test if absent.
+func mustHarness(t *testing.T, id string) harness {
+	t.Helper()
+	h, ok := harnessByID(id)
+	require.True(t, ok, "harness %q not in registry", id)
+	return h
+}
+
+// stubLookPath makes exactly the named binaries appear installed, at a
+// synthetic path, for the duration of the test.
+func stubLookPath(t *testing.T, installed ...string) {
+	t.Helper()
+	present := make(map[string]bool, len(installed))
+	for _, name := range installed {
+		present[name] = true
+	}
+	original := lookPath
+	lookPath = func(file string) (string, error) {
+		if present[file] {
+			return "/usr/local/bin/" + file, nil
+		}
+		return "", errors.New("not found")
+	}
+	t.Cleanup(func() { lookPath = original })
+}
+
+// stubSelect answers the harness picker with choice and records the options it
+// was offered.
+func stubSelect(t *testing.T, choice string) *[]huh.Option[string] {
+	t.Helper()
+	var offered []huh.Option[string]
+	original := selectString
+	selectString = func(title string, options []huh.Option[string], value *string) error {
+		offered = options
+		*value = choice
+		return nil
+	}
+	t.Cleanup(func() { selectString = original })
+	return &offered
+}
+
+func TestRegistryEntriesAreWellFormed(t *testing.T) {
+	seenIDs := map[string]bool{}
+	seenBinaries := map[string]bool{}
+
+	for _, h := range supportedHarnesses {
+		t.Run(h.id, func(t *testing.T) {
+			assert.NotEmpty(t, h.id)
+			assert.NotEmpty(t, h.displayName)
+			assert.NotEmpty(t, h.binary)
+			assert.False(t, seenIDs[h.id], "duplicate harness id %q", h.id)
+			assert.False(t, seenBinaries[h.binary], "duplicate harness binary %q", h.binary)
+			seenIDs[h.id] = true
+			seenBinaries[h.binary] = true
+		})
+	}
+}
+
+func TestHarnessForMatchesIDBinaryAndPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		agent   string
+		path    string
+		wantID  string
+		wantHit bool
+	}{
+		{name: "by id", agent: "cursor", path: "/usr/local/bin/cursor-agent", wantID: "cursor", wantHit: true},
+		{name: "by binary", agent: "cursor-agent", path: "/usr/local/bin/cursor-agent", wantID: "cursor", wantHit: true},
+		{name: "by absolute path", agent: "/opt/homebrew/bin/gemini", path: "/opt/homebrew/bin/gemini", wantID: "gemini", wantHit: true},
+		{name: "windows extension", agent: "cursor-agent.exe", path: `C:\tools\cursor-agent.exe`, wantID: "cursor", wantHit: true},
+		{name: "unknown binary", agent: "mycoder", path: "/usr/local/bin/mycoder", wantHit: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, ok := harnessFor(tt.agent, tt.path)
+
+			assert.Equal(t, tt.wantHit, ok)
+			if tt.wantHit {
+				assert.Equal(t, tt.wantID, h.id)
+			}
+		})
+	}
+}
+
+// TestHarnessForRejectsLookalikePaths guards the substring-matching bug the
+// registry replaced: a custom binary living under a directory whose name merely
+// contains "claude" must not inherit Claude Code's flags.
+func TestHarnessForRejectsLookalikePaths(t *testing.T) {
+	lookalikes := []struct{ agent, path string }{
+		{agent: "mycoder", path: "/home/claude-vm/bin/mycoder"},
+		{agent: "mycoder", path: "/opt/codex-tools/bin/mycoder"},
+		{agent: "claude-wrapper", path: "/usr/local/bin/claude-wrapper"},
+		// A wrapper script is a different program from the harness it shares a
+		// stem with; only Windows executable extensions are stripped.
+		{agent: "claude.sh", path: "/usr/local/bin/claude.sh"},
+	}
+
+	for _, tt := range lookalikes {
+		t.Run(tt.path, func(t *testing.T) {
+			_, ok := harnessFor(tt.agent, tt.path)
+
+			assert.False(t, ok, "%s must not resolve to a registry harness", tt.path)
+		})
+	}
+}
+
+func TestDetectAgentReturnsSoleInstalledHarness(t *testing.T) {
+	stubLookPath(t, "gemini")
+
+	agent, err := (&coopRunCmd{}).detectAgent()
+
+	require.NoError(t, err)
+	assert.Equal(t, "gemini", agent.harness.id)
+	assert.Equal(t, "/usr/local/bin/gemini", agent.path)
+}
+
+func TestDetectAgentPromptsWhenMultipleInstalled(t *testing.T) {
+	stubLookPath(t, "claude", "opencode", "cursor-agent")
+	offered := stubSelect(t, "opencode")
+
+	agent, err := (&coopRunCmd{}).detectAgent()
+
+	require.NoError(t, err)
+	assert.Equal(t, "opencode", agent.harness.id)
+
+	// Every installed harness is offered, in registry order, and nothing else.
+	var labels, values []string
+	for _, option := range *offered {
+		labels = append(labels, option.Key)
+		values = append(values, option.Value)
+	}
+	assert.Equal(t, []string{"claude", "cursor", "opencode"}, values)
+	assert.Equal(t, []string{"Claude Code", "Cursor CLI", "opencode"}, labels)
+}
+
+func TestDetectAgentPropagatesPickerError(t *testing.T) {
+	stubLookPath(t, "claude", "codex")
+	pickerErr := errors.New("picker canceled")
+	original := selectString
+	selectString = func(string, []huh.Option[string], *string) error { return pickerErr }
+	t.Cleanup(func() { selectString = original })
+
+	agent, err := (&coopRunCmd{}).detectAgent()
+
+	require.ErrorIs(t, err, pickerErr)
+	assert.Nil(t, agent)
+}
+
+func TestDetectAgentErrorListsSupportedHarnesses(t *testing.T) {
+	stubLookPath(t)
+
+	_, err := (&coopRunCmd{}).detectAgent()
+
+	require.Error(t, err)
+	for _, h := range supportedHarnesses {
+		assert.Contains(t, err.Error(), h.id)
+	}
+}
+
+func TestDetectAgentResolvesExplicitAgentFlag(t *testing.T) {
+	// --agent names a harness whose binary is installed but which is not the
+	// first in registry order.
+	stubLookPath(t, "claude", "cursor-agent")
+
+	agent, err := (&coopRunCmd{agent: "cursor-agent"}).detectAgent()
+
+	require.NoError(t, err)
+	assert.Equal(t, "cursor", agent.harness.id)
+	assert.Equal(t, "--force", agent.harness.autoApproveFlag)
+}
+
+func TestDetectAgentFallsBackToCustomHarness(t *testing.T) {
+	stubLookPath(t, "mycoder")
+
+	agent, err := (&coopRunCmd{agent: "mycoder"}).detectAgent()
+
+	require.NoError(t, err)
+	assert.Equal(t, "mycoder", agent.harness.id)
+	// A custom binary gets no flags: co-op cannot know its permission model or
+	// whether it seeds an interactive session from a flag.
+	assert.Empty(t, agent.harness.autoApproveFlag)
+	assert.Empty(t, agent.harness.promptFlag)
+}
+
+func TestDetectAgentErrorsWhenExplicitAgentMissing(t *testing.T) {
+	stubLookPath(t)
+
+	_, err := (&coopRunCmd{agent: "mycoder"}).detectAgent()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `agent "mycoder" not found in PATH`)
+}
+
+func TestPromptAutoApproveSkippedWithoutAutoApproveFlag(t *testing.T) {
+	original := selectString
+	selectString = func(string, []huh.Option[string], *string) error {
+		t.Fatal("permission prompt shown for a harness with no auto-approve flag")
+		return nil
+	}
+	t.Cleanup(func() { selectString = original })
+
+	autoApprove, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{harness: customHarness("mycoder")})
+
+	require.NoError(t, err)
+	assert.False(t, autoApprove)
+}
+
+func TestPromptAutoApproveTitleNamesHarness(t *testing.T) {
+	var title string
+	original := selectString
+	selectString = func(t string, _ []huh.Option[string], value *string) error {
+		title = t
+		*value = "bypass"
+		return nil
+	}
+	t.Cleanup(func() { selectString = original })
+
+	autoApprove, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{harness: mustHarness(t, "opencode")})
+
+	require.NoError(t, err)
+	assert.True(t, autoApprove)
+	assert.Equal(t, "Permission mode for opencode:", title)
+}
+
+func TestBuildAgentCmdRendersHarnessInvocation(t *testing.T) {
+	tests := []struct {
+		name        string
+		harness     harness
+		autoApprove bool
+		wantExec    string
+	}{
+		// Codex stands in for the plain positional-prompt shape. Claude also
+		// takes a positional prompt but always carries --agents <defs>, whose
+		// JSON would make an exact-match expectation brittle; the Claude
+		// launcher tests cover that flag with Contains assertions instead.
+		{
+			name:     "positional prompt",
+			harness:  mustHarness(t, "codex"),
+			wantExec: `exec '/usr/local/bin/codex' "$prompt"`,
+		},
+		{
+			name:        "positional prompt with auto approve",
+			harness:     mustHarness(t, "codex"),
+			autoApprove: true,
+			wantExec:    `exec '/usr/local/bin/codex' --dangerously-bypass-approvals-and-sandbox "$prompt"`,
+		},
+		{
+			name:     "interactive prompt flag",
+			harness:  mustHarness(t, "gemini"),
+			wantExec: `exec '/usr/local/bin/gemini' -i "$prompt"`,
+		},
+		{
+			name:        "interactive prompt flag with auto approve",
+			harness:     mustHarness(t, "gemini"),
+			autoApprove: true,
+			wantExec:    `exec '/usr/local/bin/gemini' --approval-mode=yolo -i "$prompt"`,
+		},
+		{
+			name:        "opencode seeds the tui with --prompt",
+			harness:     mustHarness(t, "opencode"),
+			autoApprove: true,
+			wantExec:    `exec '/usr/local/bin/opencode' --auto --prompt "$prompt"`,
+		},
+		{
+			name:     "subcommand args precede flags",
+			harness:  mustHarness(t, "goose"),
+			wantExec: `exec '/usr/local/bin/goose' run -s -t "$prompt"`,
+		},
+		{
+			name:     "pi takes a bare positional prompt",
+			harness:  mustHarness(t, "pi"),
+			wantExec: `exec '/usr/local/bin/pi' "$prompt"`,
+		},
+		{
+			name:        "custom agent never gets flags",
+			harness:     customHarness("mycoder"),
+			autoApprove: true,
+			wantExec:    `exec '/usr/local/bin/mycoder' "$prompt"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			promptPath := filepath.Join(t.TempDir(), "prompt.txt")
+			require.NoError(t, os.WriteFile(promptPath, []byte("do the thing"), 0o600))
+			agent := &agentInfo{harness: tt.harness, path: "/usr/local/bin/" + tt.harness.binary}
+
+			launcherPath, err := (&coopRunCmd{}).buildAgentCmd(agent, promptPath, tt.autoApprove)
+			require.NoError(t, err)
+
+			script, err := os.ReadFile(launcherPath)
+			require.NoError(t, err)
+			assert.Contains(t, string(script), tt.wantExec+"\n")
+			// The launcher removes the prompt file and itself before exec'ing,
+			// so a stale prompt is never left behind in TMPDIR.
+			assert.Contains(t, string(script), "rm -f "+shellQuote(promptPath)+" "+shellQuote(launcherPath))
+		})
+	}
+}
+
+// TestBuildAgentCmdExportsAutoApproveEnv covers Goose, whose approval policy is
+// an environment variable rather than a flag.
+func TestBuildAgentCmdExportsAutoApproveEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		autoApprove bool
+		wantEnv     bool
+	}{
+		{name: "auto approve exports GOOSE_MODE", autoApprove: true, wantEnv: true},
+		// Declining must not export anything: GOOSE_MODE already defaults to
+		// auto, and overriding it would silently discard a developer's
+		// configured approval mode.
+		{name: "normal mode leaves env untouched", autoApprove: false, wantEnv: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			promptPath := filepath.Join(t.TempDir(), "prompt.txt")
+			require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
+			agent := &agentInfo{harness: mustHarness(t, "goose"), path: "/usr/local/bin/goose"}
+
+			launcherPath, err := (&coopRunCmd{}).buildAgentCmd(agent, promptPath, tt.autoApprove)
+			require.NoError(t, err)
+
+			script, err := os.ReadFile(launcherPath)
+			require.NoError(t, err)
+			if tt.wantEnv {
+				assert.Contains(t, string(script), "export GOOSE_MODE=auto\n")
+			} else {
+				assert.NotContains(t, string(script), "GOOSE_MODE")
+			}
+			// The export must precede exec, or it never reaches the agent.
+			assert.Contains(t, string(script), `exec '/usr/local/bin/goose' run -s -t "$prompt"`)
+		})
+	}
+}
+
+// TestHarnessesWithoutApprovalControlSkipThePrompt documents the harnesses where
+// co-op deliberately shows no permission-mode choice.
+func TestHarnessesWithoutApprovalControlSkipThePrompt(t *testing.T) {
+	// Pi has no permission system at all, so there is nothing to auto-approve.
+	assert.False(t, mustHarness(t, "pi").offersAutoApprove())
+	// Goose controls approvals via the environment, which still counts.
+	assert.True(t, mustHarness(t, "goose").offersAutoApprove())
+	assert.True(t, mustHarness(t, "claude").offersAutoApprove())
+}
+
+// TestBuildAgentCmdQuotesAgentPath keeps the shell-injection guard in place for
+// the registry-driven argv construction.
+func TestBuildAgentCmdQuotesAgentPath(t *testing.T) {
+	promptPath := filepath.Join(t.TempDir(), "prompt.txt")
+	require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
+	agent := &agentInfo{harness: mustHarness(t, "codex"), path: "/tmp/a$(touch pwned)/codex"}
+
+	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(agent, promptPath, false)
+	require.NoError(t, err)
+
+	script, err := os.ReadFile(launcherPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(script), `exec '/tmp/a$(touch pwned)/codex' "$prompt"`)
+}

--- a/pkg/cmd/coop/harness_test.go
+++ b/pkg/cmd/coop/harness_test.go
@@ -359,6 +359,32 @@ func TestHarnessesWithoutApprovalControlSkipThePrompt(t *testing.T) {
 	assert.True(t, mustHarness(t, "claude").offersAutoApprove())
 }
 
+// TestPermissionNoticeWarnsWhenNoGateExists guards against the missing
+// permission-mode prompt reading as "the safe default applied". Every harness
+// that offers no permission choice must either say why, or be a custom binary
+// whose permission model co-op cannot know.
+func TestPermissionNoticeWarnsWhenNoGateExists(t *testing.T) {
+	for _, h := range supportedHarnesses {
+		t.Run(h.id, func(t *testing.T) {
+			if h.offersAutoApprove() {
+				assert.Empty(t, h.permissionNotice(), "harness with a permission gate must not warn")
+				return
+			}
+			assert.NotEmpty(t, h.permissionNotice(),
+				"harness %q shows no permission prompt and no warning, so users cannot tell it is ungated", h.id)
+		})
+	}
+}
+
+// TestCustomHarnessDoesNotClaimToBeUngated separates "known to have no gate"
+// from "co-op does not know", which must not produce the same warning.
+func TestCustomHarnessDoesNotClaimToBeUngated(t *testing.T) {
+	custom := customHarness("mycoder")
+
+	assert.False(t, custom.offersAutoApprove())
+	assert.Empty(t, custom.permissionNotice())
+}
+
 // TestBuildAgentCmdQuotesAgentPath keeps the shell-injection guard in place for
 // the registry-driven argv construction.
 func TestBuildAgentCmdQuotesAgentPath(t *testing.T) {

--- a/pkg/coop/DEBUG_AGENT.md
+++ b/pkg/coop/DEBUG_AGENT.md
@@ -1,6 +1,6 @@
 # Co-op Debug Agent
 
-The debug agent is a deterministic fake agent for local TUI debugging. It runs the normal Co-op TUI flow, but the right-hand pane is driven by scripted session updates instead of a real Claude/Codex agent.
+The debug agent is a deterministic fake agent for local TUI debugging. It runs the normal Co-op TUI flow, but the right-hand pane is driven by scripted session updates instead of a real coding agent.
 
 ## Manual TUI debugging
 

--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -9,7 +9,8 @@ Co-op mode enables an AI agent and a human developer to build Stripe integration
 │ tmux session                                                │
 │                                                             │
 │  ┌──────────────────────┐   ┌────────────────────────────┐ │
-│  │  TUI (coop join)     │   │  Agent (Claude/Codex)      │ │
+│  │  TUI (coop join)     │   │  Agent (see Supported      │ │
+│  │                      │   │  Agents below)             │ │
 │  │                      │   │                            │ │
 │  │  Reads session.json  │   │  Writes session.json via   │ │
 │  │  every 500ms         │   │  stripe coop agent commands│ │
@@ -25,6 +26,59 @@ Co-op mode enables an AI agent and a human developer to build Stripe integration
 ```
 
 No server, no HTTP, no WebSocket. Communication is through a shared JSON session file with atomic writes (write to .tmp, rename).
+
+## Supported Agents
+
+`stripe coop start` detects installed agents on PATH and, when more than one is
+present, asks which to use. `--agent=<id-or-command>` forces a specific one.
+The registry lives in `pkg/cmd/coop/harness.go`.
+
+| Agent | `--agent` | Binary | Invocation | Auto-approve |
+|-------|-----------|--------|------------|--------------|
+| Claude Code | `claude` | `claude` | positional prompt | `--dangerously-skip-permissions` |
+| Codex | `codex` | `codex` | positional prompt | `--dangerously-bypass-approvals-and-sandbox` |
+| Cursor CLI | `cursor` | `cursor-agent` | positional prompt | `--force` |
+| Gemini CLI | `gemini` | `gemini` | `-i <prompt>` | `--approval-mode=yolo` |
+| Goose | `goose` | `goose` | `run -s -t <prompt>` | `GOOSE_MODE=auto` (env) |
+| opencode | `opencode` | `opencode` | `--prompt <prompt>` | `--auto` |
+| Pi | `pi` | `pi` | positional prompt | none — see below |
+
+### Adding an agent
+
+The launcher generates one script per session — `exec <path> [args] [auto-approve] [prompt-flag] "$prompt"` —
+so a new agent must **accept an initial prompt that leaves an interactive session
+running**. This is the binding constraint, and it disqualifies more agents than
+it admits.
+
+Watch for two traps when reading a candidate's docs:
+
+- **The obvious prompt flag is usually the wrong one.** On Gemini, Qwen, Copilot
+  and others, `-p`/`--prompt` means "run headless and exit"; a *different* flag
+  (`-i`, `--prompt-interactive`) is what seeds an interactive session. opencode
+  inverts this — its `--prompt` is the interactive one. Only the interactive
+  spelling belongs in `promptFlag`.
+- **A headless one-shot agent cannot drive co-op's review loop.** Co-op depends
+  on the agent process surviving `stripe coop agent await-review`, which blocks
+  until the developer confirms in the TUI, and on discovery mode the agent must
+  be able to ask the developer questions directly.
+
+Known-incompatible as of 2026-07: **Crush** (`crush run` is non-interactive;
+seeding the TUI is [charmbracelet/crush#1791](https://github.com/charmbracelet/crush/issues/1791),
+still open), **Hermes** (`-q`/`-z` are both non-interactive; no positional prompt),
+**GitHub Copilot CLI** (`-p` forces one-shot), **Aider** (`--message` forces
+one-shot), and **Amp** (seeds only via stdin, which would break the pane's TUI).
+
+`Qwen Code` and `Factory Droid` are compatible but not yet registered — Qwen is a
+gemini-cli fork (`-i`, `--yolo`) and Droid takes a positional prompt with
+`--skip-permissions-unsafe`.
+
+### A note on Pi
+
+Pi ships **no permission system and no sandbox**: it runs with the privileges of
+the process that launched it and never prompts before acting. Co-op therefore
+skips the permission-mode question for Pi, because there is nothing to skip —
+not because it is running in a safe mode. Every co-op session with Pi behaves as
+if auto-approve were on.
 
 ## Node State Machine
 
@@ -115,7 +169,7 @@ $ stripe coop start one-time-payment --language=node
 
 # What happens behind the scenes:
 # 1. CLI creates the session and gives the agent the exact session protocol
-# 2. Agent (Claude/Codex) is launched in right pane
+# 2. The detected agent is launched in right pane
 # 3. TUI appears in left pane showing step progress
 # 4. Agent starts from the provided next command:
 #      stripe coop agent start-work --session=coop_abc123 --step=1 --note="Beginning: Understand the project"
@@ -266,6 +320,7 @@ pkg/coop/helpers/
 pkg/cmd/coop/
   coop.go           — Parent command, subcommand registration, command-package options
   coop_start.go     — User-facing orchestrator (tmux launcher)
+  harness.go        — Supported agent registry and --agent resolution
   coop_launcher.go  — Agent detection and tmux/process management
   coop_run.go       — Agent-facing session creator
   coop_agent.go     — Typed agent lifecycle commands

--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -9,7 +9,8 @@ Co-op mode enables an AI agent and a human developer to build Stripe integration
 │ tmux session                                                │
 │                                                             │
 │  ┌──────────────────────┐   ┌────────────────────────────┐ │
-│  │  TUI (coop join)     │   │  Agent (Claude/Codex)      │ │
+│  │  TUI (coop join)     │   │  Agent (see Supported      │ │
+│  │                      │   │  Agents below)             │ │
 │  │                      │   │                            │ │
 │  │  Reads session.json  │   │  Writes session.json via   │ │
 │  │  every 500ms         │   │  stripe coop agent commands│ │
@@ -25,6 +26,59 @@ Co-op mode enables an AI agent and a human developer to build Stripe integration
 ```
 
 No server, no HTTP, no WebSocket. Communication is through a shared JSON session file with atomic writes (write to .tmp, rename).
+
+## Supported Agents
+
+`stripe coop start` detects installed agents on PATH and, when more than one is
+present, asks which to use. `--agent=<id-or-command>` forces a specific one.
+The registry lives in `pkg/cmd/coop/harness.go`.
+
+| Agent | `--agent` | Binary | Invocation | Auto-approve |
+|-------|-----------|--------|------------|--------------|
+| Claude Code | `claude` | `claude` | positional prompt | `--dangerously-skip-permissions` |
+| Codex | `codex` | `codex` | positional prompt | `--dangerously-bypass-approvals-and-sandbox` |
+| Cursor CLI | `cursor` | `cursor-agent` | positional prompt | `--force` |
+| Gemini CLI | `gemini` | `gemini` | `-i <prompt>` | `--approval-mode=yolo` |
+| Goose | `goose` | `goose` | `run -s -t <prompt>` | `GOOSE_MODE=auto` (env) |
+| opencode | `opencode` | `opencode` | `--prompt <prompt>` | `--auto` |
+| Pi | `pi` | `pi` | positional prompt | none — see below |
+
+### Adding an agent
+
+The launcher generates one script per session — `exec <path> [args] [auto-approve] [prompt-flag] "$prompt"` —
+so a new agent must **accept an initial prompt that leaves an interactive session
+running**. This is the binding constraint, and it disqualifies more agents than
+it admits.
+
+Watch for two traps when reading a candidate's docs:
+
+- **The obvious prompt flag is usually the wrong one.** On Gemini, Qwen, Copilot
+  and others, `-p`/`--prompt` means "run headless and exit"; a *different* flag
+  (`-i`, `--prompt-interactive`) is what seeds an interactive session. opencode
+  inverts this — its `--prompt` is the interactive one. Only the interactive
+  spelling belongs in `promptFlag`.
+- **A headless one-shot agent cannot drive co-op's review loop.** Co-op depends
+  on the agent process surviving `stripe coop agent await-review`, which blocks
+  until the developer confirms in the TUI, and on discovery mode the agent must
+  be able to ask the developer questions directly.
+
+Known-incompatible as of 2026-07: **Crush** (`crush run` is non-interactive;
+seeding the TUI is [charmbracelet/crush#1791](https://github.com/charmbracelet/crush/issues/1791),
+still open), **Hermes** (`-q`/`-z` are both non-interactive; no positional prompt),
+**GitHub Copilot CLI** (`-p` forces one-shot), **Aider** (`--message` forces
+one-shot), and **Amp** (seeds only via stdin, which would break the pane's TUI).
+
+`Qwen Code` and `Factory Droid` are compatible but not yet registered — Qwen is a
+gemini-cli fork (`-i`, `--yolo`) and Droid takes a positional prompt with
+`--skip-permissions-unsafe`.
+
+### A note on Pi
+
+Pi ships **no permission system and no sandbox**: it runs with the privileges of
+the process that launched it and never prompts before acting. Co-op therefore
+skips the permission-mode question for Pi, because there is nothing to skip —
+not because it is running in a safe mode. Every co-op session with Pi behaves as
+if auto-approve were on.
 
 ## Node State Machine
 
@@ -132,7 +186,7 @@ $ stripe coop start one-time-payment --language=node
 
 # What happens behind the scenes:
 # 1. CLI creates the session and gives the agent a compact protocol bootstrap
-# 2. Agent (Claude/Codex) is launched in right pane
+# 2. The detected agent is launched in right pane
 # 3. TUI appears in left pane showing step progress
 # 4. Agent starts from the provided next command; its response supplies the
 #    current node's task and acceptance criteria:
@@ -288,6 +342,7 @@ pkg/coop/helpers/
 pkg/cmd/coop/
   coop.go           — Parent command, subcommand registration, command-package options
   coop_start.go     — User-facing orchestrator (tmux launcher)
+  harness.go        — Supported agent registry and --agent resolution
   coop_launcher.go  — Agent detection and tmux/process management
   coop_run.go       — Agent-facing session creator
   coop_agent.go     — Typed agent lifecycle commands


### PR DESCRIPTION
## What

Co-op could only launch Claude Code or Codex. Agent names, permission flags, and picker options were hardcoded across `detectAgent`, `promptAutoApprove`, and `buildAgentCmd`, so adding an agent meant editing three switch statements.

This replaces them with a registry in `pkg/cmd/coop/harness.go` and adds five agents: **Cursor CLI, Gemini CLI, Goose, opencode, and Pi**.

| Agent | `--agent` | Binary | Invocation | Auto-approve |
|-------|-----------|--------|------------|--------------|
| Claude Code | `claude` | `claude` | positional prompt | `--dangerously-skip-permissions` |
| Codex | `codex` | `codex` | positional prompt | `--dangerously-bypass-approvals-and-sandbox` |
| Cursor CLI | `cursor` | `cursor-agent` | positional prompt | `--force` |
| Gemini CLI | `gemini` | `gemini` | `-i <prompt>` | `--approval-mode=yolo` |
| Goose | `goose` | `goose` | `run -s -t <prompt>` | `GOOSE_MODE=auto` (env) |
| opencode | `opencode` | `opencode` | `--prompt <prompt>` | `--auto` |
| Pi | `pi` | `pi` | positional prompt | none (see below) |

The picker, permission prompt, `--agent` resolution, and `--help` text all read from the same list, so the next agent is a struct literal.

## The constraint that shapes this

The launcher generates `exec <path> [args] [auto-approve] [prompt-flag] "$prompt"`, so an agent must accept an initial prompt that leaves an **interactive** session running. Co-op's review loop depends on the agent process surviving `stripe coop agent await-review`, and discovery mode needs the agent to ask the developer questions in its own pane.

This disqualifies more agents than it admits. Two traps worth knowing, both documented in the README:

- **The obvious prompt flag is usually the wrong one.** On Gemini and Qwen, `-p`/`--prompt` runs headless and exits; `-i` is what seeds an interactive session. opencode inverts this — its `--prompt` is the interactive one.
- **Crush, Hermes, Copilot CLI, Aider, and Amp cannot do this today.** Crush is the sharpest case: its `--yolo` is registered on `rootCmd.Flags()` rather than `PersistentFlags()`, so `crush run` has no reachable auto-approve, and its permission gate blocks on a channel with no subscriber in headless mode — it would hang on the first gated tool call rather than fail. The README records why each is excluded so this isn't re-derived later.

## Two registry fields exist for Goose specifically

`args`, because its seeded-interactive mode lives behind `goose run -s`, and `autoApproveEnv`, because it has no auto-approve flag — `GOOSE_MODE` selects the approval policy. `GOOSE_MODE` is exported only when the developer opts into auto-approve, so declining leaves a configured mode untouched.

## Pi has no permission gate, and now says so

Pi ships no permission system and no sandbox: it runs with the privileges of the launching process and never prompts. `promptAutoApprove` therefore returns early and the permission-mode question never appears.

Silence was the wrong signal — a developer who chose "Normal — agent asks before running commands" for Claude reasonably reads a missing prompt as that default having applied. The second commit prints an explicit warning instead:

```
Warning: Pi has no permission prompts: it reads, writes, and runs commands
without asking. Co-op cannot gate it, so there is no permission mode to choose.
```

The `noPermissionGate` field is deliberately narrower than "declares no `autoApproveFlag`". A custom `--agent` binary also declares none, but that reflects co-op not knowing its permission model rather than knowing it has none, so it must not claim the same thing. A registry test fails if a harness offers no permission choice and no explanation.

## Incidental fix

`--agent` resolution used `strings.Contains(path, "claude")`, so a custom binary at `/home/claude-vm/bin/mycoder` silently inherited Claude Code's `--dangerously-skip-permissions`. Matching is now exact against harness ids, binary names, and the resolved executable's base name, stripping only Windows executable extensions so a `claude.sh` wrapper isn't mistaken for Claude Code.

## Testing

`detectAgent` and `buildAgentCmd` previously had no direct coverage. New tests cover picker ordering, `--agent` resolution and its lookalike-path rejection, env-var export, subcommand args, and the shell-injection guard.

Beyond unit tests, all 14 generated launcher scripts (7 agents x auto-approve on/off) were checked with `bash -n`, and **opencode and Pi were verified end-to-end against the real binaries** by executing the actual generated launcher:

- **opencode** — stayed running past 6s and rendered its full TUI with `Build auto` in the status bar, confirming `--auto` applied and `--prompt` did *not* force headless mode. This was the softest claim in the set.
- **Pi** — parsed the positional prompt and reached its auth wall with no usage error.

**Not run-verified:** `cursor-agent`, `gemini`, and `goose` are documentation- and source-verified only, as they aren't installed locally. Goose has the most complex invocation and is the one most worth a manual check.

Qwen Code and Factory Droid are compatible but not registered here; both would be pure data additions.