### PR TITLE
Refactor auth logic into a new Credentials struct

### DIFF
--- a/pkg/cmd/data.go
+++ b/pkg/cmd/data.go
@@ -159,7 +159,7 @@ func (c *dataMetricsRunCmd) runDataMetricsRunCmd(cmd *cobra.Command, args []stri
 		return fmt.Errorf("at least one --metric is required")
 	}
 
-	apiKey, err := c.rb.Profile.GetAPIKey(c.rb.Livemode)
+	creds, err := c.rb.ResolveCredentials()
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func (c *dataMetricsRunCmd) runDataMetricsRunCmd(cmd *cobra.Command, args []stri
 	}
 
 	if c.rb.DryRun {
-		output, err := c.rb.BuildDryRunOutput(apiKey, c.rb.APIBaseURL, dataMetricsRunPath, &requests.RequestParameters{}, body)
+		output, err := c.rb.BuildDryRunOutput(creds, c.rb.APIBaseURL, dataMetricsRunPath, &requests.RequestParameters{}, body)
 		if err != nil {
 			return err
 		}
@@ -180,7 +180,7 @@ func (c *dataMetricsRunCmd) runDataMetricsRunCmd(cmd *cobra.Command, args []stri
 		return nil
 	}
 
-	_, err = c.rb.MakeRequest(cmd.Context(), apiKey, dataMetricsRunPath, &requests.RequestParameters{}, body, true, nil)
+	_, err = c.rb.MakeRequest(cmd.Context(), creds, dataMetricsRunPath, &requests.RequestParameters{}, body, true, nil)
 	return err
 }
 

--- a/pkg/cmd/fixtures.go
+++ b/pkg/cmd/fixtures.go
@@ -67,7 +67,7 @@ func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	apiKey, err := fc.Cfg.Profile.GetAPIKey(false)
+	creds, err := fc.Cfg.Profile.ResolveCredentials(false)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
 
 	fixture, err := fixtures.NewFixtureFromFile(
 		afero.NewOsFs(),
-		apiKey,
+		creds,
 		fc.stripeAccount,
 		fc.apiBaseURL,
 		args[0],

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -160,7 +160,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 
 	client := &stripe.Client{
 		BaseURL:     apiBase,
-		Credentials: stripe.Credentials{Token: key},
+		Credentials: stripe.NewAPIKeyCredentials(key),
 	}
 
 	// --print-secret option

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -159,8 +159,8 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	})
 
 	client := &stripe.Client{
-		APIKey:  key,
-		BaseURL: apiBase,
+		BaseURL:     apiBase,
+		Credentials: stripe.Credentials{APIKey: key},
 	}
 
 	// --print-secret option

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -160,7 +160,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 
 	client := &stripe.Client{
 		BaseURL:     apiBase,
-		Credentials: stripe.Credentials{APIKey: key},
+		Credentials: stripe.Credentials{Token: key},
 	}
 
 	// --print-secret option

