### PR TITLE
Fail early when trying to access livemode with a UAT authorized for a sandbox

### DIFF
--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -675,6 +675,9 @@ func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) 
 			if err != nil {
 				return stripe.Credentials{}, err
 			}
+			if livemode && compartmentID == "" {
+				return stripe.Credentials{}, fmt.Errorf("you're logged in to a sandbox; to access livemode, reauthenticate with 'stripe login' and select your live account")
+			}
 			return stripe.NewOAKCredentials(uat, compartmentID, livemode), nil
 		}
 	}

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -261,6 +261,49 @@ func TestLiveModeAPIKeyKeychainItemReplaced(t *testing.T) {
 	require.Equal(t, []byte("rk_live_0000000002"), data)
 }
 
+func TestResolveCredentialsOAKLivemodeNoCompartment(t *testing.T) {
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(profilesFile, []byte{}, 0600))
+	KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		UATKeychainItemKey: []byte("oak_live_1234567890"),
+	})
+	t.Cleanup(func() {
+		KeyRing = nil
+		viper.Reset()
+	})
+	(&Config{LogLevel: "info", ProfilesFile: profilesFile}).InitConfig()
+
+	p := Profile{ProfileName: "default"}
+	_, err := p.ResolveCredentials(true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "you're logged in to a sandbox")
+	require.Contains(t, err.Error(), "stripe login")
+}
+
+func TestResolveCredentialsOAKLivemodeWithCompartment(t *testing.T) {
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(profilesFile, []byte{}, 0600))
+	KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		UATKeychainItemKey: []byte("oak_live_1234567890"),
+	})
+	t.Cleanup(func() {
+		KeyRing = nil
+		viper.Reset()
+	})
+	(&Config{LogLevel: "info", ProfilesFile: profilesFile}).InitConfig()
+	viper.Set(UserInfoName, &UserInfo{
+		Compartments: []Compartment{
+			{CompartmentID: "acct_live123", Livemode: true},
+			{CompartmentID: "acct_test456", Livemode: false},
+		},
+	})
+
+	p := Profile{ProfileName: "default"}
+	creds, err := p.ResolveCredentials(true)
+	require.NoError(t, err)
+	require.Equal(t, "oak_live_1234567890", creds.Token)
+}
+
 func helperLoadBytes(t *testing.T, name string) []byte {
 	bytes, err := os.ReadFile(name)
 	if err != nil {


### PR DESCRIPTION
What it says on the tin.

Before:
```
go run cmd/stripe/main.go customers list --live
{
  "error": {
    "message": "Permission denied.",
    "type": "api_error",
    "code": "unauthorized"
  }
}
```

After:
```
go run cmd/stripe/main.go customers list --live
you're logged in to a sandbox; to access livemode, reauthenticate with 'stripe login' and select your live account
```