### PR TITLE
Add --runtime-version flag to plugin commands

### DIFF
--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -61,6 +61,7 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 	}
 
 	ptc.cmd.Flags().String("runtime-version", "", "Run a specific installed plugin version (e.g. 1.5.2 or local.build.dev)")
+	ptc.cmd.Flags().MarkHidden("runtime-version") // #nosec G104 -- development-only flag
 
 	// override the CLI's help command and let the plugin supply the help text instead
 	ptc.cmd.SetHelpFunc(func(c *cobra.Command, s []string) {

--- a/pkg/cmd/plugin_cmds.go
+++ b/pkg/cmd/plugin_cmds.go
@@ -18,13 +18,14 @@ import (
 )
 
 var pluginTelemetryFlagsWithValues = map[string]struct{}{
-	"--api-key":      {},
-	"--color":        {},
-	"--config":       {},
-	"--device-name":  {},
-	"--log-level":    {},
-	"--project-name": {},
-	"-p":             {},
+	"--api-key":         {},
+	"--color":           {},
+	"--config":          {},
+	"--device-name":     {},
+	"--log-level":       {},
+	"--project-name":    {},
+	"--runtime-version": {},
+	"-p":                {},
 }
 
 type pluginTemplateCmd struct {
@@ -58,6 +59,8 @@ func newPluginTemplateCmd(config *config.Config, plugin *plugins.Plugin) *plugin
 			UnknownFlags: true,
 		},
 	}
+
+	ptc.cmd.Flags().String("runtime-version", "", "Run a specific installed plugin version (e.g. 1.5.2 or local.build.dev)")
 
 	// override the CLI's help command and let the plugin supply the help text instead
 	ptc.cmd.SetHelpFunc(func(c *cobra.Command, s []string) {
@@ -113,7 +116,8 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
-	ptc.ParsedArgs = args
+	cleanedArgs, runtimeVersion := stripRuntimeVersionFlag(args)
+	ptc.ParsedArgs = cleanedArgs
 
 	fs := afero.NewOsFs()
 	plugin, err := plugins.LookUpPlugin(ctx, ptc.cfg, fs, ptc.cmd.Name())
@@ -126,7 +130,7 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 		"prefix": "cmd.pluginCmd.runPluginCmd",
 	}).Debug("Running plugin...")
 
-	err = plugin.Run(ctx, ptc.cfg, fs, ptc.ParsedArgs, "")
+	err = plugin.Run(ctx, ptc.cfg, fs, ptc.ParsedArgs, "", runtimeVersion)
 	plugins.CleanupAllClients()
 	if err == nil {
 		dashboardBaseURL := stripe.DashboardBaseURLForAPIBaseURL(stripe.DefaultAPIBaseURL)
@@ -148,6 +152,35 @@ func (ptc *pluginTemplateCmd) runPluginCmd(cmd *cobra.Command, args []string) er
 	}
 
 	return nil
+}
+
+// stripRuntimeVersionFlag removes --runtime-version and its value from args
+// so the flag is not forwarded to the plugin binary. It handles both
+// "--runtime-version <val>" and "--runtime-version=<val>" forms.
+// Args after "--" are not inspected.
+func stripRuntimeVersionFlag(args []string) (cleaned []string, version string) {
+	const flagName = "--runtime-version"
+	cleaned = make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			cleaned = append(cleaned, args[i:]...)
+			break
+		}
+		if arg == flagName {
+			if i+1 < len(args) {
+				version = args[i+1]
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(arg, flagName+"=") {
+			version = strings.TrimPrefix(arg, flagName+"=")
+			continue
+		}
+		cleaned = append(cleaned, arg)
+	}
+	return cleaned, version
 }
 
 func commandContextOrBackground(cmd *cobra.Command) context.Context {

--- a/pkg/cmd/plugin_cmds_test.go
+++ b/pkg/cmd/plugin_cmds_test.go
@@ -69,6 +69,14 @@ func TestPluginCommandSetsLongFromDescription(t *testing.T) {
 	assert.Equal(t, "Manage your account from the terminal and update settings like branding, checkout color and more.", ptc.cmd.Long)
 }
 
+func TestRuntimeVersionFlagIsHidden(t *testing.T) {
+	pluginCmd := createPluginCmd()
+
+	flag := pluginCmd.cmd.Flags().Lookup("runtime-version")
+	require.NotNil(t, flag)
+	assert.True(t, flag.Hidden)
+}
+
 func TestPluginCommandLongEmptyWhenNoDescription(t *testing.T) {
 	plugin := plugins.Plugin{
 		Shortname:        "simple",

--- a/pkg/cmd/plugin_cmds_test.go
+++ b/pkg/cmd/plugin_cmds_test.go
@@ -318,3 +318,113 @@ func TestResolvePluginTelemetryCommandPathUsesResolvedPluginStubPath(t *testing.
 		resolvePluginTelemetryCommandPath(listCmd, []string{"stripe", "projects", "billing", "list", "--json"}),
 	)
 }
+
+func TestStripRuntimeVersionFlag(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		expectedCleaned []string
+		expectedVersion string
+	}{
+		{
+			name:            "no flag present",
+			args:            []string{"list", "--json"},
+			expectedCleaned: []string{"list", "--json"},
+			expectedVersion: "",
+		},
+		{
+			name:            "space-separated form",
+			args:            []string{"--runtime-version", "1.5.2", "list"},
+			expectedCleaned: []string{"list"},
+			expectedVersion: "1.5.2",
+		},
+		{
+			name:            "equals form",
+			args:            []string{"--runtime-version=1.5.2", "list"},
+			expectedCleaned: []string{"list"},
+			expectedVersion: "1.5.2",
+		},
+		{
+			name:            "local.build.dev value",
+			args:            []string{"--runtime-version", "local.build.dev", "list"},
+			expectedCleaned: []string{"list"},
+			expectedVersion: "local.build.dev",
+		},
+		{
+			name:            "flag in the middle",
+			args:            []string{"create", "--runtime-version", "2.0.0", "--name", "foo"},
+			expectedCleaned: []string{"create", "--name", "foo"},
+			expectedVersion: "2.0.0",
+		},
+		{
+			name:            "flag at the end",
+			args:            []string{"list", "--runtime-version", "1.0.0"},
+			expectedCleaned: []string{"list"},
+			expectedVersion: "1.0.0",
+		},
+		{
+			name:            "flag after double dash is not stripped",
+			args:            []string{"run", "--", "--runtime-version", "1.0.0"},
+			expectedCleaned: []string{"run", "--", "--runtime-version", "1.0.0"},
+			expectedVersion: "",
+		},
+		{
+			name:            "empty args",
+			args:            []string{},
+			expectedCleaned: []string{},
+			expectedVersion: "",
+		},
+		{
+			name:            "flag with no value",
+			args:            []string{"--runtime-version"},
+			expectedCleaned: []string{},
+			expectedVersion: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleaned, version := stripRuntimeVersionFlag(tt.args)
+			assert.Equal(t, tt.expectedCleaned, cleaned)
+			assert.Equal(t, tt.expectedVersion, version)
+		})
+	}
+}
+
+func TestRuntimeVersionFlagStrippedFromParsedArgs(t *testing.T) {
+	pluginCmd := createPluginCmd()
+
+	sentinelErr := errors.New("stop")
+	pluginCmd.runPluginCmdFn = func(cmd *cobra.Command, args []string) error {
+		cleaned, _ := stripRuntimeVersionFlag(args)
+		pluginCmd.ParsedArgs = cleaned
+		return sentinelErr
+	}
+
+	root := &cobra.Command{Use: "stripe"}
+	root.AddCommand(pluginCmd.cmd)
+
+	oldArgs := os.Args
+	os.Args = []string{"stripe", "test", "--runtime-version", "1.0.0", "subcommand"}
+	defer func() { os.Args = oldArgs }()
+
+	root.SetArgs([]string{"test", "--runtime-version", "1.0.0", "subcommand"})
+	root.ExecuteContext(context.Background())
+
+	assert.Equal(t, []string{"subcommand"}, pluginCmd.ParsedArgs)
+}
+
+func TestResolvePluginTelemetryCommandPathSkipsRuntimeVersionFlag(t *testing.T) {
+	root := &cobra.Command{Use: "stripe"}
+	pluginCmd := &cobra.Command{
+		Use:         "apps",
+		Annotations: map[string]string{"scope": "plugin"},
+	}
+	root.AddCommand(pluginCmd)
+
+	assert.Equal(
+		t,
+		"stripe apps list",
+		resolvePluginTelemetryCommandPath(pluginCmd, []string{"stripe", "apps", "--runtime-version", "1.5.2", "list"}),
+	)
+}

