### PR TITLE
coop: persist node outputs for references

### DIFF
--- a/pkg/cmd/coop/coop_agent.go
+++ b/pkg/cmd/coop/coop_agent.go
@@ -1,6 +1,7 @@
 package coopcmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -30,6 +31,7 @@ type coopAgentActionCmd struct {
 	snippet string
 	check   string
 	passed  bool
+	outputs []string
 
 	completed string
 	action    string
@@ -96,6 +98,14 @@ func newCoopAgentReportWorkCmd() *coopAgentActionCmd {
 			if err := c.validateSessionStep("report-work"); err != nil {
 				return err
 			}
+			outputs, err := parseReportedOutputs(c.outputs)
+			if err != nil {
+				return outputCoopError(
+					err.Error(),
+					"Use --output field=value or --output source:field=value.",
+					coop.ReportWorkOutputTemplate(c.session, c.step),
+				)
+			}
 			service, err := newWorkflowService()
 			if err != nil {
 				return outputAgentError(err)
@@ -105,6 +115,7 @@ func newCoopAgentReportWorkCmd() *coopAgentActionCmd {
 				Lines:   c.lines,
 				Snippet: c.snippet,
 				Note:    c.note,
+				Outputs: outputs,
 			}, false)
 			return outputAgentResponse(resp, err)
 		},
@@ -114,6 +125,7 @@ func newCoopAgentReportWorkCmd() *coopAgentActionCmd {
 	c.cmd.Flags().StringVar(&c.lines, "lines", "", "Line range, e.g. 1-15")
 	c.cmd.Flags().StringVar(&c.snippet, "snippet", "", "Code snippet")
 	c.cmd.Flags().StringVar(&c.note, "note", "", "Implementation summary")
+	c.cmd.Flags().StringArrayVar(&c.outputs, "output", nil, "Produced value as field=value or source:field=value (repeatable)")
 	configureAgentCommand(c.cmd)
 	return c
 }
@@ -282,6 +294,50 @@ func newWorkflowService() (*workflow.Service, error) {
 		return nil, fmt.Errorf("creating store: %w", err)
 	}
 	return workflow.NewService(store), nil
+}
+
+func parseReportedOutputs(values []string) (coop.NodeOutputs, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	outputs := coop.NodeOutputs{}
+	for _, value := range values {
+		selector, rawValue, ok := strings.Cut(value, "=")
+		if !ok {
+			return nil, fmt.Errorf("--output must be in field=value or source:field=value format: %q", value)
+		}
+		selector = strings.TrimSpace(selector)
+		if selector == "" {
+			return nil, fmt.Errorf("--output field cannot be empty: %q", value)
+		}
+		if rawValue == "" {
+			return nil, fmt.Errorf("--output value cannot be empty: %q", value)
+		}
+
+		source := coop.DefaultOutputSource
+		field := selector
+		if parsedSource, parsedField, hasSource := strings.Cut(selector, ":"); hasSource {
+			source = strings.TrimSpace(parsedSource)
+			field = strings.TrimSpace(parsedField)
+			if source == "" || field == "" {
+				return nil, fmt.Errorf("--output source and field cannot be empty: %q", value)
+			}
+		}
+
+		raw := json.RawMessage(rawValue)
+		if !json.Valid(raw) {
+			encoded, err := json.Marshal(rawValue)
+			if err != nil {
+				return nil, fmt.Errorf("encoding --output %q: %w", selector, err)
+			}
+			raw = encoded
+		}
+		if outputs[source] == nil {
+			outputs[source] = map[string]json.RawMessage{}
+		}
+		outputs[source][field] = append(json.RawMessage(nil), raw...)
+	}
+	return outputs, nil
 }
 
 func runCoopNextAction(sessionID, completed string) error {

--- a/pkg/cmd/coop/coop_agent_test.go
+++ b/pkg/cmd/coop/coop_agent_test.go
@@ -409,3 +409,28 @@ func TestOutputAgentErrorEmitsStructuredJSON(t *testing.T) {
 	require.NotNil(t, resp.Recovery)
 	assert.Equal(t, "stripe coop status", resp.Recovery.Next)
 }
+
+func TestParseReportedOutputsPreservesStringsAndJSONTypes(t *testing.T) {
+	outputs, err := parseReportedOutputs([]string{
+		"id=prod_123",
+		"latest_version=7",
+		"create-clock-request:id=clock_123",
+		"metadata={\"source\":\"coop\"}",
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `"prod_123"`, string(outputs[coop.DefaultOutputSource]["id"]))
+	assert.JSONEq(t, `7`, string(outputs[coop.DefaultOutputSource]["latest_version"]))
+	assert.JSONEq(t, `"clock_123"`, string(outputs["create-clock-request"]["id"]))
+	assert.JSONEq(t, `{"source":"coop"}`, string(outputs[coop.DefaultOutputSource]["metadata"]))
+}
+
+func TestParseReportedOutputsRejectsMalformedValues(t *testing.T) {
+	tests := []string{"id", "=prod_123", "source:=value", "id="}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			_, err := parseReportedOutputs([]string{value})
+			require.Error(t, err)
+		})
+	}
+}

--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -67,14 +67,30 @@ active ──→ completed    (all nodes done/skipped, or "stripe coop stop")
 |---------|---------|
 | `stripe coop run <blueprint>` | Create a session (outputs a compact JSON bootstrap) |
 | `stripe coop agent start-work --step <n>` | Mark a node active and return its task context |
-| `stripe coop agent report-work --step <n>` | Mark a node complete (→ review or → done if auto_confirm) |
+| `stripe coop agent report-work --step <n>` | Record implementation and outputs, then mark a node complete |
 | `stripe coop agent report-check --step <n>` | Add a verification check |
 | `stripe coop agent skip --step <n>` | Skip a node |
 | `stripe coop agent await-review --step <n>` | Block until developer confirms or requests changes |
 | `stripe coop agent next-action` | Show post-completion options (blocks until selection) |
 | `stripe coop agent start-followup` | Start an internal guided follow-up session selected from next actions |
 
-Agent commands return `next` only when the value is immediately executable. Commands that still need values return `next_template` with `required_inputs`. Failures use a single `recovery` object containing a hint and one of those continuation forms. Session creation does not front-load the full blueprint: each successful `start-work` response returns an `agent_prompt` for only the current node, plus any relevant `api_request`, `test_requests`, `events`, and SDK example. The `--step` flag name is retained for the CLI, but its value is the 1-based node number across the session.
+Agent commands return `next` only when the value is immediately executable. Commands that still need values return `next_template` with `required_inputs`. Failures use a single `recovery` object containing a hint and one of those continuation forms. Session creation does not front-load the full blueprint: each successful `start-work` response returns an `agent_prompt` for only the current node, plus any relevant `api_request`, `test_requests`, `events`, SDK example, and `required_outputs`. The `--step` flag name is retained for the CLI, but its value is the 1-based node number across the session.
+
+`report-work` requires a concrete `--note`. Use repeatable `--output` flags for values named by `required_outputs`:
+
+```bash
+stripe coop agent report-work \
+  --session=coop_abc123 \
+  --step=2 \
+  --note="Created the product and captured its result" \
+  --output=id=prod_123 \
+  --output=latest_version=7 \
+  --output=create-test-clock-request:id=clock_123
+```
+
+Values that are valid JSON retain their type; other values are stored as strings. Co-op resolves `${node.<step>.<node>:<field>}` references from these persisted outputs before returning a later node's request.
+
+Skipping an output-producing node also skips later nodes that directly or transitively reference its outputs. Co-op refuses the skip if one of those dependent nodes is already done.
 
 ## TUI Keybindings
 
