### PR TITLE
Add optional Slack notification support to notify.sh (v2)

### DIFF
--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -26,6 +26,16 @@ send_pagerduty_event() {
     fi
 }
 
+send_slack_notification() {
+    message="$1"
+    if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+        return 0
+    fi
+    curl -s -X POST "$SLACK_WEBHOOK_URL" \
+        -H "Content-Type: application/json" \
+        -d "{\"text\": \"$message\"}"
+}
+
 trigger_pagerduty_alert() {
     if [ "${DRYRUN:-false}" = "true" ]; then
         echo "Dry run: PagerDuty alert would have fired with:"
@@ -35,8 +45,10 @@ trigger_pagerduty_alert() {
         echo "  timestamp: $(date)"
         echo "  source:    Stripe CLI GitHub Actions"
         echo "  severity:  $SEVERITY"
+        send_slack_notification ":red_circle: [DRY RUN] $SUMMARY"
         return 0
     fi
+    send_slack_notification ":red_circle: $SUMMARY"
     send_pagerduty_event '{
         "routing_key": "'"$PAGERDUTY_INTEGRATION_KEY"'",
         "event_action": "trigger",


### PR DESCRIPTION
Ports the `send_slack_notification()` helper from master (PR #1848) onto `v2` so the auto-upgrade canary workflow can send Slack alerts.

No-op when `SLACK_WEBHOOK_URL` is unset — existing callers are unaffected.

This is a cherry-pick of the same change already merged to master. When `v2` is eventually merged into `master`, the content is identical on both sides so git will merge cleanly with no conflict.