### PR TITLE
Accept both text/plain and text/markdown content types

### DIFF
--- a/pkg/docs/client.go
+++ b/pkg/docs/client.go
@@ -8,6 +8,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -141,7 +142,7 @@ func (c *Client) FetchPage(ctx context.Context, ref *url.URL) (Page, error) {
 	if err != nil {
 		return Page{}, fmt.Errorf("docs: build request: %w", err)
 	}
-	req.Header.Set("Accept", "text/plain")
+	req.Header.Set("Accept", "text/plain, text/markdown")
 
 	res, err := c.do(req)
 	if err != nil {
@@ -200,8 +201,16 @@ func (c *Client) do(req *http.Request) (response, error) {
 	accept := req.Header.Get("Accept")
 	if ct := resp.Header.Get("Content-Type"); ct != "" && accept != "" {
 		mediaType, _, _ := mime.ParseMediaType(ct)
-		acceptMedia, _, _ := mime.ParseMediaType(accept)
-		if mediaType != acceptMedia {
+
+		supported := false
+		for _, acceptType := range strings.Split(accept, ",") {
+			acceptMedia, _, _ := mime.ParseMediaType(strings.TrimSpace(acceptType))
+			if mediaType == acceptMedia {
+				supported = true
+				break
+			}
+		}
+		if !supported {
 			return response{}, fmt.Errorf("docs: %s returned unsupported content type %q", req.URL, ct)
 		}
 	}

--- a/pkg/docs/client_test.go
+++ b/pkg/docs/client_test.go
@@ -137,7 +137,7 @@ func TestFetchPage(t *testing.T) {
 			name: "success with params",
 			ref:  &url.URL{Path: "/payments", RawQuery: "api_version=2024-06-30"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, "text/plain", r.Header.Get("Accept"))
+				assert.Equal(t, "text/plain, text/markdown", r.Header.Get("Accept"))
 				assert.Contains(t, r.Header.Get("User-Agent"), "stripe-cli/")
 				assert.Equal(t, "/payments", r.URL.Path)
 				assert.Equal(t, "2024-06-30", r.URL.Query().Get("api_version"))
@@ -194,6 +194,17 @@ func TestFetchPage(t *testing.T) {
 			},
 			wantCheck: func(t *testing.T, got Page) {
 				assert.Equal(t, []byte("plain content"), got.Content)
+			},
+		},
+		{
+			name: "text/markdown with charset is accepted",
+			ref:  &url.URL{Path: "/markdown"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+				fmt.Fprint(w, "# markdown content")
+			},
+			wantCheck: func(t *testing.T, got Page) {
+				assert.Equal(t, []byte("# markdown content"), got.Content)
 			},
 		},
 	}


### PR DESCRIPTION
 ### Summary

The CLI only accepts the `text/plain` content type, in reality it should also accept `text/markdown` which is equivalent in response. To support this, we add `text/plain; text/markdown` to the accept header and validate that either of those are the returned content type so we could support a response that's either `text/plain` or `text/markdown`.