### PR TITLE
coop: keep the agent pane open when the agent exits

### DIFF
--- a/pkg/cmd/coop/coop_debug_agent_test.go
+++ b/pkg/cmd/coop/coop_debug_agent_test.go
@@ -31,10 +31,10 @@ func TestCoopStartDebugAgentRequiresBlueprint(t *testing.T) {
 func TestDebugAgentPaneCommandUsesStripeBinaryAndSession(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg config")
 	rc := &coopRunCmd{}
-	cmd, cleanup, err := rc.debugAgentPaneCommandBuilder("/tmp/stripe bin")(&coop.Session{ID: "coop_123"})
+	pane, cleanup, err := rc.debugAgentPaneCommandBuilder("/tmp/stripe bin")(&coop.Session{ID: "coop_123"})
 	require.NoError(t, err)
 	assert.Nil(t, cleanup)
-	assert.Equal(t, "XDG_CONFIG_HOME='/tmp/xdg config' '/tmp/stripe bin' coop debug-agent --session 'coop_123'", cmd)
+	assert.Equal(t, "XDG_CONFIG_HOME='/tmp/xdg config' '/tmp/stripe bin' coop debug-agent --session 'coop_123'", pane.cmd)
 }
 
 func TestCoopDebugAgentRerunsRequestedChanges(t *testing.T) {

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -30,7 +30,21 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-type coopPaneCommandBuilder func(session *coop.Session) (string, func(), error)
+// paneHint is one "here's what you can do next" line shown in the agent pane
+// after the agent process exits.
+type paneHint struct {
+	label   string
+	command string
+}
+
+// coopPaneCommand describes what runs in the agent pane, plus the hints shown
+// once that command exits.
+type coopPaneCommand struct {
+	cmd   string
+	hints []paneHint
+}
+
+type coopPaneCommandBuilder func(session *coop.Session) (coopPaneCommand, func(), error)
 
 var (
 	selectString = helpers.Select[string]
@@ -156,45 +170,135 @@ func (rc *coopRunCmd) hasTmux() bool {
 }
 
 func (rc *coopRunCmd) agentPaneCommandBuilder(agent *agentInfo, discoveryPrompt string, autoApprove bool) coopPaneCommandBuilder {
-	return func(session *coop.Session) (string, func(), error) {
+	return func(session *coop.Session) (coopPaneCommand, func(), error) {
 		prompt := discoveryPrompt
 		if session != nil {
 			var err error
 			prompt, err = rc.buildAgentPromptForSession(session)
 			if err != nil {
-				return "", nil, err
+				return coopPaneCommand{}, nil, err
 			}
 		}
 		promptPath, err := writePromptFile(prompt)
 		if err != nil {
-			return "", nil, err
+			return coopPaneCommand{}, nil, err
 		}
 
 		agentCmd, err := rc.buildAgentCmd(agent, promptPath, autoApprove)
 		if err != nil {
 			os.Remove(promptPath)
-			return "", nil, err
+			return coopPaneCommand{}, nil, err
 		}
 		// The returned command is run via `bash -c`, so the launcher path itself
 		// must be shell-quoted — otherwise a temp dir (TMPDIR) containing a space
 		// or shell syntax would be parsed by bash before the launcher runs. The
 		// cleanup closure keeps the raw path for os.Remove.
-		return shellQuote(agentCmd), func() {
+		pane := coopPaneCommand{
+			cmd:   shellQuote(agentCmd),
+			hints: agentRestartHints(agent, autoApprove),
+		}
+		return pane, func() {
 			os.Remove(promptPath)
 			os.Remove(agentCmd)
 		}, nil
 	}
 }
 
+// agentRestartHints lists the commands that bring the agent back after it
+// exits. The generated launcher deletes itself on start, so restarting means
+// invoking the agent directly — with the same permission mode the developer
+// picked when the session was launched.
+func agentRestartHints(agent *agentInfo, autoApprove bool) []paneHint {
+	invocation := agent.name
+	if autoApprove {
+		switch agent.name {
+		case "claude":
+			invocation += " --dangerously-skip-permissions"
+		case "codex":
+			invocation += " --dangerously-bypass-approvals-and-sandbox"
+		}
+	}
+
+	if agent.name == "claude" {
+		return []paneHint{
+			{label: "Resume where the agent left off", command: invocation + " --continue"},
+			{label: "Start the agent fresh", command: invocation},
+		}
+	}
+	return []paneHint{{label: "Start the agent again", command: invocation}}
+}
+
 func (rc *coopRunCmd) debugAgentPaneCommandBuilder(stripeBin string) coopPaneCommandBuilder {
-	return func(session *coop.Session) (string, func(), error) {
+	return func(session *coop.Session) (coopPaneCommand, func(), error) {
 		sessionID := ""
 		if session != nil {
 			sessionID = session.ID
 		}
 		cmd := fmt.Sprintf("%s coop debug-agent --session %s", shellQuote(stripeBin), shellQuote(sessionID))
-		return shellCommandWithCoopEnv(cmd), nil, nil
+		pane := coopPaneCommand{
+			cmd:   shellCommandWithCoopEnv(cmd),
+			hints: []paneHint{{label: "Run the debug agent again", command: cmd}},
+		}
+		return pane, nil, nil
 	}
+}
+
+// holdOpenPaneScript wraps the agent pane command so the tmux pane outlives it.
+// tmux destroys a pane the moment its command exits, so quitting the agent used
+// to make the right half of the split vanish — which reads as a crash rather
+// than "your agent stopped". Instead the pane explains what happened and hands
+// itself to an interactive shell the developer can restart the agent from.
+//
+// The co-op env is exported (rather than prefixed onto the command) so that the
+// shell left behind, and anything started from it, still points at the same
+// co-op session state.
+func holdOpenPaneScript(pane coopPaneCommand) string {
+	var script strings.Builder
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		fmt.Fprintf(&script, "export XDG_CONFIG_HOME=%s\n", shellQuote(xdgConfigHome))
+	}
+	// ctrl-c reaches the whole foreground process group, so without this the
+	// wrapper dies alongside the agent and tmux closes the pane anyway. A no-op
+	// handler (rather than ignoring the signal) is reset to the default in the
+	// agent process, so the agent's own ctrl-c handling is untouched. SIGHUP is
+	// deliberately left alone so `tmux kill-pane` still works.
+	script.WriteString("trap ':' INT TERM\n")
+	// The agent command runs in a subshell so that an `exit` inside it ends the
+	// subshell rather than this script — the notice below must always run.
+	script.WriteString("(\n" + pane.cmd + "\n)\n")
+	script.WriteString(agentExitNoticeScript(pane.hints))
+	// A login shell would re-run profile scripts that may cd elsewhere; a plain
+	// interactive shell keeps the pane in the project directory.
+	script.WriteString("exec \"${SHELL:-/bin/bash}\"\n")
+	return script.String()
+}
+
+// agentExitNoticeScript renders the message shown in the agent pane once the
+// agent exits. Every line goes through printf so the notice survives whatever
+// the agent left on screen.
+func agentExitNoticeScript(hints []paneHint) string {
+	const rule = `printf '\033[90m──────────────────────────────────────────────────────\033[0m\n'`
+
+	lines := []string{
+		`__coop_agent_status=$?`,
+		`printf '\n'`,
+		rule,
+		`printf '\033[1mThe agent exited\033[0m (status %s).\n' "$__coop_agent_status"`,
+		`printf 'This pane stayed open on purpose — your co-op session is still\n'`,
+		`printf 'running in the left pane.\n'`,
+		`printf '\n'`,
+	}
+	for _, hint := range hints {
+		lines = append(lines, fmt.Sprintf(`printf '  %%s\n    \033[1m%%s\033[0m\n' %s %s`,
+			shellQuote(hint.label), shellQuote(hint.command)))
+	}
+	lines = append(lines,
+		`printf '  Jump back to the co-op TUI\n    \033[1mctrl-b then left arrow\033[0m\n'`,
+		`printf '  Close this pane\n    \033[1mexit\033[0m\n'`,
+		rule,
+		`printf '\n'`,
+	)
+	return strings.Join(lines, "\n") + "\n"
 }
 
 func shellCommandWithCoopEnv(cmd string) string {
@@ -227,12 +331,12 @@ func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprintID st
 		return err
 	}
 
-	paneCmd, cleanup, err := buildPaneCmd(session)
+	pane, cleanup, err := buildPaneCmd(session)
 	if err != nil {
 		rc.abortStartedSession(session, "agent pane command failed")
 		return err
 	}
-	paneCmd = shellCommandWithCoopEnv(paneCmd)
+	paneCmd := holdOpenPaneScript(pane)
 
 	if err := runTmux("split-window", "-h", "-p", "60", "bash", "-c", paneCmd); err != nil {
 		if cleanup != nil {
@@ -296,12 +400,12 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprintID stri
 	}
 	tuiCmd = shellCommandWithCoopEnv(tuiCmd)
 
-	paneCmd, cleanup, err := buildPaneCmd(session)
+	pane, cleanup, err := buildPaneCmd(session)
 	if err != nil {
 		rc.abortStartedSession(session, "agent pane command failed")
 		return err
 	}
-	paneCmd = shellCommandWithCoopEnv(paneCmd)
+	paneCmd := holdOpenPaneScript(pane)
 
 	width, height := coopTmuxSessionDimensions()
 	if err := runTmux("new-session", "-d", "-s", sessionName, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height),
@@ -369,7 +473,7 @@ func (rc *coopRunCmd) runFallbackWithCommand(stripeBin string, blueprintID strin
 	}
 	fmt.Println()
 
-	paneCmd, cleanup, err := buildPaneCmd(session)
+	pane, cleanup, err := buildPaneCmd(session)
 	if err != nil {
 		rc.abortStartedSession(session, "agent pane command failed")
 		return err
@@ -377,7 +481,9 @@ func (rc *coopRunCmd) runFallbackWithCommand(stripeBin string, blueprintID strin
 	if cleanup != nil {
 		defer cleanup()
 	}
-	agentExec := exec.Command("bash", "-c", paneCmd)
+	// No hold-open wrapper here: this runs in the developer's own terminal, so
+	// exiting the agent returns them to their existing shell.
+	agentExec := exec.Command("bash", "-c", pane.cmd)
 	agentExec.Stdin = os.Stdin
 	agentExec.Stdout = os.Stdout
 	agentExec.Stderr = os.Stderr

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -270,11 +270,28 @@ func holdOpenPaneScript(pane coopPaneCommand) string {
 	// The agent command runs in a subshell so that an `exit` inside it ends the
 	// subshell rather than this script — the notice below must always run.
 	script.WriteString("(\n" + pane.cmd + "\n)\n")
+	// Captured before anything else runs, so the notice can report the agent's
+	// own exit status rather than the untag command's.
+	script.WriteString("__coop_agent_status=$?\n")
+	script.WriteString(untagAgentPaneScript())
 	script.WriteString(agentExitNoticeScript(pane.hints))
 	// A login shell would re-run profile scripts that may cd elsewhere; a plain
 	// interactive shell keeps the pane in the project directory.
 	script.WriteString("exec \"${SHELL:-/bin/bash}\"\n")
 	return script.String()
+}
+
+// untagAgentPaneScript drops the tmux option marking this pane as the co-op
+// agent pane. splitCoopAgentPane sets it so the TUI can wake the agent with
+// send-keys after a review decision; once the agent has exited the pane holds
+// a plain shell, and those keystrokes would run there as commands (the resume
+// prompt is backtick-quoted, so command substitution fires). Untagging makes
+// the TUI's pane lookup come up empty instead, which it already handles by
+// telling the developer to run the resume command in the agent pane — exactly
+// the shell this script leaves behind.
+func untagAgentPaneScript() string {
+	return fmt.Sprintf("[ -n \"$TMUX_PANE\" ] && tmux set-option -p -t \"$TMUX_PANE\" -u %s 2>/dev/null\n",
+		coopAgentPaneOption)
 }
 
 // agentExitNoticeScript renders the message shown in the agent pane once the
@@ -284,7 +301,6 @@ func agentExitNoticeScript(hints []paneHint) string {
 	const rule = `printf '\033[90m──────────────────────────────────────────────────────\033[0m\n'`
 
 	lines := []string{
-		`__coop_agent_status=$?`,
 		`printf '\n'`,
 		rule,
 		`printf '\033[1mThe agent exited\033[0m (status %s).\n' "$__coop_agent_status"`,

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -30,7 +30,21 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-type coopPaneCommandBuilder func(session *coop.Session) (string, func(), error)
+// paneHint is one "here's what you can do next" line shown in the agent pane
+// after the agent process exits.
+type paneHint struct {
+	label   string
+	command string
+}
+
+// coopPaneCommand describes what runs in the agent pane, plus the hints shown
+// once that command exits.
+type coopPaneCommand struct {
+	cmd   string
+	hints []paneHint
+}
+
+type coopPaneCommandBuilder func(session *coop.Session) (coopPaneCommand, func(), error)
 
 var (
 	selectString = helpers.Select[string]
@@ -160,45 +174,135 @@ func (rc *coopRunCmd) hasTmux() bool {
 }
 
 func (rc *coopRunCmd) agentPaneCommandBuilder(agent *agentInfo, discoveryPrompt string, autoApprove bool) coopPaneCommandBuilder {
-	return func(session *coop.Session) (string, func(), error) {
+	return func(session *coop.Session) (coopPaneCommand, func(), error) {
 		prompt := discoveryPrompt
 		if session != nil {
 			var err error
 			prompt, err = rc.buildAgentPromptForSession(session)
 			if err != nil {
-				return "", nil, err
+				return coopPaneCommand{}, nil, err
 			}
 		}
 		promptPath, err := writePromptFile(prompt)
 		if err != nil {
-			return "", nil, err
+			return coopPaneCommand{}, nil, err
 		}
 
 		agentCmd, err := rc.buildAgentCmd(agent, promptPath, autoApprove)
 		if err != nil {
 			os.Remove(promptPath)
-			return "", nil, err
+			return coopPaneCommand{}, nil, err
 		}
 		// The returned command is run via `bash -c`, so the launcher path itself
 		// must be shell-quoted — otherwise a temp dir (TMPDIR) containing a space
 		// or shell syntax would be parsed by bash before the launcher runs. The
 		// cleanup closure keeps the raw path for os.Remove.
-		return shellQuote(agentCmd), func() {
+		pane := coopPaneCommand{
+			cmd:   shellQuote(agentCmd),
+			hints: agentRestartHints(agent, autoApprove),
+		}
+		return pane, func() {
 			os.Remove(promptPath)
 			os.Remove(agentCmd)
 		}, nil
 	}
 }
 
+// agentRestartHints lists the commands that bring the agent back after it
+// exits. The generated launcher deletes itself on start, so restarting means
+// invoking the agent directly — with the same permission mode the developer
+// picked when the session was launched.
+func agentRestartHints(agent *agentInfo, autoApprove bool) []paneHint {
+	invocation := agent.name
+	if autoApprove {
+		switch agent.name {
+		case "claude":
+			invocation += " --dangerously-skip-permissions"
+		case "codex":
+			invocation += " --dangerously-bypass-approvals-and-sandbox"
+		}
+	}
+
+	if agent.name == "claude" {
+		return []paneHint{
+			{label: "Resume where the agent left off", command: invocation + " --continue"},
+			{label: "Start the agent fresh", command: invocation},
+		}
+	}
+	return []paneHint{{label: "Start the agent again", command: invocation}}
+}
+
 func (rc *coopRunCmd) debugAgentPaneCommandBuilder(stripeBin string) coopPaneCommandBuilder {
-	return func(session *coop.Session) (string, func(), error) {
+	return func(session *coop.Session) (coopPaneCommand, func(), error) {
 		sessionID := ""
 		if session != nil {
 			sessionID = session.ID
 		}
 		cmd := fmt.Sprintf("%s coop debug-agent --session %s", shellQuote(stripeBin), shellQuote(sessionID))
-		return shellCommandWithCoopEnv(cmd), nil, nil
+		pane := coopPaneCommand{
+			cmd:   shellCommandWithCoopEnv(cmd),
+			hints: []paneHint{{label: "Run the debug agent again", command: cmd}},
+		}
+		return pane, nil, nil
 	}
+}
+
+// holdOpenPaneScript wraps the agent pane command so the tmux pane outlives it.
+// tmux destroys a pane the moment its command exits, so quitting the agent used
+// to make the right half of the split vanish — which reads as a crash rather
+// than "your agent stopped". Instead the pane explains what happened and hands
+// itself to an interactive shell the developer can restart the agent from.
+//
+// The co-op env is exported (rather than prefixed onto the command) so that the
+// shell left behind, and anything started from it, still points at the same
+// co-op session state.
+func holdOpenPaneScript(pane coopPaneCommand) string {
+	var script strings.Builder
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		fmt.Fprintf(&script, "export XDG_CONFIG_HOME=%s\n", shellQuote(xdgConfigHome))
+	}
+	// ctrl-c reaches the whole foreground process group, so without this the
+	// wrapper dies alongside the agent and tmux closes the pane anyway. A no-op
+	// handler (rather than ignoring the signal) is reset to the default in the
+	// agent process, so the agent's own ctrl-c handling is untouched. SIGHUP is
+	// deliberately left alone so `tmux kill-pane` still works.
+	script.WriteString("trap ':' INT TERM\n")
+	// The agent command runs in a subshell so that an `exit` inside it ends the
+	// subshell rather than this script — the notice below must always run.
+	script.WriteString("(\n" + pane.cmd + "\n)\n")
+	script.WriteString(agentExitNoticeScript(pane.hints))
+	// A login shell would re-run profile scripts that may cd elsewhere; a plain
+	// interactive shell keeps the pane in the project directory.
+	script.WriteString("exec \"${SHELL:-/bin/bash}\"\n")
+	return script.String()
+}
+
+// agentExitNoticeScript renders the message shown in the agent pane once the
+// agent exits. Every line goes through printf so the notice survives whatever
+// the agent left on screen.
+func agentExitNoticeScript(hints []paneHint) string {
+	const rule = `printf '\033[90m──────────────────────────────────────────────────────\033[0m\n'`
+
+	lines := []string{
+		`__coop_agent_status=$?`,
+		`printf '\n'`,
+		rule,
+		`printf '\033[1mThe agent exited\033[0m (status %s).\n' "$__coop_agent_status"`,
+		`printf 'This pane stayed open on purpose — your co-op session is still\n'`,
+		`printf 'running in the left pane.\n'`,
+		`printf '\n'`,
+	}
+	for _, hint := range hints {
+		lines = append(lines, fmt.Sprintf(`printf '  %%s\n    \033[1m%%s\033[0m\n' %s %s`,
+			shellQuote(hint.label), shellQuote(hint.command)))
+	}
+	lines = append(lines,
+		`printf '  Jump back to the co-op TUI\n    \033[1mctrl-b then left arrow\033[0m\n'`,
+		`printf '  Close this pane\n    \033[1mexit\033[0m\n'`,
+		rule,
+		`printf '\n'`,
+	)
+	return strings.Join(lines, "\n") + "\n"
 }
 
 func shellCommandWithCoopEnv(cmd string) string {
@@ -231,12 +335,12 @@ func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprint *coo
 		return err
 	}
 
-	paneCmd, cleanup, err := buildPaneCmd(session)
+	pane, cleanup, err := buildPaneCmd(session)
 	if err != nil {
 		rc.abortStartedSession(session, "agent pane command failed")
 		return err
 	}
-	paneCmd = shellCommandWithCoopEnv(paneCmd)
+	paneCmd := holdOpenPaneScript(pane)
 
 	if _, err := splitCoopAgentPane("-h", "-p", "60", "bash", "-c", paneCmd); err != nil {
 		if cleanup != nil {
@@ -300,12 +404,12 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 	}
 	tuiCmd = shellCommandWithCoopEnv(tuiCmd)
 
-	paneCmd, cleanup, err := buildPaneCmd(session)
+	pane, cleanup, err := buildPaneCmd(session)
 	if err != nil {
 		rc.abortStartedSession(session, "agent pane command failed")
 		return err
 	}
-	paneCmd = shellCommandWithCoopEnv(paneCmd)
+	paneCmd := holdOpenPaneScript(pane)
 
 	width, height := coopTmuxSessionDimensions()
 	if err := runTmux("new-session", "-d", "-s", sessionName, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height),
@@ -373,7 +477,7 @@ func (rc *coopRunCmd) runFallbackWithCommand(stripeBin string, blueprint *coop.B
 	}
 	fmt.Println()
 
-	paneCmd, cleanup, err := buildPaneCmd(session)
+	pane, cleanup, err := buildPaneCmd(session)
 	if err != nil {
 		rc.abortStartedSession(session, "agent pane command failed")
 		return err
@@ -381,7 +485,9 @@ func (rc *coopRunCmd) runFallbackWithCommand(stripeBin string, blueprint *coop.B
 	if cleanup != nil {
 		defer cleanup()
 	}
-	agentExec := exec.Command("bash", "-c", paneCmd)
+	// No hold-open wrapper here: this runs in the developer's own terminal, so
+	// exiting the agent returns them to their existing shell.
+	agentExec := exec.Command("bash", "-c", pane.cmd)
 	agentExec.Stdin = os.Stdin
 	agentExec.Stdout = os.Stdout
 	agentExec.Stderr = os.Stderr

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -3,7 +3,9 @@ package coopcmd
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"charm.land/huh/v2"
@@ -84,9 +86,9 @@ func TestFallbackPaneBuildFailureAbortsStartedSession(t *testing.T) {
 	rc := &coopRunCmd{language: "node"}
 	buildErr := errors.New("pane build failed")
 
-	err := rc.runFallbackWithCommand("/stripe", "one-time-payment", func(session *coop.Session) (string, func(), error) {
+	err := rc.runFallbackWithCommand("/stripe", "one-time-payment", func(session *coop.Session) (coopPaneCommand, func(), error) {
 		require.NotNil(t, session)
-		return "", nil, buildErr
+		return coopPaneCommand{}, nil, buildErr
 	})
 	require.ErrorIs(t, err, buildErr)
 
@@ -108,9 +110,9 @@ func TestFallbackJoinInstructionsIncludeCoopEnv(t *testing.T) {
 
 	rc := &coopRunCmd{language: "node"}
 	output := captureStdout(t, func() {
-		err := rc.runFallbackWithCommand("/stripe", "one-time-payment", func(session *coop.Session) (string, func(), error) {
+		err := rc.runFallbackWithCommand("/stripe", "one-time-payment", func(session *coop.Session) (coopPaneCommand, func(), error) {
 			require.NotNil(t, session)
-			return "true", nil, nil
+			return coopPaneCommand{cmd: "true"}, nil, nil
 		})
 		require.NoError(t, err)
 	})
@@ -124,9 +126,9 @@ func TestFallbackWaitInstructionsIncludeCoopEnv(t *testing.T) {
 
 	rc := &coopRunCmd{language: "node"}
 	output := captureStdout(t, func() {
-		err := rc.runFallbackWithCommand("/stripe", "", func(session *coop.Session) (string, func(), error) {
+		err := rc.runFallbackWithCommand("/stripe", "", func(session *coop.Session) (coopPaneCommand, func(), error) {
 			require.Nil(t, session)
-			return "true", nil, nil
+			return coopPaneCommand{cmd: "true"}, nil, nil
 		})
 		require.NoError(t, err)
 	})
@@ -158,9 +160,9 @@ func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T
 
 	cleanupCalled := false
 	rc := &coopRunCmd{language: "node"}
-	err := rc.runInNewTmuxWithCommand("/stripe", "one-time-payment", func(session *coop.Session) (string, func(), error) {
+	err := rc.runInNewTmuxWithCommand("/stripe", "one-time-payment", func(session *coop.Session) (coopPaneCommand, func(), error) {
 		require.NotNil(t, session)
-		return "agent", func() { cleanupCalled = true }, nil
+		return coopPaneCommand{cmd: "agent"}, func() { cleanupCalled = true }, nil
 	})
 	require.ErrorIs(t, err, splitErr)
 	assert.True(t, cleanupCalled)
@@ -247,7 +249,7 @@ func TestAgentPaneCommandShellQuotesLauncherPath(t *testing.T) {
 
 	rc := &coopRunCmd{}
 	build := rc.agentPaneCommandBuilder(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, "discovery prompt", false)
-	paneCmd, cleanup, err := build(nil)
+	pane, cleanup, err := build(nil)
 	require.NoError(t, err)
 	require.NotNil(t, cleanup)
 	defer cleanup()
@@ -259,5 +261,144 @@ func TestAgentPaneCommandShellQuotesLauncherPath(t *testing.T) {
 
 	// The pane command must be exactly the single-quoted launcher path, so
 	// `bash -c` executes the launcher instead of parsing the path.
-	assert.Equal(t, shellQuote(matches[0]), paneCmd)
+	assert.Equal(t, shellQuote(matches[0]), pane.cmd)
+}
+
+// TestHoldOpenPaneScriptSurvivesAgentExit runs the generated pane script
+// through a real bash so the printf quoting is exercised the way tmux would
+// exercise it: the agent command runs, the notice explains the exit, and the
+// script ends by handing the pane to a shell instead of letting tmux tear it
+// down.
+func TestHoldOpenPaneScriptSurvivesAgentExit(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg config")
+
+	script := holdOpenPaneScript(coopPaneCommand{
+		cmd: `printf 'agent ran with %s\n' "$XDG_CONFIG_HOME"; exit 3`,
+		hints: []paneHint{
+			{label: "Resume where the agent left off", command: "claude --continue"},
+		},
+	})
+
+	cmd := exec.Command("bash", "-c", script)
+	// The trailing `exec $SHELL` needs a closed stdin to return; in a tmux pane
+	// it is an interactive shell that stays put.
+	cmd.Stdin = strings.NewReader("")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	output := string(out)
+	assert.Contains(t, output, "agent ran with /tmp/xdg config")
+	assert.Contains(t, output, "The agent exited")
+	assert.Contains(t, output, "(status 3)")
+	assert.Contains(t, output, "still")
+	assert.Contains(t, output, "Resume where the agent left off")
+	assert.Contains(t, output, "claude --continue")
+	assert.Contains(t, output, "ctrl-b then left arrow")
+	assert.Contains(t, output, "exit")
+}
+
+// TestHoldOpenPaneScriptQuotesHints guards against a hint containing shell
+// syntax being evaluated when the notice prints.
+func TestHoldOpenPaneScriptQuotesHints(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	script := holdOpenPaneScript(coopPaneCommand{
+		cmd:   "true",
+		hints: []paneHint{{label: "Restart", command: "'/tmp/my agent' $(touch pwned) `whoami`"}},
+	})
+
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Dir = t.TempDir()
+	cmd.Stdin = strings.NewReader("")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	assert.Contains(t, string(out), "'/tmp/my agent' $(touch pwned) `whoami`")
+	_, statErr := os.Stat(filepath.Join(cmd.Dir, "pwned"))
+	assert.True(t, os.IsNotExist(statErr), "command substitution in a hint must not execute")
+}
+
+func TestAgentRestartHints(t *testing.T) {
+	claude := agentRestartHints(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, false)
+	require.Len(t, claude, 2)
+	assert.Equal(t, "claude --continue", claude[0].command)
+	assert.Equal(t, "claude", claude[1].command)
+
+	claudeAuto := agentRestartHints(&agentInfo{name: "claude"}, true)
+	assert.Equal(t, "claude --dangerously-skip-permissions --continue", claudeAuto[0].command)
+
+	codex := agentRestartHints(&agentInfo{name: "codex"}, true)
+	require.Len(t, codex, 1)
+	assert.Equal(t, "codex --dangerously-bypass-approvals-and-sandbox", codex[0].command)
+}
+
+// TestTmuxSplitPaneCommandHoldsPaneOpen pins the wiring: the command handed to
+// tmux must be the hold-open script, not the bare agent command.
+func TestTmuxSplitPaneCommandHoldsPaneOpen(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	var splitCmd string
+	originalRunTmux := runTmux
+	runTmux = func(args ...string) error {
+		if args[0] == "split-window" {
+			splitCmd = args[len(args)-1]
+			return errors.New("stop before the TUI runs")
+		}
+		return nil
+	}
+	t.Cleanup(func() { runTmux = originalRunTmux })
+
+	rc := &coopRunCmd{language: "node"}
+	err := rc.runInTmuxSplitWithCommand("/stripe", "one-time-payment", func(session *coop.Session) (coopPaneCommand, func(), error) {
+		return coopPaneCommand{cmd: "agent", hints: []paneHint{{label: "Start the agent again", command: "claude"}}}, nil, nil
+	})
+	require.Error(t, err)
+
+	assert.Contains(t, splitCmd, "export XDG_CONFIG_HOME=")
+	assert.Contains(t, splitCmd, "(\nagent\n)")
+	assert.Contains(t, splitCmd, "The agent exited")
+	assert.Contains(t, splitCmd, `exec "${SHELL:-/bin/bash}"`)
+}
+
+// TestFallbackDoesNotHoldTerminalOpen keeps the non-tmux path unchanged: the
+// developer is in their own shell already, so the agent exiting should return
+// them to it rather than nesting another shell.
+func TestFallbackDoesNotHoldTerminalOpen(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	rc := &coopRunCmd{language: "node"}
+	output := captureStdout(t, func() {
+		err := rc.runFallbackWithCommand("/stripe", "", func(session *coop.Session) (coopPaneCommand, func(), error) {
+			return coopPaneCommand{cmd: "printf fallback-ran", hints: []paneHint{{label: "Restart", command: "claude"}}}, nil, nil
+		})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "fallback-ran")
+	assert.NotContains(t, output, "The agent exited")
+}
+
+// TestHoldOpenPaneScriptSurvivesInterrupt covers the most common way a
+// developer stops the agent: ctrl-c, which the terminal delivers to every
+// process in the pane's foreground group — the wrapper included. Without the
+// trap the wrapper dies too and tmux closes the pane before the notice prints.
+func TestHoldOpenPaneScriptSurvivesInterrupt(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	// $$ is the wrapper's PID even inside the subshell, so this interrupts the
+	// wrapper the same way ctrl-c would.
+	script := holdOpenPaneScript(coopPaneCommand{cmd: "kill -INT $$"})
+
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Stdin = strings.NewReader("")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Contains(t, string(out), "The agent exited")
 }

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -211,9 +212,9 @@ func TestFallbackPaneBuildFailureAbortsStartedSession(t *testing.T) {
 	rc := &coopRunCmd{language: "node"}
 	buildErr := errors.New("pane build failed")
 
-	err := rc.runFallbackWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (string, func(), error) {
+	err := rc.runFallbackWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (coopPaneCommand, func(), error) {
 		require.NotNil(t, session)
-		return "", nil, buildErr
+		return coopPaneCommand{}, nil, buildErr
 	})
 	require.ErrorIs(t, err, buildErr)
 
@@ -235,9 +236,9 @@ func TestFallbackJoinInstructionsIncludeCoopEnv(t *testing.T) {
 
 	rc := &coopRunCmd{language: "node"}
 	output := captureStdout(t, func() {
-		err := rc.runFallbackWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (string, func(), error) {
+		err := rc.runFallbackWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (coopPaneCommand, func(), error) {
 			require.NotNil(t, session)
-			return "true", nil, nil
+			return coopPaneCommand{cmd: "true"}, nil, nil
 		})
 		require.NoError(t, err)
 	})
@@ -251,9 +252,9 @@ func TestFallbackWaitInstructionsIncludeCoopEnv(t *testing.T) {
 
 	rc := &coopRunCmd{language: "node"}
 	output := captureStdout(t, func() {
-		err := rc.runFallbackWithCommand("/stripe", nil, func(session *coop.Session) (string, func(), error) {
+		err := rc.runFallbackWithCommand("/stripe", nil, func(session *coop.Session) (coopPaneCommand, func(), error) {
 			require.Nil(t, session)
-			return "true", nil, nil
+			return coopPaneCommand{cmd: "true"}, nil, nil
 		})
 		require.NoError(t, err)
 	})
@@ -292,9 +293,9 @@ func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T
 
 	cleanupCalled := false
 	rc := &coopRunCmd{language: "node"}
-	err := rc.runInNewTmuxWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (string, func(), error) {
+	err := rc.runInNewTmuxWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (coopPaneCommand, func(), error) {
 		require.NotNil(t, session)
-		return "agent", func() { cleanupCalled = true }, nil
+		return coopPaneCommand{cmd: "agent"}, func() { cleanupCalled = true }, nil
 	})
 	require.ErrorIs(t, err, splitErr)
 	assert.True(t, cleanupCalled)
@@ -381,7 +382,7 @@ func TestAgentPaneCommandShellQuotesLauncherPath(t *testing.T) {
 
 	rc := &coopRunCmd{}
 	build := rc.agentPaneCommandBuilder(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, "discovery prompt", false)
-	paneCmd, cleanup, err := build(nil)
+	pane, cleanup, err := build(nil)
 	require.NoError(t, err)
 	require.NotNil(t, cleanup)
 	defer cleanup()
@@ -393,5 +394,151 @@ func TestAgentPaneCommandShellQuotesLauncherPath(t *testing.T) {
 
 	// The pane command must be exactly the single-quoted launcher path, so
 	// `bash -c` executes the launcher instead of parsing the path.
-	assert.Equal(t, shellQuote(matches[0]), paneCmd)
+	assert.Equal(t, shellQuote(matches[0]), pane.cmd)
+}
+
+// TestHoldOpenPaneScriptSurvivesAgentExit runs the generated pane script
+// through a real bash so the printf quoting is exercised the way tmux would
+// exercise it: the agent command runs, the notice explains the exit, and the
+// script ends by handing the pane to a shell instead of letting tmux tear it
+// down.
+func TestHoldOpenPaneScriptSurvivesAgentExit(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg config")
+
+	script := holdOpenPaneScript(coopPaneCommand{
+		cmd: `printf 'agent ran with %s\n' "$XDG_CONFIG_HOME"; exit 3`,
+		hints: []paneHint{
+			{label: "Resume where the agent left off", command: "claude --continue"},
+		},
+	})
+
+	cmd := exec.Command("bash", "-c", script)
+	// The trailing `exec $SHELL` needs a closed stdin to return; in a tmux pane
+	// it is an interactive shell that stays put.
+	cmd.Stdin = strings.NewReader("")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	output := string(out)
+	assert.Contains(t, output, "agent ran with /tmp/xdg config")
+	assert.Contains(t, output, "The agent exited")
+	assert.Contains(t, output, "(status 3)")
+	assert.Contains(t, output, "still")
+	assert.Contains(t, output, "Resume where the agent left off")
+	assert.Contains(t, output, "claude --continue")
+	assert.Contains(t, output, "ctrl-b then left arrow")
+	assert.Contains(t, output, "exit")
+}
+
+// TestHoldOpenPaneScriptQuotesHints guards against a hint containing shell
+// syntax being evaluated when the notice prints.
+func TestHoldOpenPaneScriptQuotesHints(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	script := holdOpenPaneScript(coopPaneCommand{
+		cmd:   "true",
+		hints: []paneHint{{label: "Restart", command: "'/tmp/my agent' $(touch pwned) `whoami`"}},
+	})
+
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Dir = t.TempDir()
+	cmd.Stdin = strings.NewReader("")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	assert.Contains(t, string(out), "'/tmp/my agent' $(touch pwned) `whoami`")
+	_, statErr := os.Stat(filepath.Join(cmd.Dir, "pwned"))
+	assert.True(t, os.IsNotExist(statErr), "command substitution in a hint must not execute")
+}
+
+func TestAgentRestartHints(t *testing.T) {
+	claude := agentRestartHints(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, false)
+	require.Len(t, claude, 2)
+	assert.Equal(t, "claude --continue", claude[0].command)
+	assert.Equal(t, "claude", claude[1].command)
+
+	claudeAuto := agentRestartHints(&agentInfo{name: "claude"}, true)
+	assert.Equal(t, "claude --dangerously-skip-permissions --continue", claudeAuto[0].command)
+
+	codex := agentRestartHints(&agentInfo{name: "codex"}, true)
+	require.Len(t, codex, 1)
+	assert.Equal(t, "codex --dangerously-bypass-approvals-and-sandbox", codex[0].command)
+}
+
+// TestTmuxSplitPaneCommandHoldsPaneOpen pins the wiring: the command handed to
+// tmux must be the hold-open script, not the bare agent command.
+func TestTmuxSplitPaneCommandHoldsPaneOpen(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	var splitCmd string
+	originalRunTmux := runTmux
+	originalRunTmuxOutput := runTmuxOutput
+	// The agent pane is split through splitCoopAgentPane, which needs the new
+	// pane's ID back and so goes via runTmuxOutput rather than runTmux.
+	runTmuxOutput = func(args ...string) (string, error) {
+		if args[0] == "split-window" {
+			splitCmd = args[len(args)-1]
+			return "", errors.New("stop before the TUI runs")
+		}
+		return "", nil
+	}
+	runTmux = func(args ...string) error { return nil }
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalRunTmuxOutput
+	})
+
+	rc := &coopRunCmd{language: "node"}
+	err := rc.runInTmuxSplitWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (coopPaneCommand, func(), error) {
+		return coopPaneCommand{cmd: "agent", hints: []paneHint{{label: "Start the agent again", command: "claude"}}}, nil, nil
+	})
+	require.Error(t, err)
+
+	assert.Contains(t, splitCmd, "export XDG_CONFIG_HOME=")
+	assert.Contains(t, splitCmd, "(\nagent\n)")
+	assert.Contains(t, splitCmd, "The agent exited")
+	assert.Contains(t, splitCmd, `exec "${SHELL:-/bin/bash}"`)
+}
+
+// TestFallbackDoesNotHoldTerminalOpen keeps the non-tmux path unchanged: the
+// developer is in their own shell already, so the agent exiting should return
+// them to it rather than nesting another shell.
+func TestFallbackDoesNotHoldTerminalOpen(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	rc := &coopRunCmd{language: "node"}
+	output := captureStdout(t, func() {
+		err := rc.runFallbackWithCommand("/stripe", nil, func(session *coop.Session) (coopPaneCommand, func(), error) {
+			return coopPaneCommand{cmd: "printf fallback-ran", hints: []paneHint{{label: "Restart", command: "claude"}}}, nil, nil
+		})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "fallback-ran")
+	assert.NotContains(t, output, "The agent exited")
+}
+
+// TestHoldOpenPaneScriptSurvivesInterrupt covers the most common way a
+// developer stops the agent: ctrl-c, which the terminal delivers to every
+// process in the pane's foreground group — the wrapper included. Without the
+// trap the wrapper dies too and tmux closes the pane before the notice prints.
+func TestHoldOpenPaneScriptSurvivesInterrupt(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	// $$ is the wrapper's PID even inside the subshell, so this interrupts the
+	// wrapper the same way ctrl-c would.
+	script := holdOpenPaneScript(coopPaneCommand{cmd: "kill -INT $$"})
+
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Stdin = strings.NewReader("")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Contains(t, string(out), "The agent exited")
 }

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -542,3 +542,88 @@ func TestHoldOpenPaneScriptSurvivesInterrupt(t *testing.T) {
 	require.NoError(t, err, string(out))
 	assert.Contains(t, string(out), "The agent exited")
 }
+
+// runHoldOpenScriptWithFakeTmux runs the hold-open script with a stub tmux on
+// PATH and returns everything that script asked tmux to do.
+func runHoldOpenScriptWithFakeTmux(t *testing.T, pane coopPaneCommand, tmuxPane string) string {
+	t.Helper()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	dir := t.TempDir()
+	log := filepath.Join(dir, "tmux-args.log")
+	stub := "#!/bin/bash\nprintf '%s\\n' \"$*\" >> " + shellQuote(log) + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tmux"), []byte(stub), 0o700))
+
+	cmd := exec.Command("bash", "-c", holdOpenPaneScript(pane))
+	env := []string{"PATH=" + dir + string(os.PathListSeparator) + os.Getenv("PATH")}
+	for _, kv := range os.Environ() {
+		if !strings.HasPrefix(kv, "PATH=") && !strings.HasPrefix(kv, "TMUX_PANE=") {
+			env = append(env, kv)
+		}
+	}
+	if tmuxPane != "" {
+		env = append(env, "TMUX_PANE="+tmuxPane)
+	}
+	cmd.Env = env
+	cmd.Stdin = strings.NewReader("")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	recorded, err := os.ReadFile(log)
+	if os.IsNotExist(err) {
+		return ""
+	}
+	require.NoError(t, err)
+	return string(recorded)
+}
+
+// TestHoldOpenPaneScriptUntagsAgentPane covers the interaction with the TUI's
+// agent resumer. splitCoopAgentPane tags the pane so a review decision can
+// send-keys a resume prompt to the agent; once the agent exits the pane holds
+// a plain shell, so the tag has to come off or those keystrokes execute there
+// as shell commands.
+func TestHoldOpenPaneScriptUntagsAgentPane(t *testing.T) {
+	calls := runHoldOpenScriptWithFakeTmux(t, coopPaneCommand{cmd: "true"}, "%42")
+
+	assert.Contains(t, calls, "set-option -p -t %42 -u "+coopAgentPaneOption)
+}
+
+// TestHoldOpenPaneScriptSkipsUntagOutsideTmux keeps the script quiet when it is
+// not running in a pane, so no stray tmux invocation reaches the terminal.
+func TestHoldOpenPaneScriptSkipsUntagOutsideTmux(t *testing.T) {
+	calls := runHoldOpenScriptWithFakeTmux(t, coopPaneCommand{cmd: "true"}, "")
+
+	assert.Empty(t, calls)
+}
+
+// TestHoldOpenPaneScriptUntagsBeforeHandingOverTheShell pins the ordering: the
+// tag must be gone before the developer's shell takes over the pane, since
+// from that point on the script no longer runs.
+func TestHoldOpenPaneScriptUntagsBeforeHandingOverTheShell(t *testing.T) {
+	script := holdOpenPaneScript(coopPaneCommand{cmd: "agent"})
+
+	untag := strings.Index(script, coopAgentPaneOption)
+	handover := strings.Index(script, `exec "${SHELL:-/bin/bash}"`)
+	require.NotEqual(t, -1, untag)
+	require.NotEqual(t, -1, handover)
+	assert.Less(t, untag, handover)
+}
+
+// TestHoldOpenPaneScriptReportsAgentStatusNotUntagStatus guards the exit status
+// shown in the notice: the untag runs between the agent exiting and the notice
+// printing, so the status has to be captured before it.
+func TestHoldOpenPaneScriptReportsAgentStatusNotUntagStatus(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	script := holdOpenPaneScript(coopPaneCommand{cmd: "exit 7"})
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Stdin = strings.NewReader("")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	assert.Contains(t, string(out), "(status 7)")
+}


### PR DESCRIPTION
## Problem

`stripe coop start` splits the terminal — TUI on the left, agent on the right. tmux destroys a pane the moment its command exits, so quitting the agent made the right half of the split vanish. That reads as a crash rather than "your agent stopped," and leaves no hint that the co-op session is still running.

## What this does

The tmux paths now wrap the agent command in a script that keeps the pane alive, explains what happened, and hands the pane to an interactive shell:

```
──────────────────────────────────────────────────────
The agent exited (status 130).
This pane stayed open on purpose — your co-op session is still
running in the left pane.

  Resume where the agent left off
    claude --continue
  Start the agent fresh
    claude
  Jump back to the co-op TUI
    ctrl-b then left arrow
  Close this pane
    exit
──────────────────────────────────────────────────────
```

Restart hints are agent-aware: Claude gets a `--continue` line, both agents carry over the permission mode picked at launch, and `--debug-agent` gets its own rerun command. The generated launcher deletes itself on start, so the hints invoke the agent directly rather than pointing at a path that no longer exists.

Two details the implementation depends on:

- **`trap ':' INT TERM`** — ctrl-c reaches the whole foreground process group, so without this the wrapper died alongside the agent and the pane closed anyway. A no-op handler (rather than ignoring the signal) is reset to the default in the agent process, so the agent's own ctrl-c handling is untouched. SIGHUP is left alone so `tmux kill-pane` still works.
- **the agent runs in a subshell** — an `exit` inside the pane command would otherwise end the wrapper before the notice printed.

The co-op env is exported rather than prefixed onto the command, so the shell left behind — and anything started from it — still points at the same co-op session state.

The non-tmux fallback is deliberately unchanged: there the developer is in their own terminal already, so exiting the agent should return them to it.

## Verification

End-to-end in a real tmux session with `stripe coop start one-time-payment --debug-agent`:

- ctrl-c in the agent pane — previously closed the pane, now holds with the notice (status 130). This was the case that made the trap necessary.
- agent process killed — pane holds, status 143 shown.
- the shell left behind has `XDG_CONFIG_HOME` exported and starts in the project directory, so a restarted agent talks to the same session; typing `exit` closes the pane.

Tests run the generated script through real bash: agent output and exit status, the hints, the interrupt case, and shell syntax in a hint not executing. Plus coverage that the tmux split gets the hold-open script and that the fallback path doesn't. `make lint` is clean; `go test ./pkg/cmd/...` passes.

## Known rough edge

When the agent is killed by a signal, bash prints its own `Terminated: 15 (<full command>)` line just above the notice. It only appears on signal-kill, not on a normal agent exit, and suppressing it would mean giving up the subshell that guarantees the notice runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)