### PR TITLE
Add merge_group trigger to CI workflows

### DIFF
--- a/.github/workflows/canary-test.yml
+++ b/.github/workflows/canary-test.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   push:
     branches: [master]
+  merge_group:
+    branches: [master]
   workflow_call:
     inputs:
       run_api_tests:

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     paths:
     - 'goreleaser/**'
+  merge_group:
+    paths:
+    - '.goreleaser/**'
 
 jobs:
   build-linux:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 on:
   push:
   pull_request:
+  merge_group:
 name: Test
 permissions:
   contents: read


### PR DESCRIPTION
Follows [this guide](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues) to enable our CI workflows for merge queue branches. I plan on enabling the merge queue after and seeing what happens. This is additive so I don't expect anything too crazy to happen.