--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -192,7 +192,7 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 	tailer := logtailing.New(&logtailing.Config{
 		Client: &stripe.Client{
 			BaseURL:     apiBase,
-			Credentials: stripe.Credentials{Token: key},
+			Credentials: stripe.NewAPIKeyCredentials(key),
 		},
 		DeviceName: deviceName,
 		Filters:    tailCmd.LogFilters,

--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -191,8 +191,8 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 
 	tailer := logtailing.New(&logtailing.Config{
 		Client: &stripe.Client{
-			APIKey:  key,
-			BaseURL: apiBase,
+			BaseURL:     apiBase,
+			Credentials: stripe.Credentials{APIKey: key},
 		},
 		DeviceName: deviceName,
 		Filters:    tailCmd.LogFilters,

--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -192,7 +192,7 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 	tailer := logtailing.New(&logtailing.Config{
 		Client: &stripe.Client{
 			BaseURL:     apiBase,
-			Credentials: stripe.Credentials{APIKey: key},
+			Credentials: stripe.Credentials{Token: key},
 		},
 		DeviceName: deviceName,
 		Filters:    tailCmd.LogFilters,

--- a/pkg/cmd/reporting.go
+++ b/pkg/cmd/reporting.go
@@ -167,7 +167,7 @@ func (cc *reportingQueryRunsCreateCmd) runReportingQueryRunsCreateCmd(cmd *cobra
 		return err
 	}
 
-	apiKey, err := cc.rb.Profile.GetAPIKey(cc.rb.Livemode)
+	creds, err := cc.rb.ResolveCredentials()
 	if err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func (cc *reportingQueryRunsCreateCmd) runReportingQueryRunsCreateCmd(cmd *cobra
 	body := cc.buildRequestBody(sql)
 
 	if cc.rb.DryRun {
-		output, err := cc.rb.BuildDryRunOutput(apiKey, cc.rb.APIBaseURL, queryRunsPath, &requests.RequestParameters{}, body)
+		output, err := cc.rb.BuildDryRunOutput(creds, cc.rb.APIBaseURL, queryRunsPath, &requests.RequestParameters{}, body)
 		if err != nil {
 			return err
 		}
@@ -187,7 +187,7 @@ func (cc *reportingQueryRunsCreateCmd) runReportingQueryRunsCreateCmd(cmd *cobra
 		return nil
 	}
 
-	_, err = cc.rb.MakeRequest(cmd.Context(), apiKey, queryRunsPath, &requests.RequestParameters{}, body, true, nil)
+	_, err = cc.rb.MakeRequest(cmd.Context(), creds, queryRunsPath, &requests.RequestParameters{}, body, true, nil)
 	return err
 }
 
@@ -242,14 +242,14 @@ func (rc *reportingQueryRunsRetrieveCmd) runReportingQueryRunsRetrieveCmd(cmd *c
 		return err
 	}
 
-	apiKey, err := rc.rb.Profile.GetAPIKey(rc.rb.Livemode)
+	creds, err := rc.rb.ResolveCredentials()
 	if err != nil {
 		return err
 	}
 
 	path := queryRunsPath + "/" + url.PathEscape(args[0])
 
-	_, err = rc.rb.MakeRequest(cmd.Context(), apiKey, path, &requests.RequestParameters{}, nil, true, nil)
+	_, err = rc.rb.MakeRequest(cmd.Context(), creds, path, &requests.RequestParameters{}, nil, true, nil)
 	return err
 }
 

--- a/pkg/cmd/resource/climate.go
+++ b/pkg/cmd/resource/climate.go
@@ -89,13 +89,13 @@ func runClimateOperation(cmd *cobra.Command, opCmd *OperationCmd, requestParams 
 	// Suppress base output so we can transform the response before printing.
 	opCmd.SuppressOutput = true
 
-	apiKey, apiKeyErr := opCmd.Profile.GetAPIKey(opCmd.Livemode)
+	creds, credsErr := opCmd.ResolveCredentials()
 	if opCmd.DryRun {
-		dryRunKey := apiKey
-		if apiKeyErr != nil {
-			dryRunKey = ""
+		dryRunCreds := creds
+		if credsErr != nil {
+			dryRunCreds = stripe.Credentials{}
 		}
-		output, err := opCmd.BuildDryRunOutput(dryRunKey, opCmd.APIBaseURL, opCmd.Path, &opCmd.Parameters, requestParams)
+		output, err := opCmd.BuildDryRunOutput(dryRunCreds, opCmd.APIBaseURL, opCmd.Path, &opCmd.Parameters, requestParams)
 		if err != nil {
 			return err
 		}
@@ -104,11 +104,11 @@ func runClimateOperation(cmd *cobra.Command, opCmd *OperationCmd, requestParams 
 		return nil
 	}
 
-	if apiKeyErr != nil {
-		return apiKeyErr
+	if credsErr != nil {
+		return credsErr
 	}
 
-	body, err := opCmd.MakeRequest(cmd.Context(), apiKey, opCmd.Path, &opCmd.Parameters, requestParams, false, nil)
+	body, err := opCmd.MakeRequest(cmd.Context(), creds, opCmd.Path, &opCmd.Parameters, requestParams, false, nil)
 	if err != nil || len(body) == 0 {
 		return err
 	}

--- a/pkg/cmd/resource/databases.go
+++ b/pkg/cmd/resource/databases.go
@@ -496,14 +496,14 @@ func executeDatabaseOperation(cmd *cobra.Command, opCmd *OperationCmd, args []st
 		return nil, err
 	}
 
-	apiKey, apiKeyErr := opCmd.Profile.GetAPIKey(opCmd.Livemode)
+	creds, credsErr := opCmd.ResolveCredentials()
 	if opCmd.DryRun {
-		dryRunKey := apiKey
-		if apiKeyErr != nil {
-			dryRunKey = ""
+		dryRunCreds := creds
+		if credsErr != nil {
+			dryRunCreds = stripe.Credentials{}
 		}
 
-		output, err := opCmd.BuildDryRunOutput(dryRunKey, opCmd.APIBaseURL, path, &opCmd.Parameters, requestParams)
+		output, err := opCmd.BuildDryRunOutput(dryRunCreds, opCmd.APIBaseURL, path, &opCmd.Parameters, requestParams)
 		if err != nil {
 			return nil, err
 		}
@@ -517,11 +517,11 @@ func executeDatabaseOperation(cmd *cobra.Command, opCmd *OperationCmd, args []st
 		return nil, nil
 	}
 
-	if apiKeyErr != nil {
-		return nil, apiKeyErr
+	if credsErr != nil {
+		return nil, credsErr
 	}
 
-	body, err := opCmd.MakeRequest(cmd.Context(), apiKey, path, &opCmd.Parameters, requestParams, true, nil)
+	body, err := opCmd.MakeRequest(cmd.Context(), creds, path, &opCmd.Parameters, requestParams, true, nil)
 	return body, err
 }
 

--- a/pkg/cmd/resource/keys_permissions.go
+++ b/pkg/cmd/resource/keys_permissions.go
@@ -67,7 +67,7 @@ func (kpc *KeysPermissionsCmd) runKeysPermissionsCmd(cmd *cobra.Command, args []
 	baseURL, _ := url.Parse(kpc.apiBaseURL)
 	client := &stripe.Client{
 		BaseURL:     baseURL,
-		Credentials: stripe.Credentials{Token: apiKey},
+		Credentials: stripe.NewAPIKeyCredentials(apiKey),
 	}
 
 	// Build form-encoded body

--- a/pkg/cmd/resource/keys_permissions.go
+++ b/pkg/cmd/resource/keys_permissions.go
@@ -67,7 +67,7 @@ func (kpc *KeysPermissionsCmd) runKeysPermissionsCmd(cmd *cobra.Command, args []
 	baseURL, _ := url.Parse(kpc.apiBaseURL)
 	client := &stripe.Client{
 		BaseURL:     baseURL,
-		Credentials: stripe.Credentials{APIKey: apiKey},
+		Credentials: stripe.Credentials{Token: apiKey},
 	}
 
 	// Build form-encoded body

--- a/pkg/cmd/resource/keys_permissions.go
+++ b/pkg/cmd/resource/keys_permissions.go
@@ -66,8 +66,8 @@ func (kpc *KeysPermissionsCmd) runKeysPermissionsCmd(cmd *cobra.Command, args []
 
 	baseURL, _ := url.Parse(kpc.apiBaseURL)
 	client := &stripe.Client{
-		BaseURL: baseURL,
-		APIKey:  apiKey,
+		BaseURL:     baseURL,
+		Credentials: stripe.Credentials{APIKey: apiKey},
 	}
 
 	// Build form-encoded body

--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -50,7 +50,7 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	apiKey, apiKeyErr := oc.Profile.GetAPIKey(oc.Livemode)
+	creds, credsErr := oc.ResolveCredentials()
 
 	path := formatURL(oc.Path, args)
 	requestParams := make(map[string]interface{})
@@ -63,11 +63,11 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 	}
 
 	if oc.DryRun {
-		dryRunKey := apiKey
-		if apiKeyErr != nil {
-			dryRunKey = ""
+		dryRunCreds := creds
+		if credsErr != nil {
+			dryRunCreds = stripe.Credentials{}
 		}
-		output, err := oc.BuildDryRunOutput(dryRunKey, oc.APIBaseURL, path, &oc.Parameters, requestParams)
+		output, err := oc.BuildDryRunOutput(dryRunCreds, oc.APIBaseURL, path, &oc.Parameters, requestParams)
 		if err != nil {
 			return err
 		}
@@ -76,8 +76,8 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 		return nil
 	}
 
-	if apiKeyErr != nil {
-		return apiKeyErr
+	if credsErr != nil {
+		return credsErr
 	}
 
 	if oc.HTTPVerb == http.MethodDelete {
@@ -110,12 +110,12 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 		}
 
 		// if confirmation is provided, make the request
-		_, err = oc.MakeRequest(cmd.Context(), apiKey, path, &oc.Parameters, requestParams, false, nil)
+		_, err = oc.MakeRequest(cmd.Context(), creds, path, &oc.Parameters, requestParams, false, nil)
 
 		return err
 	}
 	// else
-	_, err := oc.MakeRequest(cmd.Context(), apiKey, path, &oc.Parameters, requestParams, false, nil)
+	_, err := oc.MakeRequest(cmd.Context(), creds, path, &oc.Parameters, requestParams, false, nil)
 	return err
 }
 

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -84,14 +84,14 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	apiKey, err := Config.Profile.GetAPIKey(false)
+	creds, err := Config.Profile.ResolveCredentials(false)
 	if err != nil {
 		return err
 	}
 
 	event := args[0]
 
-	_, err = fixtures.Trigger(cmd.Context(), event, tc.stripeAccount, tc.apiBaseURL, apiKey, tc.skip, tc.override, tc.add, tc.remove, tc.raw, tc.apiVersion, tc.edit)
+	_, err = fixtures.Trigger(cmd.Context(), event, tc.stripeAccount, tc.apiBaseURL, creds, tc.skip, tc.override, tc.add, tc.remove, tc.raw, tc.apiVersion, tc.edit)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/keyring"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
@@ -307,6 +308,15 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 	}
 
 	return "", validators.ErrAPIKeyNotConfigured
+}
+
+// ResolveCredentials returns the API credentials for the given profile and livemode.
+func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) {
+	apiKey, err := p.GetAPIKey(livemode)
+	if err != nil {
+		return stripe.Credentials{}, err
+	}
+	return stripe.NewAPIKeyCredentials(apiKey), nil
 }
 
 // GetExpiresAt returns the API key expirary date

--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/git"
 	"github.com/stripe/stripe-cli/pkg/parsers"
 	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 // SupportedVersions is the version number of the fixture template the CLI supports
@@ -56,7 +57,7 @@ type FixtureRequest struct {
 // Fixture contains a mapping of an individual fixtures responses for querying
 type Fixture struct {
 	Fs            afero.Fs
-	APIKey        string
+	Credentials   stripe.Credentials
 	StripeAccount string
 	Skip          []string
 	Overrides     map[string]interface{}
@@ -68,10 +69,10 @@ type Fixture struct {
 }
 
 // NewFixtureFromFile creates a to later run steps for populating test data
-func NewFixtureFromFile(fs afero.Fs, apiKey, stripeAccount, baseURL, file string, skip, override, add, remove []string, edit bool) (*Fixture, error) {
+func NewFixtureFromFile(fs afero.Fs, creds stripe.Credentials, stripeAccount, baseURL, file string, skip, override, add, remove []string, edit bool) (*Fixture, error) {
 	fxt := Fixture{
 		Fs:            fs,
-		APIKey:        apiKey,
+		Credentials:   creds,
 		StripeAccount: stripeAccount,
 		BaseURL:       baseURL,
 		Responses:     make(map[string]gjson.Result),
@@ -136,10 +137,10 @@ func NewFixtureFromFile(fs afero.Fs, apiKey, stripeAccount, baseURL, file string
 }
 
 // NewFixtureFromRawString creates fixtures from user inputted string
-func NewFixtureFromRawString(fs afero.Fs, apiKey, stripeAccount, baseURL, raw string) (*Fixture, error) {
+func NewFixtureFromRawString(fs afero.Fs, creds stripe.Credentials, stripeAccount, baseURL, raw string) (*Fixture, error) {
 	fxt := Fixture{
 		Fs:            fs,
-		APIKey:        apiKey,
+		Credentials:   creds,
 		StripeAccount: stripeAccount,
 		Skip:          []string{},
 		BaseURL:       baseURL,
@@ -343,7 +344,7 @@ func (fxt *Fixture) getAPIBase(request FixtureRequest) string {
 }
 
 func (fxt *Fixture) unsupportedAPIKey(path string) bool {
-	return strings.HasPrefix(path, "/v2/") && !strings.HasPrefix(fxt.APIKey, "sk_")
+	return strings.HasPrefix(path, "/v2/") && !strings.HasPrefix(fxt.Credentials.Token, "sk_")
 }
 
 func (fxt *Fixture) addCustomHeaders(headers map[string]string) func(req *http.Request) error {
@@ -394,7 +395,7 @@ func (fxt *Fixture) makeRequest(ctx context.Context, data FixtureRequest, apiVer
 		additionalConfigure = fxt.addCustomHeaders(data.Headers)
 	}
 
-	return req.MakeRequest(ctx, fxt.APIKey, path, params, make(map[string]interface{}), true, additionalConfigure)
+	return req.MakeRequest(ctx, fxt.Credentials, path, params, make(map[string]interface{}), true, additionalConfigure)
 }
 
 func (fxt *Fixture) createParams(params interface{}, apiVersion string, path string, method string) (*requests.RequestParameters, error) {

--- a/pkg/fixtures/fixtures_test.go
+++ b/pkg/fixtures/fixtures_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 const testFixture = `
@@ -113,7 +115,7 @@ func TestMakeRequest(t *testing.T) {
 
 	afero.WriteFile(fs, file, []byte(testFixture), os.ModePerm)
 
-	fxt, err := NewFixtureFromFile(fs, apiKey, "", ts.URL, file, []string{}, []string{}, []string{}, []string{}, false)
+	fxt, err := NewFixtureFromFile(fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, file, []string{}, []string{}, []string{}, []string{}, false)
 	require.NoError(t, err)
 
 	_, err = fxt.Execute(context.Background(), "")
@@ -145,7 +147,7 @@ func TestMakeRequestWithStringFixture(t *testing.T) {
 
 	defer func() { ts.Close() }()
 
-	fxt, err := NewFixtureFromRawString(fs, apiKey, "", ts.URL, testFixture)
+	fxt, err := NewFixtureFromRawString(fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, testFixture)
 	require.NoError(t, err)
 
 	_, err = fxt.Execute(context.Background(), "")
@@ -175,7 +177,7 @@ func TestWithSkipMakeRequest(t *testing.T) {
 
 	afero.WriteFile(fs, file, []byte(testFixture), os.ModePerm)
 
-	fxt, err := NewFixtureFromFile(fs, apiKey, "", ts.URL, file, []string{"char_bender", "capt_bender"}, []string{}, []string{}, []string{}, false)
+	fxt, err := NewFixtureFromFile(fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, file, []string{"char_bender", "capt_bender"}, []string{}, []string{}, []string{}, false)
 	require.NoError(t, err)
 
 	_, err = fxt.Execute(context.Background(), "")
@@ -216,7 +218,7 @@ func TestMakeRequestWithOverride(t *testing.T) {
 
 	afero.WriteFile(fs, file, []byte(testFixture), os.ModePerm)
 
-	fxt, err := NewFixtureFromFile(fs, apiKey, "", ts.URL, file, []string{}, []string{"cust_bender:name=Fry", "char_bender:amount=3000"}, []string{}, []string{}, false)
+	fxt, err := NewFixtureFromFile(fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, file, []string{}, []string{"cust_bender:name=Fry", "char_bender:amount=3000"}, []string{}, []string{}, false)
 	require.NoError(t, err)
 
 	_, err = fxt.Execute(context.Background(), "")
@@ -253,7 +255,7 @@ func TestMakeRequestWithAdd(t *testing.T) {
 	afero.WriteFile(fs, file, []byte(testFixture), os.ModePerm)
 
 	fxt, err := NewFixtureFromFile(
-		fs, apiKey, "", ts.URL, file,
+		fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, file,
 		[]string{}, []string{}, []string{
 			"cust_bender:birthdate=2996-09-04",
 			"char_bender:receipt_email=prof.farnsworth@planex.com",
@@ -298,7 +300,7 @@ func TestMakeRequestWithRemove(t *testing.T) {
 	afero.WriteFile(fs, file, []byte(testFixture), os.ModePerm)
 
 	fxt, err := NewFixtureFromFile(
-		fs, apiKey, "", ts.URL, file, []string{}, []string{},
+		fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, file, []string{}, []string{},
 		[]string{}, []string{"cust_bender:phone", "char_bender:capture"},
 		false)
 	require.NoError(t, err)
@@ -316,7 +318,7 @@ func TestMakeRequestExpectedFailure(t *testing.T) {
 
 	defer func() { ts.Close() }()
 	afero.WriteFile(fs, "failured_test_fixture.json", []byte(failureTestFixture), os.ModePerm)
-	fxt, err := NewFixtureFromFile(fs, apiKey, "", ts.URL, "failured_test_fixture.json", []string{}, []string{}, []string{}, []string{}, false)
+	fxt, err := NewFixtureFromFile(fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, "failured_test_fixture.json", []string{}, []string{}, []string{}, []string{}, false)
 	require.NoError(t, err)
 
 	_, err = fxt.Execute(context.Background(), "")
@@ -333,7 +335,7 @@ func TestMakeRequestUnexpectedFailure(t *testing.T) {
 
 	defer func() { ts.Close() }()
 	afero.WriteFile(fs, "failured_test_fixture.json", []byte(failureTestFixture), os.ModePerm)
-	fxt, err := NewFixtureFromFile(fs, apiKey, "", ts.URL, "failured_test_fixture.json", []string{}, []string{}, []string{}, []string{}, false)
+	fxt, err := NewFixtureFromFile(fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, "failured_test_fixture.json", []string{}, []string{}, []string{}, []string{}, false)
 	require.NoError(t, err)
 
 	_, err = fxt.Execute(context.Background(), "")
@@ -417,7 +419,7 @@ func TestExecuteReturnsRequestNames(t *testing.T) {
 
 	afero.WriteFile(fs, file, []byte(testFixture), os.ModePerm)
 
-	fxt, err := NewFixtureFromFile(fs, apiKey, "", ts.URL, file, []string{}, []string{}, []string{}, []string{}, false)
+	fxt, err := NewFixtureFromFile(fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, file, []string{}, []string{}, []string{}, []string{}, false)
 	require.NoError(t, err)
 
 	requestNames, err := fxt.Execute(context.Background(), "")
@@ -572,7 +574,7 @@ func TestSkipSkipFlagIfEditIsTrue(t *testing.T) {
 
 	afero.WriteFile(fs, file, []byte(testFixture), os.ModePerm)
 
-	fxt, err := NewFixtureFromFile(fs, apiKey, "", ts.URL, file, []string{"char_bender", "capt_bender"}, []string{}, []string{}, []string{}, true)
+	fxt, err := NewFixtureFromFile(fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, file, []string{"char_bender", "capt_bender"}, []string{}, []string{}, []string{}, true)
 	require.NoError(t, err)
 
 	_, err = fxt.Execute(context.Background(), "")
@@ -614,7 +616,7 @@ func TestSkipOverrideFlagIfEditIsTrue(t *testing.T) {
 
 	afero.WriteFile(fs, file, []byte(testFixture), os.ModePerm)
 
-	fxt, err := NewFixtureFromFile(fs, apiKey, "", ts.URL, file, []string{}, []string{"cust_bender:name=Fry", "char_bender:amount=3000"}, []string{}, []string{}, true)
+	fxt, err := NewFixtureFromFile(fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, file, []string{}, []string{"cust_bender:name=Fry", "char_bender:amount=3000"}, []string{}, []string{}, true)
 	require.NoError(t, err)
 
 	_, err = fxt.Execute(context.Background(), "")
@@ -652,7 +654,7 @@ func TestSkipAddFlagIfEditIsTrue(t *testing.T) {
 	afero.WriteFile(fs, file, []byte(testFixture), os.ModePerm)
 
 	fxt, err := NewFixtureFromFile(
-		fs, apiKey, "", ts.URL, file,
+		fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, file,
 		[]string{}, []string{}, []string{
 			"cust_bender:birthdate=2996-09-04",
 			"char_bender:receipt_email=prof.farnsworth@planex.com",
@@ -698,7 +700,7 @@ func TestSkipRemoveFlagIfEditIsTrue(t *testing.T) {
 	afero.WriteFile(fs, file, []byte(testFixture), os.ModePerm)
 
 	fxt, err := NewFixtureFromFile(
-		fs, apiKey, "", ts.URL, file, []string{}, []string{},
+		fs, stripe.NewAPIKeyCredentials(apiKey), "", ts.URL, file, []string{}, []string{},
 		[]string{}, []string{"cust_bender:phone", "char_bender:capture"},
 		true)
 	require.NoError(t, err)

--- a/pkg/fixtures/triggers.go
+++ b/pkg/fixtures/triggers.go
@@ -299,7 +299,7 @@ func FixtureContents(eventName string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("event %q is not supported", eventName)
 	}
-	f, err := NewFixtureFromFile(nil, "", "", "", path, nil, nil, nil, nil, false)
+	f, err := NewFixtureFromFile(nil, stripe.Credentials{}, "", "", path, nil, nil, nil, nil, false)
 	if err != nil {
 		return "", err
 	}
@@ -307,10 +307,10 @@ func FixtureContents(eventName string) (string, error) {
 }
 
 // BuildFromFixtureFile creates a new fixture struct for a file
-func BuildFromFixtureFile(fs afero.Fs, apiKey, stripeAccount, apiBaseURL, jsonFile string, skip, override, add, remove []string, edit bool) (*Fixture, error) {
+func BuildFromFixtureFile(fs afero.Fs, creds stripe.Credentials, stripeAccount, apiBaseURL, jsonFile string, skip, override, add, remove []string, edit bool) (*Fixture, error) {
 	fixture, err := NewFixtureFromFile(
 		fs,
-		apiKey,
+		creds,
 		stripeAccount,
 		apiBaseURL,
 		jsonFile,
@@ -328,8 +328,8 @@ func BuildFromFixtureFile(fs afero.Fs, apiKey, stripeAccount, apiBaseURL, jsonFi
 }
 
 // BuildFromFixtureString creates a new fixture from a string
-func BuildFromFixtureString(fs afero.Fs, apiKey, stripeAccount, apiBaseURL, raw string) (*Fixture, error) {
-	fixture, err := NewFixtureFromRawString(fs, apiKey, stripeAccount, apiBaseURL, raw)
+func BuildFromFixtureString(fs afero.Fs, creds stripe.Credentials, stripeAccount, apiBaseURL, raw string) (*Fixture, error) {
+	fixture, err := NewFixtureFromRawString(fs, creds, stripeAccount, apiBaseURL, raw)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +365,7 @@ func EventNames() []string {
 }
 
 // Trigger triggers a Stripe event.
-func Trigger(ctx context.Context, event string, stripeAccount string, baseURL string, apiKey string, skip, override, add, remove []string, raw string, apiVersion string, edit bool) ([]string, error) {
+func Trigger(ctx context.Context, event string, stripeAccount string, baseURL string, creds stripe.Credentials, skip, override, add, remove []string, raw string, apiVersion string, edit bool) ([]string, error) {
 	var fixture *Fixture
 	var err error
 	fs := afero.NewOsFs()
@@ -378,7 +378,7 @@ func Trigger(ctx context.Context, event string, stripeAccount string, baseURL st
 
 	if len(raw) == 0 {
 		if file, ok := getEvents()[event]; ok {
-			fixture, err = BuildFromFixtureFile(fs, apiKey, stripeAccount, baseURL, file, skip, override, add, remove, edit)
+			fixture, err = BuildFromFixtureFile(fs, creds, stripeAccount, baseURL, file, skip, override, add, remove, edit)
 			if err != nil {
 				return nil, err
 			}
@@ -388,13 +388,13 @@ func Trigger(ctx context.Context, event string, stripeAccount string, baseURL st
 				return nil, fmt.Errorf("%s", fmt.Sprintf("The event `%s` is not supported by Stripe CLI. To trigger unsupported events, use the Stripe API or Dashboard to perform actions that lead to the event you want to trigger (for example, create a Customer to generate a `customer.created` event). You can also create a custom fixture: https://docs.stripe.com/cli/fixtures", event))
 			}
 
-			fixture, err = BuildFromFixtureFile(fs, apiKey, stripeAccount, baseURL, event, skip, override, add, remove, edit)
+			fixture, err = BuildFromFixtureFile(fs, creds, stripeAccount, baseURL, event, skip, override, add, remove, edit)
 			if err != nil {
 				return nil, err
 			}
 		}
 	} else {
-		fixture, err = BuildFromFixtureString(fs, apiKey, stripeAccount, baseURL, raw)
+		fixture, err = BuildFromFixtureString(fs, creds, stripeAccount, baseURL, raw)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/login/acct/retrieve_account.go
+++ b/pkg/login/acct/retrieve_account.go
@@ -34,7 +34,7 @@ func GetUserAccount(ctx context.Context, baseURL string, apiKey string) (*Accoun
 
 	client := &stripe.Client{
 		BaseURL:     parsedBaseURL,
-		Credentials: stripe.Credentials{Token: apiKey},
+		Credentials: stripe.NewAPIKeyCredentials(apiKey),
 	}
 
 	resp, err := client.PerformRequest(ctx, "GET", "/v1/account", "", nil)

--- a/pkg/login/acct/retrieve_account.go
+++ b/pkg/login/acct/retrieve_account.go
@@ -33,8 +33,8 @@ func GetUserAccount(ctx context.Context, baseURL string, apiKey string) (*Accoun
 	}
 
 	client := &stripe.Client{
-		BaseURL: parsedBaseURL,
-		APIKey:  apiKey,
+		BaseURL:     parsedBaseURL,
+		Credentials: stripe.Credentials{APIKey: apiKey},
 	}
 
 	resp, err := client.PerformRequest(ctx, "GET", "/v1/account", "", nil)

--- a/pkg/login/acct/retrieve_account.go
+++ b/pkg/login/acct/retrieve_account.go
@@ -34,7 +34,7 @@ func GetUserAccount(ctx context.Context, baseURL string, apiKey string) (*Accoun
 
 	client := &stripe.Client{
 		BaseURL:     parsedBaseURL,
-		Credentials: stripe.Credentials{APIKey: apiKey},
+		Credentials: stripe.Credentials{Token: apiKey},
 	}
 
 	resp, err := client.PerformRequest(ctx, "GET", "/v1/account", "", nil)

--- a/pkg/logtailing/tailer_test.go
+++ b/pkg/logtailing/tailer_test.go
@@ -71,7 +71,7 @@ func TestRun_RetryOnAuthorizationServerError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	tailer := New(&cfg)
@@ -94,7 +94,7 @@ func TestRun_NoRetryOnAuthorizationClientError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	tailer := New(&cfg)
@@ -117,7 +117,7 @@ func TestRun_NoRetryOnAuthorizationClientError_TooManyRequests(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	tailer := New(&cfg)

--- a/pkg/logtailing/tailer_test.go
+++ b/pkg/logtailing/tailer_test.go
@@ -71,7 +71,7 @@ func TestRun_RetryOnAuthorizationServerError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	tailer := New(&cfg)
@@ -94,7 +94,7 @@ func TestRun_NoRetryOnAuthorizationClientError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	tailer := New(&cfg)
@@ -117,7 +117,7 @@ func TestRun_NoRetryOnAuthorizationClientError_TooManyRequests(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	tailer := New(&cfg)

--- a/pkg/logtailing/tailer_test.go
+++ b/pkg/logtailing/tailer_test.go
@@ -71,7 +71,7 @@ func TestRun_RetryOnAuthorizationServerError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	tailer := New(&cfg)
@@ -94,7 +94,7 @@ func TestRun_NoRetryOnAuthorizationClientError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	tailer := New(&cfg)
@@ -117,7 +117,7 @@ func TestRun_NoRetryOnAuthorizationClientError_TooManyRequests(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	tailer := New(&cfg)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -228,7 +228,7 @@ func TestRun_RetryOnAuthorizationServerError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	p, err := Init(context.Background(), &cfg)
@@ -253,7 +253,7 @@ func TestRun_NoRetryOnAuthorizationClientError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	p, err := Init(context.Background(), &cfg)
@@ -278,7 +278,7 @@ func TestRun_NoRetryOnAuthorizationClientError_TooManyRequests(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	p, err := Init(context.Background(), &cfg)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -228,7 +228,7 @@ func TestRun_RetryOnAuthorizationServerError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	p, err := Init(context.Background(), &cfg)
@@ -253,7 +253,7 @@ func TestRun_NoRetryOnAuthorizationClientError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	p, err := Init(context.Background(), &cfg)
@@ -278,7 +278,7 @@ func TestRun_NoRetryOnAuthorizationClientError_TooManyRequests(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	p, err := Init(context.Background(), &cfg)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -228,7 +228,7 @@ func TestRun_RetryOnAuthorizationServerError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	p, err := Init(context.Background(), &cfg)
@@ -253,7 +253,7 @@ func TestRun_NoRetryOnAuthorizationClientError(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	p, err := Init(context.Background(), &cfg)
@@ -278,7 +278,7 @@ func TestRun_NoRetryOnAuthorizationClientError_TooManyRequests(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 
 	cfg := Config{
-		Client: &stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL},
+		Client: &stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL},
 		OutCh:  make(chan websocket.IElement, 2),
 	}
 	p, err := Init(context.Background(), &cfg)

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -245,7 +245,7 @@ func (rb *Base) MakeMultiPartRequest(ctx context.Context, apiKey, path string, p
 
 	client := &stripe.Client{
 		BaseURL:     parsedBaseURL,
-		Credentials: stripe.Credentials{APIKey: apiKey},
+		Credentials: stripe.Credentials{Token: apiKey},
 		Verbose:     rb.showHeaders,
 	}
 
@@ -261,7 +261,7 @@ func (rb *Base) MakeRequest(ctx context.Context, apiKey, path string, params *Re
 
 	client := &stripe.Client{
 		BaseURL:     parsedBaseURL,
-		Credentials: stripe.Credentials{APIKey: apiKey},
+		Credentials: stripe.Credentials{Token: apiKey},
 		Verbose:     rb.showHeaders,
 	}
 

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -159,8 +159,8 @@ func (rb *Base) RunRequestsCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if rb.DryRun {
-		apiKey, _ := rb.Profile.GetAPIKey(rb.Livemode)
-		output, err := rb.BuildDryRunOutput(apiKey, rb.APIBaseURL, path, &rb.Parameters, make(map[string]interface{}))
+		creds, _ := rb.ResolveCredentials()
+		output, err := rb.BuildDryRunOutput(creds, rb.APIBaseURL, path, &rb.Parameters, make(map[string]interface{}))
 		if err != nil {
 			return err
 		}
@@ -177,12 +177,12 @@ func (rb *Base) RunRequestsCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	apiKey, err := rb.Profile.GetAPIKey(rb.Livemode)
+	creds, err := rb.ResolveCredentials()
 	if err != nil {
 		return err
 	}
 
-	_, err = rb.MakeRequest(cmd.Context(), apiKey, path, &rb.Parameters, make(map[string]interface{}), false, nil)
+	_, err = rb.MakeRequest(cmd.Context(), creds, path, &rb.Parameters, make(map[string]interface{}), false, nil)
 
 	return err
 }
@@ -224,10 +224,15 @@ func (rb *Base) InitFlags() {
 	rb.Cmd.Flags().MarkHidden("api-base") // #nosec G104
 }
 
+// ResolveCredentials returns Credentials for this request using the associated profile.
+func (rb *Base) ResolveCredentials() (stripe.Credentials, error) {
+	return rb.Profile.ResolveCredentials(rb.Livemode)
+}
+
 // MakeMultiPartRequest will make a multipart/form-data request to the Stripe API with the specific variables given to it.
 // Similar to making a multipart request using curl, add the local filepath to params arg with @ prefix.
 // e.g. params.AppendData([]string{"photo=@/path/to/local/file.png"})
-func (rb *Base) MakeMultiPartRequest(ctx context.Context, apiKey, path string, params *RequestParameters, errOnStatus bool) ([]byte, error) {
+func (rb *Base) MakeMultiPartRequest(ctx context.Context, creds stripe.Credentials, path string, params *RequestParameters, errOnStatus bool) ([]byte, error) {
 	reqBody, contentType, err := rb.buildMultiPartRequest(params)
 	if err != nil {
 		return []byte{}, err
@@ -245,7 +250,7 @@ func (rb *Base) MakeMultiPartRequest(ctx context.Context, apiKey, path string, p
 
 	client := &stripe.Client{
 		BaseURL:     parsedBaseURL,
-		Credentials: stripe.Credentials{Token: apiKey},
+		Credentials: creds,
 		Verbose:     rb.showHeaders,
 	}
 
@@ -253,7 +258,7 @@ func (rb *Base) MakeMultiPartRequest(ctx context.Context, apiKey, path string, p
 }
 
 // MakeRequest will make a request to the Stripe API with the specific variables given to it
-func (rb *Base) MakeRequest(ctx context.Context, apiKey, path string, params *RequestParameters, additionalParams map[string]interface{}, errOnStatus bool, additionalConfigure func(req *http.Request) error) ([]byte, error) {
+func (rb *Base) MakeRequest(ctx context.Context, creds stripe.Credentials, path string, params *RequestParameters, additionalParams map[string]interface{}, errOnStatus bool, additionalConfigure func(req *http.Request) error) ([]byte, error) {
 	parsedBaseURL, err := url.Parse(rb.APIBaseURL)
 	if err != nil {
 		return []byte{}, err
@@ -261,7 +266,7 @@ func (rb *Base) MakeRequest(ctx context.Context, apiKey, path string, params *Re
 
 	client := &stripe.Client{
 		BaseURL:     parsedBaseURL,
-		Credentials: stripe.Credentials{Token: apiKey},
+		Credentials: creds,
 		Verbose:     rb.showHeaders,
 	}
 
@@ -358,7 +363,7 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 }
 
 // BuildDryRunOutput constructs the dry-run output for a request without executing it.
-func (rb *Base) BuildDryRunOutput(apiKey, baseURL, path string, params *RequestParameters, additionalParams map[string]interface{}) (*DryRunOutput, error) {
+func (rb *Base) BuildDryRunOutput(creds stripe.Credentials, baseURL, path string, params *RequestParameters, additionalParams map[string]interface{}) (*DryRunOutput, error) {
 	isV2 := stripe.IsV2Path(path)
 
 	// Build params map
@@ -446,10 +451,10 @@ func (rb *Base) BuildDryRunOutput(apiKey, baseURL, path string, params *RequestP
 		headers["Stripe-Context"] = params.stripeContext
 	}
 
-	if apiKey != "" && len(apiKey) >= 12 {
-		headers["Authorization"] = "Bearer " + config.RedactAPIKey(apiKey)
-	} else if apiKey != "" {
-		headers["Authorization"] = "Bearer " + apiKey
+	if creds.Token != "" && len(creds.Token) >= 12 {
+		headers["Authorization"] = "Bearer " + config.RedactAPIKey(creds.Token)
+	} else if creds.Token != "" {
+		headers["Authorization"] = "Bearer " + creds.Token
 	}
 
 	return &DryRunOutput{

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -244,9 +244,9 @@ func (rb *Base) MakeMultiPartRequest(ctx context.Context, apiKey, path string, p
 	}
 
 	client := &stripe.Client{
-		BaseURL: parsedBaseURL,
-		APIKey:  apiKey,
-		Verbose: rb.showHeaders,
+		BaseURL:     parsedBaseURL,
+		Credentials: stripe.Credentials{APIKey: apiKey},
+		Verbose:     rb.showHeaders,
 	}
 
 	return rb.performRequest(ctx, client, path, params, reqBody.String(), errOnStatus, configure)
@@ -260,9 +260,9 @@ func (rb *Base) MakeRequest(ctx context.Context, apiKey, path string, params *Re
 	}
 
 	client := &stripe.Client{
-		BaseURL: parsedBaseURL,
-		APIKey:  apiKey,
-		Verbose: rb.showHeaders,
+		BaseURL:     parsedBaseURL,
+		Credentials: stripe.Credentials{APIKey: apiKey},
+		Verbose:     rb.showHeaders,
 	}
 
 	return rb.MakeRequestWithClient(ctx, client, path, params, additionalParams, errOnStatus, additionalConfigure)

--- a/pkg/requests/base_test.go
+++ b/pkg/requests/base_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 func TestBuildDataForRequest(t *testing.T) {
@@ -110,7 +112,7 @@ func TestMakeRequest(t *testing.T) {
 		expand: []string{"futurama.employees", "futurama.ships"},
 	}
 
-	_, err := rb.MakeRequest(context.Background(), "sk_test_1234", "/foo/bar", params, make(map[string]interface{}), true, nil)
+	_, err := rb.MakeRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/foo/bar", params, make(map[string]interface{}), true, nil)
 	require.NoError(t, err)
 }
 
@@ -138,7 +140,7 @@ func TestMakeRequest_RefusesWriteThroughPDFSymlink(t *testing.T) {
 	rb.Method = http.MethodGet
 
 	params := &RequestParameters{}
-	_, err = rb.MakeRequest(context.Background(), "sk_test_1234", "/v1/quotes/qt_123/pdf", params, make(map[string]interface{}), false, nil)
+	_, err = rb.MakeRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/v1/quotes/qt_123/pdf", params, make(map[string]interface{}), false, nil)
 	require.ErrorContains(t, err, "symlink")
 
 	victimContents, err := os.ReadFile(victimFile)
@@ -177,7 +179,7 @@ func TestMakeRequest_GetV2(t *testing.T) {
 		}`},
 	}
 
-	_, err := rb.MakeRequest(context.Background(), "sk_test_1234", "/v2/core/events", params, make(map[string]interface{}), true, nil)
+	_, err := rb.MakeRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/v2/core/events", params, make(map[string]interface{}), true, nil)
 	require.NoError(t, err)
 }
 
@@ -207,7 +209,7 @@ func TestMakeRequest_PostV2(t *testing.T) {
 		data: []string{`{"name": "foo"}`},
 	}
 
-	_, err := rb.MakeRequest(context.Background(), "sk_test_1234", "/v2/core/event_destinations", params, make(map[string]interface{}), true, nil)
+	_, err := rb.MakeRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/v2/core/event_destinations", params, make(map[string]interface{}), true, nil)
 	require.NoError(t, err)
 }
 
@@ -223,7 +225,7 @@ func TestMakeRequest_ErrOnStatus(t *testing.T) {
 
 	params := &RequestParameters{}
 
-	_, err := rb.MakeRequest(context.Background(), "sk_test_1234", "/foo/bar", params, make(map[string]interface{}), true, nil)
+	_, err := rb.MakeRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/foo/bar", params, make(map[string]interface{}), true, nil)
 	require.Error(t, err)
 	require.Equal(t, "Request failed, status=500, body=:(", err.Error())
 }
@@ -249,7 +251,7 @@ func TestMakeRequest_ErrOnAPIKeyExpired(t *testing.T) {
 
 	params := &RequestParameters{}
 
-	_, err := rb.MakeRequest(context.Background(), "sk_test_1234", "/foo/bar", params, make(map[string]interface{}), false, nil)
+	_, err := rb.MakeRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/foo/bar", params, make(map[string]interface{}), false, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Request failed, status=401, body=")
 }
@@ -286,7 +288,7 @@ func TestMakeMultiPartRequest(t *testing.T) {
 		data: []string{"purpose=app_upload", fmt.Sprintf("file=@%v", tempFile.Name())},
 	}
 
-	_, err = rb.MakeMultiPartRequest(context.Background(), "sk_test_1234", "/foo/bar", params, true)
+	_, err = rb.MakeMultiPartRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/foo/bar", params, true)
 	require.NoError(t, err)
 }
 
@@ -481,7 +483,7 @@ func TestBuildDryRunOutput_V1Post(t *testing.T) {
 	}
 
 	// "sk_test_1234567890abcdef" (24 chars) redacts to "sk_test_************cdef"
-	output, err := rb.BuildDryRunOutput("sk_test_1234567890abcdef", "https://api.stripe.com", "/v1/customers", &RequestParameters{}, additional)
+	output, err := rb.BuildDryRunOutput(stripe.NewAPIKeyCredentials("sk_test_1234567890abcdef"), "https://api.stripe.com", "/v1/customers", &RequestParameters{}, additional)
 	require.NoError(t, err)
 	require.Equal(t, DryRunOutput{DryRun: DryRunDetails{
 		Method: "POST",
@@ -503,7 +505,7 @@ func TestBuildDryRunOutput_V1PostDataParams(t *testing.T) {
 		data: []string{"metadata[env]=staging", "metadata[version]=2"},
 	}
 
-	output, err := rb.BuildDryRunOutput("", "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{"email": "test@example.com"})
+	output, err := rb.BuildDryRunOutput(stripe.Credentials{}, "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{"email": "test@example.com"})
 	require.NoError(t, err)
 	require.Equal(t, DryRunOutput{DryRun: DryRunDetails{
 		Method: "POST",
@@ -530,7 +532,7 @@ func TestBuildDryRunOutput_V1Get(t *testing.T) {
 		expand:        []string{"default_source"},
 	}
 
-	output, err := rb.BuildDryRunOutput("", "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{})
+	output, err := rb.BuildDryRunOutput(stripe.Credentials{}, "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{})
 	require.NoError(t, err)
 	require.Equal(t, DryRunOutput{DryRun: DryRunDetails{
 		Method: "GET",
@@ -551,7 +553,7 @@ func TestBuildDryRunOutput_V1PostExpand(t *testing.T) {
 		expand: []string{"default_source", "invoice_settings"},
 	}
 
-	output, err := rb.BuildDryRunOutput("", "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{"email": "test@example.com"})
+	output, err := rb.BuildDryRunOutput(stripe.Credentials{}, "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{"email": "test@example.com"})
 	require.NoError(t, err)
 	require.Equal(t, DryRunOutput{DryRun: DryRunDetails{
 		Method: "POST",
@@ -572,7 +574,7 @@ func TestBuildDryRunOutput_V2Post(t *testing.T) {
 		data: []string{`{"event_name": "foo", "value": 100}`},
 	}
 
-	output, err := rb.BuildDryRunOutput("", "https://api.stripe.com", "/v2/billing/meter_events", params, map[string]interface{}{})
+	output, err := rb.BuildDryRunOutput(stripe.Credentials{}, "https://api.stripe.com", "/v2/billing/meter_events", params, map[string]interface{}{})
 	require.NoError(t, err)
 	require.Equal(t, DryRunOutput{DryRun: DryRunDetails{
 		Method: "POST",
@@ -591,7 +593,7 @@ func TestBuildDryRunOutput_V2Post(t *testing.T) {
 func TestBuildDryRunOutput_NoAPIKey(t *testing.T) {
 	rb := Base{Method: http.MethodPost}
 
-	output, err := rb.BuildDryRunOutput("", "https://api.stripe.com", "/v1/customers", &RequestParameters{}, map[string]interface{}{})
+	output, err := rb.BuildDryRunOutput(stripe.Credentials{}, "https://api.stripe.com", "/v1/customers", &RequestParameters{}, map[string]interface{}{})
 	require.NoError(t, err)
 	require.Equal(t, DryRunOutput{DryRun: DryRunDetails{
 		Method:  "POST",
@@ -604,7 +606,7 @@ func TestBuildDryRunOutput_NoAPIKey(t *testing.T) {
 func TestBuildDryRunOutput_ExplicitStripeVersion(t *testing.T) {
 	rb := Base{Method: http.MethodPost}
 
-	output, err := rb.BuildDryRunOutput("", "https://api.stripe.com", "/v1/customers", &RequestParameters{version: "2025-01-01"}, map[string]interface{}{})
+	output, err := rb.BuildDryRunOutput(stripe.Credentials{}, "https://api.stripe.com", "/v1/customers", &RequestParameters{version: "2025-01-01"}, map[string]interface{}{})
 	require.NoError(t, err)
 	require.Equal(t, DryRunOutput{DryRun: DryRunDetails{
 		Method:  "POST",
@@ -622,7 +624,7 @@ func TestBuildDryRunOutput_OptionalHeaders(t *testing.T) {
 		stripeContext: "ctx_456",
 	}
 
-	output, err := rb.BuildDryRunOutput("", "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{})
+	output, err := rb.BuildDryRunOutput(stripe.Credentials{}, "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{})
 	require.NoError(t, err)
 	require.Equal(t, DryRunOutput{DryRun: DryRunDetails{
 		Method: "POST",
@@ -640,7 +642,7 @@ func TestBuildDryRunOutput_OptionalHeaders(t *testing.T) {
 func TestBuildDryRunOutput_PathParamSubstitutedURL(t *testing.T) {
 	rb := Base{Method: http.MethodGet}
 
-	output, err := rb.BuildDryRunOutput("", "https://api.stripe.com", "/v1/customers/cus_abc123", &RequestParameters{}, map[string]interface{}{})
+	output, err := rb.BuildDryRunOutput(stripe.Credentials{}, "https://api.stripe.com", "/v1/customers/cus_abc123", &RequestParameters{}, map[string]interface{}{})
 	require.NoError(t, err)
 	require.Equal(t, DryRunOutput{DryRun: DryRunDetails{
 		Method:  "GET",
@@ -680,7 +682,7 @@ func TestMakeRequest_StripeNotice(t *testing.T) {
 		rb := Base{APIBaseURL: ts.URL}
 		rb.Method = http.MethodGet
 		params := &RequestParameters{}
-		_, err := rb.MakeRequest(context.Background(), "sk_test_1234", "/v1/charges", params, make(map[string]interface{}), false, nil)
+		_, err := rb.MakeRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/v1/charges", params, make(map[string]interface{}), false, nil)
 		require.NoError(t, err)
 	})
 
@@ -700,7 +702,7 @@ func TestMakeRequest_StripeNoticeMultiNotice(t *testing.T) {
 		rb := Base{APIBaseURL: ts.URL}
 		rb.Method = http.MethodGet
 		params := &RequestParameters{}
-		_, err := rb.MakeRequest(context.Background(), "sk_test_1234", "/v1/charges", params, make(map[string]interface{}), false, nil)
+		_, err := rb.MakeRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/v1/charges", params, make(map[string]interface{}), false, nil)
 		require.NoError(t, err)
 	})
 
@@ -718,7 +720,7 @@ func TestMakeRequest_NoUpgradeNotice(t *testing.T) {
 		rb := Base{APIBaseURL: ts.URL}
 		rb.Method = http.MethodGet
 		params := &RequestParameters{}
-		_, err := rb.MakeRequest(context.Background(), "sk_test_1234", "/v1/charges", params, make(map[string]interface{}), false, nil)
+		_, err := rb.MakeRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/v1/charges", params, make(map[string]interface{}), false, nil)
 		require.NoError(t, err)
 	})
 
@@ -737,7 +739,7 @@ func TestMakeRequest_UpgradeNoticeSuppressed(t *testing.T) {
 		rb := Base{APIBaseURL: ts.URL, SuppressOutput: true}
 		rb.Method = http.MethodGet
 		params := &RequestParameters{}
-		_, err := rb.MakeRequest(context.Background(), "sk_test_1234", "/v1/charges", params, make(map[string]interface{}), false, nil)
+		_, err := rb.MakeRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/v1/charges", params, make(map[string]interface{}), false, nil)
 		require.NoError(t, err)
 	})
 

--- a/pkg/requests/plugin.go
+++ b/pkg/requests/plugin.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 // PluginMetadata contains plugin-specific manifest and binary information.
@@ -70,7 +71,7 @@ func GetPluginMetadata(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVer
 		APIBaseURL:     metadataBaseURL,
 	}
 
-	resp, err := base.MakeRequest(ctx, apiKey, metadataPath, params, map[string]interface{}{
+	resp, err := base.MakeRequest(ctx, stripe.NewAPIKeyCredentials(apiKey), metadataPath, params, map[string]interface{}{
 		"plugin":  pluginName,
 		"version": version,
 		"os":      os,
@@ -115,7 +116,7 @@ func GetPluginList(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVersion
 		APIBaseURL:     listBaseURL,
 	}
 
-	resp, err := base.MakeRequest(ctx, apiKey, listPath, params, map[string]interface{}{
+	resp, err := base.MakeRequest(ctx, stripe.NewAPIKeyCredentials(apiKey), listPath, params, map[string]interface{}{
 		"os":   os,
 		"arch": arch,
 	}, true, nil)

--- a/pkg/requests/webhook_endpoints.go
+++ b/pkg/requests/webhook_endpoints.go
@@ -37,7 +37,7 @@ func WebhookEndpointsList(ctx context.Context, baseURL, apiVersion, apiKey strin
 		SuppressOutput: true,
 		APIBaseURL:     baseURL,
 	}
-	resp, _ := base.MakeRequest(ctx, apiKey, "/v1/webhook_endpoints", params, make(map[string]interface{}), true, nil)
+	resp, _ := base.MakeRequest(ctx, stripe.NewAPIKeyCredentials(apiKey), "/v1/webhook_endpoints", params, make(map[string]interface{}), true, nil)
 	data := WebhookEndpointList{}
 	json.Unmarshal(resp, &data)
 
@@ -91,7 +91,7 @@ func WebhookEndpointCreate(ctx context.Context, baseURL, apiVersion, apiKey, url
 		SuppressOutput: true,
 		APIBaseURL:     baseURL,
 	}
-	_, err := base.MakeRequest(ctx, apiKey, "/v1/webhook_endpoints", params, make(map[string]interface{}), true, nil)
+	_, err := base.MakeRequest(ctx, stripe.NewAPIKeyCredentials(apiKey), "/v1/webhook_endpoints", params, make(map[string]interface{}), true, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/rpcservice/events_resend.go
+++ b/pkg/rpcservice/events_resend.go
@@ -19,7 +19,7 @@ import (
 
 // EventsResend resends an event given an event ID
 func (srv *RPCService) EventsResend(ctx context.Context, req *rpc.EventsResendRequest) (*rpc.EventsResendResponse, error) {
-	apiKey, err := srv.cfg.UserCfg.Profile.GetAPIKey(req.Live)
+	creds, err := srv.cfg.UserCfg.Profile.ResolveCredentials(req.Live)
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
@@ -48,7 +48,7 @@ func (srv *RPCService) EventsResend(ctx context.Context, req *rpc.EventsResendRe
 		return nil, err
 	}
 
-	stripeResp, err := stripeReq.MakeRequest(ctx, apiKey, path, params, make(map[string]interface{}), true, nil)
+	stripeResp, err := stripeReq.MakeRequest(ctx, creds, path, params, make(map[string]interface{}), true, nil)
 	if err != nil {
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}

--- a/pkg/rpcservice/listen.go
+++ b/pkg/rpcservice/listen.go
@@ -62,7 +62,7 @@ func (srv *RPCService) Listen(req *rpc.ListenRequest, stream rpc.StripeCLI_Liste
 	p, err := createProxy(ctx, &proxy.Config{
 		Client: &stripe.Client{
 			BaseURL:     apiBase,
-			Credentials: stripe.Credentials{APIKey: key},
+			Credentials: stripe.Credentials{Token: key},
 		},
 		DeviceName:            deviceName,
 		ForwardURL:            req.ForwardTo,

--- a/pkg/rpcservice/listen.go
+++ b/pkg/rpcservice/listen.go
@@ -62,7 +62,7 @@ func (srv *RPCService) Listen(req *rpc.ListenRequest, stream rpc.StripeCLI_Liste
 	p, err := createProxy(ctx, &proxy.Config{
 		Client: &stripe.Client{
 			BaseURL:     apiBase,
-			Credentials: stripe.Credentials{Token: key},
+			Credentials: stripe.NewAPIKeyCredentials(key),
 		},
 		DeviceName:            deviceName,
 		ForwardURL:            req.ForwardTo,

--- a/pkg/rpcservice/listen.go
+++ b/pkg/rpcservice/listen.go
@@ -61,8 +61,8 @@ func (srv *RPCService) Listen(req *rpc.ListenRequest, stream rpc.StripeCLI_Liste
 
 	p, err := createProxy(ctx, &proxy.Config{
 		Client: &stripe.Client{
-			APIKey:  key,
-			BaseURL: apiBase,
+			BaseURL:     apiBase,
+			Credentials: stripe.Credentials{APIKey: key},
 		},
 		DeviceName:            deviceName,
 		ForwardURL:            req.ForwardTo,

--- a/pkg/rpcservice/logs_tail.go
+++ b/pkg/rpcservice/logs_tail.go
@@ -47,8 +47,8 @@ func (srv *RPCService) LogsTail(req *rpc.LogsTailRequest, stream rpc.StripeCLI_L
 
 	tailer := createTailer(&logtailing.Config{
 		Client: &stripe.Client{
-			APIKey:  key,
-			BaseURL: apiBase,
+			BaseURL:     apiBase,
+			Credentials: stripe.Credentials{APIKey: key},
 		},
 		DeviceName: deviceName,
 		Filters:    filters,

--- a/pkg/rpcservice/logs_tail.go
+++ b/pkg/rpcservice/logs_tail.go
@@ -48,7 +48,7 @@ func (srv *RPCService) LogsTail(req *rpc.LogsTailRequest, stream rpc.StripeCLI_L
 	tailer := createTailer(&logtailing.Config{
 		Client: &stripe.Client{
 			BaseURL:     apiBase,
-			Credentials: stripe.Credentials{APIKey: key},
+			Credentials: stripe.Credentials{Token: key},
 		},
 		DeviceName: deviceName,
 		Filters:    filters,

--- a/pkg/rpcservice/logs_tail.go
+++ b/pkg/rpcservice/logs_tail.go
@@ -48,7 +48,7 @@ func (srv *RPCService) LogsTail(req *rpc.LogsTailRequest, stream rpc.StripeCLI_L
 	tailer := createTailer(&logtailing.Config{
 		Client: &stripe.Client{
 			BaseURL:     apiBase,
-			Credentials: stripe.Credentials{Token: key},
+			Credentials: stripe.NewAPIKeyCredentials(key),
 		},
 		DeviceName: deviceName,
 		Filters:    filters,

--- a/pkg/rpcservice/trigger.go
+++ b/pkg/rpcservice/trigger.go
@@ -15,7 +15,7 @@ var baseURL = stripe.DefaultAPIBaseURL
 
 // Trigger triggers a Stripe event.
 func (srv *RPCService) Trigger(ctx context.Context, req *rpc.TriggerRequest) (*rpc.TriggerResponse, error) {
-	apiKey, err := srv.cfg.UserCfg.Profile.GetAPIKey(false)
+	creds, err := srv.cfg.UserCfg.Profile.ResolveCredentials(false)
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
@@ -25,7 +25,7 @@ func (srv *RPCService) Trigger(ctx context.Context, req *rpc.TriggerRequest) (*r
 		req.Event,
 		req.StripeAccount,
 		baseURL,
-		apiKey,
+		creds,
 		req.Skip,
 		req.Override,
 		req.Add,

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -337,7 +337,7 @@ func ConfigureDotEnv(ctx context.Context, config *config.Config) (map[string]str
 
 	stripeClient := &stripe.Client{
 		BaseURL:     apiBase,
-		Credentials: stripe.Credentials{Token: apiKey},
+		Credentials: stripe.NewAPIKeyCredentials(apiKey),
 	}
 	authClient := stripeauth.NewClient(stripeClient, nil)
 

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -336,8 +336,8 @@ func ConfigureDotEnv(ctx context.Context, config *config.Config) (map[string]str
 	apiBase, _ := url.Parse(stripe.DefaultAPIBaseURL)
 
 	stripeClient := &stripe.Client{
-		APIKey:  apiKey,
-		BaseURL: apiBase,
+		BaseURL:     apiBase,
+		Credentials: stripe.Credentials{APIKey: apiKey},
 	}
 	authClient := stripeauth.NewClient(stripeClient, nil)
 

--- a/pkg/samples/samples.go
+++ b/pkg/samples/samples.go
@@ -337,7 +337,7 @@ func ConfigureDotEnv(ctx context.Context, config *config.Config) (map[string]str
 
 	stripeClient := &stripe.Client{
 		BaseURL:     apiBase,
-		Credentials: stripe.Credentials{APIKey: apiKey},
+		Credentials: stripe.Credentials{Token: apiKey},
 	}
 	authClient := stripeauth.NewClient(stripeClient, nil)
 

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -32,6 +32,11 @@ type Credentials struct {
 	Token string
 }
 
+// NewAPIKeyCredentials returns Credentials using a standard Stripe API key.
+func NewAPIKeyCredentials(key string) Credentials {
+	return Credentials{Token: key}
+}
+
 // SetRequestHeaders applies auth-related headers to req.
 func (c Credentials) SetRequestHeaders(req *http.Request) {
 	if c.Token != "" {

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,15 +28,23 @@ const (
 	V2Request     = "v2"
 )
 
+// Credentials holds the auth credentials for a Stripe API request. For plain
+// API keys only APIKey is set. For OAK tokens all three fields are populated.
+type Credentials struct {
+	APIKey      string
+	OAKContext  string
+	OAKLivemode *bool
+}
+
 // Client is the API client used to send requests to Stripe.
 type Client struct {
 	// The base URL (protocol + hostname) used for all requests sent by this
 	// client.
 	BaseURL *url.URL
 
-	// API key used to authenticate requests sent by this client. If left
-	// empty, the `Authorization` header will be omitted.
-	APIKey string
+	// Credentials holds the auth credentials for the request. If APIKey is
+	// empty, the Authorization header is omitted.
+	Credentials Credentials
 
 	// When this is enabled, request and response headers will be printed to
 	// stdout.
@@ -87,8 +96,15 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 	req.Header.Set("User-Agent", useragent.GetEncodedUserAgent())
 	req.Header.Set("X-Stripe-Client-User-Agent", useragent.GetEncodedStripeUserAgent())
 
-	if c.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	if c.Credentials.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Credentials.APIKey)
+	}
+
+	if c.Credentials.OAKContext != "" {
+		req.Header.Set("Stripe-Context", c.Credentials.OAKContext)
+	}
+	if c.Credentials.OAKLivemode != nil {
+		req.Header.Set("Stripe-Livemode", strconv.FormatBool(*c.Credentials.OAKLivemode))
 	}
 
 	if configure != nil {
@@ -112,7 +128,7 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 
 	// RequestID of the API Request
 	requestID := resp.Header.Get("Request-Id")
-	livemode := strings.Contains(c.APIKey, "live")
+	livemode := strings.Contains(c.Credentials.APIKey, "live")
 	go sendTelemetryEvent(ctx, requestID, livemode)
 	return resp, nil
 }

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -29,9 +29,9 @@ const (
 )
 
 // Credentials holds the auth credentials for a Stripe API request. For plain
-// API keys only APIKey is set. For OAK tokens all three fields are populated.
+// API keys only Token is set. For OAK tokens all three fields are populated.
 type Credentials struct {
-	APIKey      string
+	Token       string
 	OAKContext  string
 	OAKLivemode *bool
 }
@@ -42,7 +42,7 @@ type Client struct {
 	// client.
 	BaseURL *url.URL
 
-	// Credentials holds the auth credentials for the request. If APIKey is
+	// Credentials holds the auth credentials for the request. If Token is
 	// empty, the Authorization header is omitted.
 	Credentials Credentials
 
@@ -96,8 +96,8 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 	req.Header.Set("User-Agent", useragent.GetEncodedUserAgent())
 	req.Header.Set("X-Stripe-Client-User-Agent", useragent.GetEncodedStripeUserAgent())
 
-	if c.Credentials.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.Credentials.APIKey)
+	if c.Credentials.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Credentials.Token)
 	}
 
 	if c.Credentials.OAKContext != "" {
@@ -128,7 +128,7 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 
 	// RequestID of the API Request
 	requestID := resp.Header.Get("Request-Id")
-	livemode := strings.Contains(c.Credentials.APIKey, "live")
+	livemode := strings.Contains(c.Credentials.Token, "live")
 	go sendTelemetryEvent(ctx, requestID, livemode)
 	return resp, nil
 }

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -28,12 +27,21 @@ const (
 	V2Request     = "v2"
 )
 
-// Credentials holds the auth credentials for a Stripe API request. For plain
-// API keys only Token is set. For OAK tokens all three fields are populated.
+// Credentials holds the auth credentials for a Stripe API request.
 type Credentials struct {
-	Token       string
-	OAKContext  string
-	OAKLivemode *bool
+	Token string
+}
+
+// SetRequestHeaders applies auth-related headers to req.
+func (c Credentials) SetRequestHeaders(req *http.Request) {
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+}
+
+// Livemode reports whether the credentials are for live mode.
+func (c Credentials) Livemode() bool {
+	return strings.Contains(c.Token, "live")
 }
 
 // Client is the API client used to send requests to Stripe.
@@ -96,16 +104,7 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 	req.Header.Set("User-Agent", useragent.GetEncodedUserAgent())
 	req.Header.Set("X-Stripe-Client-User-Agent", useragent.GetEncodedStripeUserAgent())
 
-	if c.Credentials.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.Credentials.Token)
-	}
-
-	if c.Credentials.OAKContext != "" {
-		req.Header.Set("Stripe-Context", c.Credentials.OAKContext)
-	}
-	if c.Credentials.OAKLivemode != nil {
-		req.Header.Set("Stripe-Livemode", strconv.FormatBool(*c.Credentials.OAKLivemode))
-	}
+	c.Credentials.SetRequestHeaders(req)
 
 	if configure != nil {
 		if err := configure(req); err != nil {
@@ -128,8 +127,7 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 
 	// RequestID of the API Request
 	requestID := resp.Header.Get("Request-Id")
-	livemode := strings.Contains(c.Credentials.Token, "live")
-	go sendTelemetryEvent(ctx, requestID, livemode)
+	go sendTelemetryEvent(ctx, requestID, c.Credentials.Livemode())
 	return resp, nil
 }
 

--- a/pkg/stripe/client_test.go
+++ b/pkg/stripe/client_test.go
@@ -98,8 +98,8 @@ func TestPerformRequest_ApiKey_Provided(t *testing.T) {
 
 	baseURL, _ := url.Parse(ts.URL)
 	client := Client{
-		BaseURL: baseURL,
-		APIKey:  "sk_test_1234",
+		BaseURL:     baseURL,
+		Credentials: Credentials{APIKey: "sk_test_1234"},
 	}
 
 	resp, err := client.PerformRequest(context.Background(), http.MethodGet, "/get", "", nil)

--- a/pkg/stripe/client_test.go
+++ b/pkg/stripe/client_test.go
@@ -99,7 +99,7 @@ func TestPerformRequest_ApiKey_Provided(t *testing.T) {
 	baseURL, _ := url.Parse(ts.URL)
 	client := Client{
 		BaseURL:     baseURL,
-		Credentials: Credentials{APIKey: "sk_test_1234"},
+		Credentials: Credentials{Token: "sk_test_1234"},
 	}
 
 	resp, err := client.PerformRequest(context.Background(), http.MethodGet, "/get", "", nil)

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -38,7 +38,7 @@ func TestAuthorize(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	session, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -65,7 +65,7 @@ func TestUserAgent(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -92,7 +92,7 @@ func TestStripeClientUserAgent(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -115,7 +115,7 @@ func TestAuthorizeWithURLDeviceMap(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	devURLMap := DeviceURLMap{
 		ForwardURL:            "http://localhost:3000/events",
@@ -140,7 +140,7 @@ func TestAuthorizeClientError(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -162,7 +162,7 @@ func TestAuthorizeServerError(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{APIKey: "sk_test_123", BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -38,7 +38,7 @@ func TestAuthorize(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL}, nil)
 
 	session, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -65,7 +65,7 @@ func TestUserAgent(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -92,7 +92,7 @@ func TestStripeClientUserAgent(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -115,7 +115,7 @@ func TestAuthorizeWithURLDeviceMap(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL}, nil)
 
 	devURLMap := DeviceURLMap{
 		ForwardURL:            "http://localhost:3000/events",
@@ -140,7 +140,7 @@ func TestAuthorizeClientError(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -162,7 +162,7 @@ func TestAuthorizeServerError(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -38,7 +38,7 @@ func TestAuthorize(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	session, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -65,7 +65,7 @@ func TestUserAgent(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -92,7 +92,7 @@ func TestStripeClientUserAgent(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -115,7 +115,7 @@ func TestAuthorizeWithURLDeviceMap(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	devURLMap := DeviceURLMap{
 		ForwardURL:            "http://localhost:3000/events",
@@ -140,7 +140,7 @@ func TestAuthorizeClientError(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",
@@ -162,7 +162,7 @@ func TestAuthorizeServerError(t *testing.T) {
 	defer ts.Close()
 
 	baseURL, _ := url.Parse(ts.URL)
-	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{APIKey: "sk_test_123"}, BaseURL: baseURL}, nil)
+	client := NewClient(&stripe.Client{Credentials: stripe.Credentials{Token: "sk_test_123"}, BaseURL: baseURL}, nil)
 
 	_, err := client.Authorize(context.Background(), CreateSessionRequest{
 		DeviceName:        "my-device",

--- a/pkg/terminal/p400/stripe_requests.go
+++ b/pkg/terminal/p400/stripe_requests.go
@@ -65,7 +65,7 @@ func DiscoverReaders(ctx context.Context, tsCtx TerminalSessionContext) ([]Reade
 
 	client := &stripe.Client{
 		BaseURL:     parsedBaseURL,
-		Credentials: stripe.Credentials{Token: tsCtx.PstToken},
+		Credentials: stripe.NewAPIKeyCredentials(tsCtx.PstToken),
 		Verbose:     false,
 	}
 
@@ -166,7 +166,7 @@ func GetNewConnectionToken(ctx context.Context, tsCtx TerminalSessionContext) (s
 
 	client := &stripe.Client{
 		BaseURL:     parsedBaseURL,
-		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
+		Credentials: stripe.NewAPIKeyCredentials(tsCtx.APIKey),
 		Verbose:     false,
 	}
 
@@ -209,7 +209,7 @@ func CreatePaymentIntent(ctx context.Context, tsCtx TerminalSessionContext) (str
 
 	client := &stripe.Client{
 		BaseURL:     parsedBaseURL,
-		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
+		Credentials: stripe.NewAPIKeyCredentials(tsCtx.APIKey),
 		Verbose:     false,
 	}
 
@@ -258,7 +258,7 @@ func CapturePaymentIntent(ctx context.Context, tsCtx TerminalSessionContext) err
 
 	client := &stripe.Client{
 		BaseURL:     parsedBaseURL,
-		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
+		Credentials: stripe.NewAPIKeyCredentials(tsCtx.APIKey),
 		Verbose:     false,
 	}
 
@@ -295,7 +295,7 @@ func RegisterReader(ctx context.Context, regcode string, tsCtx TerminalSessionCo
 
 	client := &stripe.Client{
 		BaseURL:     parsedBaseURL,
-		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
+		Credentials: stripe.NewAPIKeyCredentials(tsCtx.APIKey),
 		Verbose:     false,
 	}
 

--- a/pkg/terminal/p400/stripe_requests.go
+++ b/pkg/terminal/p400/stripe_requests.go
@@ -64,9 +64,9 @@ func DiscoverReaders(ctx context.Context, tsCtx TerminalSessionContext) ([]Reade
 	var readersList []Reader
 
 	client := &stripe.Client{
-		BaseURL: parsedBaseURL,
+		BaseURL:     parsedBaseURL,
 		Credentials: stripe.Credentials{Token: tsCtx.PstToken},
-		Verbose: false,
+		Verbose:     false,
 	}
 
 	res, err := client.PerformRequest(ctx, http.MethodGet, stripeTerminalReadersPath, "", nil)
@@ -165,9 +165,9 @@ func GetNewConnectionToken(ctx context.Context, tsCtx TerminalSessionContext) (s
 	}
 
 	client := &stripe.Client{
-		BaseURL: parsedBaseURL,
+		BaseURL:     parsedBaseURL,
 		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
-		Verbose: false,
+		Verbose:     false,
 	}
 
 	res, err := client.PerformRequest(ctx, http.MethodPost, stripeTerminalConnectionTokensPath, "", nil)
@@ -208,9 +208,9 @@ func CreatePaymentIntent(ctx context.Context, tsCtx TerminalSessionContext) (str
 	amountStr := strconv.Itoa(tsCtx.Amount)
 
 	client := &stripe.Client{
-		BaseURL: parsedBaseURL,
+		BaseURL:     parsedBaseURL,
 		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
-		Verbose: false,
+		Verbose:     false,
 	}
 
 	data := url.Values{}
@@ -257,9 +257,9 @@ func CapturePaymentIntent(ctx context.Context, tsCtx TerminalSessionContext) err
 	stripeCapturePaymentIntentURL := fmt.Sprintf(stripeCapturePaymentIntentPath, tsCtx.PaymentIntentID)
 
 	client := &stripe.Client{
-		BaseURL: parsedBaseURL,
+		BaseURL:     parsedBaseURL,
 		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
-		Verbose: false,
+		Verbose:     false,
 	}
 
 	res, err := client.PerformRequest(ctx, http.MethodPost, stripeCapturePaymentIntentURL, "", nil)
@@ -294,9 +294,9 @@ func RegisterReader(ctx context.Context, regcode string, tsCtx TerminalSessionCo
 	}
 
 	client := &stripe.Client{
-		BaseURL: parsedBaseURL,
+		BaseURL:     parsedBaseURL,
 		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
-		Verbose: false,
+		Verbose:     false,
 	}
 
 	data := url.Values{}

--- a/pkg/terminal/p400/stripe_requests.go
+++ b/pkg/terminal/p400/stripe_requests.go
@@ -65,7 +65,7 @@ func DiscoverReaders(ctx context.Context, tsCtx TerminalSessionContext) ([]Reade
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
-		Credentials: stripe.Credentials{APIKey: tsCtx.PstToken},
+		Credentials: stripe.Credentials{Token: tsCtx.PstToken},
 		Verbose: false,
 	}
 
@@ -166,7 +166,7 @@ func GetNewConnectionToken(ctx context.Context, tsCtx TerminalSessionContext) (s
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
-		Credentials: stripe.Credentials{APIKey: tsCtx.APIKey},
+		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
 		Verbose: false,
 	}
 
@@ -209,7 +209,7 @@ func CreatePaymentIntent(ctx context.Context, tsCtx TerminalSessionContext) (str
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
-		Credentials: stripe.Credentials{APIKey: tsCtx.APIKey},
+		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
 		Verbose: false,
 	}
 
@@ -258,7 +258,7 @@ func CapturePaymentIntent(ctx context.Context, tsCtx TerminalSessionContext) err
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
-		Credentials: stripe.Credentials{APIKey: tsCtx.APIKey},
+		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
 		Verbose: false,
 	}
 
@@ -295,7 +295,7 @@ func RegisterReader(ctx context.Context, regcode string, tsCtx TerminalSessionCo
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
-		Credentials: stripe.Credentials{APIKey: tsCtx.APIKey},
+		Credentials: stripe.Credentials{Token: tsCtx.APIKey},
 		Verbose: false,
 	}
 

--- a/pkg/terminal/p400/stripe_requests.go
+++ b/pkg/terminal/p400/stripe_requests.go
@@ -65,7 +65,7 @@ func DiscoverReaders(ctx context.Context, tsCtx TerminalSessionContext) ([]Reade
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
-		APIKey:  tsCtx.PstToken,
+		Credentials: stripe.Credentials{APIKey: tsCtx.PstToken},
 		Verbose: false,
 	}
 
@@ -166,7 +166,7 @@ func GetNewConnectionToken(ctx context.Context, tsCtx TerminalSessionContext) (s
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
-		APIKey:  tsCtx.APIKey,
+		Credentials: stripe.Credentials{APIKey: tsCtx.APIKey},
 		Verbose: false,
 	}
 
@@ -209,7 +209,7 @@ func CreatePaymentIntent(ctx context.Context, tsCtx TerminalSessionContext) (str
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
-		APIKey:  tsCtx.APIKey,
+		Credentials: stripe.Credentials{APIKey: tsCtx.APIKey},
 		Verbose: false,
 	}
 
@@ -258,7 +258,7 @@ func CapturePaymentIntent(ctx context.Context, tsCtx TerminalSessionContext) err
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
-		APIKey:  tsCtx.APIKey,
+		Credentials: stripe.Credentials{APIKey: tsCtx.APIKey},
 		Verbose: false,
 	}
 
@@ -295,7 +295,7 @@ func RegisterReader(ctx context.Context, regcode string, tsCtx TerminalSessionCo
 
 	client := &stripe.Client{
 		BaseURL: parsedBaseURL,
-		APIKey:  tsCtx.APIKey,
+		Credentials: stripe.Credentials{APIKey: tsCtx.APIKey},
 		Verbose: false,
 	}
 


### PR DESCRIPTION
This refactors the logic for authenticating requests into a struct called `Credentials` instead of passing an API key around. The idea is that `Credentials` will encapsulate the data and logic for different authentication mechanisms so that calling code doesn't have to know about this. `Credentials` can only hold an API key currently, but we'll extend it to support authenticating with a UAT in a [follow up PR](https://github.com/stripe/stripe-cli/pull/1847), which is a little more complex than using an API key.

I confirmed these commands haven't changed in behavior:
- `stripe login`
- `stripe customers list`
- `stripe customers list --live`
- `stripe customers create`
- `stripe customers create --api-key ...`
- `STRIPE_API_KEY=... stripe customers create`
- `stripe customers create --live`
- `stripe trigger customer.created`
- `stripe listen`
- `stripe logs tail`