### PR TITLE
Add response content type in debug log message

### DIFF
--- a/pkg/docs/client.go
+++ b/pkg/docs/client.go
@@ -192,7 +192,12 @@ func (c *Client) do(req *http.Request) (response, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	c.logger.WithFields(log.Fields{"url": req.URL, "status": resp.StatusCode, "duration": time.Since(start).Round(time.Millisecond)}).Debug("request complete")
+	c.logger.WithFields(log.Fields{
+		"url":          req.URL,
+		"status":       resp.StatusCode,
+		"content-type": resp.Header.Get("Content-Type"),
+		"duration":     time.Since(start).Round(time.Millisecond),
+	}).Debug("request complete")
 
 	if resp.StatusCode != http.StatusOK {
 		return response{}, fmt.Errorf("docs: %s returned %d", req.URL, resp.StatusCode)


### PR DESCRIPTION
 ### Summary

Adds the returned content type in the debug log message when making requests to docs.stripe.com.

<img width="936" height="133" alt="CleanShot 2026-08-04 at 12 50 53" src="https://github.com/user-attachments/assets/7364aa07-2e84-42ff-8581-44482de7f2a7" />

