### PR TITLE
Use OAK token for API requests when available

### DIFF
--- a/pkg/cmd/docs/root.go
+++ b/pkg/cmd/docs/root.go
@@ -148,8 +148,8 @@ func (r *RootCommand) initClient() {
 		if accountID, err := r.cfg.Profile.GetAccountID(); err == nil {
 			clientOpts = append(clientOpts, pkgdocs.WithCacheKeyPrefix(accountID))
 		}
-		if apiKey, err := r.cfg.Profile.GetAPIKey(false); err == nil {
-			clientOpts = append(clientOpts, pkgdocs.WithAPIKey(apiKey))
+		if creds, err := r.cfg.Profile.ResolveCredentials(false); err == nil {
+			clientOpts = append(clientOpts, pkgdocs.WithAPIKey(creds.Token))
 		}
 	}
 	if len(clientOpts) > 0 {

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -137,12 +137,12 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	key, err := Config.Profile.GetAPIKey(lc.livemode)
+	creds, err := Config.Profile.ResolveCredentials(lc.livemode)
 	if err != nil {
 		return err
 	}
 
-	if strings.Contains(key, "sk_org") {
+	if strings.Contains(creds.Token, "sk_org") {
 		log.Errorf("The listen command is not supported in an organization sandbox at this time.")
 		return nil
 	}
@@ -160,7 +160,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 
 	client := &stripe.Client{
 		BaseURL:     apiBase,
-		Credentials: stripe.NewAPIKeyCredentials(key),
+		Credentials: creds,
 	}
 
 	// --print-secret option

--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -172,7 +172,7 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	key, err := tailCmd.cfg.Profile.GetAPIKey(false)
+	creds, err := tailCmd.cfg.Profile.ResolveCredentials(false)
 	if err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 	tailer := logtailing.New(&logtailing.Config{
 		Client: &stripe.Client{
 			BaseURL:     apiBase,
-			Credentials: stripe.NewAPIKeyCredentials(key),
+			Credentials: creds,
 		},
 		DeviceName: deviceName,
 		Filters:    tailCmd.LogFilters,

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -310,15 +310,6 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 	return "", validators.ErrAPIKeyNotConfigured
 }
 
-// ResolveCredentials returns the API credentials for the given profile and livemode.
-func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) {
-	apiKey, err := p.GetAPIKey(livemode)
-	if err != nil {
-		return stripe.Credentials{}, err
-	}
-	return stripe.NewAPIKeyCredentials(apiKey), nil
-}
-
 // GetExpiresAt returns the API key expirary date
 func (p *Profile) GetExpiresAt(livemode bool) (time.Time, error) {
 	var timeString string
@@ -636,6 +627,67 @@ type SessionCredentials struct {
 	UAT        string `json:"uat"`
 	PrivateKey string `json:"private_key"`
 	AccountID  string `json:"account_id"`
+}
+
+// GetUAT retrieves the user access token from the keyring.
+// Returns an empty string if no UAT is stored.
+func (p *Profile) GetUAT() (string, error) {
+	if KeyRing == nil {
+		return "", nil
+	}
+	data, err := KeyRing.Get(UATKeychainItemKey)
+	if err != nil {
+		if errors.Is(err, keyring.ErrKeyNotFound) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(data), nil
+}
+
+// GetCompartmentID returns the compartment (workspace) ID for the given mode
+// from the stored UserInfo. Returns an empty string if none is configured.
+func (p *Profile) GetCompartmentID(livemode bool) (string, error) {
+	ui, err := p.GetUserInfo()
+	if err != nil || ui == nil {
+		return "", err
+	}
+	for _, c := range ui.Compartments {
+		if c.Livemode == livemode {
+			return c.CompartmentID, nil
+		}
+	}
+	return "", nil
+}
+
+// ResolveCredentials returns the credentials for the given mode. If an OAK
+// token (prefix "oak_") is stored in the keyring and no explicit override is
+// active, it is preferred over the configured API key and the compartment ID
+// and livemode flag are populated. Otherwise it falls back to GetAPIKey.
+func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) {
+	if !p.HasOverrideAPIKey() {
+		uat, err := p.GetUAT()
+		if err != nil {
+			return stripe.Credentials{}, err
+		}
+		if strings.HasPrefix(uat, "oak_") {
+			compartmentID, err := p.GetCompartmentID(livemode)
+			if err != nil {
+				return stripe.Credentials{}, err
+			}
+			lm := livemode
+			return stripe.Credentials{
+				Token:       uat,
+				OAKContext:  compartmentID,
+				OAKLivemode: &lm,
+			}, nil
+		}
+	}
+	key, err := p.GetAPIKey(livemode)
+	if err != nil {
+		return stripe.Credentials{}, err
+	}
+	return stripe.Credentials{Token: key}, nil
 }
 
 // GetSessionCredentials retrieves the session credentials from the keyring

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -675,19 +675,14 @@ func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) 
 			if err != nil {
 				return stripe.Credentials{}, err
 			}
-			lm := livemode
-			return stripe.Credentials{
-				Token:       uat,
-				OAKContext:  compartmentID,
-				OAKLivemode: &lm,
-			}, nil
+			return stripe.NewOAKCredentials(uat, compartmentID, livemode), nil
 		}
 	}
 	key, err := p.GetAPIKey(livemode)
 	if err != nil {
 		return stripe.Credentials{}, err
 	}
-	return stripe.Credentials{Token: key}, nil
+	return stripe.NewAPIKeyCredentials(key), nil
 }
 
 // GetSessionCredentials retrieves the session credentials from the keyring

