### PR TITLE
Add <plugin> argument to plugin install and upgrade help text

### DIFF
--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -41,7 +41,7 @@ func NewInstallCmd(config *config.Config) *InstallCmd {
 	ic.cfg = config
 
 	ic.Cmd = &cobra.Command{
-		Use:   "install",
+		Use:   "install <plugin>",
 		Args:  validators.ExactArgs(1),
 		Short: "Install a Stripe CLI plugin",
 		Long: `Install a Stripe CLI plugin. To download a specific version, run stripe install [plugin_name]@[version].

--- a/pkg/cmd/plugin/upgrade.go
+++ b/pkg/cmd/plugin/upgrade.go
@@ -33,7 +33,7 @@ func NewUpgradeCmd(config *config.Config) *UpgradeCmd {
 	uc.cfg = config
 
 	uc.Cmd = &cobra.Command{
-		Use:   "upgrade",
+		Use:   "upgrade <plugin>",
 		Args:  validators.ExactArgs(1),
 		Short: "Upgrade a Stripe CLI plugin",
 		Long:  "Upgrade a Stripe CLI plugin to the latest version available. To download a specific version, please see the `install` command",


### PR DESCRIPTION
What it says on the tin

```
go run cmd/stripe/main.go plugin install -h    
Install a Stripe CLI plugin. To download a specific version, run stripe install [plugin_name]@[version].
			By default, the most recent version will be installed.

Usage:
  stripe plugin install <plugin> [flags]

Flags:
  -h, --help   help for install

Global flags:
      --api-key string        Your API key to use for the command
      --color string          turn on/off color output (on, off, auto)
      --config string         config file (default is $HOME/.config/stripe/config.toml)
      --device-name string    device name
      --log-level string      log level (debug, info, trace, warn, error) (default "info")
      --map string[="tree"]   Print a command tree [tree|compact|paths|json]
  -p, --project-name string   the project name to read from for config (default "default")

```

```
go run cmd/stripe/main.go plugin upgrade -h        
Upgrade a Stripe CLI plugin to the latest version available. To download a specific version, please see the `install` command

Usage:
  stripe plugin upgrade <plugin> [flags]

Flags:
  -h, --help   help for upgrade

Global flags:
      --api-key string        Your API key to use for the command
      --color string          turn on/off color output (on, off, auto)
      --config string         config file (default is $HOME/.config/stripe/config.toml)
      --device-name string    device name
      --log-level string      log level (debug, info, trace, warn, error) (default "info")
      --map string[="tree"]   Print a command tree [tree|compact|paths|json]
  -p, --project-name string   the project name to read from for config (default "default")
```