### PR TITLE
Silent the page duty alert for now

### DIFF
--- a/.github/workflows/data-analytics-canary.yml
+++ b/.github/workflows/data-analytics-canary.yml
@@ -57,7 +57,12 @@ jobs:
         run: bash scripts/notify.sh
         env:
           OVERALL_RESULT: ${{ steps.canary.outcome == 'success' && 'success' || 'failure' }}
-          DRYRUN: ${{ inputs.dryrun }}
+          # TEMPORARY: PagerDuty paging is silenced (forced dry-run) while the
+          # Analytics API private-preview enrollment for the canary account is
+          # still in progress (metric_query currently 404s). notify.sh will log
+          # what it *would* send but won't page. Revert to
+          # `DRYRUN: ${{ inputs.dryrun }}` once the account is enrolled.
+          DRYRUN: "true"
           PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_DATA_ANALYTICS_KEY }}
           PAGERDUTY_DEDUP_KEY: data-analytics-canary
           PAGERDUTY_SEVERITY: warning


### PR DESCRIPTION
 ### Reviewers
r? @
cc @stripe/developer-products

### Summary
Temporarily silences PagerDuty paging for the Data & Analytics canary workflow by forcing `notify.sh` into dry-run mode (`DRYRUN: "true"`).

The `metric_query` live test (`stripe data metrics run` → `POST /v2/data/analytics/metric_query`) currently 404s because the canary account isn't yet enrolled in the Analytics API private preview. That enrollment is still in progress, so we don't want the daily run paging on-call for a known, non-CLI-regression entitlement gap. `notify.sh` still logs what it *would* have sent, and the job still shows red in CI for visibility — only the page is suppressed. The `query_runs` tests are already passing (Sigma plan enabled).

This is a one-line, easily reverted change: once the account is enrolled in the Analytics preview, revert `DRYRUN: "true"` back to `DRYRUN: ${{ inputs.dryrun }}` to re-enable paging. An inline `TEMPORARY:` comment documents the reason and the revert step.