--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -344,7 +344,7 @@ func (fxt *Fixture) getAPIBase(request FixtureRequest) string {
 }
 
 func (fxt *Fixture) unsupportedAPIKey(path string) bool {
-	return strings.HasPrefix(path, "/v2/") && !strings.HasPrefix(fxt.Credentials.Token, "sk_")
+	return strings.HasPrefix(path, "/v2/") && !strings.HasPrefix(fxt.Credentials.Token, "sk_") && !strings.HasPrefix(fxt.Credentials.Token, "oak_")
 }
 
 func (fxt *Fixture) addCustomHeaders(headers map[string]string) func(req *http.Request) error {
@@ -390,7 +390,7 @@ func (fxt *Fixture) makeRequest(ctx context.Context, data FixtureRequest, apiVer
 		params.SetIdempotency(idempotencyKey)
 	}
 
-	var additionalConfigure func(req *http.Request) error
+	var additionalConfigure func(*http.Request) error
 	if data.Headers != nil {
 		additionalConfigure = fxt.addCustomHeaders(data.Headers)
 	}

--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -308,32 +308,12 @@ func FixtureContents(eventName string) (string, error) {
 
 // BuildFromFixtureFile creates a new fixture struct for a file
 func BuildFromFixtureFile(fs afero.Fs, creds stripe.Credentials, stripeAccount, apiBaseURL, jsonFile string, skip, override, add, remove []string, edit bool) (*Fixture, error) {
-	fixture, err := NewFixtureFromFile(
-		fs,
-		creds,
-		stripeAccount,
-		apiBaseURL,
-		jsonFile,
-		skip,
-		override,
-		add,
-		remove,
-		edit,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return fixture, nil
+	return NewFixtureFromFile(fs, creds, stripeAccount, apiBaseURL, jsonFile, skip, override, add, remove, edit)
 }
 
 // BuildFromFixtureString creates a new fixture from a string
 func BuildFromFixtureString(fs afero.Fs, creds stripe.Credentials, stripeAccount, apiBaseURL, raw string) (*Fixture, error) {
-	fixture, err := NewFixtureFromRawString(fs, creds, stripeAccount, apiBaseURL, raw)
-	if err != nil {
-		return nil, err
-	}
-	return fixture, nil
+	return NewFixtureFromRawString(fs, creds, stripeAccount, apiBaseURL, raw)
 }
 
 // EventList prints out a padded list of supported trigger events for printing the help file

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -318,7 +318,8 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, apiBaseURL, dashboardBaseURL, resolvedBinaryURL string, skipMetadataLookup bool) error {
 	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)
 
-	apiKey, _ := cfg.GetProfile().GetAPIKey(false)
+	creds, _ := cfg.GetProfile().ResolveCredentials(false)
+	apiKey := creds.Token
 	pluginToInstall := p
 	pluginDownloadURL := resolvedBinaryURL
 	var metadataLookupErr error

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -324,10 +324,11 @@ func PersistInstalledPluginState(config config.IConfig, fs afero.Fs, plugin Plug
 // ListPlugins fetches the live plugin list visible to the current caller for
 // the current platform using the list-plugins API endpoints.
 func ListPlugins(ctx context.Context, config config.IConfig, apiBaseURL, dashboardBaseURL string) (PluginList, error) {
-	apiKey, err := config.GetProfile().GetAPIKey(false)
+	creds, err := config.GetProfile().ResolveCredentials(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return PluginList{}, err
 	}
+	apiKey := creds.Token
 
 	if dashboardBaseURL == "" {
 		dashboardBaseURL = stripe.DashboardBaseURLForAPIBaseURL(apiBaseURL)
@@ -371,10 +372,11 @@ func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.I
 		dashboardBaseURL = stripe.DashboardBaseURLForAPIBaseURL(apiBaseURL)
 	}
 
-	apiKey, err := config.GetProfile().GetAPIKey(false)
+	creds, err := config.GetProfile().ResolveCredentials(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return err
 	}
+	apiKey := creds.Token
 
 	pluginNames, err := GetInstalledPluginNames(config, fs)
 	if err != nil {
@@ -505,10 +507,11 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 		return nil, err
 	}
 
-	apiKey, err := config.GetProfile().GetAPIKey(false)
+	creds, err := config.GetProfile().ResolveCredentials(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return nil, err
 	}
+	apiKey := creds.Token
 
 	resolvedPlugin, err := resolvePluginFromMetadata(ctx, config, fs, pluginName, version, apiBaseURL, dashboardBaseURL, apiKey)
 	if err == nil {
@@ -555,10 +558,11 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 		return nil, err
 	}
 
-	apiKey, err := config.GetProfile().GetAPIKey(false)
+	creds, err := config.GetProfile().ResolveCredentials(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return nil, err
 	}
+	apiKey := creds.Token
 
 	resolvedPlugin, endpointErr := resolvePluginFromMetadata(ctx, config, fs, pluginName, "", apiBaseURL, dashboardBaseURL, apiKey)
 	if endpointErr == nil {

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -449,6 +449,11 @@ func (rb *Base) BuildDryRunOutput(creds stripe.Credentials, baseURL, path string
 	}
 	if params.stripeContext != "" {
 		headers["Stripe-Context"] = params.stripeContext
+	} else if creds.OAKContext != "" {
+		headers["Stripe-Context"] = creds.OAKContext
+	}
+	if creds.OAKLivemode != nil {
+		headers["Stripe-Livemode"] = strconv.FormatBool(*creds.OAKLivemode)
 	}
 
 	if creds.Token != "" && len(creds.Token) >= 12 {

--- a/pkg/requests/plugin.go
+++ b/pkg/requests/plugin.go
@@ -71,7 +71,12 @@ func GetPluginMetadata(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVer
 		APIBaseURL:     metadataBaseURL,
 	}
 
-	resp, err := base.MakeRequest(ctx, stripe.NewAPIKeyCredentials(apiKey), metadataPath, params, map[string]interface{}{
+	resolvedCreds, err := base.ResolveCredentials()
+	if err != nil {
+		resolvedCreds = stripe.NewAPIKeyCredentials(apiKey)
+	}
+
+	resp, err := base.MakeRequest(ctx, resolvedCreds, metadataPath, params, map[string]interface{}{
 		"plugin":  pluginName,
 		"version": version,
 		"os":      os,
@@ -116,7 +121,12 @@ func GetPluginList(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVersion
 		APIBaseURL:     listBaseURL,
 	}
 
-	resp, err := base.MakeRequest(ctx, stripe.NewAPIKeyCredentials(apiKey), listPath, params, map[string]interface{}{
+	resolvedCreds, err := base.ResolveCredentials()
+	if err != nil {
+		resolvedCreds = stripe.NewAPIKeyCredentials(apiKey)
+	}
+
+	resp, err := base.MakeRequest(ctx, resolvedCreds, listPath, params, map[string]interface{}{
 		"os":   os,
 		"arch": arch,
 	}, true, nil)

--- a/pkg/requests/webhook_endpoints.go
+++ b/pkg/requests/webhook_endpoints.go
@@ -25,7 +25,7 @@ type WebhookEndpoint struct {
 }
 
 // WebhookEndpointsList returns all the webhook endpoints on a users' account
-func WebhookEndpointsList(ctx context.Context, baseURL, apiVersion, apiKey string, profile *config.Profile) WebhookEndpointList {
+func WebhookEndpointsList(ctx context.Context, baseURL, apiVersion string, profile *config.Profile) WebhookEndpointList {
 	params := &RequestParameters{
 		data:    []string{"limit=30"},
 		version: apiVersion,
@@ -37,7 +37,11 @@ func WebhookEndpointsList(ctx context.Context, baseURL, apiVersion, apiKey strin
 		SuppressOutput: true,
 		APIBaseURL:     baseURL,
 	}
-	resp, _ := base.MakeRequest(ctx, stripe.NewAPIKeyCredentials(apiKey), "/v1/webhook_endpoints", params, make(map[string]interface{}), true, nil)
+	creds, err := base.ResolveCredentials()
+	if err != nil {
+		return WebhookEndpointList{}
+	}
+	resp, _ := base.MakeRequest(ctx, creds, "/v1/webhook_endpoints", params, make(map[string]interface{}), true, nil)
 	data := WebhookEndpointList{}
 	json.Unmarshal(resp, &data)
 
@@ -64,7 +68,7 @@ func WebhookEndpointsListWithClient(ctx context.Context, client stripe.RequestPe
 }
 
 // WebhookEndpointCreate creates a new webhook endpoint
-func WebhookEndpointCreate(ctx context.Context, baseURL, apiVersion, apiKey, url, description string, connect bool, profile *config.Profile) error {
+func WebhookEndpointCreate(ctx context.Context, baseURL, apiVersion, url, description string, connect bool, profile *config.Profile) error {
 	if strings.TrimSpace(url) == "" {
 		return fmt.Errorf("url cannot be empty")
 	}
@@ -91,7 +95,11 @@ func WebhookEndpointCreate(ctx context.Context, baseURL, apiVersion, apiKey, url
 		SuppressOutput: true,
 		APIBaseURL:     baseURL,
 	}
-	_, err := base.MakeRequest(ctx, stripe.NewAPIKeyCredentials(apiKey), "/v1/webhook_endpoints", params, make(map[string]interface{}), true, nil)
+	creds, err := base.ResolveCredentials()
+	if err != nil {
+		return err
+	}
+	_, err = base.MakeRequest(ctx, creds, "/v1/webhook_endpoints", params, make(map[string]interface{}), true, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/rpcservice/events_resend.go
+++ b/pkg/rpcservice/events_resend.go
@@ -24,7 +24,6 @@ func (srv *RPCService) EventsResend(ctx context.Context, req *rpc.EventsResendRe
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
-
 	if req.EventId == "" {
 		return nil, status.Error(codes.InvalidArgument, "Event ID is required")
 	}

--- a/pkg/rpcservice/events_resend.go
+++ b/pkg/rpcservice/events_resend.go
@@ -24,6 +24,7 @@ func (srv *RPCService) EventsResend(ctx context.Context, req *rpc.EventsResendRe
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
+
 	if req.EventId == "" {
 		return nil, status.Error(codes.InvalidArgument, "Event ID is required")
 	}

--- a/pkg/rpcservice/listen.go
+++ b/pkg/rpcservice/listen.go
@@ -44,7 +44,7 @@ func (srv *RPCService) Listen(req *rpc.ListenRequest, stream rpc.StripeCLI_Liste
 		return status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	key, err := srv.cfg.UserCfg.Profile.GetAPIKey(req.Live)
+	creds, err := srv.cfg.UserCfg.Profile.ResolveCredentials(req.Live)
 	if err != nil {
 		return status.Error(codes.Unauthenticated, err.Error())
 	}
@@ -62,7 +62,7 @@ func (srv *RPCService) Listen(req *rpc.ListenRequest, stream rpc.StripeCLI_Liste
 	p, err := createProxy(ctx, &proxy.Config{
 		Client: &stripe.Client{
 			BaseURL:     apiBase,
-			Credentials: stripe.NewAPIKeyCredentials(key),
+			Credentials: creds,
 		},
 		DeviceName:            deviceName,
 		ForwardURL:            req.ForwardTo,

--- a/pkg/rpcservice/logs_tail.go
+++ b/pkg/rpcservice/logs_tail.go
@@ -31,7 +31,7 @@ func (srv *RPCService) LogsTail(req *rpc.LogsTailRequest, stream rpc.StripeCLI_L
 		return status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	key, err := srv.cfg.UserCfg.Profile.GetAPIKey(false)
+	creds, err := srv.cfg.UserCfg.Profile.ResolveCredentials(false)
 	if err != nil {
 		return status.Error(codes.Unauthenticated, err.Error())
 	}
@@ -48,7 +48,7 @@ func (srv *RPCService) LogsTail(req *rpc.LogsTailRequest, stream rpc.StripeCLI_L
 	tailer := createTailer(&logtailing.Config{
 		Client: &stripe.Client{
 			BaseURL:     apiBase,
-			Credentials: stripe.NewAPIKeyCredentials(key),
+			Credentials: creds,
 		},
 		DeviceName: deviceName,
 		Filters:    filters,

--- a/pkg/rpcservice/webhook_endpoint_create.go
+++ b/pkg/rpcservice/webhook_endpoint_create.go
@@ -11,18 +11,11 @@ import (
 // WebhookEndpointCreate create a new webhook endpoint
 func (srv *RPCService) WebhookEndpointCreate(ctx context.Context, req *rpc.WebhookEndpointCreateRequest) (*rpc.WebhookEndpointCreateResponse, error) {
 	userConfig := srv.cfg.UserCfg
-	livemode := false
 
-	key, err := userConfig.Profile.GetAPIKey(livemode)
-	if err != nil {
-		return nil, err
-	}
-
-	err = requests.WebhookEndpointCreate(
+	err := requests.WebhookEndpointCreate(
 		ctx,
 		stripe.DefaultAPIBaseURL,
 		stripe.APIVersion,
-		key,
 		req.Url,
 		req.Description,
 		req.Connect,

--- a/pkg/rpcservice/webhook_endpoints_list.go
+++ b/pkg/rpcservice/webhook_endpoints_list.go
@@ -11,14 +11,8 @@ import (
 // WebhookEndpointsList returns a list of webhook endpoints.
 func (srv *RPCService) WebhookEndpointsList(ctx context.Context, req *rpc.WebhookEndpointsListRequest) (*rpc.WebhookEndpointsListResponse, error) {
 	userConfig := srv.cfg.UserCfg
-	livemode := false
 
-	key, err := userConfig.Profile.GetAPIKey(livemode)
-	if err != nil {
-		return nil, err
-	}
-
-	endpoints := requests.WebhookEndpointsList(ctx, stripe.DefaultAPIBaseURL, stripe.APIVersion, key, &userConfig.Profile)
+	endpoints := requests.WebhookEndpointsList(ctx, stripe.DefaultAPIBaseURL, stripe.APIVersion, &userConfig.Profile)
 
 	formattedEndpoints := make([]*rpc.WebhookEndpointsListResponse_WebhookEndpointData, 0, len(endpoints.Data))
 	for _, v := range endpoints.Data {

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -323,7 +323,7 @@ func ConfigureDotEnv(ctx context.Context, config *config.Config) (map[string]str
 		publishableKey = TestPublishableKeyPlaceholder
 	}
 
-	apiKey, err := config.Profile.GetAPIKey(false)
+	creds, err := config.Profile.ResolveCredentials(false)
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +337,7 @@ func ConfigureDotEnv(ctx context.Context, config *config.Config) (map[string]str
 
 	stripeClient := &stripe.Client{
 		BaseURL:     apiBase,
-		Credentials: stripe.NewAPIKeyCredentials(apiKey),
+		Credentials: creds,
 	}
 	authClient := stripeauth.NewClient(stripeClient, nil)
 
@@ -351,7 +351,7 @@ func ConfigureDotEnv(ctx context.Context, config *config.Config) (map[string]str
 
 	return map[string]string{
 		"STRIPE_PUBLISHABLE_KEY": publishableKey,
-		"STRIPE_SECRET_KEY":      apiKey,
+		"STRIPE_SECRET_KEY":      creds.Token,
 		"STRIPE_WEBHOOK_SECRET":  authSession.Secret,
 		"STATIC_DIR":             "../client",
 	}, nil

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -41,6 +41,12 @@ func NewAPIKeyCredentials(key string) Credentials {
 	return Credentials{Token: key}
 }
 
+// NewOAKCredentials returns Credentials for an OAK (User Access Token).
+func NewOAKCredentials(token, context string, livemode bool) Credentials {
+	return Credentials{Token: token, OAKContext: context, OAKLivemode: &livemode}
+}
+
+
 // SetRequestHeaders applies all auth-related headers to req.
 func (c Credentials) SetRequestHeaders(req *http.Request) {
 	if c.Token != "" {

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -46,7 +46,6 @@ func NewOAKCredentials(token, context string, livemode bool) Credentials {
 	return Credentials{Token: token, OAKContext: context, OAKLivemode: &livemode}
 }
 
-
 // SetRequestHeaders applies all auth-related headers to req.
 func (c Credentials) SetRequestHeaders(req *http.Request) {
 	if c.Token != "" {

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,9 +28,12 @@ const (
 	V2Request     = "v2"
 )
 
-// Credentials holds the auth credentials for a Stripe API request.
+// Credentials holds the auth credentials for a Stripe API request. For plain
+// API keys only Token is set. For OAK tokens all three fields are populated.
 type Credentials struct {
-	Token string
+	Token       string
+	OAKContext  string
+	OAKLivemode *bool
 }
 
 // NewAPIKeyCredentials returns Credentials using a standard Stripe API key.
@@ -37,15 +41,25 @@ func NewAPIKeyCredentials(key string) Credentials {
 	return Credentials{Token: key}
 }
 
-// SetRequestHeaders applies auth-related headers to req.
+// SetRequestHeaders applies all auth-related headers to req.
 func (c Credentials) SetRequestHeaders(req *http.Request) {
 	if c.Token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.Token)
 	}
+	if c.OAKContext != "" {
+		req.Header.Set("Stripe-Context", c.OAKContext)
+	}
+	if c.OAKLivemode != nil {
+		req.Header.Set("Stripe-Livemode", strconv.FormatBool(*c.OAKLivemode))
+	}
 }
 
-// Livemode reports whether the credentials are for live mode.
+// Livemode reports the effective livemode for the credentials. For OAK tokens
+// this is explicit; for plain API keys it is inferred from the key string.
 func (c Credentials) Livemode() bool {
+	if c.OAKLivemode != nil {
+		return *c.OAKLivemode
+	}
 	return strings.Contains(c.Token, "live")
 }
 

--- a/pkg/stripe/verbosetransport.go
+++ b/pkg/stripe/verbosetransport.go
@@ -20,6 +20,7 @@ var inspectHeaders = []string{
 	"Request-Id",
 	"Stripe-Account",
 	"Stripe-Context",
+	"Stripe-Livemode",
 	"Stripe-Version",
 }
 


### PR DESCRIPTION
Introduce support for making requests with the new token automatically if it's in the keychain. You need a flag enabled to receive it, otherwise we will just use an API key.

Same test procedure as https://github.com/stripe/stripe-cli/pull/1852. It currently does not work for some CLI specific commands but I am going to fix that in the backend:
- `stripe listen`
- `stripe logs tail`
- `stripe plugin install`