--- a/pkg/plugins/core_cli_helper.go
+++ b/pkg/plugins/core_cli_helper.go
@@ -317,5 +317,5 @@ func (h *coreCLIHelper) RunPeerPlugin(pluginName string, args []string, cwd stri
 	if !ok {
 		return fmt.Errorf("could not run peer plugin %q: config type mismatch", pluginName)
 	}
-	return plugin.Run(h.ctx, cfg, h.fs, args, cwd)
+	return plugin.Run(h.ctx, cfg, h.fs, args, cwd, "")
 }

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -582,14 +582,26 @@ func buildAdditionalInfo(logger *log.Entry) *proto.AdditionalInfo {
 
 // Run boots up the binary and then sends the command to it via RPC.
 // cwd sets the working directory for the plugin process; an empty string uses the current directory.
-func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, args []string, cwd string) error {
+// versionOverride, when non-empty, forces the plugin to run at that specific installed version,
+// bypassing the automatic version resolution (including local.build.dev priority).
+func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, args []string, cwd string, versionOverride string) error {
 	logger := log.WithFields(log.Fields{
 		"prefix": "plugins.plugin.Run",
 	})
 
 	var version string
 
-	if PluginsPath != "" {
+	if versionOverride != "" {
+		version = versionOverride
+		if !p.IsVersionInstalled(config, fs, version) {
+			installed := p.InstalledVersion(config, fs)
+			hint := ""
+			if installed != "" {
+				hint = fmt.Sprintf("; installed version is %s", installed)
+			}
+			return fmt.Errorf("plugin %q version %q is not installed%s", p.Shortname, version, hint)
+		}
+	} else if PluginsPath != "" {
 		version = localDevelopmentVersion
 	} else {
 		var err error

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -591,7 +591,8 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 
 	var version string
 
-	if versionOverride != "" {
+	switch {
+	case versionOverride != "":
 		version = versionOverride
 		if !p.IsVersionInstalled(config, fs, version) {
 			installed := p.InstalledVersion(config, fs)
@@ -601,9 +602,9 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 			}
 			return fmt.Errorf("plugin %q version %q is not installed%s", p.Shortname, version, hint)
 		}
-	} else if PluginsPath != "" {
+	case PluginsPath != "":
 		version = localDevelopmentVersion
-	} else {
+	default:
 		var err error
 		version, err = p.lookUpInstalledVersion(config, fs)
 		if err != nil {

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -787,6 +787,84 @@ func TestInstallDoesNotCleanIfInstallFails(t *testing.T) {
 	require.True(t, fileExists, "Did not expect the original version of the plugin to be deleted.")
 }
 
+func TestRunVersionOverrideNotInstalled(t *testing.T) {
+	fs := setUpFS()
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+
+	t.Setenv("STRIPE_PLUGINS_PATH", "/plugins")
+
+	plugin, _ := LookUpPlugin(context.Background(), cfg, fs, "appA")
+
+	// Only local.build.dev is on disk
+	require.NoError(t, fs.MkdirAll("/plugins/appA/local.build.dev", 0755))
+	afero.WriteFile(fs, "/plugins/appA/local.build.dev/stripe-cli-app-a"+GetBinaryExtension(), []byte("bin"), 0755)
+
+	// Temporarily clear PluginsPath so it doesn't force local.build.dev
+	origPluginsPath := PluginsPath
+	PluginsPath = ""
+	defer func() { PluginsPath = origPluginsPath }()
+
+	err := plugin.Run(context.Background(), &cfg.Config, fs, nil, "", "9.9.9")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `plugin "appA" version "9.9.9" is not installed`)
+	require.Contains(t, err.Error(), "installed version is local.build.dev")
+}
+
+func TestRunVersionOverrideSelectsSpecifiedVersion(t *testing.T) {
+	fs := setUpFS()
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+
+	t.Setenv("STRIPE_PLUGINS_PATH", "/plugins")
+
+	plugin, _ := LookUpPlugin(context.Background(), cfg, fs, "appA")
+
+	// Both local.build.dev and 1.0.1 exist on disk
+	require.NoError(t, fs.MkdirAll("/plugins/appA/local.build.dev", 0755))
+	afero.WriteFile(fs, "/plugins/appA/local.build.dev/stripe-cli-app-a"+GetBinaryExtension(), []byte("bin"), 0755)
+	require.NoError(t, fs.MkdirAll("/plugins/appA/1.0.1", 0755))
+	afero.WriteFile(fs, "/plugins/appA/1.0.1/stripe-cli-app-a"+GetBinaryExtension(), []byte("bin"), 0755)
+
+	origPluginsPath := PluginsPath
+	PluginsPath = ""
+	defer func() { PluginsPath = origPluginsPath }()
+
+	// Run with override "1.0.1" — this will get past version resolution but fail
+	// at the go-plugin handshake (expected; we're testing that version resolution works).
+	err := plugin.Run(context.Background(), &cfg.Config, fs, nil, "", "1.0.1")
+	// The error should NOT be about version not installed; it should be a runtime error
+	// from trying to actually execute the fake binary.
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "is not installed")
+}
+
+func TestRunVersionOverrideBypassesLocalBuildDev(t *testing.T) {
+	fs := setUpFS()
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+
+	t.Setenv("STRIPE_PLUGINS_PATH", "/plugins")
+
+	plugin, _ := LookUpPlugin(context.Background(), cfg, fs, "appA")
+
+	// Both exist
+	require.NoError(t, fs.MkdirAll("/plugins/appA/local.build.dev", 0755))
+	afero.WriteFile(fs, "/plugins/appA/local.build.dev/stripe-cli-app-a"+GetBinaryExtension(), []byte("bin"), 0755)
+	require.NoError(t, fs.MkdirAll("/plugins/appA/2.0.1", 0755))
+	afero.WriteFile(fs, "/plugins/appA/2.0.1/stripe-cli-app-a"+GetBinaryExtension(), []byte("bin"), 0755)
+
+	origPluginsPath := PluginsPath
+	PluginsPath = ""
+	defer func() { PluginsPath = origPluginsPath }()
+
+	// Without override, lookUpInstalledVersion would return local.build.dev.
+	// With override "2.0.1", it should bypass that and use 2.0.1.
+	err := plugin.Run(context.Background(), &cfg.Config, fs, nil, "", "2.0.1")
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "is not installed")
+}
+
 func TestLookUpInstalledVersionPrefersLocalDevelopmentVersion(t *testing.T) {
 	fs := setUpFS()
 	config := &TestConfig{}


### PR DESCRIPTION
Allow users to specify which installed plugin version to run, bypassing the automatic version resolution that always prefers local.build.dev.

This feature is requested by the plugin owners

Locally tested:


<img width="1320" height="221" alt="Screenshot 2026-08-04 at 4 05 51 PM" src="https://github.com/user-attachments/assets/3d86120f-1921-4729-8703-730a5afa707a" />


<img width="1420" height="147" alt="Screenshot 2026-08-04 at 4 05 15 PM" src="https://github.com/user-attachments/assets/950e1ab5-fdf4-43aa-b161-765f34436b9f" />

 ### Reviewers
r? @
cc @stripe/developer-products

