### PR TITLE
Route authenticated docs requests to the v2 API

### DIFF
--- a/pkg/cmd/docs/api_test.go
+++ b/pkg/cmd/docs/api_test.go
@@ -55,6 +55,36 @@ func TestAPICommand_FollowsRedirect(t *testing.T) {
 	assert.Contains(t, out.String(), "Returns a list of")
 }
 
+func TestAPICommand_Authenticated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/docs/page", r.URL.Path)
+		assert.Equal(t, "/_endpoint/api-reference-locator?q=GET+%2Fv1%2Fproducts", r.URL.Query().Get("path"))
+		assert.Equal(t, "Bearer sk_test_123", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"content":"# List Products\n\nReturns a list of products."}`)
+	}))
+	defer server.Close()
+
+	client := docs.NewClient("test").WithOptions(
+		docs.WithAPIBaseURL(server.URL),
+		docs.WithAPIKey("sk_test_123"),
+	)
+	renderer, err := markdown.NewRenderer(markdown.WithStyle("notty"))
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	root := cmd.New().WithOptions(
+		cmd.WithClient(client),
+		cmd.WithRenderer(renderer),
+	).Root()
+	root.SetOut(&out)
+	root.SetArgs([]string{"api", "GET", "/v1/products"})
+
+	err = root.ExecuteContext(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Returns a list of")
+}
+
 func TestAPICommand_ResourceLookup(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/pkg/cmd/docs/root.go
+++ b/pkg/cmd/docs/root.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/term"
 
 	cliconfig "github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/useragent"
 	"github.com/stripe/stripe-cli/pkg/version"
 
@@ -38,6 +39,7 @@ type RootCommand struct {
 
 	noPager        bool
 	nonInteractive bool
+	apiBaseURL     string
 }
 
 // Option is a functional option for configuring RootCommand.
@@ -62,6 +64,11 @@ func WithLogger(logger *log.Entry) Option {
 // populated by cobra flag parsing at runtime (e.g. --color, --log-level).
 func WithConfig(cfg *cliconfig.Config) Option {
 	return func(r *RootCommand) { r.cfg = cfg }
+}
+
+// WithAPIBaseURL sets the Stripe API base URL used for authenticated requests.
+func WithAPIBaseURL(u string) Option {
+	return func(r *RootCommand) { r.apiBaseURL = u }
 }
 
 // New creates a new RootCommand with sensible defaults.
@@ -96,6 +103,8 @@ Read API Reference pages by their identifier:
 	agentDetected := useragent.DetectAIAgent(os.Getenv) != ""
 	r.cmd.PersistentFlags().BoolVar(&r.noPager, "no-pager", agentDetected, "Write output directly to stdout")
 	r.cmd.PersistentFlags().BoolVar(&r.nonInteractive, "non-interactive", agentDetected, "Write output directly without the interactive browser")
+	r.cmd.PersistentFlags().StringVar(&r.apiBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
+	_ = r.cmd.PersistentFlags().MarkHidden("api-base")
 
 	docsGroup := &cobra.Group{ID: "docs", Title: "Docs Commands:"}
 
@@ -152,6 +161,9 @@ func (r *RootCommand) initClient() {
 			clientOpts = append(clientOpts, pkgdocs.WithAPIKey(creds.Token))
 		}
 	}
+	if r.apiBaseURL != "" {
+		clientOpts = append(clientOpts, pkgdocs.WithAPIBaseURL(r.apiBaseURL))
+	}
 	if len(clientOpts) > 0 {
 		r.client.WithOptions(clientOpts...)
 	}
@@ -196,6 +208,18 @@ func (r *RootCommand) preRun(_ *cobra.Command, _ []string) error {
 	r.initLogger()
 	r.initRenderer()
 	if r.client != nil {
+		var credOpts []pkgdocs.ClientOption
+		if r.cfg != nil {
+			if creds, err := r.cfg.Profile.ResolveCredentials(false); err == nil {
+				credOpts = append(credOpts, pkgdocs.WithAPIKey(creds.Token))
+			}
+		}
+		if r.cmd.PersistentFlags().Changed("api-base") {
+			credOpts = append(credOpts, pkgdocs.WithAPIBaseURL(r.apiBaseURL))
+		}
+		if len(credOpts) > 0 {
+			r.client.WithOptions(credOpts...)
+		}
 		r.client.WithOptions(pkgdocs.WithPrefs(r.loadDocsPrefMap()))
 	}
 	if r.logger != nil {

--- a/pkg/cmd/docs/root_test.go
+++ b/pkg/cmd/docs/root_test.go
@@ -17,6 +17,7 @@ import (
 	cmd "github.com/stripe/stripe-cli/pkg/cmd/docs"
 	"github.com/stripe/stripe-cli/pkg/docs"
 	"github.com/stripe/stripe-cli/pkg/docs/markdown"
+	"github.com/stripe/stripe-cli/pkg/requests"
 )
 
 func TestNew(t *testing.T) {
@@ -356,7 +357,7 @@ func TestFetchPage_Authenticated(t *testing.T) {
 	assert.Contains(t, out.String(), "Payments")
 	assert.Equal(t, "/payments", gotPath)
 	assert.Equal(t, "Bearer sk_test_123", gotAuth)
-	assert.Equal(t, "unsafe-development", gotVersion)
+	assert.Equal(t, requests.StripeVersionHeaderValue, gotVersion)
 }
 
 func TestRootCommand_NoTUI_RendersOutput(t *testing.T) {

--- a/pkg/cmd/docs/root_test.go
+++ b/pkg/cmd/docs/root_test.go
@@ -324,6 +324,41 @@ func TestPrefsNotOverriddenByExistingQueryParam(t *testing.T) {
 	assert.NotContains(t, gotQuery, "lang=ruby")
 }
 
+func TestFetchPage_Authenticated(t *testing.T) {
+	var gotPath, gotAuth, gotVersion string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/docs/page", r.URL.Path)
+		gotPath = r.URL.Query().Get("path")
+		gotAuth = r.Header.Get("Authorization")
+		gotVersion = r.Header.Get("Stripe-Version")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"content":"# Payments\n\nAccept payments with Stripe."}`)
+	}))
+	defer server.Close()
+
+	client := docs.NewClient("test").WithOptions(
+		docs.WithAPIBaseURL(server.URL),
+		docs.WithAPIKey("sk_test_123"),
+	)
+	renderer, err := markdown.NewRenderer()
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	root := cmd.New().WithOptions(
+		cmd.WithClient(client),
+		cmd.WithRenderer(renderer),
+	).Root()
+	root.SetOut(&out)
+	root.SetArgs([]string{"--non-interactive", "/payments"})
+
+	err = root.ExecuteContext(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Payments")
+	assert.Equal(t, "/payments", gotPath)
+	assert.Equal(t, "Bearer sk_test_123", gotAuth)
+	assert.Equal(t, "unsafe-development", gotVersion)
+}
+
 func TestRootCommand_NoTUI_RendersOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "# Payments\n\nAccept payments with Stripe.")

