### PR TITLE
cmd: add token billing init

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -259,6 +259,7 @@ func init() {
 	bindEnv("project-name", "STRIPE_PROJECT_NAME")
 
 	rootCmd.AddCommand(newReportingCmd().cmd)
+	rootCmd.AddCommand(newTokenBillingCmd().cmd)
 	rootCmd.AddCommand(newAgentCmd().cmd)
 	rootCmd.AddCommand(newDataCmd().cmd)
 	rootCmd.AddCommand(cmddocs.New().WithOptions(cmddocs.WithConfig(&Config)).Root())

--- a/pkg/cmd/token_billing.go
+++ b/pkg/cmd/token_billing.go
@@ -1,13 +1,17 @@
 package cmd
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
@@ -72,7 +76,7 @@ func newTokenBillingInitCmd() *tokenBillingInitCmd {
 		defaultMarkupPercent:       "20.0",
 		priceTrackingPreference:    "disabled",
 		subscriptionFeeAmount:      "0",
-		creditGrantPerPeriodAmount: "0",
+		creditGrantPerPeriodAmount: "1000",
 		interval:                   "month",
 	}
 
@@ -97,7 +101,7 @@ the gateway endpoint, suggested environment variables, and next steps.`,
     --model openai/gpt-4o-mini \
     --default-markup-percent 20.0 \
     --subscription-fee-amount 0 \
-    --credit-grant-per-period-amount 0 \
+    --credit-grant-per-period-amount 1000 \
     --interval month`,
 		RunE: ic.runTokenBillingInitCmd,
 		Args: validators.NoArgs,
@@ -122,6 +126,12 @@ the gateway endpoint, suggested environment variables, and next steps.`,
 func (ic *tokenBillingInitCmd) runTokenBillingInitCmd(cmd *cobra.Command, args []string) error {
 	if err := stripe.ValidateAPIBaseURL(ic.rb.APIBaseURL); err != nil {
 		return err
+	}
+
+	if ic.shouldPromptForInit(cmd) {
+		if err := ic.promptForInitConfig(cmd); err != nil {
+			return err
+		}
 	}
 
 	if len(ic.models) == 0 {
@@ -159,6 +169,148 @@ func (ic *tokenBillingInitCmd) runTokenBillingInitCmd(cmd *cobra.Command, args [
 
 	ic.printStatus(cmd, status)
 	return nil
+}
+
+func (ic *tokenBillingInitCmd) shouldPromptForInit(cmd *cobra.Command) bool {
+	if !cmdInputIsTerminal(cmd) {
+		return false
+	}
+
+	for _, flagName := range []string{
+		"plan-name",
+		"model",
+		"default-markup-percent",
+		"price-tracking-preference",
+		"subscription-fee-amount",
+		"credit-grant-per-period-amount",
+		"interval",
+	} {
+		flag := cmd.Flags().Lookup(flagName)
+		if flag != nil && flag.Changed {
+			return false
+		}
+	}
+
+	return true
+}
+
+func cmdInputIsTerminal(cmd *cobra.Command) bool {
+	f, ok := cmd.InOrStdin().(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
+}
+
+func (ic *tokenBillingInitCmd) promptForInitConfig(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
+	reader := bufio.NewReader(cmd.InOrStdin())
+
+	fmt.Fprintln(out, "Token Billing setup")
+	fmt.Fprintln(out, "Press Enter to accept the suggested default for each prompt.")
+	fmt.Fprintln(out)
+
+	var err error
+	ic.planName, err = promptString(out, reader, "Plan name", ic.planName)
+	if err != nil {
+		return err
+	}
+
+	models, err := promptString(out, reader, "Models (comma-separated publisher/model values)", strings.Join(ic.models, ", "))
+	if err != nil {
+		return err
+	}
+	ic.models = splitCommaSeparatedValues(models)
+
+	ic.defaultMarkupPercent, err = promptString(out, reader, "Default markup percent", ic.defaultMarkupPercent)
+	if err != nil {
+		return err
+	}
+
+	ic.priceTrackingPreference, err = promptString(out, reader, "Price tracking preference", ic.priceTrackingPreference)
+	if err != nil {
+		return err
+	}
+
+	ic.subscriptionFeeAmount, err = promptString(out, reader, "Subscription fee amount in USD minor units", ic.subscriptionFeeAmount)
+	if err != nil {
+		return err
+	}
+
+	ic.creditGrantPerPeriodAmount, err = promptString(out, reader, "Credit grant amount per billing period in USD minor units", ic.creditGrantPerPeriodAmount)
+	if err != nil {
+		return err
+	}
+
+	ic.interval, err = promptString(out, reader, "Billing interval", ic.interval)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Token Billing will initialize with:")
+	fmt.Fprintf(out, "  Plan name: %s\n", ic.planName)
+	fmt.Fprintf(out, "  Models: %s\n", strings.Join(ic.models, ", "))
+	fmt.Fprintf(out, "  Default markup percent: %s\n", ic.defaultMarkupPercent)
+	fmt.Fprintf(out, "  Price tracking preference: %s\n", ic.priceTrackingPreference)
+	fmt.Fprintf(out, "  Subscription fee amount: %s\n", ic.subscriptionFeeAmount)
+	fmt.Fprintf(out, "  Credit grant amount per period: %s\n", ic.creditGrantPerPeriodAmount)
+	fmt.Fprintf(out, "  Billing interval: %s\n", ic.interval)
+	fmt.Fprintln(out)
+
+	confirmed, err := promptConfirm(out, reader, "Proceed with creating Token Billing resources?", true)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		return fmt.Errorf("Token Billing initialization canceled")
+	}
+
+	fmt.Fprintln(out)
+	return nil
+}
+
+func promptString(out io.Writer, reader *bufio.Reader, label string, defaultValue string) (string, error) {
+	fmt.Fprintf(out, "%s [%s]: ", label, defaultValue)
+	input, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	value := strings.TrimSpace(input)
+	if value == "" {
+		return defaultValue, nil
+	}
+	return value, nil
+}
+
+func promptConfirm(out io.Writer, reader *bufio.Reader, label string, defaultYes bool) (bool, error) {
+	suffix := "[y/N]"
+	if defaultYes {
+		suffix = "[Y/n]"
+	}
+
+	fmt.Fprintf(out, "%s %s ", label, suffix)
+	input, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+
+	value := strings.ToLower(strings.TrimSpace(input))
+	if value == "" {
+		return defaultYes, nil
+	}
+
+	return value == "y" || value == "yes", nil
+}
+
+func splitCommaSeparatedValues(value string) []string {
+	parts := strings.Split(value, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	return values
 }
 
 func (ic *tokenBillingInitCmd) buildRequestBody() map[string]interface{} {

--- a/pkg/cmd/token_billing.go
+++ b/pkg/cmd/token_billing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -157,10 +158,13 @@ func (ic *tokenBillingInitCmd) runTokenBillingInitCmd(cmd *cobra.Command, args [
 		return nil
 	}
 
+	spinner := ansi.StartNewSpinner("Initializing Token Billing resources...", cmd.OutOrStdout())
 	resp, err := ic.rb.MakeRequest(cmd.Context(), apiKey, tokenBillingOnboardingInitPath, &requests.RequestParameters{}, body, true, nil)
 	if err != nil {
+		ansi.StopSpinner(spinner, "Token Billing initialization failed", cmd.OutOrStdout())
 		return err
 	}
+	ansi.StopSpinner(spinner, "Token Billing resources ready", cmd.OutOrStdout())
 
 	var status tokenBillingOnboardingStatus
 	if err := json.Unmarshal(resp, &status); err != nil {
@@ -202,9 +206,11 @@ func cmdInputIsTerminal(cmd *cobra.Command) bool {
 func (ic *tokenBillingInitCmd) promptForInitConfig(cmd *cobra.Command) error {
 	out := cmd.OutOrStdout()
 	reader := bufio.NewReader(cmd.InOrStdin())
+	color := ansi.Color(out)
 
-	fmt.Fprintln(out, "Token Billing setup")
-	fmt.Fprintln(out, "Press Enter to accept the suggested default for each prompt.")
+	fmt.Fprintln(out, color.Bold("Token Billing setup"))
+	fmt.Fprintln(out, faint(out, "Create pricing, meter, and AI Gateway testmode resources for this account."))
+	fmt.Fprintln(out, faint(out, "Press Enter to accept the suggested default for each prompt."))
 	fmt.Fprintln(out)
 
 	var err error
@@ -245,14 +251,14 @@ func (ic *tokenBillingInitCmd) promptForInitConfig(cmd *cobra.Command) error {
 	}
 
 	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Token Billing will initialize with:")
-	fmt.Fprintf(out, "  Plan name: %s\n", ic.planName)
-	fmt.Fprintf(out, "  Models: %s\n", strings.Join(ic.models, ", "))
-	fmt.Fprintf(out, "  Default markup percent: %s\n", ic.defaultMarkupPercent)
-	fmt.Fprintf(out, "  Price tracking preference: %s\n", ic.priceTrackingPreference)
-	fmt.Fprintf(out, "  Subscription fee amount: %s\n", ic.subscriptionFeeAmount)
-	fmt.Fprintf(out, "  Credit grant amount per period: %s\n", ic.creditGrantPerPeriodAmount)
-	fmt.Fprintf(out, "  Billing interval: %s\n", ic.interval)
+	fmt.Fprintln(out, color.Bold("Review configuration"))
+	printSummaryLine(out, "Plan name", ic.planName)
+	printSummaryLine(out, "Models", strings.Join(ic.models, ", "))
+	printSummaryLine(out, "Default markup percent", ic.defaultMarkupPercent)
+	printSummaryLine(out, "Price tracking preference", ic.priceTrackingPreference)
+	printSummaryLine(out, "Subscription fee amount", ic.subscriptionFeeAmount)
+	printSummaryLine(out, "Credit grant amount per period", ic.creditGrantPerPeriodAmount)
+	printSummaryLine(out, "Billing interval", ic.interval)
 	fmt.Fprintln(out)
 
 	confirmed, err := promptConfirm(out, reader, "Proceed with creating Token Billing resources?", true)
@@ -268,7 +274,8 @@ func (ic *tokenBillingInitCmd) promptForInitConfig(cmd *cobra.Command) error {
 }
 
 func promptString(out io.Writer, reader *bufio.Reader, label string, defaultValue string) (string, error) {
-	fmt.Fprintf(out, "%s [%s]: ", label, defaultValue)
+	color := ansi.Color(out)
+	fmt.Fprintf(out, "%s %s: ", color.Bold(label), faint(out, "["+defaultValue+"]"))
 	input, err := reader.ReadString('\n')
 	if err != nil && err != io.EOF {
 		return "", err
@@ -287,7 +294,8 @@ func promptConfirm(out io.Writer, reader *bufio.Reader, label string, defaultYes
 		suffix = "[Y/n]"
 	}
 
-	fmt.Fprintf(out, "%s %s ", label, suffix)
+	color := ansi.Color(out)
+	fmt.Fprintf(out, "%s %s ", color.Bold(label), faint(out, suffix))
 	input, err := reader.ReadString('\n')
 	if err != nil && err != io.EOF {
 		return false, err
@@ -313,6 +321,14 @@ func splitCommaSeparatedValues(value string) []string {
 	return values
 }
 
+func printSummaryLine(out io.Writer, label string, value string) {
+	fmt.Fprintf(out, "  %s %s\n", faint(out, label+":"), value)
+}
+
+func faint(out io.Writer, text string) string {
+	return ansi.Color(out).Faint(text).String()
+}
+
 func (ic *tokenBillingInitCmd) buildRequestBody() map[string]interface{} {
 	models := make([]interface{}, 0, len(ic.models))
 	for _, model := range ic.models {
@@ -332,21 +348,22 @@ func (ic *tokenBillingInitCmd) buildRequestBody() map[string]interface{} {
 
 func (ic *tokenBillingInitCmd) printStatus(cmd *cobra.Command, status tokenBillingOnboardingStatus) {
 	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, "Token Billing initialized")
+	color := ansi.Color(out)
+	fmt.Fprintf(out, "%s %s\n", color.Green("✔"), color.Bold("Token Billing initialized"))
 	if status.Status != "" {
-		fmt.Fprintf(out, "Status: %s\n", status.Status)
+		printSummaryLine(out, "Status", status.Status)
 	}
 	if status.Message != "" {
-		fmt.Fprintf(out, "%s\n", status.Message)
+		fmt.Fprintf(out, "%s\n", faint(out, status.Message))
 	}
 	if status.GatewayEndpoint != "" {
-		fmt.Fprintf(out, "\nGateway endpoint:\n  %s\n", status.GatewayEndpoint)
+		fmt.Fprintf(out, "\n%s\n  %s\n", color.Bold("Gateway endpoint"), status.GatewayEndpoint)
 	}
 
 	printStringMap(out, "Resources", status.Resources)
 	printStringMap(out, "Suggested environment variables", status.EnvironmentVariables)
 
-	fmt.Fprintln(out, "\nChecklist:")
+	fmt.Fprintf(out, "\n%s\n", color.Bold("Checklist"))
 	printChecklistItem(out, "AI Gateway enabled", status.AIGatewayEnabled)
 	printChecklistItem(out, "Pricing configured", status.PricingConfigured)
 	printChecklistItem(out, "Token meters configured", status.TokenMetersConfigured)
@@ -354,13 +371,13 @@ func (ic *tokenBillingInitCmd) printStatus(cmd *cobra.Command, status tokenBilli
 	printChecklistItem(out, "Zero-credit rejection enabled", status.ZeroCreditRejectionEnabled)
 	printChecklistItem(out, "Webhook healthy", status.WebhookHealthy)
 	if status.InferenceMode != "" {
-		fmt.Fprintf(out, "  Inference mode: %s\n", status.InferenceMode)
+		printSummaryLine(out, "Inference mode", status.InferenceMode)
 	}
 
 	if len(status.NextSteps) > 0 {
-		fmt.Fprintln(out, "\nNext steps:")
+		fmt.Fprintf(out, "\n%s\n", color.Bold("Next steps"))
 		for _, step := range status.NextSteps {
-			fmt.Fprintf(out, "  - %s\n", step)
+			fmt.Fprintf(out, "  %s %s\n", color.Cyan("→"), step)
 		}
 	}
 }
@@ -370,7 +387,8 @@ func printStringMap(out interface{ Write([]byte) (int, error) }, title string, v
 		return
 	}
 
-	fmt.Fprintf(out, "\n%s:\n", title)
+	color := ansi.Color(out)
+	fmt.Fprintf(out, "\n%s\n", color.Bold(title))
 	keys := make([]string, 0, len(values))
 	for key := range values {
 		keys = append(keys, key)
@@ -381,14 +399,15 @@ func printStringMap(out interface{ Write([]byte) (int, error) }, title string, v
 		if value == "" {
 			continue
 		}
-		fmt.Fprintf(out, "  %s=%s\n", key, value)
+		fmt.Fprintf(out, "  %s%s\n", faint(out, key+"="), value)
 	}
 }
 
 func printChecklistItem(out interface{ Write([]byte) (int, error) }, label string, done bool) {
-	marker := " "
+	color := ansi.Color(out)
+	marker := color.Yellow("○")
 	if done {
-		marker = "x"
+		marker = color.Green("✔")
 	}
-	fmt.Fprintf(out, "  [%s] %s\n", marker, label)
+	fmt.Fprintf(out, "  %s %s\n", marker, label)
 }

--- a/pkg/cmd/token_billing.go
+++ b/pkg/cmd/token_billing.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/stripe"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+const tokenBillingOnboardingInitPath = "/v1/token_billing/onboarding/init"
+
+type tokenBillingCmd struct {
+	cmd *cobra.Command
+}
+
+type tokenBillingInitCmd struct {
+	cmd *cobra.Command
+	rb  requests.Base
+
+	planName                   string
+	models                     []string
+	defaultMarkupPercent       string
+	priceTrackingPreference    string
+	subscriptionFeeAmount      string
+	creditGrantPerPeriodAmount string
+	interval                   string
+}
+
+type tokenBillingOnboardingStatus struct {
+	Status                     string            `json:"status"`
+	Message                    string            `json:"message"`
+	AIGatewayEnabled           bool              `json:"ai_gateway_enabled"`
+	TestRequestCompleted       bool              `json:"test_request_completed"`
+	PricingConfigured          bool              `json:"pricing_configured"`
+	TokenMetersConfigured      bool              `json:"token_meters_configured"`
+	ZeroCreditRejectionEnabled bool              `json:"zero_credit_rejection_enabled"`
+	WebhookHealthy             bool              `json:"webhook_healthy"`
+	InferenceMode              string            `json:"inference_mode"`
+	GatewayEndpoint            string            `json:"gateway_endpoint"`
+	EnvironmentVariables       map[string]string `json:"environment_variables"`
+	Resources                  map[string]string `json:"resources"`
+	NextSteps                  []string          `json:"next_steps"`
+}
+
+func newTokenBillingCmd() *tokenBillingCmd {
+	tbc := &tokenBillingCmd{}
+	tbc.cmd = &cobra.Command{
+		Use:   "token-billing",
+		Short: "Initialize and inspect Token Billing setup",
+		Long: `Initialize and inspect Token Billing setup.
+
+Token Billing lets you meter AI gateway usage and connect it to Stripe Billing
+resources for testing token-based pricing flows.`,
+		Args: validators.NoArgs,
+	}
+
+	tbc.cmd.AddCommand(newTokenBillingInitCmd().cmd)
+	return tbc
+}
+
+func newTokenBillingInitCmd() *tokenBillingInitCmd {
+	ic := &tokenBillingInitCmd{
+		planName:                   "AI starter",
+		models:                     []string{"openai/gpt-4o-mini"},
+		defaultMarkupPercent:       "20.0",
+		priceTrackingPreference:    "disabled",
+		subscriptionFeeAmount:      "0",
+		creditGrantPerPeriodAmount: "0",
+		interval:                   "month",
+	}
+
+	ic.rb = requests.Base{
+		Method:         http.MethodPost,
+		Profile:        &Config.Profile,
+		SuppressOutput: true,
+	}
+
+	ic.cmd = &cobra.Command{
+		Use:   "init",
+		Short: "Initialize Token Billing resources for the current account",
+		Long: `Initialize Token Billing resources for the current account.
+
+This command creates or reuses the Token Billing pricing plan and meter setup
+needed for the AI gateway testmode onboarding flow, then prints resource IDs,
+the gateway endpoint, suggested environment variables, and next steps.`,
+		Example: `  stripe token-billing init
+
+  stripe token-billing init \
+    --plan-name "AI starter" \
+    --model openai/gpt-4o-mini \
+    --default-markup-percent 20.0 \
+    --subscription-fee-amount 0 \
+    --credit-grant-per-period-amount 0 \
+    --interval month`,
+		RunE: ic.runTokenBillingInitCmd,
+		Args: validators.NoArgs,
+	}
+
+	ic.cmd.Flags().StringVar(&ic.planName, "plan-name", ic.planName, "Name for the Token Billing pricing plan")
+	ic.cmd.Flags().StringArrayVar(&ic.models, "model", ic.models, "AI model to configure, formatted as publisher/model. Repeat for multiple models")
+	ic.cmd.Flags().StringVar(&ic.defaultMarkupPercent, "default-markup-percent", ic.defaultMarkupPercent, "Default markup percentage for model prices")
+	ic.cmd.Flags().StringVar(&ic.priceTrackingPreference, "price-tracking-preference", ic.priceTrackingPreference, "Price tracking preference: disabled, migrate_all, or new_customers_only")
+	ic.cmd.Flags().StringVar(&ic.subscriptionFeeAmount, "subscription-fee-amount", ic.subscriptionFeeAmount, "Subscription fee amount in USD minor units")
+	ic.cmd.Flags().StringVar(&ic.creditGrantPerPeriodAmount, "credit-grant-per-period-amount", ic.creditGrantPerPeriodAmount, "Credit grant amount per billing period in USD minor units")
+	ic.cmd.Flags().StringVar(&ic.interval, "interval", ic.interval, "Billing interval for the pricing plan")
+	ic.cmd.Flags().BoolVar(&ic.rb.Livemode, "live", false, "Make a live request (default: test)")
+	ic.cmd.Flags().BoolVar(&ic.rb.DryRun, "dry-run", false, "Preview the request without sending it")
+	ic.cmd.Flags().BoolVar(&ic.rb.DarkStyle, "dark-style", false, "Use a darker color scheme better suited for lighter command-lines")
+	ic.cmd.Flags().StringVar(&ic.rb.APIBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
+	ic.cmd.Flags().MarkHidden("api-base") // #nosec G104
+
+	return ic
+}
+
+func (ic *tokenBillingInitCmd) runTokenBillingInitCmd(cmd *cobra.Command, args []string) error {
+	if err := stripe.ValidateAPIBaseURL(ic.rb.APIBaseURL); err != nil {
+		return err
+	}
+
+	if len(ic.models) == 0 {
+		return fmt.Errorf("at least one --model is required")
+	}
+
+	apiKey, err := ic.rb.Profile.GetAPIKey(ic.rb.Livemode)
+	if err != nil {
+		return err
+	}
+
+	body := ic.buildRequestBody()
+	if ic.rb.DryRun {
+		output, err := ic.rb.BuildDryRunOutput(apiKey, ic.rb.APIBaseURL, tokenBillingOnboardingInitPath, &requests.RequestParameters{}, body)
+		if err != nil {
+			return err
+		}
+		b, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(b))
+		return nil
+	}
+
+	resp, err := ic.rb.MakeRequest(cmd.Context(), apiKey, tokenBillingOnboardingInitPath, &requests.RequestParameters{}, body, true, nil)
+	if err != nil {
+		return err
+	}
+
+	var status tokenBillingOnboardingStatus
+	if err := json.Unmarshal(resp, &status); err != nil {
+		return fmt.Errorf("failed to parse Token Billing onboarding response: %w", err)
+	}
+
+	ic.printStatus(cmd, status)
+	return nil
+}
+
+func (ic *tokenBillingInitCmd) buildRequestBody() map[string]interface{} {
+	models := make([]interface{}, 0, len(ic.models))
+	for _, model := range ic.models {
+		models = append(models, model)
+	}
+
+	return map[string]interface{}{
+		"plan_name":                      ic.planName,
+		"models":                         models,
+		"default_markup_percent":         ic.defaultMarkupPercent,
+		"price_tracking_preference":      ic.priceTrackingPreference,
+		"subscription_fee_amount":        ic.subscriptionFeeAmount,
+		"credit_grant_per_period_amount": ic.creditGrantPerPeriodAmount,
+		"interval":                       ic.interval,
+	}
+}
+
+func (ic *tokenBillingInitCmd) printStatus(cmd *cobra.Command, status tokenBillingOnboardingStatus) {
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, "Token Billing initialized")
+	if status.Status != "" {
+		fmt.Fprintf(out, "Status: %s\n", status.Status)
+	}
+	if status.Message != "" {
+		fmt.Fprintf(out, "%s\n", status.Message)
+	}
+	if status.GatewayEndpoint != "" {
+		fmt.Fprintf(out, "\nGateway endpoint:\n  %s\n", status.GatewayEndpoint)
+	}
+
+	printStringMap(out, "Resources", status.Resources)
+	printStringMap(out, "Suggested environment variables", status.EnvironmentVariables)
+
+	fmt.Fprintln(out, "\nChecklist:")
+	printChecklistItem(out, "AI Gateway enabled", status.AIGatewayEnabled)
+	printChecklistItem(out, "Pricing configured", status.PricingConfigured)
+	printChecklistItem(out, "Token meters configured", status.TokenMetersConfigured)
+	printChecklistItem(out, "Test request completed", status.TestRequestCompleted)
+	printChecklistItem(out, "Zero-credit rejection enabled", status.ZeroCreditRejectionEnabled)
+	printChecklistItem(out, "Webhook healthy", status.WebhookHealthy)
+	if status.InferenceMode != "" {
+		fmt.Fprintf(out, "  Inference mode: %s\n", status.InferenceMode)
+	}
+
+	if len(status.NextSteps) > 0 {
+		fmt.Fprintln(out, "\nNext steps:")
+		for _, step := range status.NextSteps {
+			fmt.Fprintf(out, "  - %s\n", step)
+		}
+	}
+}
+
+func printStringMap(out interface{ Write([]byte) (int, error) }, title string, values map[string]string) {
+	if len(values) == 0 {
+		return
+	}
+
+	fmt.Fprintf(out, "\n%s:\n", title)
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := strings.TrimSpace(values[key])
+		if value == "" {
+			continue
+		}
+		fmt.Fprintf(out, "  %s=%s\n", key, value)
+	}
+}
+
+func printChecklistItem(out interface{ Write([]byte) (int, error) }, label string, done bool) {
+	marker := " "
+	if done {
+		marker = "x"
+	}
+	fmt.Fprintf(out, "  [%s] %s\n", marker, label)
+}

--- a/pkg/cmd/token_billing.go
+++ b/pkg/cmd/token_billing.go
@@ -34,6 +34,12 @@ var defaultTokenBillingModels = []string{
 	"meta/llama-3.1-70b-instruct",
 }
 
+var tokenBillingPriceTrackingPreferences = []string{
+	"disabled",
+	"migrate_all",
+	"new_customers_only",
+}
+
 type tokenBillingCmd struct {
 	cmd *cobra.Command
 }
@@ -246,9 +252,12 @@ func (ic *tokenBillingInitCmd) promptForInitConfig(cmd *cobra.Command) error {
 		return err
 	}
 
-	ic.priceTrackingPreference, err = promptString(out, reader, "Price tracking preference", ic.priceTrackingPreference)
-	if err != nil {
-		return err
+	if cmdInputIsTerminal(cmd) {
+		priceTrackingPreference, err := runTokenBillingPriceTrackingPicker(cmd, ic.priceTrackingPreference)
+		if err != nil {
+			return err
+		}
+		ic.priceTrackingPreference = priceTrackingPreference
 	}
 
 	ic.subscriptionFeeAmount, err = promptString(out, reader, "Subscription fee amount in USD minor units", ic.subscriptionFeeAmount)
@@ -461,6 +470,109 @@ func runTokenBillingModelPicker(cmd *cobra.Command, selectedModels []string) ([]
 		return nil, fmt.Errorf("Token Billing initialization canceled")
 	}
 	return result.selectedModels(), nil
+}
+
+type tokenBillingPriceTrackingPicker struct {
+	options []string
+	cursor  int
+	done    bool
+	quit    bool
+}
+
+func newTokenBillingPriceTrackingPicker(selected string) tokenBillingPriceTrackingPicker {
+	options := append([]string(nil), tokenBillingPriceTrackingPreferences...)
+	cursor := 0
+	for i, option := range options {
+		if option == selected {
+			cursor = i
+			break
+		}
+	}
+	return tokenBillingPriceTrackingPicker{options: options, cursor: cursor}
+}
+
+func (m tokenBillingPriceTrackingPicker) Init() tea.Cmd { return nil }
+
+func (m tokenBillingPriceTrackingPicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch {
+	case key.Code == tea.KeyUp || key.Code == 'k':
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case key.Code == tea.KeyDown || key.Code == 'j':
+		if m.cursor < len(m.options)-1 {
+			m.cursor++
+		}
+	case key.Code == tea.KeyEnter || key.Code == tea.KeySpace:
+		m.done = true
+		return m, tea.Quit
+	case key.Code == 'q' || key.Code == tea.KeyEscape || (key.Code == 'c' && key.Mod == tea.ModCtrl):
+		m.quit = true
+		return m, tea.Quit
+	}
+
+	return m, nil
+}
+
+func (m tokenBillingPriceTrackingPicker) selectedPreference() string {
+	if len(m.options) == 0 {
+		return ""
+	}
+	return m.options[m.cursor]
+}
+
+func (m tokenBillingPriceTrackingPicker) View() tea.View {
+	body := "Choose a price tracking preference:\n\n"
+	for i, option := range m.options {
+		marker := "( )"
+		if i == m.cursor {
+			marker = tokenBillingPickerSelectedStyle.Render("(•)")
+		}
+
+		line := fmt.Sprintf("  %s %s  %s", marker, option, priceTrackingPreferenceDescription(option))
+		if i == m.cursor {
+			line = tokenBillingPickerCursorStyle.Render(line)
+		}
+		body += line + "\n"
+	}
+
+	body += "\n↑/↓ move · enter select · q cancel"
+	return tea.NewView(tokenBillingPickerBoxStyle.Render(body))
+}
+
+func priceTrackingPreferenceDescription(option string) string {
+	switch option {
+	case "disabled":
+		return tokenBillingPickerMutedStyle.Render("do not automatically update prices")
+	case "migrate_all":
+		return tokenBillingPickerMutedStyle.Render("update prices for all customers")
+	case "new_customers_only":
+		return tokenBillingPickerMutedStyle.Render("update prices for new customers only")
+	default:
+		return ""
+	}
+}
+
+func runTokenBillingPriceTrackingPicker(cmd *cobra.Command, selected string) (string, error) {
+	final, err := tea.NewProgram(
+		newTokenBillingPriceTrackingPicker(selected),
+		tea.WithInput(cmd.InOrStdin()),
+		tea.WithOutput(cmd.OutOrStdout()),
+	).Run()
+	if err != nil {
+		return "", fmt.Errorf("price tracking selection: %w", err)
+	}
+
+	result, ok := final.(tokenBillingPriceTrackingPicker)
+	if !ok || result.quit || !result.done {
+		return "", fmt.Errorf("Token Billing initialization canceled")
+	}
+	return result.selectedPreference(), nil
 }
 
 func printSummaryLine(out io.Writer, label string, value string) {

--- a/pkg/cmd/token_billing.go
+++ b/pkg/cmd/token_billing.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
@@ -20,6 +22,17 @@ import (
 )
 
 const tokenBillingOnboardingInitPath = "/v1/token_billing/onboarding/init"
+
+var defaultTokenBillingModels = []string{
+	"openai/gpt-4.1-mini",
+	"openai/gpt-4.1",
+	"openai/o4-mini",
+	"anthropic/claude-3-5-sonnet",
+	"anthropic/claude-3-5-haiku",
+	"google/gemini-1.5-pro",
+	"google/gemini-1.5-flash",
+	"meta/llama-3.1-70b-instruct",
+}
 
 type tokenBillingCmd struct {
 	cmd *cobra.Command
@@ -73,7 +86,7 @@ resources for testing token-based pricing flows.`,
 func newTokenBillingInitCmd() *tokenBillingInitCmd {
 	ic := &tokenBillingInitCmd{
 		planName:                   "AI starter",
-		models:                     []string{"openai/gpt-4o-mini"},
+		models:                     append([]string(nil), defaultTokenBillingModels...),
 		defaultMarkupPercent:       "20.0",
 		priceTrackingPreference:    "disabled",
 		subscriptionFeeAmount:      "0",
@@ -99,7 +112,8 @@ the gateway endpoint, suggested environment variables, and next steps.`,
 
   stripe token-billing init \
     --plan-name "AI starter" \
-    --model openai/gpt-4o-mini \
+    --model openai/gpt-4.1-mini \
+    --model anthropic/claude-3-5-sonnet \
     --default-markup-percent 20.0 \
     --subscription-fee-amount 0 \
     --credit-grant-per-period-amount 1000 \
@@ -210,7 +224,7 @@ func (ic *tokenBillingInitCmd) promptForInitConfig(cmd *cobra.Command) error {
 
 	fmt.Fprintln(out, color.Bold("Token Billing setup"))
 	fmt.Fprintln(out, faint(out, "Create pricing, meter, and AI Gateway testmode resources for this account."))
-	fmt.Fprintln(out, faint(out, "Press Enter to accept the suggested default for each prompt."))
+	fmt.Fprintln(out, faint(out, "Press Enter to accept text defaults. Use the model picker to choose models."))
 	fmt.Fprintln(out)
 
 	var err error
@@ -219,11 +233,13 @@ func (ic *tokenBillingInitCmd) promptForInitConfig(cmd *cobra.Command) error {
 		return err
 	}
 
-	models, err := promptString(out, reader, "Models (comma-separated publisher/model values)", strings.Join(ic.models, ", "))
-	if err != nil {
-		return err
+	if cmdInputIsTerminal(cmd) {
+		models, err := runTokenBillingModelPicker(cmd, ic.models)
+		if err != nil {
+			return err
+		}
+		ic.models = models
 	}
-	ic.models = splitCommaSeparatedValues(models)
 
 	ic.defaultMarkupPercent, err = promptString(out, reader, "Default markup percent", ic.defaultMarkupPercent)
 	if err != nil {
@@ -309,16 +325,142 @@ func promptConfirm(out io.Writer, reader *bufio.Reader, label string, defaultYes
 	return value == "y" || value == "yes", nil
 }
 
-func splitCommaSeparatedValues(value string) []string {
-	parts := strings.Split(value, ",")
-	values := make([]string, 0, len(parts))
-	for _, part := range parts {
-		trimmed := strings.TrimSpace(part)
-		if trimmed != "" {
-			values = append(values, trimmed)
+type tokenBillingModelRow struct {
+	name     string
+	selected bool
+}
+
+type tokenBillingModelPicker struct {
+	rows   []tokenBillingModelRow
+	cursor int
+	done   bool
+	quit   bool
+}
+
+func newTokenBillingModelPicker(selectedModels []string) tokenBillingModelPicker {
+	selected := make(map[string]bool, len(selectedModels))
+	for _, model := range selectedModels {
+		selected[model] = true
+	}
+
+	rows := make([]tokenBillingModelRow, 0, len(defaultTokenBillingModels)+len(selectedModels))
+	seen := make(map[string]bool, len(defaultTokenBillingModels)+len(selectedModels))
+	for _, model := range defaultTokenBillingModels {
+		rows = append(rows, tokenBillingModelRow{name: model, selected: selected[model]})
+		seen[model] = true
+	}
+	for _, model := range selectedModels {
+		if !seen[model] {
+			rows = append(rows, tokenBillingModelRow{name: model, selected: true})
 		}
 	}
-	return values
+
+	return tokenBillingModelPicker{rows: rows}
+}
+
+func (m tokenBillingModelPicker) Init() tea.Cmd { return nil }
+
+func (m tokenBillingModelPicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch {
+	case key.Code == tea.KeyUp || key.Code == 'k':
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case key.Code == tea.KeyDown || key.Code == 'j':
+		if m.cursor < len(m.rows)-1 {
+			m.cursor++
+		}
+	case key.Code == tea.KeyEnter || key.Code == tea.KeySpace:
+		if len(m.rows) > 0 {
+			m.rows[m.cursor].selected = !m.rows[m.cursor].selected
+		}
+	case key.Code == 'a':
+		m.toggleAllModels()
+	case key.Code == 'd' || key.Code == tea.KeyTab:
+		m.done = true
+		return m, tea.Quit
+	case key.Code == 'q' || key.Code == tea.KeyEscape || (key.Code == 'c' && key.Mod == tea.ModCtrl):
+		m.quit = true
+		return m, tea.Quit
+	}
+
+	return m, nil
+}
+
+func (m *tokenBillingModelPicker) toggleAllModels() {
+	anyUnselected := false
+	for _, row := range m.rows {
+		if !row.selected {
+			anyUnselected = true
+			break
+		}
+	}
+	for i := range m.rows {
+		m.rows[i].selected = anyUnselected
+	}
+}
+
+func (m tokenBillingModelPicker) selectedModels() []string {
+	models := make([]string, 0, len(m.rows))
+	for _, row := range m.rows {
+		if row.selected {
+			models = append(models, row.name)
+		}
+	}
+	return models
+}
+
+var (
+	tokenBillingPickerSelectedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	tokenBillingPickerMutedStyle    = lipgloss.NewStyle().Faint(true)
+	tokenBillingPickerCursorStyle   = lipgloss.NewStyle().Bold(true)
+	tokenBillingPickerBoxStyle      = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(1, 2)
+)
+
+func (m tokenBillingModelPicker) View() tea.View {
+	body := "Select models to include in your Token Billing pricing plan:\n\n"
+	for i, row := range m.rows {
+		pointer := "  "
+		if i == m.cursor {
+			pointer = "▶ "
+		}
+
+		box := tokenBillingPickerMutedStyle.Render("·")
+		if row.selected {
+			box = tokenBillingPickerSelectedStyle.Render("✔")
+		}
+
+		line := fmt.Sprintf("%s[%s] %s", pointer, box, row.name)
+		if i == m.cursor {
+			line = tokenBillingPickerCursorStyle.Render(line)
+		}
+		body += line + "\n"
+	}
+
+	body += "\n↑/↓ move · enter toggle · a all · d done · q cancel"
+	return tea.NewView(tokenBillingPickerBoxStyle.Render(body))
+}
+
+func runTokenBillingModelPicker(cmd *cobra.Command, selectedModels []string) ([]string, error) {
+	final, err := tea.NewProgram(
+		newTokenBillingModelPicker(selectedModels),
+		tea.WithInput(cmd.InOrStdin()),
+		tea.WithOutput(cmd.OutOrStdout()),
+	).Run()
+	if err != nil {
+		return nil, fmt.Errorf("model selection: %w", err)
+	}
+
+	result, ok := final.(tokenBillingModelPicker)
+	if !ok || result.quit || !result.done {
+		return nil, fmt.Errorf("Token Billing initialization canceled")
+	}
+	return result.selectedModels(), nil
 }
 
 func printSummaryLine(out io.Writer, label string, value string) {

--- a/pkg/cmd/token_billing_test.go
+++ b/pkg/cmd/token_billing_test.go
@@ -40,6 +40,11 @@ func updateTokenBillingModelPicker(m tokenBillingModelPicker, code rune) tokenBi
 	return next.(tokenBillingModelPicker)
 }
 
+func updateTokenBillingPriceTrackingPicker(m tokenBillingPriceTrackingPicker, code rune) tokenBillingPriceTrackingPicker {
+	next, _ := m.Update(tea.KeyPressMsg{Code: code})
+	return next.(tokenBillingPriceTrackingPicker)
+}
+
 func TestTokenBillingInitDefaults(t *testing.T) {
 	ic := newTokenBillingInitCmd()
 
@@ -103,6 +108,25 @@ func TestTokenBillingModelPickerIncludesFlagModels(t *testing.T) {
 	require.Equal(t, []string{"custom/provider-model"}, m.selectedModels())
 }
 
+func TestTokenBillingPriceTrackingPickerDefaultsToSelectedPreference(t *testing.T) {
+	m := newTokenBillingPriceTrackingPicker("migrate_all")
+
+	require.Equal(t, "migrate_all", m.selectedPreference())
+}
+
+func TestTokenBillingPriceTrackingPickerSelectsSingleOption(t *testing.T) {
+	m := newTokenBillingPriceTrackingPicker("disabled")
+
+	m = updateTokenBillingPriceTrackingPicker(m, tea.KeyDown)
+	require.Equal(t, "migrate_all", m.selectedPreference())
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = next.(tokenBillingPriceTrackingPicker)
+	require.True(t, m.done)
+	require.False(t, m.quit)
+	require.NotNil(t, cmd)
+}
+
 func TestTokenBillingInitPromptAcceptsDefaults(t *testing.T) {
 	ic := newTokenBillingInitCmd()
 	ic.cmd.SetIn(strings.NewReader("\n\n\n\n\n\n\n\n"))
@@ -130,7 +154,6 @@ func TestTokenBillingInitPromptCollectsValues(t *testing.T) {
 	ic.cmd.SetIn(strings.NewReader(strings.Join([]string{
 		"Production AI plan",
 		"15.5",
-		"new_customers_only",
 		"2000",
 		"500",
 		"year",
@@ -148,7 +171,7 @@ func TestTokenBillingInitPromptCollectsValues(t *testing.T) {
 	assert.Equal(t, "Production AI plan", body["plan_name"])
 	assert.Equal(t, defaultTokenBillingModelsAsInterfaces(), body["models"])
 	assert.Equal(t, "15.5", body["default_markup_percent"])
-	assert.Equal(t, "new_customers_only", body["price_tracking_preference"])
+	assert.Equal(t, "disabled", body["price_tracking_preference"])
 	assert.Equal(t, "2000", body["subscription_fee_amount"])
 	assert.Equal(t, "500", body["credit_grant_per_period_amount"])
 	assert.Equal(t, "year", body["interval"])

--- a/pkg/cmd/token_billing_test.go
+++ b/pkg/cmd/token_billing_test.go
@@ -26,6 +26,20 @@ func newTestTokenBillingInitCmd(t *testing.T, serverURL string) *tokenBillingIni
 	return ic
 }
 
+func TestTokenBillingInitDefaults(t *testing.T) {
+	ic := newTokenBillingInitCmd()
+
+	body := ic.buildRequestBody()
+
+	assert.Equal(t, "AI starter", body["plan_name"])
+	assert.Equal(t, []interface{}{"openai/gpt-4o-mini"}, body["models"])
+	assert.Equal(t, "20.0", body["default_markup_percent"])
+	assert.Equal(t, "disabled", body["price_tracking_preference"])
+	assert.Equal(t, "0", body["subscription_fee_amount"])
+	assert.Equal(t, "1000", body["credit_grant_per_period_amount"])
+	assert.Equal(t, "month", body["interval"])
+}
+
 func TestTokenBillingInitBuildRequestBody(t *testing.T) {
 	ic := newTokenBillingInitCmd()
 	ic.planName = "Custom AI plan"
@@ -45,6 +59,68 @@ func TestTokenBillingInitBuildRequestBody(t *testing.T) {
 	assert.Equal(t, "1000", body["subscription_fee_amount"])
 	assert.Equal(t, "500", body["credit_grant_per_period_amount"])
 	assert.Equal(t, "month", body["interval"])
+}
+
+func TestTokenBillingInitPromptAcceptsDefaults(t *testing.T) {
+	ic := newTokenBillingInitCmd()
+	ic.cmd.SetIn(strings.NewReader("\n\n\n\n\n\n\n\n"))
+
+	var output strings.Builder
+	ic.cmd.SetOut(&output)
+
+	err := ic.promptForInitConfig(ic.cmd)
+	require.NoError(t, err)
+
+	body := ic.buildRequestBody()
+	assert.Equal(t, "AI starter", body["plan_name"])
+	assert.Equal(t, []interface{}{"openai/gpt-4o-mini"}, body["models"])
+	assert.Equal(t, "20.0", body["default_markup_percent"])
+	assert.Equal(t, "disabled", body["price_tracking_preference"])
+	assert.Equal(t, "0", body["subscription_fee_amount"])
+	assert.Equal(t, "1000", body["credit_grant_per_period_amount"])
+	assert.Equal(t, "month", body["interval"])
+	assert.Contains(t, output.String(), "Token Billing setup")
+	assert.Contains(t, output.String(), "Proceed with creating Token Billing resources?")
+}
+
+func TestTokenBillingInitPromptCollectsValues(t *testing.T) {
+	ic := newTokenBillingInitCmd()
+	ic.cmd.SetIn(strings.NewReader(strings.Join([]string{
+		"Production AI plan",
+		"openai/gpt-4o-mini, anthropic/claude-3-5-sonnet",
+		"15.5",
+		"new_customers_only",
+		"2000",
+		"500",
+		"year",
+		"y",
+		"",
+	}, "\n")))
+
+	var output strings.Builder
+	ic.cmd.SetOut(&output)
+
+	err := ic.promptForInitConfig(ic.cmd)
+	require.NoError(t, err)
+
+	body := ic.buildRequestBody()
+	assert.Equal(t, "Production AI plan", body["plan_name"])
+	assert.Equal(t, []interface{}{"openai/gpt-4o-mini", "anthropic/claude-3-5-sonnet"}, body["models"])
+	assert.Equal(t, "15.5", body["default_markup_percent"])
+	assert.Equal(t, "new_customers_only", body["price_tracking_preference"])
+	assert.Equal(t, "2000", body["subscription_fee_amount"])
+	assert.Equal(t, "500", body["credit_grant_per_period_amount"])
+	assert.Equal(t, "year", body["interval"])
+	assert.Contains(t, output.String(), "Production AI plan")
+}
+
+func TestTokenBillingInitPromptCanCancel(t *testing.T) {
+	ic := newTokenBillingInitCmd()
+	ic.cmd.SetIn(strings.NewReader("\n\n\n\n\n\n\nn\n"))
+
+	err := ic.promptForInitConfig(ic.cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "canceled")
 }
 
 func TestTokenBillingInitCmd_HTTPRequest(t *testing.T) {

--- a/pkg/cmd/token_billing_test.go
+++ b/pkg/cmd/token_billing_test.go
@@ -188,7 +188,7 @@ func TestTokenBillingInitCmd_HTTPRequest(t *testing.T) {
 	assert.Contains(t, output.String(), "Token Billing initialized")
 	assert.Contains(t, output.String(), "STRIPE_TOKEN_BILLING_GATEWAY_URL=https://llm.stripe.com/v1")
 	assert.Contains(t, output.String(), "pricing_plan_id=bpp_test_123")
-	assert.Contains(t, output.String(), "[x] Pricing configured")
+	assert.Contains(t, output.String(), "✔ Pricing configured")
 	assert.Contains(t, output.String(), "Run one AI Gateway test request.")
 }
 

--- a/pkg/cmd/token_billing_test.go
+++ b/pkg/cmd/token_billing_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -26,13 +27,26 @@ func newTestTokenBillingInitCmd(t *testing.T, serverURL string) *tokenBillingIni
 	return ic
 }
 
+func defaultTokenBillingModelsAsInterfaces() []interface{} {
+	models := make([]interface{}, 0, len(defaultTokenBillingModels))
+	for _, model := range defaultTokenBillingModels {
+		models = append(models, model)
+	}
+	return models
+}
+
+func updateTokenBillingModelPicker(m tokenBillingModelPicker, code rune) tokenBillingModelPicker {
+	next, _ := m.Update(tea.KeyPressMsg{Code: code})
+	return next.(tokenBillingModelPicker)
+}
+
 func TestTokenBillingInitDefaults(t *testing.T) {
 	ic := newTokenBillingInitCmd()
 
 	body := ic.buildRequestBody()
 
 	assert.Equal(t, "AI starter", body["plan_name"])
-	assert.Equal(t, []interface{}{"openai/gpt-4o-mini"}, body["models"])
+	assert.Equal(t, defaultTokenBillingModelsAsInterfaces(), body["models"])
 	assert.Equal(t, "20.0", body["default_markup_percent"])
 	assert.Equal(t, "disabled", body["price_tracking_preference"])
 	assert.Equal(t, "0", body["subscription_fee_amount"])
@@ -61,6 +75,34 @@ func TestTokenBillingInitBuildRequestBody(t *testing.T) {
 	assert.Equal(t, "month", body["interval"])
 }
 
+func TestTokenBillingModelPickerDefaultsToSelectedModels(t *testing.T) {
+	m := newTokenBillingModelPicker(defaultTokenBillingModels)
+
+	require.Len(t, m.rows, len(defaultTokenBillingModels))
+	require.Equal(t, defaultTokenBillingModels, m.selectedModels())
+}
+
+func TestTokenBillingModelPickerTogglesWithEnterAndFinishesWithD(t *testing.T) {
+	m := newTokenBillingModelPicker(defaultTokenBillingModels)
+
+	m = updateTokenBillingModelPicker(m, tea.KeyEnter)
+	require.False(t, m.rows[0].selected)
+	require.Equal(t, defaultTokenBillingModels[1:], m.selectedModels())
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'd'})
+	m = next.(tokenBillingModelPicker)
+	require.True(t, m.done)
+	require.False(t, m.quit)
+	require.NotNil(t, cmd)
+}
+
+func TestTokenBillingModelPickerIncludesFlagModels(t *testing.T) {
+	m := newTokenBillingModelPicker([]string{"custom/provider-model"})
+
+	require.Equal(t, "custom/provider-model", m.rows[len(m.rows)-1].name)
+	require.Equal(t, []string{"custom/provider-model"}, m.selectedModels())
+}
+
 func TestTokenBillingInitPromptAcceptsDefaults(t *testing.T) {
 	ic := newTokenBillingInitCmd()
 	ic.cmd.SetIn(strings.NewReader("\n\n\n\n\n\n\n\n"))
@@ -73,7 +115,7 @@ func TestTokenBillingInitPromptAcceptsDefaults(t *testing.T) {
 
 	body := ic.buildRequestBody()
 	assert.Equal(t, "AI starter", body["plan_name"])
-	assert.Equal(t, []interface{}{"openai/gpt-4o-mini"}, body["models"])
+	assert.Equal(t, defaultTokenBillingModelsAsInterfaces(), body["models"])
 	assert.Equal(t, "20.0", body["default_markup_percent"])
 	assert.Equal(t, "disabled", body["price_tracking_preference"])
 	assert.Equal(t, "0", body["subscription_fee_amount"])
@@ -87,7 +129,6 @@ func TestTokenBillingInitPromptCollectsValues(t *testing.T) {
 	ic := newTokenBillingInitCmd()
 	ic.cmd.SetIn(strings.NewReader(strings.Join([]string{
 		"Production AI plan",
-		"openai/gpt-4o-mini, anthropic/claude-3-5-sonnet",
 		"15.5",
 		"new_customers_only",
 		"2000",
@@ -105,7 +146,7 @@ func TestTokenBillingInitPromptCollectsValues(t *testing.T) {
 
 	body := ic.buildRequestBody()
 	assert.Equal(t, "Production AI plan", body["plan_name"])
-	assert.Equal(t, []interface{}{"openai/gpt-4o-mini", "anthropic/claude-3-5-sonnet"}, body["models"])
+	assert.Equal(t, defaultTokenBillingModelsAsInterfaces(), body["models"])
 	assert.Equal(t, "15.5", body["default_markup_percent"])
 	assert.Equal(t, "new_customers_only", body["price_tracking_preference"])
 	assert.Equal(t, "2000", body["subscription_fee_amount"])
@@ -116,7 +157,7 @@ func TestTokenBillingInitPromptCollectsValues(t *testing.T) {
 
 func TestTokenBillingInitPromptCanCancel(t *testing.T) {
 	ic := newTokenBillingInitCmd()
-	ic.cmd.SetIn(strings.NewReader("\n\n\n\n\n\n\nn\n"))
+	ic.cmd.SetIn(strings.NewReader("\n\n\n\n\n\nn\n"))
 
 	err := ic.promptForInitConfig(ic.cmd)
 	require.Error(t, err)

--- a/pkg/cmd/token_billing_test.go
+++ b/pkg/cmd/token_billing_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+func newTestTokenBillingInitCmd(t *testing.T, serverURL string) *tokenBillingInitCmd {
+	t.Helper()
+	t.Setenv("STRIPE_API_KEY", "")
+	ic := newTokenBillingInitCmd()
+	ic.rb.Profile = &config.Profile{APIKey: "sk_test_1234567890abcdef"}
+	ic.rb.APIBaseURL = serverURL
+	ic.cmd.SetContext(context.Background())
+	return ic
+}
+
+func TestTokenBillingInitBuildRequestBody(t *testing.T) {
+	ic := newTokenBillingInitCmd()
+	ic.planName = "Custom AI plan"
+	ic.models = []string{"openai/gpt-4o-mini", "anthropic/claude-3-5-sonnet"}
+	ic.defaultMarkupPercent = "15.5"
+	ic.priceTrackingPreference = "new_customers_only"
+	ic.subscriptionFeeAmount = "1000"
+	ic.creditGrantPerPeriodAmount = "500"
+	ic.interval = "month"
+
+	body := ic.buildRequestBody()
+
+	assert.Equal(t, "Custom AI plan", body["plan_name"])
+	assert.Equal(t, []interface{}{"openai/gpt-4o-mini", "anthropic/claude-3-5-sonnet"}, body["models"])
+	assert.Equal(t, "15.5", body["default_markup_percent"])
+	assert.Equal(t, "new_customers_only", body["price_tracking_preference"])
+	assert.Equal(t, "1000", body["subscription_fee_amount"])
+	assert.Equal(t, "500", body["credit_grant_per_period_amount"])
+	assert.Equal(t, "month", body["interval"])
+}
+
+func TestTokenBillingInitCmd_HTTPRequest(t *testing.T) {
+	var capturedReq *http.Request
+	var capturedBody []byte
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"status":"initialized",
+			"message":"Token Billing is initialized for testmode.",
+			"ai_gateway_enabled":true,
+			"test_request_completed":false,
+			"pricing_configured":true,
+			"token_meters_configured":true,
+			"zero_credit_rejection_enabled":false,
+			"webhook_healthy":false,
+			"inference_mode":"not_tested",
+			"gateway_endpoint":"https://llm.stripe.com/v1",
+			"environment_variables":{
+				"STRIPE_TOKEN_BILLING_GATEWAY_URL":"https://llm.stripe.com/v1",
+				"STRIPE_TOKEN_BILLING_PRICING_PLAN_ID":"bpp_test_123"
+			},
+			"resources":{
+				"pricing_plan_id":"bpp_test_123",
+				"rate_card_id":"rc_test_123",
+				"meter_id":"mtr_test_123",
+				"settings_id":"tbset_test_123"
+			},
+			"next_steps":["Run one AI Gateway test request."]
+		}`))
+	}))
+	defer ts.Close()
+
+	ic := newTestTokenBillingInitCmd(t, ts.URL)
+	ic.planName = "Custom AI plan"
+	ic.models = []string{"openai/gpt-4o-mini", "anthropic/claude-3-5-sonnet"}
+	ic.defaultMarkupPercent = "15.5"
+	ic.subscriptionFeeAmount = "1000"
+	ic.creditGrantPerPeriodAmount = "500"
+
+	var output strings.Builder
+	ic.cmd.SetOut(&output)
+
+	err := ic.runTokenBillingInitCmd(ic.cmd, []string{})
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq)
+
+	assert.Equal(t, http.MethodPost, capturedReq.Method)
+	assert.Equal(t, tokenBillingOnboardingInitPath, capturedReq.URL.Path)
+	assert.Equal(t, "Bearer sk_test_1234567890abcdef", capturedReq.Header.Get("Authorization"))
+
+	values, err := url.ParseQuery(string(capturedBody))
+	require.NoError(t, err)
+	assert.Equal(t, "Custom AI plan", values.Get("plan_name"))
+	assert.Equal(t, "15.5", values.Get("default_markup_percent"))
+	assert.Equal(t, "1000", values.Get("subscription_fee_amount"))
+	assert.Equal(t, "500", values.Get("credit_grant_per_period_amount"))
+	assert.Equal(t, "month", values.Get("interval"))
+	assert.Equal(t, "disabled", values.Get("price_tracking_preference"))
+	assert.Equal(t, []string{"openai/gpt-4o-mini", "anthropic/claude-3-5-sonnet"}, values["models[]"])
+
+	assert.Contains(t, output.String(), "Token Billing initialized")
+	assert.Contains(t, output.String(), "STRIPE_TOKEN_BILLING_GATEWAY_URL=https://llm.stripe.com/v1")
+	assert.Contains(t, output.String(), "pricing_plan_id=bpp_test_123")
+	assert.Contains(t, output.String(), "[x] Pricing configured")
+	assert.Contains(t, output.String(), "Run one AI Gateway test request.")
+}
+
+func TestTokenBillingInitCmd_DryRun(t *testing.T) {
+	ic := newTestTokenBillingInitCmd(t, "https://api.stripe.com")
+	ic.rb.DryRun = true
+
+	var output strings.Builder
+	ic.cmd.SetOut(&output)
+
+	err := ic.runTokenBillingInitCmd(ic.cmd, []string{})
+	require.NoError(t, err)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(output.String()), &body))
+	dryRun := body["dry_run"].(map[string]interface{})
+	assert.Equal(t, http.MethodPost, dryRun["method"])
+	assert.Equal(t, "https://api.stripe.com/v1/token_billing/onboarding/init", dryRun["url"])
+}
+
+func TestTokenBillingInitCmd_RequiresModel(t *testing.T) {
+	ic := newTestTokenBillingInitCmd(t, "https://api.stripe.com")
+	ic.models = []string{}
+
+	err := ic.runTokenBillingInitCmd(ic.cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one --model is required")
+}


### PR DESCRIPTION
Add a first-class token-billing init command that calls the pay-server onboarding API and prints the gateway URL, resource IDs, suggested environment variables, checklist status, and next steps.