### PR TITLE
Fix flaky winget install test by falling back to source reset

### DIFF
--- a/scripts/install-test.sh
+++ b/scripts/install-test.sh
@@ -41,7 +41,9 @@ run_install() {
     winget)
         # Re-register the WinGet source package to avoid 0x8a15000f "data required is missing".
         # See: https://github.com/microsoft/winget-cli/issues/3068#issuecomment-1934922201
-        powershell.exe -Command "Add-AppPackage -path 'https://cdn.winget.microsoft.com/cache/source.msix'"
+        # Falls back to source reset if the CDN is temporarily unavailable.
+        powershell.exe -Command "Add-AppPackage -path 'https://cdn.winget.microsoft.com/cache/source.msix'" || \
+            winget source reset --force
         winget install --exact --id Stripe.StripeCli --source winget
         # winget modifies PATH but the current shell process doesn't inherit the change;
         # explicitly add the WinGet Links directory where the stripe alias was created.


### PR DESCRIPTION
When the winget CDN is temporarily unavailable (HTTP 403), the Add-AppPackage step fails and leaves the winget source in a broken state. Retrying the same CDN download doesn't help since the source remains corrupted. Fall back to `winget source reset --force` which repairs the source locally without needing the CDN.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
