### PR TITLE
Filter events by source in `--events-from` for terminal display

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -226,6 +226,7 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		ThinEvents:            thinEvents,
 		OutCh:                 proxyOutCh,
 		LoggedInAccountID:     accountID,
+		EventsFrom:            lc.eventsFrom,
 	})
 	if err != nil {
 		return err

--- a/pkg/proxy/filter_by_source_test.go
+++ b/pkg/proxy/filter_by_source_test.go
@@ -1,0 +1,128 @@
+package proxy
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stripe/stripe-cli/pkg/websocket"
+)
+
+func newProcessorWithEventsFrom(eventsFrom string) *WebhookEventProcessor {
+	return &WebhookEventProcessor{
+		cfg: &WebhookEventProcessorConfig{
+			Log:        log.StandardLogger(),
+			OutCh:      make(chan websocket.IElement, 1),
+			EventsFrom: eventsFrom,
+		},
+	}
+}
+
+func TestFilterBySource(t *testing.T) {
+	tests := []struct {
+		name       string
+		eventsFrom string
+		account    string
+		wantSkip   bool
+	}{
+		{
+			name:       "@self skips connect events",
+			eventsFrom: "@self",
+			account:    "acct_123",
+			wantSkip:   true,
+		},
+		{
+			name:       "@self allows self events",
+			eventsFrom: "@self",
+			account:    "",
+			wantSkip:   false,
+		},
+		{
+			name:       "@accounts skips self events",
+			eventsFrom: "@accounts",
+			account:    "",
+			wantSkip:   true,
+		},
+		{
+			name:       "@accounts allows connect events",
+			eventsFrom: "@accounts",
+			account:    "acct_123",
+			wantSkip:   false,
+		},
+		{
+			name:       "all allows self events",
+			eventsFrom: "all",
+			account:    "",
+			wantSkip:   false,
+		},
+		{
+			name:       "all allows connect events",
+			eventsFrom: "all",
+			account:    "acct_123",
+			wantSkip:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newProcessorWithEventsFrom(tt.eventsFrom)
+			evt := &StripeEvent{Account: tt.account}
+			assert.Equal(t, tt.wantSkip, p.filterBySource(evt))
+		})
+	}
+}
+
+func TestFilterByV2Source(t *testing.T) {
+	tests := []struct {
+		name       string
+		eventsFrom string
+		context    string
+		wantSkip   bool
+	}{
+		{
+			name:       "@self skips connect v2 events",
+			eventsFrom: "@self",
+			context:    "acct_123",
+			wantSkip:   true,
+		},
+		{
+			name:       "@self allows self v2 events",
+			eventsFrom: "@self",
+			context:    "",
+			wantSkip:   false,
+		},
+		{
+			name:       "@accounts skips self v2 events",
+			eventsFrom: "@accounts",
+			context:    "",
+			wantSkip:   true,
+		},
+		{
+			name:       "@accounts allows connect v2 events",
+			eventsFrom: "@accounts",
+			context:    "acct_123",
+			wantSkip:   false,
+		},
+		{
+			name:       "all allows self v2 events",
+			eventsFrom: "all",
+			context:    "",
+			wantSkip:   false,
+		},
+		{
+			name:       "all allows connect v2 events",
+			eventsFrom: "all",
+			context:    "acct_123",
+			wantSkip:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newProcessorWithEventsFrom(tt.eventsFrom)
+			evt := &V2EventPayload{Context: tt.context}
+			assert.Equal(t, tt.wantSkip, p.filterByV2Source(evt))
+		})
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -117,6 +117,9 @@ type Config struct {
 
 	// LoggedInAccountID is the currently logged-in account ID
 	LoggedInAccountID string
+
+	// EventsFrom filters events by source: "@self", "@accounts", or "all"
+	EventsFrom string
 }
 
 // A Proxy opens a websocket connection with Stripe, listens for incoming
@@ -453,6 +456,7 @@ func Init(ctx context.Context, cfg *Config) (*Proxy, error) {
 		SkipVerify:          cfg.SkipVerify,
 		Timeout:             cfg.Timeout,
 		LoggedInAccountID:   cfg.LoggedInAccountID,
+		EventsFrom:          cfg.EventsFrom,
 	}
 
 	p := &Proxy{

--- a/pkg/proxy/webhook_event_processor.go
+++ b/pkg/proxy/webhook_event_processor.go
@@ -38,6 +38,9 @@ type WebhookEventProcessorConfig struct {
 
 	// LoggedInAccountID is the currently logged-in account ID
 	LoggedInAccountID string
+
+	// EventsFrom filters events by source: "@self", "@accounts", or "all"
+	EventsFrom string
 }
 
 // WebhookEventProcessor encapsulates logic around processing and forwarding
@@ -150,6 +153,10 @@ func (p *WebhookEventProcessor) processEvent(webhookEvent *websocket.WebhookEven
 		return
 	}
 
+	if p.filterBySource(&evt) {
+		return
+	}
+
 	evtCtx := eventContext{
 		webhookID:             webhookEvent.WebhookID,
 		webhookConversationID: webhookEvent.WebhookConversationID,
@@ -196,6 +203,10 @@ func (p *WebhookEventProcessor) processV2Event(v2Event *websocket.StripeV2Event)
 		return
 	}
 
+	if p.filterByV2Source(&evt) {
+		return
+	}
+
 	// notify consumers
 	p.cfg.OutCh <- websocket.DataElement{
 		Data: evt,
@@ -235,6 +246,28 @@ func (p *WebhookEventProcessor) filterWebhookEvent(msg *websocket.WebhookEvent) 
 	}
 
 	return false
+}
+
+func (p *WebhookEventProcessor) filterBySource(evt *StripeEvent) bool {
+	switch p.cfg.EventsFrom {
+	case "@self":
+		return evt.IsConnect()
+	case "@accounts":
+		return !evt.IsConnect()
+	default:
+		return false
+	}
+}
+
+func (p *WebhookEventProcessor) filterByV2Source(evt *V2EventPayload) bool {
+	switch p.cfg.EventsFrom {
+	case "@self":
+		return evt.IsConnect()
+	case "@accounts":
+		return !evt.IsConnect()
+	default:
+		return false
+	}
 }
 
 func (p *WebhookEventProcessor) processEndpointResponse(evtCtx eventContext, forwardURL string, resp *http.Response) {


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Previously --events-from only controlled forwarding URLs but the terminal still displayed all events regardless of source. Now `@self` suppresses connect events and `@accounts` suppresses self events from both display and forwarding.

Before:  
connect events show up even we specified `@self`
<img width="360" height="76" alt="Screenshot 2026-07-29 at 2 55 46 PM" src="https://github.com/user-attachments/assets/5e2a60a6-9bd5-457f-9540-308e81126e0f" />

After: 
no connect events
<img width="1129" height="139" alt="Screenshot 2026-07-29 at 2 32 43 PM" src="https://github.com/user-attachments/assets/76084dc2-570e-42fc-b5a2-aa3ee7254710" />
