### PR TITLE
Update --stripe-context and --stripe-account semantics with UAT

### DIFF
--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -362,42 +362,6 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 	return body, nil
 }
 
-// applyAccountContextHeaders sets Stripe-Account and/or Stripe-Context in headers,
-// applying OAK compartment-prefixing rules. Extracted to keep BuildDryRunOutput's
-// cyclomatic complexity within bounds.
-func applyAccountContextHeaders(headers map[string]string, params *RequestParameters, creds stripe.Credentials) {
-	switch creds.Strategy() {
-	case stripe.UATStrategy:
-		switch {
-		case params.stripeAccount != "":
-			if creds.OAKContext != params.stripeAccount {
-				headers["Stripe-Account"] = creds.OAKContext + "/" + params.stripeAccount
-			} else {
-				headers["Stripe-Account"] = params.stripeAccount
-			}
-			// Stripe-Context intentionally omitted: --stripe-account with OAK only sends Stripe-Account
-		case params.stripeContext != "":
-			if creds.OAKContext != params.stripeContext {
-				headers["Stripe-Context"] = creds.OAKContext + "/" + params.stripeContext
-			} else {
-				headers["Stripe-Context"] = params.stripeContext
-			}
-		default:
-			headers["Stripe-Context"] = creds.OAKContext
-		}
-	default:
-		switch {
-		case params.stripeAccount != "":
-			headers["Stripe-Account"] = params.stripeAccount
-			if params.stripeContext != "" {
-				headers["Stripe-Context"] = params.stripeContext
-			}
-		case params.stripeContext != "":
-			headers["Stripe-Context"] = params.stripeContext
-		}
-	}
-}
-
 // BuildDryRunOutput constructs the dry-run output for a request without executing it.
 func (rb *Base) BuildDryRunOutput(creds stripe.Credentials, baseURL, path string, params *RequestParameters, additionalParams map[string]interface{}) (*DryRunOutput, error) {
 	isV2 := stripe.IsV2Path(path)
@@ -480,7 +444,7 @@ func (rb *Base) BuildDryRunOutput(creds stripe.Credentials, baseURL, path string
 	if params.idempotency != "" {
 		headers["Idempotency-Key"] = params.idempotency
 	}
-	applyAccountContextHeaders(headers, params, creds)
+	creds.ApplyAccountContextHeaders(headers, params.stripeAccount, params.stripeContext)
 	if creds.OAKLivemode != nil {
 		headers["Stripe-Livemode"] = strconv.FormatBool(*creds.OAKLivemode)
 	}

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -366,33 +366,34 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 // applying OAK compartment-prefixing rules. Extracted to keep BuildDryRunOutput's
 // cyclomatic complexity within bounds.
 func applyAccountContextHeaders(headers map[string]string, params *RequestParameters, creds stripe.Credentials) {
-	switch {
-	case params.stripeAccount != "":
-		if creds.OAKContext != "" {
+	if creds.OAKContext != "" {
+		switch {
+		case params.stripeAccount != "":
 			if creds.OAKContext != params.stripeAccount {
 				headers["Stripe-Account"] = creds.OAKContext + "/" + params.stripeAccount
 			} else {
 				headers["Stripe-Account"] = params.stripeAccount
 			}
 			// Stripe-Context intentionally omitted: --stripe-account with OAK only sends Stripe-Account
-		} else {
-			headers["Stripe-Account"] = params.stripeAccount
-			if params.stripeContext != "" {
-				headers["Stripe-Context"] = params.stripeContext
-			}
-		}
-	case params.stripeContext != "":
-		if creds.OAKContext != "" {
+		case params.stripeContext != "":
 			if creds.OAKContext != params.stripeContext {
 				headers["Stripe-Context"] = creds.OAKContext + "/" + params.stripeContext
 			} else {
 				headers["Stripe-Context"] = params.stripeContext
 			}
-		} else {
+		default:
+			headers["Stripe-Context"] = creds.OAKContext
+		}
+	} else {
+		switch {
+		case params.stripeAccount != "":
+			headers["Stripe-Account"] = params.stripeAccount
+			if params.stripeContext != "" {
+				headers["Stripe-Context"] = params.stripeContext
+			}
+		case params.stripeContext != "":
 			headers["Stripe-Context"] = params.stripeContext
 		}
-	case creds.OAKContext != "":
-		headers["Stripe-Context"] = creds.OAKContext
 	}
 }
 

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -362,6 +362,40 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 	return body, nil
 }
 
+// applyAccountContextHeaders sets Stripe-Account and/or Stripe-Context in headers,
+// applying OAK compartment-prefixing rules. Extracted to keep BuildDryRunOutput's
+// cyclomatic complexity within bounds.
+func applyAccountContextHeaders(headers map[string]string, params *RequestParameters, creds stripe.Credentials) {
+	switch {
+	case params.stripeAccount != "":
+		if creds.OAKContext != "" {
+			if creds.OAKContext != params.stripeAccount {
+				headers["Stripe-Account"] = creds.OAKContext + "/" + params.stripeAccount
+			} else {
+				headers["Stripe-Account"] = params.stripeAccount
+			}
+			// Stripe-Context intentionally omitted: --stripe-account with OAK only sends Stripe-Account
+		} else {
+			headers["Stripe-Account"] = params.stripeAccount
+			if params.stripeContext != "" {
+				headers["Stripe-Context"] = params.stripeContext
+			}
+		}
+	case params.stripeContext != "":
+		if creds.OAKContext != "" {
+			if creds.OAKContext != params.stripeContext {
+				headers["Stripe-Context"] = creds.OAKContext + "/" + params.stripeContext
+			} else {
+				headers["Stripe-Context"] = params.stripeContext
+			}
+		} else {
+			headers["Stripe-Context"] = params.stripeContext
+		}
+	case creds.OAKContext != "":
+		headers["Stripe-Context"] = creds.OAKContext
+	}
+}
+
 // BuildDryRunOutput constructs the dry-run output for a request without executing it.
 func (rb *Base) BuildDryRunOutput(creds stripe.Credentials, baseURL, path string, params *RequestParameters, additionalParams map[string]interface{}) (*DryRunOutput, error) {
 	isV2 := stripe.IsV2Path(path)
@@ -444,33 +478,7 @@ func (rb *Base) BuildDryRunOutput(creds stripe.Credentials, baseURL, path string
 	if params.idempotency != "" {
 		headers["Idempotency-Key"] = params.idempotency
 	}
-	if params.stripeAccount != "" {
-		if creds.OAKContext != "" {
-			if creds.OAKContext != params.stripeAccount {
-				headers["Stripe-Account"] = creds.OAKContext + "/" + params.stripeAccount
-			} else {
-				headers["Stripe-Account"] = params.stripeAccount
-			}
-			// Stripe-Context intentionally omitted: --stripe-account with OAK only sends Stripe-Account
-		} else {
-			headers["Stripe-Account"] = params.stripeAccount
-			if params.stripeContext != "" {
-				headers["Stripe-Context"] = params.stripeContext
-			}
-		}
-	} else if params.stripeContext != "" {
-		if creds.OAKContext != "" {
-			if creds.OAKContext != params.stripeContext {
-				headers["Stripe-Context"] = creds.OAKContext + "/" + params.stripeContext
-			} else {
-				headers["Stripe-Context"] = params.stripeContext
-			}
-		} else {
-			headers["Stripe-Context"] = params.stripeContext
-		}
-	} else if creds.OAKContext != "" {
-		headers["Stripe-Context"] = creds.OAKContext
-	}
+	applyAccountContextHeaders(headers, params, creds)
 	if creds.OAKLivemode != nil {
 		headers["Stripe-Livemode"] = strconv.FormatBool(*creds.OAKLivemode)
 	}

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -366,7 +366,8 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 // applying OAK compartment-prefixing rules. Extracted to keep BuildDryRunOutput's
 // cyclomatic complexity within bounds.
 func applyAccountContextHeaders(headers map[string]string, params *RequestParameters, creds stripe.Credentials) {
-	if creds.OAKContext != "" {
+	switch creds.Strategy() {
+	case stripe.UATStrategy:
 		switch {
 		case params.stripeAccount != "":
 			if creds.OAKContext != params.stripeAccount {
@@ -384,7 +385,7 @@ func applyAccountContextHeaders(headers map[string]string, params *RequestParame
 		default:
 			headers["Stripe-Context"] = creds.OAKContext
 		}
-	} else {
+	default:
 		switch {
 		case params.stripeAccount != "":
 			headers["Stripe-Account"] = params.stripeAccount

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -299,11 +299,20 @@ func (rb *Base) MakeRequestWithClient(ctx context.Context, client stripe.Request
 	return rb.performRequest(ctx, client, path, params, data, errOnStatus, additionalConfigure)
 }
 
+// credentialsFromPerformer extracts Credentials from a *stripe.Client performer.
+// Returns zero Credentials (non-OAK, no token) for any other RequestPerformer.
+func credentialsFromPerformer(client stripe.RequestPerformer) stripe.Credentials {
+	if c, ok := client.(*stripe.Client); ok {
+		return c.Credentials
+	}
+	return stripe.Credentials{}
+}
+
 func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerformer, path string, params *RequestParameters, data string, errOnStatus bool, additionalConfigure func(req *http.Request) error) ([]byte, error) {
+	creds := credentialsFromPerformer(client)
 	configure := func(req *http.Request) error {
 		rb.setIdempotencyHeader(req, params)
-		oakContextConsumed := rb.setStripeAccountHeader(req, params)
-		rb.setStripeContextHeader(req, params, oakContextConsumed)
+		creds.ApplyAccountContextHeaders(req.Header, params.stripeAccount, params.stripeContext)
 		rb.setVersionHeader(req, params, path)
 		if additionalConfigure != nil {
 			if err := additionalConfigure(req); err != nil {
@@ -444,7 +453,13 @@ func (rb *Base) BuildDryRunOutput(creds stripe.Credentials, baseURL, path string
 	if params.idempotency != "" {
 		headers["Idempotency-Key"] = params.idempotency
 	}
-	creds.ApplyAccountContextHeaders(headers, params.stripeAccount, params.stripeContext)
+	accountContextHeaders := make(http.Header)
+	creds.ApplyAccountContextHeaders(accountContextHeaders, params.stripeAccount, params.stripeContext)
+	for key, vals := range accountContextHeaders {
+		if len(vals) > 0 {
+			headers[key] = vals[0]
+		}
+	}
 	if creds.OAKLivemode != nil {
 		headers["Stripe-Livemode"] = strconv.FormatBool(*creds.OAKLivemode)
 	}
@@ -879,41 +894,6 @@ func (rb *Base) computeVersionHeader(params *RequestParameters, path string) str
 func (rb *Base) setVersionHeader(request *http.Request, params *RequestParameters, path string) {
 	if v := rb.computeVersionHeader(params, path); v != "" {
 		request.Header.Set("Stripe-Version", v)
-	}
-}
-
-// setStripeAccountHeader sets Stripe-Account. When an OAK token is in use the
-// client layer has already placed its compartment ID in Stripe-Context; this
-// function detects that, combines it into "context/account", removes the now-
-// redundant Stripe-Context, and returns true so the caller knows not to
-// re-add Stripe-Context from params.
-func (rb *Base) setStripeAccountHeader(request *http.Request, params *RequestParameters) (oakContextConsumed bool) {
-	if params.stripeAccount == "" {
-		return false
-	}
-	existingContext := request.Header.Get("Stripe-Context")
-	if existingContext != "" {
-		if existingContext != params.stripeAccount {
-			request.Header.Set("Stripe-Account", existingContext+"/"+params.stripeAccount)
-		} else {
-			request.Header.Set("Stripe-Account", params.stripeAccount)
-		}
-		request.Header.Del("Stripe-Context")
-		return true
-	}
-	request.Header.Set("Stripe-Account", params.stripeAccount)
-	return false
-}
-
-func (rb *Base) setStripeContextHeader(request *http.Request, params *RequestParameters, oakContextConsumed bool) {
-	if params.stripeContext == "" || oakContextConsumed {
-		return
-	}
-	existingContext := request.Header.Get("Stripe-Context")
-	if existingContext != "" && existingContext != params.stripeContext {
-		request.Header.Set("Stripe-Context", existingContext+"/"+params.stripeContext)
-	} else {
-		request.Header.Set("Stripe-Context", params.stripeContext)
 	}
 }
 

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -302,8 +302,8 @@ func (rb *Base) MakeRequestWithClient(ctx context.Context, client stripe.Request
 func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerformer, path string, params *RequestParameters, data string, errOnStatus bool, additionalConfigure func(req *http.Request) error) ([]byte, error) {
 	configure := func(req *http.Request) error {
 		rb.setIdempotencyHeader(req, params)
-		rb.setStripeAccountHeader(req, params)
-		rb.setStripeContextHeader(req, params)
+		oakContextConsumed := rb.setStripeAccountHeader(req, params)
+		rb.setStripeContextHeader(req, params, oakContextConsumed)
 		rb.setVersionHeader(req, params, path)
 		if additionalConfigure != nil {
 			if err := additionalConfigure(req); err != nil {
@@ -445,10 +445,29 @@ func (rb *Base) BuildDryRunOutput(creds stripe.Credentials, baseURL, path string
 		headers["Idempotency-Key"] = params.idempotency
 	}
 	if params.stripeAccount != "" {
-		headers["Stripe-Account"] = params.stripeAccount
-	}
-	if params.stripeContext != "" {
-		headers["Stripe-Context"] = params.stripeContext
+		if creds.OAKContext != "" {
+			if creds.OAKContext != params.stripeAccount {
+				headers["Stripe-Account"] = creds.OAKContext + "/" + params.stripeAccount
+			} else {
+				headers["Stripe-Account"] = params.stripeAccount
+			}
+			// Stripe-Context intentionally omitted: --stripe-account with OAK only sends Stripe-Account
+		} else {
+			headers["Stripe-Account"] = params.stripeAccount
+			if params.stripeContext != "" {
+				headers["Stripe-Context"] = params.stripeContext
+			}
+		}
+	} else if params.stripeContext != "" {
+		if creds.OAKContext != "" {
+			if creds.OAKContext != params.stripeContext {
+				headers["Stripe-Context"] = creds.OAKContext + "/" + params.stripeContext
+			} else {
+				headers["Stripe-Context"] = params.stripeContext
+			}
+		} else {
+			headers["Stripe-Context"] = params.stripeContext
+		}
 	} else if creds.OAKContext != "" {
 		headers["Stripe-Context"] = creds.OAKContext
 	}
@@ -889,14 +908,37 @@ func (rb *Base) setVersionHeader(request *http.Request, params *RequestParameter
 	}
 }
 
-func (rb *Base) setStripeAccountHeader(request *http.Request, params *RequestParameters) {
-	if params.stripeAccount != "" {
-		request.Header.Set("Stripe-Account", params.stripeAccount)
+// setStripeAccountHeader sets Stripe-Account. When an OAK token is in use the
+// client layer has already placed its compartment ID in Stripe-Context; this
+// function detects that, combines it into "context/account", removes the now-
+// redundant Stripe-Context, and returns true so the caller knows not to
+// re-add Stripe-Context from params.
+func (rb *Base) setStripeAccountHeader(request *http.Request, params *RequestParameters) (oakContextConsumed bool) {
+	if params.stripeAccount == "" {
+		return false
 	}
+	existingContext := request.Header.Get("Stripe-Context")
+	if existingContext != "" {
+		if existingContext != params.stripeAccount {
+			request.Header.Set("Stripe-Account", existingContext+"/"+params.stripeAccount)
+		} else {
+			request.Header.Set("Stripe-Account", params.stripeAccount)
+		}
+		request.Header.Del("Stripe-Context")
+		return true
+	}
+	request.Header.Set("Stripe-Account", params.stripeAccount)
+	return false
 }
 
-func (rb *Base) setStripeContextHeader(request *http.Request, params *RequestParameters) {
-	if params.stripeContext != "" {
+func (rb *Base) setStripeContextHeader(request *http.Request, params *RequestParameters, oakContextConsumed bool) {
+	if params.stripeContext == "" || oakContextConsumed {
+		return
+	}
+	existingContext := request.Header.Get("Stripe-Context")
+	if existingContext != "" && existingContext != params.stripeContext {
+		request.Header.Set("Stripe-Context", existingContext+"/"+params.stripeContext)
+	} else {
 		request.Header.Set("Stripe-Context", params.stripeContext)
 	}
 }

--- a/pkg/requests/base_test.go
+++ b/pkg/requests/base_test.go
@@ -639,6 +639,84 @@ func TestBuildDryRunOutput_OptionalHeaders(t *testing.T) {
 	}}, *output)
 }
 
+func TestBuildDryRunOutput_OAKStripeAccount(t *testing.T) {
+	rb := Base{Method: http.MethodPost}
+	params := &RequestParameters{stripeAccount: "acct_b"}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+
+	output, err := rb.BuildDryRunOutput(creds, "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"Content-Type":    "application/x-www-form-urlencoded",
+		"Stripe-Account":  "acct_a/acct_b",
+		"Authorization":   "Bearer oak_test_123",
+		"Stripe-Livemode": "false",
+	}, output.DryRun.Headers)
+}
+
+func TestBuildDryRunOutput_OAKStripeContext(t *testing.T) {
+	rb := Base{Method: http.MethodPost}
+	params := &RequestParameters{stripeContext: "acct_b"}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+
+	output, err := rb.BuildDryRunOutput(creds, "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"Content-Type":    "application/x-www-form-urlencoded",
+		"Stripe-Context":  "acct_a/acct_b",
+		"Authorization":   "Bearer oak_test_123",
+		"Stripe-Livemode": "false",
+	}, output.DryRun.Headers)
+}
+
+func TestBuildDryRunOutput_OAKNoFlagsUsesContext(t *testing.T) {
+	rb := Base{Method: http.MethodPost}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+
+	output, err := rb.BuildDryRunOutput(creds, "https://api.stripe.com", "/v1/customers", &RequestParameters{}, map[string]interface{}{})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"Content-Type":    "application/x-www-form-urlencoded",
+		"Stripe-Context":  "acct_a",
+		"Authorization":   "Bearer oak_test_123",
+		"Stripe-Livemode": "false",
+	}, output.DryRun.Headers)
+}
+
+func TestBuildDryRunOutput_OAKStripeAccountOmitsContext(t *testing.T) {
+	// --stripe-account with OAK: Stripe-Account gets acct_a/acct_b and Stripe-Context is absent
+	rb := Base{Method: http.MethodPost}
+	params := &RequestParameters{stripeAccount: "acct_b", stripeContext: "ctx_c"}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+
+	output, err := rb.BuildDryRunOutput(creds, "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{})
+	require.NoError(t, err)
+	require.NotContains(t, output.DryRun.Headers, "Stripe-Context")
+	require.Equal(t, "acct_a/acct_b", output.DryRun.Headers["Stripe-Account"])
+}
+
+func TestBuildDryRunOutput_OAKStripeAccountSameValue(t *testing.T) {
+	rb := Base{Method: http.MethodPost}
+	params := &RequestParameters{stripeAccount: "acct_a"}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+
+	output, err := rb.BuildDryRunOutput(creds, "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{})
+	require.NoError(t, err)
+	require.Equal(t, "acct_a", output.DryRun.Headers["Stripe-Account"])
+	require.NotContains(t, output.DryRun.Headers, "Stripe-Context")
+}
+
+func TestBuildDryRunOutput_OAKStripeContextSameValue(t *testing.T) {
+	rb := Base{Method: http.MethodPost}
+	params := &RequestParameters{stripeContext: "acct_a"}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+
+	output, err := rb.BuildDryRunOutput(creds, "https://api.stripe.com", "/v1/customers", params, map[string]interface{}{})
+	require.NoError(t, err)
+	require.Equal(t, "acct_a", output.DryRun.Headers["Stripe-Context"])
+	require.NotContains(t, output.DryRun.Headers, "Stripe-Account")
+}
+
 func TestBuildDryRunOutput_PathParamSubstitutedURL(t *testing.T) {
 	rb := Base{Method: http.MethodGet}
 
@@ -650,6 +728,102 @@ func TestBuildDryRunOutput_PathParamSubstitutedURL(t *testing.T) {
 		Params:  map[string]interface{}{},
 		Headers: map[string]string{},
 	}}, *output)
+}
+
+func TestMakeRequest_OAKStripeAccount(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "acct_a/acct_b", r.Header.Get("Stripe-Account"))
+		require.Empty(t, r.Header.Get("Stripe-Context"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	rb := Base{APIBaseURL: ts.URL, Method: http.MethodPost}
+	params := &RequestParameters{stripeAccount: "acct_b"}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+	_, err := rb.MakeRequest(context.Background(), creds, "/v1/customers", params, make(map[string]interface{}), true, nil)
+	require.NoError(t, err)
+}
+
+func TestMakeRequest_OAKStripeContext(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "acct_a/acct_b", r.Header.Get("Stripe-Context"))
+		require.Empty(t, r.Header.Get("Stripe-Account"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	rb := Base{APIBaseURL: ts.URL, Method: http.MethodPost}
+	params := &RequestParameters{stripeContext: "acct_b"}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+	_, err := rb.MakeRequest(context.Background(), creds, "/v1/customers", params, make(map[string]interface{}), true, nil)
+	require.NoError(t, err)
+}
+
+func TestMakeRequest_OAKNoFlagsUsesContext(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "acct_a", r.Header.Get("Stripe-Context"))
+		require.Empty(t, r.Header.Get("Stripe-Account"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	rb := Base{APIBaseURL: ts.URL, Method: http.MethodPost}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+	_, err := rb.MakeRequest(context.Background(), creds, "/v1/customers", &RequestParameters{}, make(map[string]interface{}), true, nil)
+	require.NoError(t, err)
+}
+
+func TestMakeRequest_OAKStripeAccountOmitsContext(t *testing.T) {
+	// --stripe-account with OAK: combined Stripe-Account, no Stripe-Context even with --stripe-context
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "acct_a/acct_b", r.Header.Get("Stripe-Account"))
+		require.Empty(t, r.Header.Get("Stripe-Context"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	rb := Base{APIBaseURL: ts.URL, Method: http.MethodPost}
+	params := &RequestParameters{stripeAccount: "acct_b", stripeContext: "ctx_c"}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+	_, err := rb.MakeRequest(context.Background(), creds, "/v1/customers", params, make(map[string]interface{}), true, nil)
+	require.NoError(t, err)
+}
+
+func TestMakeRequest_OAKStripeAccountSameValue(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "acct_a", r.Header.Get("Stripe-Account"))
+		require.Empty(t, r.Header.Get("Stripe-Context"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	rb := Base{APIBaseURL: ts.URL, Method: http.MethodPost}
+	params := &RequestParameters{stripeAccount: "acct_a"}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+	_, err := rb.MakeRequest(context.Background(), creds, "/v1/customers", params, make(map[string]interface{}), true, nil)
+	require.NoError(t, err)
+}
+
+func TestMakeRequest_OAKStripeContextSameValue(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "acct_a", r.Header.Get("Stripe-Context"))
+		require.Empty(t, r.Header.Get("Stripe-Account"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	rb := Base{APIBaseURL: ts.URL, Method: http.MethodPost}
+	params := &RequestParameters{stripeContext: "acct_a"}
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+	_, err := rb.MakeRequest(context.Background(), creds, "/v1/customers", params, make(map[string]interface{}), true, nil)
+	require.NoError(t, err)
 }
 
 func captureStderr(t *testing.T, fn func()) string {

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -41,33 +41,34 @@ type Credentials struct {
 // credentials the OAK compartment ID is prepended as "context/value" unless
 // the value already equals the compartment ID. When account is set under UAT,
 // Stripe-Context is intentionally omitted.
-func (c Credentials) ApplyAccountContextHeaders(headers map[string]string, account, context string) {
+func (c Credentials) ApplyAccountContextHeaders(headers http.Header, account, context string) {
 	if c.OAKContext != "" {
 		switch {
 		case account != "":
 			if c.OAKContext != account {
-				headers["Stripe-Account"] = c.OAKContext + "/" + account
+				headers.Set("Stripe-Account", c.OAKContext+"/"+account)
 			} else {
-				headers["Stripe-Account"] = account
+				headers.Set("Stripe-Account", account)
 			}
+			headers.Del("Stripe-Context")
 		case context != "":
 			if c.OAKContext != context {
-				headers["Stripe-Context"] = c.OAKContext + "/" + context
+				headers.Set("Stripe-Context", c.OAKContext+"/"+context)
 			} else {
-				headers["Stripe-Context"] = context
+				headers.Set("Stripe-Context", context)
 			}
 		default:
-			headers["Stripe-Context"] = c.OAKContext
+			headers.Set("Stripe-Context", c.OAKContext)
 		}
 	} else {
 		switch {
 		case account != "":
-			headers["Stripe-Account"] = account
+			headers.Set("Stripe-Account", account)
 			if context != "" {
-				headers["Stripe-Context"] = context
+				headers.Set("Stripe-Context", context)
 			}
 		case context != "":
-			headers["Stripe-Context"] = context
+			headers.Set("Stripe-Context", context)
 		}
 	}
 }

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -28,17 +28,6 @@ const (
 	V2Request     = "v2"
 )
 
-// CredentialStrategy indicates which authentication mechanism a Credentials
-// value represents.
-type CredentialStrategy int
-
-const (
-	// APIKeyStrategy is a standard Stripe API key.
-	APIKeyStrategy CredentialStrategy = iota
-	// UATStrategy is a user access token (UAT).
-	UATStrategy
-)
-
 // Credentials holds the auth credentials for a Stripe API request. For plain
 // API keys only Token is set. For OAK tokens all three fields are populated.
 type Credentials struct {
@@ -47,23 +36,13 @@ type Credentials struct {
 	OAKLivemode *bool
 }
 
-// Strategy returns UATStrategy when these credentials carry an OAK compartment
-// context, and APIKeyStrategy otherwise.
-func (c Credentials) Strategy() CredentialStrategy {
-	if c.OAKContext != "" {
-		return UATStrategy
-	}
-	return APIKeyStrategy
-}
-
 // ApplyAccountContextHeaders sets Stripe-Account and/or Stripe-Context in
 // headers from the caller-supplied account and context values. For UAT
 // credentials the OAK compartment ID is prepended as "context/value" unless
 // the value already equals the compartment ID. When account is set under UAT,
 // Stripe-Context is intentionally omitted.
 func (c Credentials) ApplyAccountContextHeaders(headers map[string]string, account, context string) {
-	switch c.Strategy() {
-	case UATStrategy:
+	if c.OAKContext != "" {
 		switch {
 		case account != "":
 			if c.OAKContext != account {
@@ -80,7 +59,7 @@ func (c Credentials) ApplyAccountContextHeaders(headers map[string]string, accou
 		default:
 			headers["Stripe-Context"] = c.OAKContext
 		}
-	default:
+	} else {
 		switch {
 		case account != "":
 			headers["Stripe-Account"] = account

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -28,12 +28,32 @@ const (
 	V2Request     = "v2"
 )
 
+// CredentialStrategy indicates which authentication mechanism a Credentials
+// value represents.
+type CredentialStrategy int
+
+const (
+	// APIKeyStrategy is a standard Stripe secret or publishable key.
+	APIKeyStrategy CredentialStrategy = iota
+	// UATStrategy is an OAK (User Access Token) with a compartment context.
+	UATStrategy
+)
+
 // Credentials holds the auth credentials for a Stripe API request. For plain
 // API keys only Token is set. For OAK tokens all three fields are populated.
 type Credentials struct {
 	Token       string
 	OAKContext  string
 	OAKLivemode *bool
+}
+
+// Strategy returns UATStrategy when these credentials carry an OAK compartment
+// context, and APIKeyStrategy otherwise.
+func (c Credentials) Strategy() CredentialStrategy {
+	if c.OAKContext != "" {
+		return UATStrategy
+	}
+	return APIKeyStrategy
 }
 
 // NewAPIKeyCredentials returns Credentials using a standard Stripe API key.

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -33,9 +33,9 @@ const (
 type CredentialStrategy int
 
 const (
-	// APIKeyStrategy is a standard Stripe secret or publishable key.
+	// APIKeyStrategy is a standard Stripe API key.
 	APIKeyStrategy CredentialStrategy = iota
-	// UATStrategy is an OAK (User Access Token) with a compartment context.
+	// UATStrategy is a user access token (UAT).
 	UATStrategy
 )
 
@@ -54,6 +54,43 @@ func (c Credentials) Strategy() CredentialStrategy {
 		return UATStrategy
 	}
 	return APIKeyStrategy
+}
+
+// ApplyAccountContextHeaders sets Stripe-Account and/or Stripe-Context in
+// headers from the caller-supplied account and context values. For UAT
+// credentials the OAK compartment ID is prepended as "context/value" unless
+// the value already equals the compartment ID. When account is set under UAT,
+// Stripe-Context is intentionally omitted.
+func (c Credentials) ApplyAccountContextHeaders(headers map[string]string, account, context string) {
+	switch c.Strategy() {
+	case UATStrategy:
+		switch {
+		case account != "":
+			if c.OAKContext != account {
+				headers["Stripe-Account"] = c.OAKContext + "/" + account
+			} else {
+				headers["Stripe-Account"] = account
+			}
+		case context != "":
+			if c.OAKContext != context {
+				headers["Stripe-Context"] = c.OAKContext + "/" + context
+			} else {
+				headers["Stripe-Context"] = context
+			}
+		default:
+			headers["Stripe-Context"] = c.OAKContext
+		}
+	default:
+		switch {
+		case account != "":
+			headers["Stripe-Account"] = account
+			if context != "" {
+				headers["Stripe-Context"] = context
+			}
+		case context != "":
+			headers["Stripe-Context"] = context
+		}
+	}
 }
 
 // NewAPIKeyCredentials returns Credentials using a standard Stripe API key.

--- a/pkg/stripe/client_test.go
+++ b/pkg/stripe/client_test.go
@@ -16,24 +16,27 @@ func TestApplyAccountContextHeaders_APIKey(t *testing.T) {
 	creds := NewAPIKeyCredentials("sk_test_123")
 
 	t.Run("no flags", func(t *testing.T) {
-		h := map[string]string{}
+		h := make(http.Header)
 		creds.ApplyAccountContextHeaders(h, "", "")
 		require.Empty(t, h)
 	})
 	t.Run("account only", func(t *testing.T) {
-		h := map[string]string{}
+		h := make(http.Header)
 		creds.ApplyAccountContextHeaders(h, "acct_b", "")
-		require.Equal(t, map[string]string{"Stripe-Account": "acct_b"}, h)
+		require.Equal(t, "acct_b", h.Get("Stripe-Account"))
+		require.Empty(t, h.Get("Stripe-Context"))
 	})
 	t.Run("context only", func(t *testing.T) {
-		h := map[string]string{}
+		h := make(http.Header)
 		creds.ApplyAccountContextHeaders(h, "", "ctx_c")
-		require.Equal(t, map[string]string{"Stripe-Context": "ctx_c"}, h)
+		require.Equal(t, "ctx_c", h.Get("Stripe-Context"))
+		require.Empty(t, h.Get("Stripe-Account"))
 	})
 	t.Run("both", func(t *testing.T) {
-		h := map[string]string{}
+		h := make(http.Header)
 		creds.ApplyAccountContextHeaders(h, "acct_b", "ctx_c")
-		require.Equal(t, map[string]string{"Stripe-Account": "acct_b", "Stripe-Context": "ctx_c"}, h)
+		require.Equal(t, "acct_b", h.Get("Stripe-Account"))
+		require.Equal(t, "ctx_c", h.Get("Stripe-Context"))
 	})
 }
 
@@ -41,35 +44,40 @@ func TestApplyAccountContextHeaders_UAT(t *testing.T) {
 	creds := NewOAKCredentials("oak_test_123", "acct_a", false)
 
 	t.Run("no flags uses OAK context", func(t *testing.T) {
-		h := map[string]string{}
+		h := make(http.Header)
 		creds.ApplyAccountContextHeaders(h, "", "")
-		require.Equal(t, map[string]string{"Stripe-Context": "acct_a"}, h)
+		require.Equal(t, "acct_a", h.Get("Stripe-Context"))
+		require.Empty(t, h.Get("Stripe-Account"))
 	})
 	t.Run("account different value", func(t *testing.T) {
-		h := map[string]string{}
+		h := make(http.Header)
 		creds.ApplyAccountContextHeaders(h, "acct_b", "")
-		require.Equal(t, map[string]string{"Stripe-Account": "acct_a/acct_b"}, h)
+		require.Equal(t, "acct_a/acct_b", h.Get("Stripe-Account"))
+		require.Empty(t, h.Get("Stripe-Context"))
 	})
 	t.Run("account same value skips prefix", func(t *testing.T) {
-		h := map[string]string{}
+		h := make(http.Header)
 		creds.ApplyAccountContextHeaders(h, "acct_a", "")
-		require.Equal(t, map[string]string{"Stripe-Account": "acct_a"}, h)
+		require.Equal(t, "acct_a", h.Get("Stripe-Account"))
+		require.Empty(t, h.Get("Stripe-Context"))
 	})
 	t.Run("context different value", func(t *testing.T) {
-		h := map[string]string{}
+		h := make(http.Header)
 		creds.ApplyAccountContextHeaders(h, "", "acct_b")
-		require.Equal(t, map[string]string{"Stripe-Context": "acct_a/acct_b"}, h)
+		require.Equal(t, "acct_a/acct_b", h.Get("Stripe-Context"))
+		require.Empty(t, h.Get("Stripe-Account"))
 	})
 	t.Run("context same value skips prefix", func(t *testing.T) {
-		h := map[string]string{}
+		h := make(http.Header)
 		creds.ApplyAccountContextHeaders(h, "", "acct_a")
-		require.Equal(t, map[string]string{"Stripe-Context": "acct_a"}, h)
+		require.Equal(t, "acct_a", h.Get("Stripe-Context"))
+		require.Empty(t, h.Get("Stripe-Account"))
 	})
 	t.Run("account set omits Stripe-Context even when context also provided", func(t *testing.T) {
-		h := map[string]string{}
+		h := make(http.Header)
 		creds.ApplyAccountContextHeaders(h, "acct_b", "ctx_c")
-		require.Equal(t, map[string]string{"Stripe-Account": "acct_a/acct_b"}, h)
-		require.NotContains(t, h, "Stripe-Context")
+		require.Equal(t, "acct_a/acct_b", h.Get("Stripe-Account"))
+		require.Empty(t, h.Get("Stripe-Context"))
 	})
 }
 

--- a/pkg/stripe/client_test.go
+++ b/pkg/stripe/client_test.go
@@ -12,6 +12,67 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestApplyAccountContextHeaders_APIKey(t *testing.T) {
+	creds := NewAPIKeyCredentials("sk_test_123")
+
+	t.Run("no flags", func(t *testing.T) {
+		h := map[string]string{}
+		creds.ApplyAccountContextHeaders(h, "", "")
+		require.Empty(t, h)
+	})
+	t.Run("account only", func(t *testing.T) {
+		h := map[string]string{}
+		creds.ApplyAccountContextHeaders(h, "acct_b", "")
+		require.Equal(t, map[string]string{"Stripe-Account": "acct_b"}, h)
+	})
+	t.Run("context only", func(t *testing.T) {
+		h := map[string]string{}
+		creds.ApplyAccountContextHeaders(h, "", "ctx_c")
+		require.Equal(t, map[string]string{"Stripe-Context": "ctx_c"}, h)
+	})
+	t.Run("both", func(t *testing.T) {
+		h := map[string]string{}
+		creds.ApplyAccountContextHeaders(h, "acct_b", "ctx_c")
+		require.Equal(t, map[string]string{"Stripe-Account": "acct_b", "Stripe-Context": "ctx_c"}, h)
+	})
+}
+
+func TestApplyAccountContextHeaders_UAT(t *testing.T) {
+	creds := NewOAKCredentials("oak_test_123", "acct_a", false)
+
+	t.Run("no flags uses OAK context", func(t *testing.T) {
+		h := map[string]string{}
+		creds.ApplyAccountContextHeaders(h, "", "")
+		require.Equal(t, map[string]string{"Stripe-Context": "acct_a"}, h)
+	})
+	t.Run("account different value", func(t *testing.T) {
+		h := map[string]string{}
+		creds.ApplyAccountContextHeaders(h, "acct_b", "")
+		require.Equal(t, map[string]string{"Stripe-Account": "acct_a/acct_b"}, h)
+	})
+	t.Run("account same value skips prefix", func(t *testing.T) {
+		h := map[string]string{}
+		creds.ApplyAccountContextHeaders(h, "acct_a", "")
+		require.Equal(t, map[string]string{"Stripe-Account": "acct_a"}, h)
+	})
+	t.Run("context different value", func(t *testing.T) {
+		h := map[string]string{}
+		creds.ApplyAccountContextHeaders(h, "", "acct_b")
+		require.Equal(t, map[string]string{"Stripe-Context": "acct_a/acct_b"}, h)
+	})
+	t.Run("context same value skips prefix", func(t *testing.T) {
+		h := map[string]string{}
+		creds.ApplyAccountContextHeaders(h, "", "acct_a")
+		require.Equal(t, map[string]string{"Stripe-Context": "acct_a"}, h)
+	})
+	t.Run("account set omits Stripe-Context even when context also provided", func(t *testing.T) {
+		h := map[string]string{}
+		creds.ApplyAccountContextHeaders(h, "acct_b", "ctx_c")
+		require.Equal(t, map[string]string{"Stripe-Account": "acct_a/acct_b"}, h)
+		require.NotContains(t, h, "Stripe-Context")
+	})
+}
+
 func TestPerformRequest_ParamsEncoding_Delete(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/delete", r.URL.Path)


### PR DESCRIPTION
### Summary

This fixes how we set the `Stripe-Context` and `Stripe-Account` headers when we make requests with UATs.

Because UATs don't encode the merchant:
- Direct requests are required to set either of the headers (e.g.`Stripe-Context: acct_platform`)
- Connect requests need to set the path to the connected account (e.g. `Stripe-Context: acct_platform/acct_connected`).

For comparison, this is the logic for API keys:
- Direct requests don't need to set the headers
- Connect requests only need to set the header to the connected account ID (e.g. `Stripe-Account: acct_connected`)

### Testing

In my testing, acct_1GcldzAppfGnVJgH is my platform and acct_1TxsTBPOlWyUOE0Y is my connected account.

If you set `--stripe-account`, we set `Stripe-Account: acct_1GcldzAppfGnVJgH/acct_1TxsTBPOlWyUOE0Y`
```
go run cmd/stripe/main.go customers list --limit 1 --stripe-account acct_1TxsTBPOlWyUOE0Y --show-headers
> GET https://api.stripe.com/v1/customers?limit=1
> Authorization: Bearer [REDACTED]
> Content-Type: application/x-www-form-urlencoded
> Stripe-Account: acct_1GcldzAppfGnVJgH/acct_1TxsTBPOlWyUOE0Y
> Stripe-Livemode: false
< HTTP 200
< Content-Type: application/json
< Date: Tue, 04 Aug 2026 20:03:06 GMT
< Request-Id: req_htlx5d93aWcCRk
< Stripe-Account: acct_1TxsTBPOlWyUOE0Y
< Stripe-Version: 2024-10-28.acacia
...
```

If you set `--stripe-context`, we set `Stripe-Context: acct_1GcldzAppfGnVJgH/acct_1TxsTBPOlWyUOE0Y`
```
go run cmd/stripe/main.go customers list --limit 1 --stripe-context acct_1TxsTBPOlWyUOE0Y --show-headers
> GET https://api.stripe.com/v1/customers?limit=1
> Authorization: Bearer [REDACTED]
> Content-Type: application/x-www-form-urlencoded
> Stripe-Context: acct_1GcldzAppfGnVJgH/acct_1TxsTBPOlWyUOE0Y
> Stripe-Livemode: false
< HTTP 200
< Content-Type: application/json
< Date: Tue, 04 Aug 2026 20:05:22 GMT
< Request-Id: req_RDn2geRTIspNon
< Stripe-Account: acct_1TxsTBPOlWyUOE0Y
< Stripe-Version: 2024-10-28.acacia
...
```

If you don't set anything, we just set `Stripe-Context: acct_1GcldzAppfGnVJgH`
```
run cmd/stripe/main.go customers list --limit 1 --show-headers
> GET https://api.stripe.com/v1/customers?limit=1
> Authorization: Bearer [REDACTED]
> Content-Type: application/x-www-form-urlencoded
> Stripe-Context: acct_1GcldzAppfGnVJgH
> Stripe-Livemode: false
< HTTP 200
< Content-Type: application/json
< Date: Tue, 04 Aug 2026 20:04:44 GMT
< Request-Id: req_tUZHM4eEgA75wR
< Stripe-Version: 2024-10-28.acacia
```

If you set either flag to be the platform, we just set `Stripe-Context: acct_1GcldzAppfGnVJgH` or `Stripe-Account: acct_1GcldzAppfGnVJgH`
```
go run cmd/stripe/main.go customers list --limit 1 --stripe-context acct_1GcldzAppfGnVJgH --show-headers
> GET https://api.stripe.com/v1/customers?limit=1
> Authorization: Bearer [REDACTED]
> Content-Type: application/x-www-form-urlencoded
> Stripe-Context: acct_1GcldzAppfGnVJgH
> Stripe-Livemode: false
< HTTP 200
< Content-Type: application/json
< Date: Tue, 04 Aug 2026 20:08:37 GMT
< Request-Id: req_UcX3SLnTvueLYu
< Stripe-Version: 2024-10-28.acacia
```
```
go run cmd/stripe/main.go customers list --limit 1 --stripe-account acct_1GcldzAppfGnVJgH --show-headers
> GET https://api.stripe.com/v1/customers?limit=1
> Authorization: Bearer [REDACTED]
> Content-Type: application/x-www-form-urlencoded
> Stripe-Account: acct_1GcldzAppfGnVJgH
> Stripe-Livemode: false
< HTTP 200
< Content-Type: application/json
< Date: Tue, 04 Aug 2026 20:08:51 GMT
< Request-Id: req_0cQVXhlq3YZTrz
< Stripe-Version: 2024-10-28.acacia
```