@@ -124,7 +140,7 @@ $ stripe coop start one-time-payment --language=node
 #      stripe coop agent start-work --session=coop_abc123 --step=1 --note="Scanning project"
 #      stripe coop agent report-work --session=coop_abc123 --step=1 --note="Found Next.js app"
 #      stripe coop agent start-work --session=coop_abc123 --step=2 --note="Creating product"
-#      stripe coop agent report-work --session=coop_abc123 --step=2 --file=server.js --lines=5-20 --note="Created product"
+#      stripe coop agent report-work --session=coop_abc123 --step=2 --file=server.js --lines=5-20 --note="Created product" --output=id=prod_123
 #      stripe coop agent await-review --session=coop_abc123 --step=2   ← blocks until developer confirms
 # 6. Developer sees progress live, presses 'c' to confirm
 # 7. Agent continues to next step
@@ -190,6 +206,8 @@ Each node has:
 - `request.hidden_params` — request fields that should not be shown directly in the TUI
 - `requests` — API-backed test helper requests for `testHelper` nodes
 - `events` — webhook events (for `asyncHandler` nodes)
+
+Node references may only point backward to completed blueprint nodes. Direct node results use `${node.<step>.<node>:<field>}`; named test-helper or numeric event results add a source segment, such as `${node.<step>.<node>.<request>:id}` or `${node.<step>.<node>.0:id}`.
 
 `testHelper` request metadata tells the agent which Stripe-backed test helpers can advance test state. Agents should use those helpers while verifying work, but should not encode helper-only request parameters into the user's application.
 

--- a/pkg/coop/blueprint.go
+++ b/pkg/coop/blueprint.go
@@ -1,11 +1,9 @@
 package coop
 
 import (
-	"bytes"
 	"embed"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 )
@@ -101,27 +99,53 @@ func validateBlueprintReferences(bp *Blueprint) error {
 		}
 	}
 