--- a/pkg/cmd/docs/search_test.go
+++ b/pkg/cmd/docs/search_test.go
@@ -87,6 +87,36 @@ func TestSearchCommand_ColorOff(t *testing.T) {
 	assert.Contains(t, output, "stripe docs /keys")
 }
 
+func TestSearchCommand_Authenticated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/docs/search", r.URL.Path)
+		assert.Equal(t, "payment methods", r.URL.Query().Get("query"))
+		assert.Equal(t, "Bearer sk_test_123", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"hits":[{"title":"Accept a payment","url":"https://docs.stripe.com/payments/accept-a-payment"}]}`)
+	}))
+	defer server.Close()
+
+	client := docs.NewClient("test").WithOptions(
+		docs.WithAPIBaseURL(server.URL),
+		docs.WithAPIKey("sk_test_123"),
+	)
+
+	var out bytes.Buffer
+	root := cmd.New().WithOptions(
+		cmd.WithClient(client),
+	).Root()
+	root.SetOut(&out)
+	root.SetArgs([]string{"search", "payment methods"})
+
+	err := root.ExecuteContext(context.Background())
+	require.NoError(t, err)
+
+	plainOutput := stripANSI(out.String())
+	assert.Contains(t, plainOutput, "Accept a payment")
+}
+
 func TestSearchCommand_MissingQuery(t *testing.T) {
 	root := cmd.New().Root()
 	root.SetOut(new(bytes.Buffer))

--- a/pkg/docs/client.go
+++ b/pkg/docs/client.go
@@ -12,12 +12,12 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/useragent"
 )
 
 const defaultBaseURL = "https://docs.stripe.com"
 const defaultAPIBaseURL = "https://api.stripe.com"
-const docsAPIVersion = "unsafe-development"
 
 // Page holds the content and metadata of a fetched documentation page.
 type Page struct {
@@ -200,7 +200,7 @@ func (c *Client) fetchPageViaAPI(ctx context.Context, ref *url.URL) (Page, error
 		return Page{}, fmt.Errorf("docs: build request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Stripe-Version", docsAPIVersion)
+	req.Header.Set("Stripe-Version", requests.StripeVersionHeaderValue)
 
 	res, err := c.do(req)
 	if err != nil {
@@ -335,7 +335,7 @@ func (c *Client) Search(ctx context.Context, query string) (*SearchResponse, err
 		return nil, fmt.Errorf("search: build request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Stripe-Version", docsAPIVersion)
+	req.Header.Set("Stripe-Version", requests.StripeVersionHeaderValue)
 
 	res, err := c.do(req)
 	if err != nil {

--- a/pkg/docs/client.go
+++ b/pkg/docs/client.go
@@ -16,6 +16,8 @@ import (
 )
 
 const defaultBaseURL = "https://docs.stripe.com"
+const defaultAPIBaseURL = "https://api.stripe.com"
+const docsAPIVersion = "unsafe-development"
 
 // Page holds the content and metadata of a fetched documentation page.
 type Page struct {
@@ -42,6 +44,7 @@ type Hit struct {
 type Client struct {
 	http           *http.Client
 	baseURL        *url.URL
+	apiBaseURL     *url.URL
 	userAgent      string
 	apiKey         string
 	cacheKeyPrefix string
@@ -70,6 +73,12 @@ func WithLogger(logger *log.Entry) ClientOption { return func(c *Client) { c.log
 // WithAPIKey sets the Stripe API key sent as an Authorization header on every request.
 func WithAPIKey(key string) ClientOption { return func(c *Client) { c.apiKey = key } }
 
+// WithAPIBaseURL overrides the Stripe API base URL used for authenticated requests
+// (defaults to https://api.stripe.com).
+func WithAPIBaseURL(u string) ClientOption {
+	return func(c *Client) { c.apiBaseURL, _ = url.Parse(u) }
+}
+
 // WithCacheKeyPrefix scopes the FetchPage cache to a specific account by prefixing
 // all cache keys with prefix. Pass the account ID (e.g. "acct_xxx") so that cached
 // entries from one account are never served to another. An empty prefix is a no-op,
@@ -87,13 +96,15 @@ func WithPrefs(prefs map[string]string) ClientOption {
 // NewClient creates a Client configured to talk to docs.stripe.com.
 func NewClient(_ string) *Client {
 	base, _ := url.Parse(defaultBaseURL)
+	apiBase, _ := url.Parse(defaultAPIBaseURL)
 	client := http.Client{Timeout: 10 * time.Second}
 
 	return &Client{
-		http:      &client,
-		baseURL:   base,
-		userAgent: useragent.GetEncodedUserAgent(),
-		logger:    log.NewEntry(log.StandardLogger()),
+		http:       &client,
+		baseURL:    base,
+		apiBaseURL: apiBase,
+		userAgent:  useragent.GetEncodedUserAgent(),
+		logger:     log.NewEntry(log.StandardLogger()),
 	}
 }
 
@@ -105,10 +116,21 @@ func (c *Client) WithOptions(opts ...ClientOption) *Client {
 	return c
 }
 
+// retrieveDocResponse is the JSON envelope returned by the authenticated
+// /v2/docs/page endpoint.
+type retrieveDocResponse struct {
+	Content     string `json:"content"`
+	ContentType string `json:"content_type"`
+}
+
 // FetchPage retrieves a documentation page as plain text, using cache when available.
 //
 //	page, err := c.FetchPage(ctx, &url.URL{Path: "/payments/accept-a-payment", RawQuery: "api_version=2024-06-30"})
 func (c *Client) FetchPage(ctx context.Context, ref *url.URL) (Page, error) {
+	if c.apiKey != "" {
+		return c.fetchPageViaAPI(ctx, ref)
+	}
+
 	resolvedURL := c.baseURL.ResolveReference(ref)
 	// Merge stored prefs as query params, skipping any key already present in the ref.
 	// url.Values.Encode() sorts params, giving a consistent cache key.
@@ -162,6 +184,45 @@ func (c *Client) FetchPage(ctx context.Context, ref *url.URL) (Page, error) {
 	}, nil
 }
 
+// fetchPageViaAPI retrieves a documentation page through the authenticated
+// v2 API on api.stripe.com. The original docs.stripe.com-style ref (path plus
+// query string) is forwarded as the "path" query parameter, so both regular
+// pages and internal endpoints like the API reference locator work the same
+// way as the unauthenticated path.
+func (c *Client) fetchPageViaAPI(ctx context.Context, ref *url.URL) (Page, error) {
+	pathValue := ref.RequestURI()
+
+	u := c.apiBaseURL.JoinPath("/v2/docs/page")
+	u.RawQuery = url.Values{"path": {pathValue}}.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return Page{}, fmt.Errorf("docs: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Stripe-Version", docsAPIVersion)
+
+	res, err := c.do(req)
+	if err != nil {
+		return Page{}, err
+	}
+
+	var apiResp retrieveDocResponse
+	if err := json.Unmarshal(res.body, &apiResp); err != nil {
+		return Page{}, fmt.Errorf("docs: unmarshal page response: %w", err)
+	}
+
+	// Reconstruct the original docs.stripe.com URL so callers (e.g. the TUI's
+	// "open in browser" action) have something meaningful to work with.
+	resolvedURL := (&url.URL{Scheme: "https", Host: "docs.stripe.com"}).ResolveReference(ref)
+
+	return Page{
+		Content:   []byte(apiResp.Content),
+		URL:       resolvedURL,
+		FetchedAt: time.Now(),
+	}, nil
+}
+
 type response struct {
 	body     []byte
 	finalURL *url.URL
@@ -178,6 +239,9 @@ func (c *Client) cacheKey(rawURL string) string {
 
 func (c *Client) do(req *http.Request) (response, error) {
 	req.Header.Set("User-Agent", c.userAgent)
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
 
 	start := time.Now()
 	resp, err := c.http.Do(req)
@@ -257,7 +321,13 @@ func (c *Client) Search(ctx context.Context, query string) (*SearchResponse, err
 	if query == "" {
 		return &SearchResponse{}, nil
 	}
-	u := c.baseURL.JoinPath("/_endpoint/search")
+
+	var u *url.URL
+	if c.apiKey != "" {
+		u = c.apiBaseURL.JoinPath("/v2/docs/search")
+	} else {
+		u = c.baseURL.JoinPath("/_endpoint/search")
+	}
 	u.RawQuery = url.Values{"query": {query}}.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
@@ -265,6 +335,7 @@ func (c *Client) Search(ctx context.Context, query string) (*SearchResponse, err
 		return nil, fmt.Errorf("search: build request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Stripe-Version", docsAPIVersion)
 
 	res, err := c.do(req)
 	if err != nil {

--- a/pkg/docs/client_test.go
+++ b/pkg/docs/client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/useragent"
 )
 
@@ -656,7 +657,7 @@ func TestFetchPage_Authenticated_UsesAPIEndpoint(t *testing.T) {
 		assert.Equal(t, "/v2/docs/page", r.URL.Path)
 		assert.Equal(t, "/payments?api_version=2024-06-30", r.URL.Query().Get("path"))
 		assert.Equal(t, "Bearer sk_test_123", r.Header.Get("Authorization"))
-		assert.Equal(t, "unsafe-development", r.Header.Get("Stripe-Version"))
+		assert.Equal(t, requests.StripeVersionHeaderValue, r.Header.Get("Stripe-Version"))
 		assert.Equal(t, "application/json", r.Header.Get("Accept"))
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"content":"page content","content_type":"text/markdown"}`)
@@ -711,7 +712,7 @@ func TestSearch_Authenticated_UsesAPIEndpoint(t *testing.T) {
 		assert.Equal(t, "/v2/docs/search", r.URL.Path)
 		assert.Equal(t, "payments", r.URL.Query().Get("query"))
 		assert.Equal(t, "Bearer sk_test_123", r.Header.Get("Authorization"))
-		assert.Equal(t, "unsafe-development", r.Header.Get("Stripe-Version"))
+		assert.Equal(t, requests.StripeVersionHeaderValue, r.Header.Get("Stripe-Version"))
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"hits":[{"title":"Accept a payment","url":"https://docs.stripe.com/payments/accept-a-payment"}]}`)
 	}))

--- a/pkg/docs/client_test.go
+++ b/pkg/docs/client_test.go
@@ -651,6 +651,98 @@ func TestFetchPageWithPrefs(t *testing.T) {
 	}
 }
 
+func TestFetchPage_Authenticated_UsesAPIEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/docs/page", r.URL.Path)
+		assert.Equal(t, "/payments?api_version=2024-06-30", r.URL.Query().Get("path"))
+		assert.Equal(t, "Bearer sk_test_123", r.Header.Get("Authorization"))
+		assert.Equal(t, "unsafe-development", r.Header.Get("Stripe-Version"))
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"content":"page content","content_type":"text/markdown"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("0.1.0").WithOptions(
+		WithAPIBaseURL(server.URL),
+		WithAPIKey("sk_test_123"),
+	)
+
+	got, err := client.FetchPage(context.Background(), &url.URL{Path: "/payments", RawQuery: "api_version=2024-06-30"})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("page content"), got.Content)
+	assert.Equal(t, "docs.stripe.com", got.URL.Host)
+	assert.Equal(t, "/payments", got.URL.Path)
+}
+
+func TestFetchPage_Authenticated_ForwardsLocatorPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/_endpoint/api-reference-locator?q=GET+%2Fv1%2Fproducts", r.URL.Query().Get("path"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"content":"locator content"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("0.1.0").WithOptions(WithAPIBaseURL(server.URL), WithAPIKey("sk_test_123"))
+
+	ref := &url.URL{
+		Path:     "/_endpoint/api-reference-locator",
+		RawQuery: url.Values{"q": {"GET /v1/products"}}.Encode(),
+	}
+	got, err := client.FetchPage(context.Background(), ref)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("locator content"), got.Content)
+}
+
+func TestFetchPage_Unauthenticated_DoesNotSetAuthorizationHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Authorization"))
+		fmt.Fprint(w, "content")
+	}))
+	defer server.Close()
+
+	client := NewClient("0.1.0").WithOptions(WithBaseURL(server.URL))
+	_, err := client.FetchPage(context.Background(), &url.URL{Path: "/payments"})
+	require.NoError(t, err)
+}
+
+func TestSearch_Authenticated_UsesAPIEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/docs/search", r.URL.Path)
+		assert.Equal(t, "payments", r.URL.Query().Get("query"))
+		assert.Equal(t, "Bearer sk_test_123", r.Header.Get("Authorization"))
+		assert.Equal(t, "unsafe-development", r.Header.Get("Stripe-Version"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"hits":[{"title":"Accept a payment","url":"https://docs.stripe.com/payments/accept-a-payment"}]}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("0.1.0").WithOptions(
+		WithAPIBaseURL(server.URL),
+		WithAPIKey("sk_test_123"),
+	)
+
+	got, err := client.Search(context.Background(), "payments")
+	require.NoError(t, err)
+	require.Len(t, got.Hits, 1)
+	assert.Equal(t, "Accept a payment", got.Hits[0].Title)
+}
+
+func TestSearch_Unauthenticated_UsesDocsEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/_endpoint/search", r.URL.Path)
+		assert.Empty(t, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"hits":[]}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("0.1.0").WithOptions(WithBaseURL(server.URL))
+	got, err := client.Search(context.Background(), "payments")
+	require.NoError(t, err)
+	assert.Empty(t, got.Hits)
+}
+
 // evictingMockCache always returns a miss, simulating TTL expiry.
 type evictingMockCache struct{}
 


### PR DESCRIPTION
**Summary**

When a user is logged in, `stripe docs` now routes page fetches, searches, and API reference lookups through `api.stripe.com/v2/docs/*` instead of `docs.stripe.com`. Unauthenticated usage is unchanged.

**Test plan**

Replace `/some-auth-gated-page` below with a docs path that requires authentication to access (e.g. a page only visible to logged-in users or a specific account).

```bash
# 1. Unauthenticated page fetch — should hit docs.stripe.com
stripe logout
./stripe docs /some-auth-gated-page --log-level debug --non-interactive --no-pager
# expect: request goes to https://docs.stripe.com/some-auth-gated-page (visible in debug log)
# expect: page is missing or returns an unauthed/restricted view

# 2. Authenticated page fetch — should hit api.stripe.com and return gated content
stripe login
./stripe docs /some-auth-gated-page --log-level debug --non-interactive --no-pager
# expect: debug log shows url=https://api.stripe.com/v2/docs/page?path=...
# expect: full page content is returned

# 3. Unauthenticated search — hits docs.stripe.com
stripe logout
./stripe docs search "payment intents" --log-level debug --non-interactive --no-pager
# expect: debug log shows url=https://docs.stripe.com/_endpoint/search?query=...

# 4. Authenticated search — hits api.stripe.com
stripe login
./stripe docs search "payment intents" --log-level debug --non-interactive --no-pager
# expect: debug log shows url=https://api.stripe.com/v2/docs/search?query=...
# expect: results reflect authenticated context (e.g. account-specific content if applicable)

# 5. Unauthenticated API reference lookup
stripe logout
./stripe docs api GET /v1/products --log-level debug --non-interactive --no-pager
# expect: debug log shows request to https://docs.stripe.com/...

# 6. Authenticated API reference lookup
stripe login
./stripe docs api GET /v1/products --log-level debug --non-interactive --no-pager
# expect: debug log shows url=https://api.stripe.com/v2/docs/page?path=...
# expect: same content, now fetched via the authenticated API path
```