### PR TITLE
Add developer-products as codeowner to all CODEOWNERS entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 * @stripe/developer-products @stripe/developer-ai
 
 # `stripe docs` ownership
-/pkg/docs/ @stripe/docs-product
-/pkg/cmd/docs/ @stripe/docs-product
+/pkg/docs/ @stripe/developer-products @stripe/docs-product
+/pkg/cmd/docs/ @stripe/developer-products @stripe/docs-product


### PR DESCRIPTION
Allows the developer-products team to approve changes to /pkg/docs/ and /pkg/cmd/docs/. Claude says this is the correct pattern, since later rules override earlier ones.