### PR TITLE
Display newer plugin version available message in yellow

### DIFF
--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
@@ -1207,8 +1208,12 @@ func CheckLatestPluginVersion(ctx context.Context, config config.IConfig, fs afe
 	}
 
 	if comparePluginVersions(installedVersion, latestVersion) < 0 {
-		fmt.Fprintf(os.Stderr, "A newer version of the %s plugin is available (v%s → v%s). Run `stripe plugin upgrade %s` to update.\n",
-			plugin.Shortname, installedVersion, latestVersion, plugin.Shortname)
+		c := ansi.Color(os.Stderr)
+		msg := fmt.Sprintf(
+			"A newer version of the %s plugin is available (v%s → v%s). Run `stripe plugin upgrade %s` to update.",
+			plugin.Shortname, installedVersion, latestVersion, plugin.Shortname,
+		)
+		fmt.Fprintln(os.Stderr, c.Yellow(msg).String())
 	}
 }
 


### PR DESCRIPTION
 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Sometimes Stripe Plugin CLI users forget to update their packages, which may contain important updates. I believe it makes sense to increase the contrast of the message stating that a newer version of the Stripe Plugin is available.

| Current message | Updated message |
| - | - |
| <img width="570" height="58" alt="Screenshot 2026-07-27 at 09 48 49" src="https://github.com/user-attachments/assets/ac8714d7-0bd9-4b24-b464-74f3f2a2cbe4" /> | <img width="570" height="58" alt="Screenshot 2026-07-27 at 09 49 27" src="https://github.com/user-attachments/assets/08a78fb9-5b73-4c47-8d42-0db0741e9621" /> |
 