-	data, err := json.Marshal(bp)
-	if err != nil {
+	metadata := *bp
+	metadata.Steps = append([]BlueprintStep(nil), bp.Steps...)
+	for i := range metadata.Steps {
+		metadata.Steps[i].Nodes = nil
+	}
+	if err := visitJSONStrings(&metadata, func(value string) error {
+		if findBlueprintNodeCandidate(value) != -1 {
+			return fmt.Errorf("node references are only supported inside node definitions: %q", value)
+		}
+		return nil
+	}); err != nil {
 		return err
 	}
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	for {
-		token, err := decoder.Token()
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		value, ok := token.(string)
-		if !ok {
-			continue
-		}
-		if err := validateBlueprintReferenceString(value, validRefs); err != nil {
-			return err
+
+	if err := visitJSONStrings(bp, func(value string) error {
+		return validateBlueprintReferenceString(value, validRefs)
+	}); err != nil {
+		return err
+	}
+	return validateBlueprintReferenceOrder(bp)
+}
+
+func validateBlueprintReferenceOrder(bp *Blueprint) error {
+	nodeOrder := map[string]int{}
+	order := 0
+	for _, step := range bp.Steps {
+		for _, node := range step.Nodes {
+			order++
+			nodeOrder[step.Key+"."+node.Key] = order
 		}
 	}
+
+	order = 0
+	for _, step := range bp.Steps {
+		for _, node := range step.Nodes {
+			order++
+			if err := walkNodeReferences(node, func(reference nodeReference) error {
+				if nodeOrder[reference.Base] >= order {
+					return fmt.Errorf("node %q references %q before it has completed", step.Key+"."+node.Key, reference.Base)
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func validateBlueprintReferenceString(value string, validRefs map[string]bool) error {

--- a/pkg/coop/blueprint_test.go
+++ b/pkg/coop/blueprint_test.go
@@ -160,6 +160,97 @@ func TestValidateBlueprintReferences(t *testing.T) {
 	}
 }
 
+func TestValidateBlueprintReferencesRejectsSelfAndForwardReferences(t *testing.T) {
+	tests := []struct {
+		name      string
+		reference string
+	}{
+		{name: "self", reference: "${node.setup.first:id}"},
+		{name: "forward", reference: "${node.setup.second:id}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bp := &Blueprint{
+				ID: "test",
+				Steps: []BlueprintStep{{
+					StepDefinition: StepDefinition{Key: "setup", Title: "Setup"},
+					Nodes: []NodeDefinition{
+						{
+							Key: "first",
+							Request: &APIRequest{
+								Path:   "/v1/resources/" + tt.reference,
+								Method: "get",
+							},
+						},
+						{Key: "second", Request: &APIRequest{Path: "/v1/resources", Method: "post"}},
+					},
+				}},
+			}
+
+			err := validateBlueprintReferences(bp)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "before it has completed")
+		})
+	}
+}
+
+func TestValidateBlueprintReferencesRejectsReferencesOutsideNodes(t *testing.T) {
+	newBlueprint := func() *Blueprint {
+		return &Blueprint{
+			ID: "test",
+			Steps: []BlueprintStep{{
+				StepDefinition: StepDefinition{Key: "setup", Title: "Setup"},
+				Nodes: []NodeDefinition{
+					{Key: "create-product", Request: &APIRequest{Path: "/v1/products", Method: "post"}},
+					{Key: "use-product", Request: &APIRequest{
+						Path:   "/v1/products/${node.setup.create-product:id}",
+						Method: "get",
+					}},
+				},
+			}},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Blueprint)
+	}{
+		{
+			name: "blueprint description",
+			mutate: func(bp *Blueprint) {
+				bp.Description = "Created ${node.setup.create-product:id}"
+			},
+		},
+		{
+			name: "step description",
+			mutate: func(bp *Blueprint) {
+				bp.Steps[0].Description = "Created ${node.setup.create-product:id}"
+			},
+		},
+		{
+			name: "setting default",
+			mutate: func(bp *Blueprint) {
+				bp.Settings = []BlueprintSetting{{
+					Key:     "product",
+					Default: "${node.setup.create-product:id}",
+				}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bp := newBlueprint()
+			tt.mutate(bp)
+
+			err := validateBlueprintReferences(bp)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "only supported inside node definitions")
+		})
+	}
+}
+
 func TestLoadBlueprintPrefixMatch(t *testing.T) {
 	bp, err := LoadBlueprint("setup-future")
 	require.NoError(t, err)

--- a/pkg/coop/commands.go
+++ b/pkg/coop/commands.go
@@ -112,12 +112,32 @@ func ReportCheckTemplate(sessionID string, nodeNumber int) Continuation {
 	)
 }
 
-// ReportWorkTemplate returns the continuation for reporting implementation.
-func ReportWorkTemplate(sessionID string, nodeNumber int) Continuation {
-	return commandTemplate(
+// ReportWorkTemplate returns the report command template and every input that
+// must be supplied for a node.
+func ReportWorkTemplate(sessionID string, nodeNumber int, outputs []RequiredOutput) Continuation {
+	continuation := commandTemplate(
 		fmt.Sprintf("stripe coop agent report-work --session=%s --step=%d --note=\"<what you did>\"", sessionID, nodeNumber),
 		commandInput("note", "--note", "Concrete summary of the completed implementation."),
 	)
+	for _, output := range outputs {
+		selector := output.Selector()
+		continuation.NextTemplate += " --output=" + strconv.Quote(selector+"=<"+selector+">")
+		continuation.RequiredInputs = append(continuation.RequiredInputs, commandInput(
+			selector, "--output", fmt.Sprintf("Value produced for the future blueprint reference %q.", selector),
+		))
+	}
+	return continuation
+}
+
+// ReportWorkOutputTemplate returns the report template used when an output flag
+// itself is malformed.
+func ReportWorkOutputTemplate(sessionID string, nodeNumber int) Continuation {
+	continuation := ReportWorkTemplate(sessionID, nodeNumber, nil)
+	continuation.NextTemplate += " --output=\"<field=value>\""
+	continuation.RequiredInputs = append(continuation.RequiredInputs, commandInput(
+		"output", "--output", "Output selector and value in field=value or source:field=value form.",
+	))
+	return continuation
 }
 
 func commandTemplate(command string, inputs ...CommandInput) Continuation {

--- a/pkg/coop/commands_test.go
+++ b/pkg/coop/commands_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExactCoopCommands(t *testing.T) {
@@ -16,4 +17,17 @@ func TestExactCoopCommands(t *testing.T) {
 	assert.Equal(t, "stripe coop agent next-action --session=coop_123", NextActionCommand("coop_123", ""))
 	assert.Equal(t, "stripe coop agent next-action --session=coop_123 --completed=deploy", NextActionCommand("coop_123", "deploy"))
 	assert.Equal(t, `stripe coop agent start-followup --session="coop_123" --action="deploy" --target="Vercel"`, StartFollowupCommand("coop_123", "deploy", "Vercel"))
+}
+
+func TestReportWorkTemplateDescribesEveryInput(t *testing.T) {
+	continuation := ReportWorkTemplate("coop_123", 2, []RequiredOutput{
+		{Field: "id"},
+		{Source: "create-clock", Field: "id"},
+	})
+
+	assert.Equal(t, `stripe coop agent report-work --session=coop_123 --step=2 --note="<what you did>" --output="id=<id>" --output="create-clock:id=<create-clock:id>"`, continuation.NextTemplate)
+	require.Len(t, continuation.RequiredInputs, 3)
+	assert.Equal(t, "note", continuation.RequiredInputs[0].Name)
+	assert.Equal(t, "id", continuation.RequiredInputs[1].Name)
+	assert.Equal(t, "create-clock:id", continuation.RequiredInputs[2].Name)
 }

--- a/pkg/coop/outputs.go
+++ b/pkg/coop/outputs.go
@@ -1,0 +1,278 @@
+package coop
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const DefaultOutputSource = "default"
+
+// Selector returns the report-work --output selector for this required value.
+func (o RequiredOutput) Selector() string {
+	if o.Source == "" {
+		return o.Field
+	}
+	return o.Source + ":" + o.Field
+}
+
+// RequiredOutputs returns the values produced by nodeNumber that later nodes
+// reference.
+func (s *Session) RequiredOutputs(nodeNumber int) ([]RequiredOutput, error) {
+	step, _, nodeIndex, err := s.StepByNodeNumber(nodeNumber)
+	if err != nil {
+		return nil, err
+	}
+	targetBase := step.Key + "." + step.Nodes[nodeIndex].Key
+
+	seen := map[string]RequiredOutput{}
+	current := 0
+	for _, candidateStep := range s.Steps {
+		for _, candidateNode := range candidateStep.Nodes {
+			current++
+			if current <= nodeNumber {
+				continue
+			}
+			if err := walkNodeReferences(candidateNode.NodeDefinition, func(reference nodeReference) error {
+				if reference.Base != targetBase {
+					return nil
+				}
+				output := RequiredOutput{Source: reference.Source, Field: reference.Field}
+				seen[output.Selector()] = output
+				return nil
+			}); err != nil {
+				return nil, fmt.Errorf("scanning node %d while finding required outputs: %w", current, err)
+			}
+		}
+	}
+
+	outputs := make([]RequiredOutput, 0, len(seen))
+	for _, output := range seen {
+		outputs = append(outputs, output)
+	}
+	sort.Slice(outputs, func(i, j int) bool {
+		return outputs[i].Selector() < outputs[j].Selector()
+	})
+	return outputs, nil
+}
+
+// DependentNodeNumbers returns later nodes that directly or transitively
+// reference outputs from nodeNumber.
+func (s *Session) DependentNodeNumbers(nodeNumber int) ([]int, error) {
+	step, _, nodeIndex, err := s.StepByNodeNumber(nodeNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	dependencyBases := map[string]bool{
+		step.Key + "." + step.Nodes[nodeIndex].Key: true,
+	}
+	var dependents []int
+	current := 0
+	for _, candidateStep := range s.Steps {
+		for _, candidateNode := range candidateStep.Nodes {
+			current++
+			if current <= nodeNumber {
+				continue
+			}
+			dependent := false
+			if err := walkNodeReferences(candidateNode.NodeDefinition, func(reference nodeReference) error {
+				if dependencyBases[reference.Base] {
+					dependent = true
+				}
+				return nil
+			}); err != nil {
+				return nil, fmt.Errorf("scanning node %d while finding dependents: %w", current, err)
+			}
+			if !dependent {
+				continue
+			}
+			dependents = append(dependents, current)
+			dependencyBases[candidateStep.Key+"."+candidateNode.Key] = true
+		}
+	}
+	return dependents, nil
+}
+
+// MissingRequiredOutputs returns required values that have not been persisted
+// for nodeNumber.
+func (s *Session) MissingRequiredOutputs(nodeNumber int) ([]RequiredOutput, error) {
+	required, err := s.RequiredOutputs(nodeNumber)
+	if err != nil {
+		return nil, err
+	}
+	node, err := s.NodeByNumber(nodeNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	var missing []RequiredOutput
+	for _, output := range required {
+		source := output.Source
+		if source == "" {
+			source = DefaultOutputSource
+		}
+		values := node.Outputs[source]
+		if values == nil || len(values[output.Field]) == 0 {
+			missing = append(missing, output)
+		}
+	}
+	return missing, nil
+}
+
+// ResolvedNodeDefinition returns a copy of a node definition with every
+// ${node...} reference replaced from persisted session outputs.
+func (s *Session) ResolvedNodeDefinition(nodeNumber int) (NodeDefinition, error) {
+	node, err := s.NodeByNumber(nodeNumber)
+	if err != nil {
+		return NodeDefinition{}, err
+	}
+
+	data, err := json.Marshal(node.NodeDefinition)
+	if err != nil {
+		return NodeDefinition{}, fmt.Errorf("encoding node %d: %w", nodeNumber, err)
+	}
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return NodeDefinition{}, fmt.Errorf("decoding node %d: %w", nodeNumber, err)
+	}
+	resolved, err := s.resolveNodeValue(value)
+	if err != nil {
+		return NodeDefinition{}, fmt.Errorf("resolving node %d: %w", nodeNumber, err)
+	}
+	data, err = json.Marshal(resolved)
+	if err != nil {
+		return NodeDefinition{}, fmt.Errorf("encoding resolved node %d: %w", nodeNumber, err)
+	}
+
+	var definition NodeDefinition
+	if err := json.Unmarshal(data, &definition); err != nil {
+		return NodeDefinition{}, fmt.Errorf("decoding resolved node %d: %w", nodeNumber, err)
+	}
+	return definition, nil
+}
+
+func (s *Session) resolveNodeValue(value any) (any, error) {
+	switch typed := value.(type) {
+	case string:
+		return s.resolveNodeString(typed)
+	case []any:
+		resolved := make([]any, len(typed))
+		for i, item := range typed {
+			value, err := s.resolveNodeValue(item)
+			if err != nil {
+				return nil, err
+			}
+			resolved[i] = value
+		}
+		return resolved, nil
+	case map[string]any:
+		resolved := make(map[string]any, len(typed))
+		for key, item := range typed {
+			resolvedKeyValue, err := s.resolveNodeString(key)
+			if err != nil {
+				return nil, err
+			}
+			resolvedKey, ok := resolvedKeyValue.(string)
+			if !ok {
+				return nil, fmt.Errorf("node reference used as an object key must resolve to a string")
+			}
+			if _, exists := resolved[resolvedKey]; exists {
+				return nil, fmt.Errorf("node reference produced duplicate object key %q", resolvedKey)
+			}
+			resolvedValue, err := s.resolveNodeValue(item)
+			if err != nil {
+				return nil, err
+			}
+			resolved[resolvedKey] = resolvedValue
+		}
+		return resolved, nil
+	default:
+		return value, nil
+	}
+}
+
+func (s *Session) resolveNodeString(value string) (any, error) {
+	matches := nodeReferencePattern.FindAllStringSubmatchIndex(value, -1)
+	if len(matches) == 0 {
+		return value, nil
+	}
+
+	if len(matches) == 1 && matches[0][0] == 0 && matches[0][1] == len(value) {
+		raw, err := s.lookupNodeOutput(value[matches[0][2]:matches[0][3]], value[matches[0][4]:matches[0][5]])
+		if err != nil {
+			return nil, err
+		}
+		var decoded any
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return nil, fmt.Errorf("decoding output for %q: %w", value, err)
+		}
+		return decoded, nil
+	}
+
+	var resolved strings.Builder
+	last := 0
+	for _, match := range matches {
+		resolved.WriteString(value[last:match[0]])
+		ref := value[match[2]:match[3]]
+		field := value[match[4]:match[5]]
+		raw, err := s.lookupNodeOutput(ref, field)
+		if err != nil {
+			return nil, err
+		}
+		text, err := outputAsString(raw)
+		if err != nil {
+			return nil, fmt.Errorf("using ${node.%s:%s} inside a string: %w", ref, field, err)
+		}
+		resolved.WriteString(text)
+		last = match[1]
+	}
+	resolved.WriteString(value[last:])
+	return resolved.String(), nil
+}
+
+func (s *Session) lookupNodeOutput(ref, field string) (json.RawMessage, error) {
+	base, source, ok := splitNodeReference(ref)
+	if !ok {
+		return nil, fmt.Errorf("invalid node output reference ${node.%s:%s}", ref, field)
+	}
+	stepKey, nodeKey, _ := strings.Cut(base, ".")
+	for i := range s.Steps {
+		if s.Steps[i].Key != stepKey {
+			continue
+		}
+		for j := range s.Steps[i].Nodes {
+			node := &s.Steps[i].Nodes[j]
+			if node.Key != nodeKey {
+				continue
+			}
+			outputSource := source
+			if outputSource == "" {
+				outputSource = DefaultOutputSource
+			}
+			if values := node.Outputs[outputSource]; values != nil && len(values[field]) > 0 {
+				return values[field], nil
+			}
+			return nil, fmt.Errorf("missing output %q for ${node.%s:%s}", RequiredOutput{Source: source, Field: field}.Selector(), ref, field)
+		}
+	}
+	return nil, fmt.Errorf("unknown output source ${node.%s:%s}", ref, field)
+}
+
+func outputAsString(raw json.RawMessage) (string, error) {
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return "", err
+	}
+	switch value := decoded.(type) {
+	case string:
+		return value, nil
+	case float64, bool:
+		return fmt.Sprint(value), nil
+	case nil:
+		return "", nil
+	default:
+		return "", fmt.Errorf("objects and arrays cannot be interpolated into strings")
+	}
+}

--- a/pkg/coop/outputs_test.go
+++ b/pkg/coop/outputs_test.go
@@ -1,0 +1,160 @@
+package coop
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequiredOutputsAndResolveNodeDefinition(t *testing.T) {
+	session := outputTestSession()
+
+	required, err := session.RequiredOutputs(1)
+	require.NoError(t, err)
+	assert.Equal(t, []RequiredOutput{
+		{Field: "id"},
+		{Field: "latest_version"},
+		{Field: "lookup_key"},
+	}, required)
+
+	required, err = session.RequiredOutputs(2)
+	require.NoError(t, err)
+	assert.Equal(t, []RequiredOutput{{Source: "create-clock-request", Field: "id"}}, required)
+
+	required, err = session.RequiredOutputs(3)
+	require.NoError(t, err)
+	assert.Equal(t, []RequiredOutput{{Source: "0", Field: "id"}}, required)
+
+	resolved, err := session.ResolvedNodeDefinition(4)
+	require.NoError(t, err)
+	require.NotNil(t, resolved.Request)
+	assert.Equal(t, "/v1/products/prod_123/versions/7", resolved.Request.Path)
+
+	params, ok := resolved.Request.Params.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "clock_123", params["clock"])
+	assert.Equal(t, "in_123", params["invoice"])
+	assert.Equal(t, float64(7), params["version"])
+	require.Contains(t, params, "metered")
+	assert.Equal(t, "usage", params["metered"])
+}
+
+func TestResolveNodeDefinitionRejectsMissingOutput(t *testing.T) {
+	session := outputTestSession()
+	delete(session.Steps[0].Nodes[0].Outputs[DefaultOutputSource], "id")
+
+	_, err := session.ResolvedNodeDefinition(4)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `missing output "id"`)
+	assert.Contains(t, err.Error(), "${node.setup.create-product:id}")
+}
+
+func TestMissingRequiredOutputs(t *testing.T) {
+	session := outputTestSession()
+	delete(session.Steps[0].Nodes[0].Outputs[DefaultOutputSource], "lookup_key")
+
+	missing, err := session.MissingRequiredOutputs(1)
+	require.NoError(t, err)
+	assert.Equal(t, []RequiredOutput{{Field: "lookup_key"}}, missing)
+}
+
+func TestEmbeddedBlueprintReferencesAreExposedAsRequiredOutputs(t *testing.T) {
+	ids, err := ListBlueprints()
+	require.NoError(t, err)
+
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			bp, err := LoadBlueprint(id)
+			require.NoError(t, err)
+
+			expected := map[string]bool{}
+			require.NoError(t, walkNodeReferences(bp, func(reference nodeReference) error {
+				expected[reference.Ref+":"+reference.Field] = true
+				return nil
+			}))
+
+			session := NewSessionFromBlueprint(bp, "required_outputs_"+id, nil, nil)
+			actual := map[string]bool{}
+			nodeNumber := 0
+			for _, step := range session.Steps {
+				for _, node := range step.Nodes {
+					nodeNumber++
+					required, err := session.RequiredOutputs(nodeNumber)
+					require.NoError(t, err)
+					for _, output := range required {
+						ref := step.Key + "." + node.Key
+						if output.Source != "" {
+							ref += "." + output.Source
+						}
+						actual[ref+":"+output.Field] = true
+					}
+				}
+			}
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func outputTestSession() *Session {
+	raw := func(value string) json.RawMessage {
+		data, err := json.Marshal(value)
+		if err != nil {
+			panic(err)
+		}
+		return data
+	}
+	return &Session{
+		ID:     "outputs",
+		Status: SessionActive,
+		Steps: []SessionStep{{
+			StepDefinition: StepDefinition{Key: "setup", Title: "Setup"},
+			Nodes: []SessionNode{
+				{
+					NodeDefinition: NodeDefinition{Key: "create-product", Title: "Create product", Type: NodeAPIRequest},
+					State:          NodeDone,
+					Outputs: NodeOutputs{
+						DefaultOutputSource: {
+							"id":             raw("prod_123"),
+							"latest_version": json.RawMessage("7"),
+							"lookup_key":     raw("metered"),
+						},
+					},
+				},
+				{
+					NodeDefinition: NodeDefinition{Key: "create-clock", Title: "Create clock", Type: NodeTestHelper},
+					State:          NodeDone,
+					Outputs: NodeOutputs{
+						"create-clock-request": {"id": raw("clock_123")},
+					},
+				},
+				{
+					NodeDefinition: NodeDefinition{Key: "wait-for-invoice", Title: "Wait for invoice", Type: NodeAsyncHandler},
+					State:          NodeDone,
+					Outputs: NodeOutputs{
+						"0": {"id": raw("in_123")},
+					},
+				},
+				{
+					NodeDefinition: NodeDefinition{
+						Key:   "use-results",
+						Title: "Use results",
+						Type:  NodeAPIRequest,
+						Request: &APIRequest{
+							Path:   "/v1/products/${node.setup.create-product:id}/versions/${node.setup.create-product:latest_version}",
+							Method: "post",
+							Params: map[string]any{
+								"clock":   "${node.setup.create-clock.create-clock-request:id}",
+								"invoice": "${node.setup.wait-for-invoice.0:id}",
+								"version": "${node.setup.create-product:latest_version}",
+								"${node.setup.create-product:lookup_key}": "usage",
+							},
+						},
+					},
+					State: NodePending,
+				},
+			},
+		}},
+	}
+}

--- a/pkg/coop/references.go
+++ b/pkg/coop/references.go
@@ -1,0 +1,74 @@
+package coop
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"regexp"
+	"strings"
+)
+
+var nodeReferencePattern = regexp.MustCompile(`\$\{node\.([^}:]+):([^}]+)\}`)
+
+type nodeReference struct {
+	Ref    string
+	Base   string
+	Source string
+	Field  string
+}
+
+func walkNodeReferences(value any, visit func(nodeReference) error) error {
+	return visitJSONStrings(value, func(text string) error {
+		for _, match := range nodeReferencePattern.FindAllStringSubmatch(text, -1) {
+			base, source, ok := splitNodeReference(match[1])
+			if !ok {
+				continue
+			}
+			if err := visit(nodeReference{
+				Ref:    match[1],
+				Base:   base,
+				Source: source,
+				Field:  match[2],
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func visitJSONStrings(value any, visit func(string) error) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		text, ok := token.(string)
+		if !ok {
+			continue
+		}
+		if err := visit(text); err != nil {
+			return err
+		}
+	}
+}
+
+func splitNodeReference(ref string) (base, source string, ok bool) {
+	parts := strings.Split(ref, ".")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	base = parts[0] + "." + parts[1]
+	if len(parts) > 2 {
+		source = strings.Join(parts[2:], ".")
+	}
+	return base, source, true
+}

--- a/pkg/coop/references_test.go
+++ b/pkg/coop/references_test.go
@@ -1,0 +1,37 @@
+package coop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWalkNodeReferencesVisitsNestedValuesAndObjectKeys(t *testing.T) {
+	value := map[string]any{
+		"${node.setup.create-product:lookup_key}": []any{
+			"/v1/products/${node.setup.create-product:id}",
+			map[string]any{
+				"clock": "${node.setup.create-clock.create-request:id}",
+			},
+		},
+	}
+
+	var references []nodeReference
+	err := walkNodeReferences(value, func(reference nodeReference) error {
+		references = append(references, reference)
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []nodeReference{
+		{Ref: "setup.create-product", Base: "setup.create-product", Field: "lookup_key"},
+		{Ref: "setup.create-product", Base: "setup.create-product", Field: "id"},
+		{
+			Ref:    "setup.create-clock.create-request",
+			Base:   "setup.create-clock",
+			Source: "create-request",
+			Field:  "id",
+		},
+	}, references)
+}

--- a/pkg/coop/store.go
+++ b/pkg/coop/store.go
@@ -254,7 +254,7 @@ func (s *Store) Read(id string) (*Session, error) {
 }
 
 func ensureSessionSchemaVersion(session *Session) {
-	if session.SchemaVersion == 0 {
+	if session.SchemaVersion < CurrentSessionSchemaVersion {
 		session.SchemaVersion = CurrentSessionSchemaVersion
 	}
 }

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -3,6 +3,7 @@
 package coop
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -15,7 +16,7 @@ var commandTemplatePlaceholder = regexp.MustCompile(`<[^>]+>`)
 type NodeState string
 
 const (
-	CurrentSessionSchemaVersion = 2
+	CurrentSessionSchemaVersion = 3
 )
 
 const (
@@ -55,6 +56,11 @@ type Implementation struct {
 	Snippet string `json:"snippet,omitempty"`
 	Note    string `json:"note,omitempty"`
 }
+
+// NodeOutputs stores values produced by a node. The outer key identifies the
+// result source ("default" for a node's primary result, or a named/numeric
+// request result); the inner key is the field path referenced by a blueprint.
+type NodeOutputs map[string]map[string]json.RawMessage
 
 // Verification is a single check the agent ran.
 type Verification struct {
@@ -103,6 +109,7 @@ type SessionNode struct {
 	State          NodeState       `json:"state"`
 	Activity       string          `json:"activity,omitempty"`
 	Implementation *Implementation `json:"implementation,omitempty"`
+	Outputs        NodeOutputs     `json:"outputs,omitempty"`
 	Verifications  []Verification  `json:"verifications,omitempty"`
 	RejectionNote  string          `json:"rejection_note,omitempty"`
 	StartedAt      *time.Time      `json:"started_at,omitempty"`
@@ -156,6 +163,13 @@ type CommandInput struct {
 	Description string `json:"description"`
 }
 
+// RequiredOutput describes a node result that a future blueprint node
+// references. Source is empty for the node's primary result.
+type RequiredOutput struct {
+	Source string `json:"source,omitempty"`
+	Field  string `json:"field"`
+}
+
 // Continuation tells an agent either what to run next or what inputs are
 // needed to complete a command template.
 type Continuation struct {
@@ -195,13 +209,14 @@ type CommandResponse struct {
 	State     string `json:"state,omitempty"`
 	Message   string `json:"message,omitempty"`
 	Continuation
-	AgentPrompt  string              `json:"agent_prompt,omitempty"`
-	APIRequest   *APIRequest         `json:"api_request,omitempty"`
-	TestRequests []TestHelperRequest `json:"test_requests,omitempty"`
-	Events       []string            `json:"events,omitempty"`
-	SDKExample   string              `json:"sdk_example,omitempty"`
-	Error        string              `json:"error,omitempty"`
-	Recovery     *Recovery           `json:"recovery,omitempty"`
+	RequiredOutputs []RequiredOutput    `json:"required_outputs,omitempty"`
+	AgentPrompt     string              `json:"agent_prompt,omitempty"`
+	APIRequest      *APIRequest         `json:"api_request,omitempty"`
+	TestRequests    []TestHelperRequest `json:"test_requests,omitempty"`
+	Events          []string            `json:"events,omitempty"`
+	SDKExample      string              `json:"sdk_example,omitempty"`
+	Error           string              `json:"error,omitempty"`
+	Recovery        *Recovery           `json:"recovery,omitempty"`
 }
 
 // Validate checks the invariants agents rely on when interpreting a response.

--- a/pkg/coop/workflow/service.go
+++ b/pkg/coop/workflow/service.go
@@ -2,7 +2,9 @@
 package workflow
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -74,11 +76,23 @@ type ReportWorkInput struct {
 	Lines   string
 	Snippet string
 	Note    string
+	Outputs coop.NodeOutputs
 }
 
 func (s *Service) StartWork(sessionID string, nodeNumber int, note string) (coop.CommandResponse, error) {
+	var resolvedDefinition coop.NodeDefinition
+	var requiredOutputs []coop.RequiredOutput
 	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
 		if err := requireActiveSession(session); err != nil {
+			return err
+		}
+		var err error
+		requiredOutputs, err = session.RequiredOutputs(nodeNumber)
+		if err != nil {
+			return err
+		}
+		resolvedDefinition, err = session.ResolvedNodeDefinition(nodeNumber)
+		if err != nil {
 			return err
 		}
 		if err := session.TransitionNode(nodeNumber, coop.NodeActive); err != nil {
@@ -89,31 +103,38 @@ func (s *Service) StartWork(sessionID string, nodeNumber int, note string) (coop
 		return nil
 	})
 	if err != nil {
-		return sessionErrorResponse(err), nil
+		return errorResponse(
+			err,
+			"Inspect the session and its recorded outputs before retrying.",
+			coop.Continue(coop.StatusCommand("")),
+		), nil
 	}
 
 	node, _ := session.NodeByNumber(nodeNumber)
+	resolvedNode := *node
+	resolvedNode.NodeDefinition = resolvedDefinition
 	resp := coop.CommandResponse{
-		OK:           true,
-		SessionID:    session.ID,
-		Node:         nodeNumber,
-		State:        string(coop.NodeActive),
-		Message:      fmt.Sprintf("Started: %s", node.Title),
-		Continuation: coop.ReportWorkTemplate(session.ID, nodeNumber),
-		AgentPrompt:  nodeAgentPrompt(session, node, nodeNumber),
-		TestRequests: node.TestRequests,
-		Events:       node.Events,
+		OK:              true,
+		SessionID:       session.ID,
+		Node:            nodeNumber,
+		State:           string(coop.NodeActive),
+		Message:         fmt.Sprintf("Started: %s", resolvedNode.Title),
+		Continuation:    coop.ReportWorkTemplate(session.ID, nodeNumber, requiredOutputs),
+		RequiredOutputs: requiredOutputs,
+		AgentPrompt:     nodeAgentPrompt(session, &resolvedNode, nodeNumber, requiredOutputs),
+		TestRequests:    resolvedNode.TestRequests,
+		Events:          resolvedNode.Events,
 	}
-	if node.Type == coop.NodeAPIRequest && node.Request != nil {
-		resp.APIRequest = node.Request
-		if snippet, err := s.fetchSnippet(node.Request.Path, node.Request.Method, node.Request.Params, language(session)); err == nil {
+	if resolvedNode.Type == coop.NodeAPIRequest && resolvedNode.Request != nil {
+		resp.APIRequest = resolvedNode.Request
+		if snippet, err := s.fetchSnippet(resolvedNode.Request.Path, resolvedNode.Request.Method, resolvedNode.Request.Params, language(session)); err == nil {
 			resp.SDKExample = snippet
 		}
 	}
 	return resp, nil
 }
 
-func nodeAgentPrompt(session *coop.Session, node *coop.SessionNode, nodeNumber int) string {
+func nodeAgentPrompt(session *coop.Session, node *coop.SessionNode, nodeNumber int, requiredOutputs []coop.RequiredOutput) string {
 	stepTitle := ""
 	if step, _, _, err := session.StepByNodeNumber(nodeNumber); err == nil {
 		stepTitle = step.Title
@@ -143,6 +164,12 @@ func nodeAgentPrompt(session *coop.Session, node *coop.SessionNode, nodeNumber i
 	}
 	if node.AutoConfirm {
 		prompt.WriteString("This node is auto-confirmed, so continue immediately after reporting the work.\n")
+	}
+	if len(requiredOutputs) > 0 {
+		prompt.WriteString("\nRecord these outputs with report-work because later nodes reference them:\n")
+		for _, output := range requiredOutputs {
+			fmt.Fprintf(&prompt, "- %s\n", output.Selector())
+		}
 	}
 
 	prompt.WriteString("\nWork only on this node. Inspect the existing project before changing it, implement a working result, and verify it. Make your report-work note and report-check evidence directly address the task")
@@ -181,14 +208,8 @@ func nodeTypeGuidance(node *coop.SessionNode) string {
 }
 
 func (s *Service) ReportWork(sessionID string, nodeNumber int, input ReportWorkInput, autoConfirm bool) (coop.CommandResponse, error) {
-	if strings.TrimSpace(input.Note) == "" {
-		return errorResponse(
-			fmt.Errorf("--note flag is required"),
-			"Describe the completed implementation.",
-			coop.ReportWorkTemplate(sessionID, nodeNumber),
-		), nil
-	}
 	var targetState coop.NodeState
+	var requiredOutputs []coop.RequiredOutput
 	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
 		if err := requireActiveSession(session); err != nil {
 			return err
@@ -196,6 +217,27 @@ func (s *Service) ReportWork(sessionID string, nodeNumber int, input ReportWorkI
 		node, err := session.NodeByNumber(nodeNumber)
 		if err != nil {
 			return err
+		}
+		requiredOutputs, err = session.RequiredOutputs(nodeNumber)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(input.Note) == "" {
+			return fmt.Errorf("--note flag is required")
+		}
+		if err := mergeNodeOutputs(node, input.Outputs); err != nil {
+			return err
+		}
+		missing, err := session.MissingRequiredOutputs(nodeNumber)
+		if err != nil {
+			return err
+		}
+		if len(missing) > 0 {
+			selectors := make([]string, 0, len(missing))
+			for _, output := range missing {
+				selectors = append(selectors, output.Selector())
+			}
+			return fmt.Errorf("missing required --output values: %s", strings.Join(selectors, ", "))
 		}
 		targetState = coop.NodeReview
 		if autoConfirm || node.AutoConfirm {
@@ -220,7 +262,16 @@ func (s *Service) ReportWork(sessionID string, nodeNumber int, input ReportWorkI
 		return nil
 	})
 	if err != nil {
-		return sessionErrorResponse(err), nil
+		if current, readErr := s.store.Read(sessionID); readErr == nil {
+			if node, nodeErr := current.NodeByNumber(nodeNumber); current.Status != coop.SessionActive || (nodeErr == nil && node.State != coop.NodeActive) {
+				return sessionErrorResponse(err), nil
+			}
+		}
+		return errorResponse(
+			err,
+			"Correct the report and submit it again.",
+			coop.ReportWorkTemplate(sessionID, nodeNumber, requiredOutputs),
+		), nil
 	}
 	node, _ := session.NodeByNumber(nodeNumber)
 	return s.reportWorkResponse(session, node, nodeNumber, targetState), nil
@@ -249,30 +300,60 @@ func (s *Service) ReportCheck(sessionID string, nodeNumber int, check string, pa
 		return sessionErrorResponse(err), nil
 	}
 	node, _ := session.NodeByNumber(nodeNumber)
+	requiredOutputs, err := session.RequiredOutputs(nodeNumber)
+	if err != nil {
+		return sessionErrorResponse(err), nil
+	}
 	status := "failed"
 	if passed {
 		status = "passed"
 	}
 	return coop.CommandResponse{
-		OK:           true,
-		SessionID:    session.ID,
-		Node:         nodeNumber,
-		State:        string(node.State),
-		Message:      fmt.Sprintf("Verification %s: %s", status, check),
-		Continuation: coop.ReportWorkTemplate(session.ID, nodeNumber),
+		OK:              true,
+		SessionID:       session.ID,
+		Node:            nodeNumber,
+		State:           string(node.State),
+		Message:         fmt.Sprintf("Verification %s: %s", status, check),
+		Continuation:    coop.ReportWorkTemplate(session.ID, nodeNumber, requiredOutputs),
+		RequiredOutputs: requiredOutputs,
 	}, nil
 }
 
 func (s *Service) Skip(sessionID string, nodeNumber int, note string) (coop.CommandResponse, error) {
+	var cascaded []int
 	session, err := s.store.Update(sessionID, func(session *coop.Session) error {
 		if err := requireActiveSession(session); err != nil {
 			return err
+		}
+		dependents, err := session.DependentNodeNumbers(nodeNumber)
+		if err != nil {
+			return err
+		}
+		for _, dependentNumber := range dependents {
+			dependent, err := session.NodeByNumber(dependentNumber)
+			if err != nil {
+				return err
+			}
+			if dependent.State == coop.NodeDone {
+				return fmt.Errorf("cannot skip node %d because dependent node %d is already done", nodeNumber, dependentNumber)
+			}
 		}
 		if err := session.TransitionNode(nodeNumber, coop.NodeSkipped); err != nil {
 			return err
 		}
 		node, _ := session.NodeByNumber(nodeNumber)
 		node.Activity = note
+		for _, dependentNumber := range dependents {
+			dependent, _ := session.NodeByNumber(dependentNumber)
+			if dependent.State == coop.NodeSkipped {
+				continue
+			}
+			if err := session.TransitionNode(dependentNumber, coop.NodeSkipped); err != nil {
+				return err
+			}
+			dependent.Activity = fmt.Sprintf("Skipped because it depends on skipped node %d.", nodeNumber)
+			cascaded = append(cascaded, dependentNumber)
+		}
 		if session.IsComplete() {
 			session.Status = coop.SessionCompleted
 		}
@@ -282,12 +363,16 @@ func (s *Service) Skip(sessionID string, nodeNumber int, note string) (coop.Comm
 		return sessionErrorResponse(err), nil
 	}
 	node, _ := session.NodeByNumber(nodeNumber)
+	message := fmt.Sprintf("Skipped: %s", node.Title)
+	if len(cascaded) > 0 {
+		message += fmt.Sprintf(". Also skipped dependent nodes: %s", formatNodeNumbers(cascaded))
+	}
 	return coop.CommandResponse{
 		OK:           true,
 		SessionID:    session.ID,
 		Node:         nodeNumber,
 		State:        string(coop.NodeSkipped),
-		Message:      fmt.Sprintf("Skipped: %s", node.Title),
+		Message:      message,
 		Continuation: nextAfterNode(session, nodeNumber),
 	}, nil
 }
@@ -337,6 +422,7 @@ func (s *Service) RequestChanges(sessionID string, nodeNumbers []int, note strin
 			}
 			node.RejectionNote = note
 			node.Implementation = nil
+			node.Outputs = nil
 			node.Verifications = nil
 		}
 		return nil
@@ -570,6 +656,41 @@ func errorResponse(err error, hint string, continuation coop.Continuation) coop.
 		Error:    err.Error(),
 		Recovery: continuation.Recovery(hint),
 	}
+}
+
+func mergeNodeOutputs(node *coop.SessionNode, reported coop.NodeOutputs) error {
+	if len(reported) == 0 {
+		return nil
+	}
+	if node.Outputs == nil {
+		node.Outputs = coop.NodeOutputs{}
+	}
+	for source, values := range reported {
+		if strings.TrimSpace(source) == "" {
+			return fmt.Errorf("output source cannot be empty")
+		}
+		if node.Outputs[source] == nil {
+			node.Outputs[source] = map[string]json.RawMessage{}
+		}
+		for field, value := range values {
+			if strings.TrimSpace(field) == "" {
+				return fmt.Errorf("output field cannot be empty")
+			}
+			if !json.Valid(value) {
+				return fmt.Errorf("output %q is not valid JSON", field)
+			}
+			node.Outputs[source][field] = append(json.RawMessage(nil), value...)
+		}
+	}
+	return nil
+}
+
+func formatNodeNumbers(nodes []int) string {
+	values := make([]string, len(nodes))
+	for i, node := range nodes {
+		values[i] = strconv.Itoa(node)
+	}
+	return strings.Join(values, ", ")
 }
 
 func requireActiveSession(session *coop.Session) error {

--- a/pkg/coop/workflow/service_test.go
+++ b/pkg/coop/workflow/service_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -68,6 +69,160 @@ func TestStartWorkReturnsOnlyCurrentNodeContext(t *testing.T) {
 	require.Len(t, resp.TestRequests, 1)
 	assert.Equal(t, "advance-clock", resp.TestRequests[0].Key)
 	assert.Equal(t, []string{"invoice.created"}, resp.Events)
+}
+
+func TestReportWorkPersistsOutputsAndStartWorkResolvesLaterRequest(t *testing.T) {
+	store, err := coop.NewStoreAt(t.TempDir())
+	require.NoError(t, err)
+	session := &coop.Session{
+		SchemaVersion: coop.CurrentSessionSchemaVersion,
+		ID:            "output_workflow",
+		Status:        coop.SessionActive,
+		Settings:      map[string]string{"language": "node"},
+		Steps: []coop.SessionStep{{
+			StepDefinition: coop.StepDefinition{Key: "setup", Title: "Setup"},
+			Nodes: []coop.SessionNode{
+				{
+					NodeDefinition: coop.NodeDefinition{
+						Key:   "create-product",
+						Title: "Create product",
+						Type:  coop.NodeAPIRequest,
+						Request: &coop.APIRequest{
+							Path:   "/v1/products",
+							Method: "post",
+						},
+					},
+					State: coop.NodePending,
+				},
+				{
+					NodeDefinition: coop.NodeDefinition{
+						Key:   "use-product",
+						Title: "Use product",
+						Type:  coop.NodeAPIRequest,
+						Request: &coop.APIRequest{
+							Path:   "/v1/products/${node.setup.create-product:id}",
+							Method: "get",
+							Params: map[string]any{
+								"version": "${node.setup.create-product:latest_version}",
+							},
+						},
+					},
+					State: coop.NodePending,
+				},
+			},
+		}},
+	}
+	require.NoError(t, store.Write(session))
+	service := NewService(store, WithSnippetFetcher(func(path, method string, params interface{}, language string) (string, error) {
+		return "", nil
+	}))
+
+	start, err := service.StartWork(session.ID, 1, "Creating product")
+	require.NoError(t, err)
+	require.True(t, start.OK)
+	assert.Equal(t, []coop.RequiredOutput{
+		{Field: "id"},
+		{Field: "latest_version"},
+	}, start.RequiredOutputs)
+	assert.Empty(t, start.Next)
+	assert.Contains(t, start.NextTemplate, `--output="id=<id>"`)
+
+	missingEverything, err := service.ReportWork(session.ID, 1, ReportWorkInput{}, false)
+	require.NoError(t, err)
+	assert.False(t, missingEverything.OK)
+	assert.Contains(t, missingEverything.Error, "--note flag is required")
+	require.NotNil(t, missingEverything.Recovery)
+	assert.Contains(t, missingEverything.Recovery.NextTemplate, `--note="<what you did>"`)
+	assert.Contains(t, missingEverything.Recovery.NextTemplate, `--output="id=<id>"`)
+	assert.Contains(t, missingEverything.Recovery.NextTemplate, `--output="latest_version=<latest_version>"`)
+	require.Len(t, missingEverything.Recovery.RequiredInputs, 3)
+
+	missing, err := service.ReportWork(session.ID, 1, ReportWorkInput{Note: "Created product"}, false)
+	require.NoError(t, err)
+	assert.False(t, missing.OK)
+	assert.Contains(t, missing.Error, "missing required --output values")
+	require.NotNil(t, missing.Recovery)
+	assert.Contains(t, missing.Recovery.NextTemplate, "--output")
+
+	loaded, err := store.Read(session.ID)
+	require.NoError(t, err)
+	first, err := loaded.NodeByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodeActive, first.State)
+	assert.Empty(t, first.Outputs)
+
+	reported, err := service.ReportWork(session.ID, 1, ReportWorkInput{
+		Note: "Created product",
+		Outputs: coop.NodeOutputs{
+			coop.DefaultOutputSource: {
+				"id":             json.RawMessage(`"prod_123"`),
+				"latest_version": json.RawMessage(`7`),
+			},
+		},
+	}, false)
+	require.NoError(t, err)
+	require.True(t, reported.OK)
+
+	next, err := service.StartWork(session.ID, 2, "Using product")
+	require.NoError(t, err)
+	require.True(t, next.OK)
+	require.NotNil(t, next.APIRequest)
+	assert.Equal(t, "/v1/products/prod_123", next.APIRequest.Path)
+	params, ok := next.APIRequest.Params.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(7), params["version"])
+}
+
+func TestSkipCascadesToTransitiveOutputDependents(t *testing.T) {
+	store, err := coop.NewStoreAt(t.TempDir())
+	require.NoError(t, err)
+	session := &coop.Session{
+		SchemaVersion: coop.CurrentSessionSchemaVersion,
+		ID:            "skip_dependencies",
+		Status:        coop.SessionActive,
+		Steps: []coop.SessionStep{{
+			StepDefinition: coop.StepDefinition{Key: "setup", Title: "Setup"},
+			Nodes: []coop.SessionNode{
+				{NodeDefinition: coop.NodeDefinition{Key: "source", Title: "Source"}, State: coop.NodePending},
+				{
+					NodeDefinition: coop.NodeDefinition{
+						Key: "direct", Title: "Direct dependent",
+						Request: &coop.APIRequest{Path: "/v1/direct/${node.setup.source:id}", Method: "get"},
+					},
+					State: coop.NodePending,
+				},
+				{
+					NodeDefinition: coop.NodeDefinition{
+						Key: "transitive", Title: "Transitive dependent",
+						Request: &coop.APIRequest{Path: "/v1/transitive/${node.setup.direct:id}", Method: "get"},
+					},
+					State: coop.NodePending,
+				},
+				{NodeDefinition: coop.NodeDefinition{Key: "independent", Title: "Independent"}, State: coop.NodePending},
+			},
+		}},
+	}
+	require.NoError(t, store.Write(session))
+
+	resp, err := NewService(store).Skip(session.ID, 1, "Does not apply")
+	require.NoError(t, err)
+	require.True(t, resp.OK)
+	assert.Contains(t, resp.Message, "dependent nodes: 2, 3")
+	assert.Contains(t, resp.Next, "--step=4")
+
+	updated, err := store.Read(session.ID)
+	require.NoError(t, err)
+	for _, nodeNumber := range []int{1, 2, 3} {
+		node, err := updated.NodeByNumber(nodeNumber)
+		require.NoError(t, err)
+		assert.Equal(t, coop.NodeSkipped, node.State)
+	}
+	direct, err := updated.NodeByNumber(2)
+	require.NoError(t, err)
+	assert.Contains(t, direct.Activity, "depends on skipped node 1")
+	independent, err := updated.NodeByNumber(4)
+	require.NoError(t, err)
+	assert.Equal(t, coop.NodePending, independent.State)
 }
 
 func TestStartWorkAPIRequestGuidanceDefersPlacementToProjectContext(t *testing.T) {


### PR DESCRIPTION
## Summary

- add repeatable `report-work --output=field=value` values and persist typed node results in session state
- expose `required_outputs` and resolve backward `${node...}` references before a later node starts
- validate that references stay inside node definitions and only target earlier nodes
- cascade skips through direct and transitive output dependents so unresolved work is not started

## Stack

This follows #1835 and is the second feature slice from the original combined change. The service and agent file-organization cleanup remains separate for the final PR.

## Testing

- `make lint`
- `go test -race -count=1 ./pkg/coop/... ./pkg/cmd/coop`
- `env -u CODEX_THREAD_ID -u CODEX_SANDBOX -u CODEX_SANDBOX_NETWORK_DISABLED -u CODEX_CI make test`