### PR TITLE
Implement OAuth login flow

### DIFF
--- a/pkg/cmd/fixtures.go
+++ b/pkg/cmd/fixtures.go
@@ -67,6 +67,8 @@ func (fc *FixturesCmd) runFixturesCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	fc.Cfg.Profile.PrintActiveContextBanner()
+
 	creds, err := fc.Cfg.Profile.ResolveCredentials(false)
 	if err != nil {
 		return err

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/login"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/useragent"
@@ -21,6 +22,7 @@ type loginCmd struct {
 	accessBaseURL    string
 	nonInteractive   bool
 	completeURL      string
+	newSession       bool
 }
 
 type loginListCmd struct {
@@ -102,6 +104,7 @@ For agents and scripts, use the two-step non-interactive flow:
 	lc.cmd.Flags().MarkHidden("dashboard-base") // #nosec G104
 	lc.cmd.Flags().StringVar(&lc.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
 	lc.cmd.Flags().MarkHidden("access-base") // #nosec G104
+	lc.cmd.Flags().BoolVar(&lc.newSession, "new-session", false, "Force a new login even if already authenticated")
 
 	listCmd := &loginListCmd{}
 	listCmd.cmd = &cobra.Command{
@@ -139,6 +142,26 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 
 	if lc.completeURL != "" {
 		return login.PollForLogin(cmd.Context(), lc.completeURL, &Config)
+	}
+
+	if !lc.newSession {
+		uat, _ := Config.Profile.GetUAT()
+		if strings.HasPrefix(uat, "oak_") {
+			identity := Config.Profile.GetDisplayName()
+			if identity == "" {
+				if ac, _ := config.GetActiveContext(); ac != nil {
+					identity = ac.AccountID
+				}
+			}
+			if identity != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "You're already logged in as %s.\n", identity)
+			} else {
+				fmt.Fprintln(cmd.OutOrStdout(), "You're already logged in.")
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Run 'stripe reauth' to change permissions or authorize access to additional accounts or sandboxes.")
+			fmt.Fprintln(cmd.OutOrStdout(), "To log in as a different user, run: stripe login --new-session")
+			return nil
+		}
 	}
 
 	if lc.nonInteractive || !shouldAutoLogin(os.Getenv, term.IsTerminal(int(os.Stdin.Fd()))) {

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -17,16 +18,20 @@ type loginCmd struct {
 	cmd              *cobra.Command
 	interactive      bool
 	dashboardBaseURL string
+	accessBaseURL    string
 	nonInteractive   bool
 	completeURL      string
 }
 
 type loginListCmd struct {
-	cmd *cobra.Command
+	cmd           *cobra.Command
+	accessBaseURL string
 }
 
 type loginSwitchCmd struct {
-	cmd *cobra.Command
+	cmd           *cobra.Command
+	livemode      bool
+	accessBaseURL string
 }
 
 func newLoginCmd() *loginCmd {
@@ -95,6 +100,8 @@ For agents and scripts, use the two-step non-interactive flow:
 	// Hidden configuration flags, useful for dev/debugging
 	lc.cmd.Flags().StringVar(&lc.dashboardBaseURL, "dashboard-base", stripe.DefaultDashboardBaseURL, "Sets the dashboard base URL")
 	lc.cmd.Flags().MarkHidden("dashboard-base") // #nosec G104
+	lc.cmd.Flags().StringVar(&lc.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	lc.cmd.Flags().MarkHidden("access-base") // #nosec G104
 
 	listCmd := &loginListCmd{}
 	listCmd.cmd = &cobra.Command{
@@ -104,17 +111,22 @@ For agents and scripts, use the two-step non-interactive flow:
 		Example: `stripe login list`,
 		RunE:    listCmd.listLoggedInAccountsCmd,
 	}
+	listCmd.cmd.Flags().StringVar(&listCmd.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	listCmd.cmd.Flags().MarkHidden("access-base") // #nosec G104
 
 	lc.cmd.AddCommand(listCmd.cmd)
 
 	switchCmd := &loginSwitchCmd{}
 	switchCmd.cmd = &cobra.Command{
-		Use:     "switch",
-		Args:    validators.ExactArgs(1),
-		Short:   "Switch to a different logged-in account",
-		Example: `stripe login switch <account_name>`,
+		Use:     "switch [account_id]",
+		Args:    validators.MaximumNArgs(1),
+		Short:   "Alias for 'stripe switch context'",
+		Example: `stripe login switch\n  stripe login switch acct_1234\n  stripe login switch acct_1234 --live`,
 		RunE:    switchCmd.switchLoggedInAccountCmd,
 	}
+	switchCmd.cmd.Flags().BoolVar(&switchCmd.livemode, "live", false, "Select livemode for the given account")
+	switchCmd.cmd.Flags().StringVar(&switchCmd.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	switchCmd.cmd.Flags().MarkHidden("access-base") // #nosec G104
 
 	lc.cmd.AddCommand(switchCmd.cmd)
 	return lc
@@ -140,14 +152,29 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 		return login.InteractiveLogin(cmd.Context(), &Config)
 	}
 
-	return login.Login(cmd.Context(), lc.dashboardBaseURL, login.DefaultAccessBaseURL, &Config)
+	return login.Login(cmd.Context(), lc.dashboardBaseURL, lc.accessBaseURL, &Config)
 }
 
 // TODO: we should support bash completion for account names
 func (lc *loginListCmd) listLoggedInAccountsCmd(cmd *cobra.Command, args []string) error {
+	uat, _ := Config.Profile.GetUAT()
+	if strings.HasPrefix(uat, "oak_") {
+		return login.PrintAuthorizedContexts(cmd.Context(), lc.accessBaseURL, uat)
+	}
 	return Config.ListProfiles()
 }
 
 func (lc *loginSwitchCmd) switchLoggedInAccountCmd(cmd *cobra.Command, args []string) error {
+	uat, _ := Config.Profile.GetUAT()
+	if strings.HasPrefix(uat, "oak_") {
+		accountID := ""
+		if len(args) > 0 {
+			accountID = args[0]
+		}
+		return login.SwitchContext(cmd.Context(), lc.accessBaseURL, &Config, accountID, lc.livemode)
+	}
+	if len(args) == 0 {
+		return fmt.Errorf("account name required")
+	}
 	return Config.SwitchProfile(args[0])
 }

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -140,7 +140,7 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 		return login.InteractiveLogin(cmd.Context(), &Config)
 	}
 
-	return login.Login(cmd.Context(), lc.dashboardBaseURL, &Config)
+	return login.Login(cmd.Context(), lc.dashboardBaseURL, login.DefaultAccessBaseURL, &Config)
 }
 
 // TODO: we should support bash completion for account names

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -168,7 +168,7 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 		if useragent.DetectAIAgent(os.Getenv) != "" {
 			fmt.Fprintln(os.Stderr, "If you do not have an account, run `stripe sandbox create` instead (provisions a claimable sandbox without a browser).")
 		}
-		return login.InitiateLogin(cmd.Context(), lc.dashboardBaseURL, &Config)
+		return login.InitiateLogin(cmd.Context(), lc.dashboardBaseURL, lc.accessBaseURL, &Config)
 	}
 
 	if lc.interactive {

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -22,6 +22,7 @@ type loginCmd struct {
 	accessBaseURL    string
 	nonInteractive   bool
 	completeURL      string
+	completeDevice   bool
 	newSession       bool
 }
 
@@ -93,6 +94,8 @@ For agents and scripts, use the two-step non-interactive flow:
 	lc.cmd.Flags().BoolVarP(&lc.interactive, "interactive", "i", false, "Run interactive configuration mode if you cannot open a browser")
 	lc.cmd.Flags().BoolVar(&lc.nonInteractive, "non-interactive", false, "Print login URL and verification code as JSON and exit; immediately run the next_step command from the output to poll while the user approves in the browser")
 	lc.cmd.Flags().StringVar(&lc.completeURL, "complete", "", "Complete a browser login by polling the given URL (from 'stripe login --non-interactive')")
+	lc.cmd.Flags().BoolVar(&lc.completeDevice, "complete-device", false, "Complete an OAuth device authorization started by 'stripe login --non-interactive'")
+	lc.cmd.Flags().MarkHidden("complete-device") // #nosec G104
 
 	// TODO: a flag to replace existing account?
 	// TODO: what happens to if already logged into that account? - profile name should be the account id
@@ -138,6 +141,10 @@ For agents and scripts, use the two-step non-interactive flow:
 func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 	if err := stripe.ValidateDashboardBaseURL(lc.dashboardBaseURL); err != nil {
 		return err
+	}
+
+	if lc.completeDevice {
+		return login.PollPendingDeviceAuth(cmd.Context(), &Config)
 	}
 
 	if lc.completeURL != "" {

--- a/pkg/cmd/logout.go
+++ b/pkg/cmd/logout.go
@@ -3,13 +3,15 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/stripe/stripe-cli/pkg/login"
 	"github.com/stripe/stripe-cli/pkg/logout"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
 type logoutCmd struct {
-	cmd *cobra.Command
-	all bool
+	cmd           *cobra.Command
+	all           bool
+	accessBaseURL string
 }
 
 func newLogoutCmd() *logoutCmd {
@@ -24,14 +26,15 @@ func newLogoutCmd() *logoutCmd {
 	}
 
 	lc.cmd.Flags().BoolVarP(&lc.all, "all", "a", false, "Clear credentials for all projects you are currently logged into.")
+	lc.cmd.Flags().StringVar(&lc.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	lc.cmd.Flags().MarkHidden("access-base") //nolint:errcheck
 
 	return lc
 }
 
 func (lc *logoutCmd) runLogoutCmd(cmd *cobra.Command, args []string) error {
 	if lc.all {
-		return logout.All(&Config)
+		return logout.All(cmd.Context(), lc.accessBaseURL, &Config)
 	}
-
-	return logout.Logout(&Config)
+	return logout.Logout(cmd.Context(), lc.accessBaseURL, &Config)
 }

--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -32,6 +32,7 @@ type InstallCmd struct {
 
 	apiBaseURL       string
 	dashboardBaseURL string
+	accessBaseURL    string
 }
 
 // NewInstallCmd creates a command for installing plugins
@@ -54,6 +55,8 @@ func NewInstallCmd(config *config.Config) *InstallCmd {
 	ic.Cmd.Flags().MarkHidden("api-base") // #nosec G104
 	ic.Cmd.Flags().StringVar(&ic.dashboardBaseURL, "dashboard-base", "", "Sets the dashboard base URL")
 	ic.Cmd.Flags().MarkHidden("dashboard-base") // #nosec G104
+	ic.Cmd.Flags().StringVar(&ic.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	ic.Cmd.Flags().MarkHidden("access-base") // #nosec G104
 
 	return ic
 }
@@ -106,7 +109,7 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 				if input != "" {
 					return fmt.Errorf("login canceled")
 				}
-				if lErr := login.Login(cmd.Context(), dashboardBaseURL, login.DefaultAccessBaseURL, ic.cfg); lErr != nil {
+				if lErr := login.Login(cmd.Context(), dashboardBaseURL, ic.accessBaseURL, ic.cfg); lErr != nil {
 					return lErr
 				}
 				resolvedPlugin, err = plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL, dashboardBaseURL)
@@ -126,7 +129,7 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 				if input != "" {
 					return fmt.Errorf("login canceled")
 				}
-				if lErr := login.Login(cmd.Context(), dashboardBaseURL, login.DefaultAccessBaseURL, ic.cfg); lErr != nil {
+				if lErr := login.Login(cmd.Context(), dashboardBaseURL, ic.accessBaseURL, ic.cfg); lErr != nil {
 					return lErr
 				}
 				resolvedPlugin, err = plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL, dashboardBaseURL)

--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -106,7 +106,7 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 				if input != "" {
 					return fmt.Errorf("login canceled")
 				}
-				if lErr := login.Login(cmd.Context(), dashboardBaseURL, ic.cfg); lErr != nil {
+				if lErr := login.Login(cmd.Context(), dashboardBaseURL, login.DefaultAccessBaseURL, ic.cfg); lErr != nil {
 					return lErr
 				}
 				resolvedPlugin, err = plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL, dashboardBaseURL)
@@ -126,7 +126,7 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 				if input != "" {
 					return fmt.Errorf("login canceled")
 				}
-				if lErr := login.Login(cmd.Context(), dashboardBaseURL, ic.cfg); lErr != nil {
+				if lErr := login.Login(cmd.Context(), dashboardBaseURL, login.DefaultAccessBaseURL, ic.cfg); lErr != nil {
 					return lErr
 				}
 				resolvedPlugin, err = plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL, dashboardBaseURL)

--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -113,7 +113,7 @@ func newPluginHintCmd(cfg *config.Config, name, description string, opts ...opti
 			return resolvedPlugin.Install(ctx, cfg, fs, stripe.DefaultAPIBaseURL, dashboardBaseURL)
 		},
 		loginFn: func(ctx context.Context) error {
-			return login.Login(ctx, dashboardBaseURL, cfg)
+			return login.Login(ctx, dashboardBaseURL, login.DefaultAccessBaseURL, cfg)
 		},
 		accountIDFn:   cfg.GetProfile().GetAccountID,
 		openBrowserFn: open.Browser,

--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -71,6 +71,7 @@ type pluginHintCmd struct {
 	name           string
 	description    string
 	privatePreview bool
+	accessBaseURL  string
 
 	lookupFn      func(ctx context.Context) error
 	installFn     func(ctx context.Context) error
@@ -99,8 +100,9 @@ func newPluginHintCmd(cfg *config.Config, name, description string, opts ...opti
 	}
 
 	p := &pluginHintCmd{
-		name:        name,
-		description: description,
+		name:          name,
+		description:   description,
+		accessBaseURL: login.DefaultAccessBaseURL,
 		lookupFn: func(ctx context.Context) error {
 			_, err := resolvePlugin(ctx)
 			return err
@@ -112,13 +114,13 @@ func newPluginHintCmd(cfg *config.Config, name, description string, opts ...opti
 			}
 			return resolvedPlugin.Install(ctx, cfg, fs, stripe.DefaultAPIBaseURL, dashboardBaseURL)
 		},
-		loginFn: func(ctx context.Context) error {
-			return login.Login(ctx, dashboardBaseURL, login.DefaultAccessBaseURL, cfg)
-		},
 		accountIDFn:   cfg.GetProfile().GetAccountID,
 		openBrowserFn: open.Browser,
 		stdin:         os.Stdin,
 		stdout:        os.Stdout,
+	}
+	p.loginFn = func(ctx context.Context) error {
+		return login.Login(ctx, dashboardBaseURL, p.accessBaseURL, cfg)
 	}
 
 	for _, opt := range opts {
@@ -132,6 +134,8 @@ func newPluginHintCmd(cfg *config.Config, name, description string, opts ...opti
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		RunE:               p.run,
 	}
+	p.Command.Flags().StringVar(&p.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	_ = p.Command.Flags().MarkHidden("access-base")
 
 	return p
 }

--- a/pkg/cmd/reauth.go
+++ b/pkg/cmd/reauth.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/login"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+type reauthCmd struct {
+	cmd           *cobra.Command
+	accessBaseURL string
+}
+
+func newReauthCmd() *reauthCmd {
+	rc := &reauthCmd{}
+	rc.cmd = &cobra.Command{
+		Use:   "reauth",
+		Args:  validators.NoArgs,
+		Short: "Re-authorize the CLI for the current OAuth session",
+		Long: `Re-authorize the CLI to change permissions or authorize access to
+additional accounts or sandboxes.
+
+Opens the Stripe Dashboard so you can re-consent for the current OAuth session.`,
+		Example: `stripe reauth`,
+		RunE:    rc.runReauthCmd,
+	}
+	rc.cmd.Flags().StringVar(&rc.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	rc.cmd.Flags().MarkHidden("access-base") //nolint:errcheck
+	return rc
+}
+
+func (rc *reauthCmd) runReauthCmd(cmd *cobra.Command, args []string) error {
+	uat, _ := Config.Profile.GetUAT()
+	if !strings.HasPrefix(uat, "oak_") {
+		return fmt.Errorf("reauth requires an OAuth session; run 'stripe login' to authenticate")
+	}
+	return login.Reauth(cmd.Context(), rc.accessBaseURL, uat)
+}

--- a/pkg/cmd/resource/climate.go
+++ b/pkg/cmd/resource/climate.go
@@ -86,6 +86,8 @@ func runClimateOperation(cmd *cobra.Command, opCmd *OperationCmd, requestParams 
 		return err
 	}
 
+	opCmd.Profile.PrintActiveContextBanner()
+
 	// Suppress base output so we can transform the response before printing.
 	opCmd.SuppressOutput = true
 

--- a/pkg/cmd/resource/databases.go
+++ b/pkg/cmd/resource/databases.go
@@ -484,6 +484,8 @@ func executeDatabaseOperation(cmd *cobra.Command, opCmd *OperationCmd, args []st
 		return nil, err
 	}
 
+	opCmd.Profile.PrintActiveContextBanner()
+
 	opCmd.Parameters.SetVersion(databaseRequestVersion)
 
 	path := formatURL(opCmd.Path, args)

--- a/pkg/cmd/resource/operation.go
+++ b/pkg/cmd/resource/operation.go
@@ -50,6 +50,8 @@ func (oc *OperationCmd) runOperationCmd(cmd *cobra.Command, args []string) error
 		return err
 	}
 
+	oc.Profile.PrintActiveContextBanner()
+
 	creds, credsErr := oc.ResolveCredentials()
 
 	path := formatURL(oc.Path, args)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -39,6 +39,8 @@ import (
 // Config is the cli configuration for the user
 var Config config.Config
 
+var rootAccessBaseURL string
+
 var fs = afero.NewOsFs()
 
 // rootCmd represents the base command when called without any subcommands
@@ -175,7 +177,7 @@ func Execute(ctx context.Context) {
 			} else {
 				fmt.Fprintf(os.Stderr, "%s. Running `stripe login`...\n", string(errRunes))
 
-				err = login.Login(updatedCtx, stripe.DefaultDashboardBaseURL, login.DefaultAccessBaseURL, &Config)
+				err = login.Login(updatedCtx, stripe.DefaultDashboardBaseURL, rootAccessBaseURL, &Config)
 
 				if err != nil {
 					fmt.Fprintln(os.Stderr, err)
@@ -250,6 +252,9 @@ func init() {
 	rootCmd.PersistentFlags().String("map", "", "Print a command tree [tree|compact|paths|json]")
 	rootCmd.PersistentFlags().Lookup("map").NoOptDefVal = "tree"
 	rootCmd.Flags().BoolP("version", "v", false, "Get the version of the Stripe CLI")
+	rootCmd.PersistentFlags().StringVar(&rootAccessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	rootCmd.PersistentFlags().MarkHidden("access-base") //nolint:errcheck
+
 	// tell viper to monitor the following flags:
 	// they will be available via viper.get(KEY), but not mapped back to the Config (by default; see below)
 	viper.BindPFlag("color", rootCmd.PersistentFlags().Lookup("color"))

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -73,6 +73,10 @@ var rootCmd = &cobra.Command{
 			fullHelpMode = true
 		}
 
+		// Make the --access-base value available to the OAuth token refresher,
+		// which runs inside ResolveCredentials without access to cobra flags.
+		Config.Profile.OAuthAccessBaseURL = rootAccessBaseURL
+
 		reporting.SetCommandPath(cmd.CommandPath())
 
 		// if getting the config errors, don't fail running the command

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -175,7 +175,7 @@ func Execute(ctx context.Context) {
 			} else {
 				fmt.Fprintf(os.Stderr, "%s. Running `stripe login`...\n", string(errRunes))
 
-				err = login.Login(updatedCtx, stripe.DefaultDashboardBaseURL, &Config)
+				err = login.Login(updatedCtx, stripe.DefaultDashboardBaseURL, login.DefaultAccessBaseURL, &Config)
 
 				if err != nil {
 					fmt.Fprintln(os.Stderr, err)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -250,7 +250,6 @@ func init() {
 	rootCmd.PersistentFlags().String("map", "", "Print a command tree [tree|compact|paths|json]")
 	rootCmd.PersistentFlags().Lookup("map").NoOptDefVal = "tree"
 	rootCmd.Flags().BoolP("version", "v", false, "Get the version of the Stripe CLI")
-
 	// tell viper to monitor the following flags:
 	// they will be available via viper.get(KEY), but not mapped back to the Config (by default; see below)
 	viper.BindPFlag("color", rootCmd.PersistentFlags().Lookup("color"))
@@ -275,6 +274,7 @@ func init() {
 	rootCmd.AddCommand(newResourcesCmd().cmd)
 	rootCmd.AddCommand(newSamplesCmd().cmd)
 	rootCmd.AddCommand(newServeCmd().cmd)
+	rootCmd.AddCommand(newSwitchCmd().cmd)
 	// current stripe status site is being deprecated
 	// hide status command until status site v2 is released
 	// rootCmd.AddCommand(newStatusCmd().cmd)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -269,6 +269,7 @@ func init() {
 	rootCmd.AddCommand(newListenCmd().cmd)
 	rootCmd.AddCommand(newLoginCmd().cmd)
 	rootCmd.AddCommand(newLogoutCmd().cmd)
+	rootCmd.AddCommand(newReauthCmd().cmd)
 	rootCmd.AddCommand(newLogsCmd(&Config).Cmd)
 	rootCmd.AddCommand(newOpenCmd().cmd)
 	rootCmd.AddCommand(newResourcesCmd().cmd)

--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -267,7 +267,7 @@ func (scc *sandboxCreateCmd) runDashboardFlow(cmd *cobra.Command, color aurora.A
 	if scc.nonInteractive {
 		return login.InitiateLogin(cmd.Context(), scc.dashboardURL, &Config)
 	}
-	return login.Login(cmd.Context(), scc.dashboardURL, &Config)
+	return login.Login(cmd.Context(), scc.dashboardURL, login.DefaultAccessBaseURL, &Config)
 }
 
 func (scc *sandboxCreateCmd) outputResult(cmd *cobra.Command, color aurora.Aurora, result *sandbox.ProvisionResponse) error {

--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -268,7 +268,7 @@ func (scc *sandboxCreateCmd) runDashboardFlow(cmd *cobra.Command, color aurora.A
 	}
 
 	if scc.nonInteractive {
-		return login.InitiateLogin(cmd.Context(), scc.dashboardURL, &Config)
+		return login.InitiateLogin(cmd.Context(), scc.dashboardURL, scc.accessBaseURL, &Config)
 	}
 	return login.Login(cmd.Context(), scc.dashboardURL, scc.accessBaseURL, &Config)
 }

--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -41,6 +41,7 @@ type sandboxCreateCmd struct {
 	nonInteractive bool
 	baseURL        string
 	dashboardURL   string
+	accessBaseURL  string
 }
 
 func newSandboxCmd() *sandboxCmd {
@@ -102,6 +103,8 @@ work immediately.`,
 
 	scc.cmd.Flags().StringVar(&scc.dashboardURL, "dashboard-base", stripe.DefaultDashboardBaseURL, "Sets the dashboard base URL")
 	_ = scc.cmd.Flags().MarkHidden("dashboard-base")
+	scc.cmd.Flags().StringVar(&scc.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	_ = scc.cmd.Flags().MarkHidden("access-base")
 
 	return scc
 }
@@ -267,7 +270,7 @@ func (scc *sandboxCreateCmd) runDashboardFlow(cmd *cobra.Command, color aurora.A
 	if scc.nonInteractive {
 		return login.InitiateLogin(cmd.Context(), scc.dashboardURL, &Config)
 	}
-	return login.Login(cmd.Context(), scc.dashboardURL, login.DefaultAccessBaseURL, &Config)
+	return login.Login(cmd.Context(), scc.dashboardURL, scc.accessBaseURL, &Config)
 }
 
 func (scc *sandboxCreateCmd) outputResult(cmd *cobra.Command, color aurora.Aurora, result *sandbox.ProvisionResponse) error {

--- a/pkg/cmd/switch.go
+++ b/pkg/cmd/switch.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/login"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+type switchCmd struct {
+	cmd *cobra.Command
+}
+
+type switchContextCmd struct {
+	cmd           *cobra.Command
+	livemode      bool
+	accessBaseURL string
+}
+
+func newSwitchCmd() *switchCmd {
+	sc := &switchCmd{}
+	sc.cmd = &cobra.Command{
+		Use:   "switch",
+		Short: "Switch active context or profile",
+	}
+
+	ctxCmd := &switchContextCmd{}
+	ctxCmd.cmd = &cobra.Command{
+		Use:   "context [account_id]",
+		Args:  validators.MaximumNArgs(1),
+		Short: "Switch to a different authorized account context",
+		Long: `Switch to a different authorized account context.
+
+Without an argument, shows an interactive list of your authorized accounts and
+modes. Navigate with ↑↓, confirm with enter, or cancel with esc.
+
+With an account ID, switches directly to that account in test mode by default.
+Use --live to switch to livemode instead.`,
+		Example: `  stripe switch context
+  stripe switch context acct_1234
+  stripe switch context acct_1234 --live`,
+		RunE: ctxCmd.run,
+	}
+	ctxCmd.cmd.Flags().BoolVar(&ctxCmd.livemode, "live", false, "Select livemode for the given account")
+	ctxCmd.cmd.Flags().StringVar(&ctxCmd.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	ctxCmd.cmd.Flags().MarkHidden("access-base") //nolint:errcheck
+
+	sc.cmd.AddCommand(ctxCmd.cmd)
+	return sc
+}
+
+func (sc *switchContextCmd) run(cmd *cobra.Command, args []string) error {
+	accountID := ""
+	if len(args) > 0 {
+		accountID = args[0]
+	}
+	return login.SwitchContext(cmd.Context(), sc.accessBaseURL, &Config, accountID, sc.livemode)
+}

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -84,6 +84,8 @@ func (tc *triggerCmd) runTriggerCmd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	Config.Profile.PrintActiveContextBanner()
+
 	creds, err := Config.Profile.ResolveCredentials(false)
 	if err != nil {
 		return err

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/login"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
@@ -21,9 +22,10 @@ import (
 var errNotAuthenticated = errors.New("not authenticated")
 
 type whoamiCmd struct {
-	cmd     *cobra.Command
-	profile *config.Profile
-	format  string
+	cmd           *cobra.Command
+	profile       *config.Profile
+	format        string
+	accessBaseURL string
 }
 
 type whoamiKeyInfo struct {
@@ -70,12 +72,19 @@ Exit codes:
 	}
 
 	wc.cmd.Flags().StringVar(&wc.format, "format", "", "Output format: 'json' for a stable JSON schema (suitable for scripting)")
+	wc.cmd.Flags().StringVar(&wc.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	wc.cmd.Flags().MarkHidden("access-base") //nolint:errcheck
 
 	return wc
 }
 
 func (wc *whoamiCmd) runWhoamiCmd(cmd *cobra.Command, args []string) error {
 	profile := wc.profile
+
+	uat, _ := profile.GetUAT()
+	if strings.HasPrefix(uat, "oak_") {
+		return wc.runWhoamiOAuth(cmd, uat)
+	}
 
 	testKey := resolveKeyInfo(profile, false)
 	liveKey := resolveKeyInfo(profile, true)
@@ -111,6 +120,25 @@ func (wc *whoamiCmd) runWhoamiCmd(cmd *cobra.Command, args []string) error {
 		return errNotAuthenticated
 	}
 	return nil
+}
+
+func (wc *whoamiCmd) runWhoamiOAuth(cmd *cobra.Command, uat string) error {
+	w := cmd.OutOrStdout()
+
+	ac, _ := config.GetActiveContext()
+	if ac != nil {
+		displayName := wc.profile.GetDisplayName()
+		mode := "test"
+		if ac.Livemode {
+			mode = "live"
+		}
+		tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+		fmt.Fprintf(tw, "Context\t%s · %s (%s)\n", displayName, mode, ac.AccountID)
+		tw.Flush()
+		fmt.Fprintln(w)
+	}
+
+	return login.PrintAuthorizedContexts(cmd.Context(), wc.accessBaseURL, uat)
 }
 
 func printWhoamiText(out io.Writer, data whoamiOutput) {

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -122,6 +122,8 @@ func (wc *whoamiCmd) runWhoamiCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+const expiryDisplayFormat = "Jan 2, 2006 at 3:04 PM"
+
 func (wc *whoamiCmd) runWhoamiOAuth(cmd *cobra.Command, uat string) error {
 	w := cmd.OutOrStdout()
 
@@ -134,6 +136,9 @@ func (wc *whoamiCmd) runWhoamiOAuth(cmd *cobra.Command, uat string) error {
 		}
 		tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 		fmt.Fprintf(tw, "Context\t%s · %s (%s)\n", displayName, mode, ac.AccountID)
+		if t, err := config.GetUATExpiresAt(); err == nil {
+			fmt.Fprintf(tw, "Expires\t%s\n", t.Local().Format(expiryDisplayFormat))
+		}
 		tw.Flush()
 		fmt.Fprintln(w)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -439,6 +439,7 @@ func (c *Config) RemoveAuthFields(profileName string) error {
 	deleteTopLevelLivemodeKey(UATKeychainItemKey)
 	deleteTopLevelLivemodeKey(OAuthRefreshTokenKeychainKey)
 	deleteTopLevelLivemodeKey(OAuthActiveContextKeychainKey)
+	deleteTopLevelLivemodeKey(OAuthUATExpiresAtKeychainKey)
 
 	// TODO: remove with legacy RAK/OIDC flow.
 	if runtimeViper.IsSet(UserInfoName) {
@@ -464,6 +465,7 @@ func (c *Config) RemoveAllAuthFields() error {
 	deleteTopLevelLivemodeKey(UATKeychainItemKey)
 	deleteTopLevelLivemodeKey(OAuthRefreshTokenKeychainKey)
 	deleteTopLevelLivemodeKey(OAuthActiveContextKeychainKey)
+	deleteTopLevelLivemodeKey(OAuthUATExpiresAtKeychainKey)
 
 	// TODO: remove with legacy RAK/OIDC flow.
 	if runtimeViper.IsSet(UserInfoName) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -437,7 +437,10 @@ func (c *Config) RemoveAuthFields(profileName string) error {
 	}
 
 	deleteTopLevelLivemodeKey(UATKeychainItemKey)
+	deleteTopLevelLivemodeKey(OAuthRefreshTokenKeychainKey)
+	deleteTopLevelLivemodeKey(OAuthActiveContextKeychainKey)
 
+	// TODO: remove with legacy RAK/OIDC flow.
 	if runtimeViper.IsSet(UserInfoName) {
 		runtimeViper, _ = removeKey(runtimeViper, UserInfoName)
 	}
@@ -459,7 +462,10 @@ func (c *Config) RemoveAllAuthFields() error {
 	}
 
 	deleteTopLevelLivemodeKey(UATKeychainItemKey)
+	deleteTopLevelLivemodeKey(OAuthRefreshTokenKeychainKey)
+	deleteTopLevelLivemodeKey(OAuthActiveContextKeychainKey)
 
+	// TODO: remove with legacy RAK/OIDC flow.
 	if runtimeViper.IsSet(UserInfoName) {
 		runtimeViper, _ = removeKey(runtimeViper, UserInfoName)
 	}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -85,6 +85,9 @@ const OAuthActiveContextKeychainKey = "oauth_active_context"
 // OAuthRefreshTokenKeychainKey is the keyring key for the OAuth refresh token.
 const OAuthRefreshTokenKeychainKey = "oauth_refresh_token"
 
+// OAuthUATExpiresAtKeychainKey is the keyring key for the UAT expiry time (RFC3339).
+const OAuthUATExpiresAtKeychainKey = "oauth_uat_expires_at"
+
 // ActiveContext identifies the account and mode that is currently selected.
 type ActiveContext struct {
 	AccountID string `json:"account_id"`
@@ -683,6 +686,27 @@ func SaveActiveContext(accountID string, livemode bool) error {
 		return err
 	}
 	return KeyRing.Set(OAuthActiveContextKeychainKey, data, "Stripe CLI OAuth active context")
+}
+
+// SaveUATExpiresAt persists the UAT expiry time in the keyring.
+func SaveUATExpiresAt(t time.Time) error {
+	if KeyRing == nil {
+		return nil
+	}
+	return KeyRing.Set(OAuthUATExpiresAtKeychainKey, []byte(t.UTC().Format(time.RFC3339)), "Stripe CLI OAuth token expiry")
+}
+
+// GetUATExpiresAt retrieves the stored UAT expiry time from the keyring.
+// Returns ErrKeyNotFound (wrapped) when no expiry has been saved.
+func GetUATExpiresAt() (time.Time, error) {
+	if KeyRing == nil {
+		return time.Time{}, keyring.ErrKeyNotFound
+	}
+	data, err := KeyRing.Get(OAuthUATExpiresAtKeychainKey)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Parse(time.RFC3339, string(data))
 }
 
 // PrintActiveContextBanner prints the active context to stderr once per

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/viper"
@@ -16,7 +17,17 @@ import (
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
-// Compartment represents a Stripe compartment from the OIDC userinfo response.
+var printActiveContextOnce sync.Once
+
+// AuthorizedAccount represents a Stripe account accessible to an OAuth token.
+type AuthorizedAccount struct {
+	ID    string   `json:"id"`
+	Name  string   `json:"name"`
+	Modes []string `json:"modes"`
+}
+
+// Compartment represents a Stripe workspace from the OIDC userinfo response.
+// TODO: remove with legacy RAK/OIDC flow.
 type Compartment struct {
 	CompartmentID string `json:"compartment_id" mapstructure:"compartment_id" toml:"compartment_id"`
 	Livemode      bool   `json:"livemode"        mapstructure:"livemode"        toml:"livemode"`
@@ -24,6 +35,7 @@ type Compartment struct {
 
 // UserInfo mirrors the OIDC userinfo endpoint response and is persisted as a
 // nested table in the profile config.
+// TODO: remove with legacy RAK/OIDC flow.
 type UserInfo struct {
 	Compartments []Compartment `json:"https://stripe.com/compartments" mapstructure:"compartments" toml:"compartments"`
 }
@@ -44,7 +56,7 @@ type Profile struct {
 	SandboxClaimURL        string
 	SandboxExpiresAt       string
 	UAT                    string
-	UserInfo               *UserInfo
+	UserInfo               *UserInfo // TODO: remove with legacy RAK/OIDC flow
 }
 
 // config key names
@@ -62,10 +74,22 @@ const (
 	LiveModeKeyExpiresAtName   = "live_mode_key_expires_at"
 	SandboxClaimURLName        = "sandbox_claim_url"
 	SandboxExpiresAtName       = "sandbox_expires_at"
-	UserInfoName               = "user_info"
+	UserInfoName               = "user_info" // TODO: remove with legacy RAK/OIDC flow
 )
 
 const UATKeychainItemKey = "uat"
+
+// OAuthActiveContextKeychainKey is the keyring key for the active OAuth context.
+const OAuthActiveContextKeychainKey = "oauth_active_context"
+
+// OAuthRefreshTokenKeychainKey is the keyring key for the OAuth refresh token.
+const OAuthRefreshTokenKeychainKey = "oauth_refresh_token"
+
+// ActiveContext identifies the account and mode that is currently selected.
+type ActiveContext struct {
+	AccountID string `json:"account_id"`
+	Livemode  bool   `json:"livemode"`
+}
 
 const (
 	// DateStringFormat is the format for expiredAt date
@@ -116,7 +140,8 @@ func (p *Profile) CreateProfile() error {
 	// Fail open to avoid blocking login
 	p.deleteLivemodeValue(LiveModeAPIKeyName)
 
-	// user_info is top-level; remove it before re-writing so stale data is never kept
+	// TODO: remove with legacy RAK/OIDC flow.
+	// user_info is top-level; remove it before re-writing so stale data is never kept.
 	if v.IsSet(UserInfoName) {
 		var err error
 		v, err = removeKey(v, UserInfoName)
@@ -485,6 +510,7 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 		}
 	}
 
+	// TODO: remove with legacy RAK/OIDC flow.
 	if p.UserInfo != nil {
 		runtimeViper.Set(UserInfoName, p.UserInfo)
 	}
@@ -603,25 +629,6 @@ func (p *Profile) deleteLivemodeValue(key string) error {
 	return err
 }
 
-// GetUserInfo reads the stored UserInfo from the profile config.
-// Returns nil, nil when no user_info has been saved yet.
-func (p *Profile) GetUserInfo() (*UserInfo, error) {
-	if err := viper.ReadInConfig(); err != nil {
-		return nil, err
-	}
-
-	if !viper.IsSet(UserInfoName) {
-		return nil, nil
-	}
-
-	var ui UserInfo
-	if err := viper.UnmarshalKey(UserInfoName, &ui); err != nil {
-		return nil, err
-	}
-
-	return &ui, nil
-}
-
 // SessionCredentials are the credentials needed for this session
 type SessionCredentials struct {
 	UAT        string `json:"uat"`
@@ -645,8 +652,81 @@ func (p *Profile) GetUAT() (string, error) {
 	return string(data), nil
 }
 
-// GetCompartmentID returns the compartment (workspace) ID for the given mode
-// from the stored UserInfo. Returns an empty string if none is configured.
+// GetActiveContext reads the stored OAuth active context from the keyring.
+// Returns nil, nil when no active context has been saved yet.
+func GetActiveContext() (*ActiveContext, error) {
+	if KeyRing == nil {
+		return nil, nil
+	}
+	data, err := KeyRing.Get(OAuthActiveContextKeychainKey)
+	if err != nil {
+		if errors.Is(err, keyring.ErrKeyNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var ac ActiveContext
+	if err := json.Unmarshal(data, &ac); err != nil {
+		return nil, err
+	}
+	return &ac, nil
+}
+
+// SaveActiveContext persists the active OAuth context (account ID + livemode) in
+// the keyring so that ResolveCredentials can build the Stripe-Context header.
+func SaveActiveContext(accountID string, livemode bool) error {
+	if KeyRing == nil {
+		return nil
+	}
+	data, err := json.Marshal(ActiveContext{AccountID: accountID, Livemode: livemode})
+	if err != nil {
+		return err
+	}
+	return KeyRing.Set(OAuthActiveContextKeychainKey, data, "Stripe CLI OAuth active context")
+}
+
+// PrintActiveContextBanner prints the active context to stderr once per
+// process. Call this at the start of commands that make user-visible Stripe
+// API requests (resource commands, raw HTTP, fixtures, triggers).
+func (p *Profile) PrintActiveContextBanner() {
+	printActiveContextOnce.Do(func() {
+		uat, _ := p.GetUAT()
+		if !strings.HasPrefix(uat, "oak_") {
+			return
+		}
+		ac, _ := GetActiveContext()
+		if ac == nil {
+			return
+		}
+		mode := "test"
+		if ac.Livemode {
+			mode = "live"
+		}
+		color := ansi.Color(os.Stderr)
+		fmt.Fprintf(os.Stderr, "%s Running in %s · %s (%s)\n", color.Faint("▸"), p.GetDisplayName(), mode, ac.AccountID)
+	})
+}
+
+// GetUserInfo reads the stored UserInfo from the profile config.
+// Returns nil, nil when no user_info has been saved yet.
+// TODO: remove with legacy RAK/OIDC flow.
+func (p *Profile) GetUserInfo() (*UserInfo, error) {
+	if err := viper.ReadInConfig(); err != nil {
+		return nil, err
+	}
+	if !viper.IsSet(UserInfoName) {
+		return nil, nil
+	}
+	var ui UserInfo
+	if err := viper.UnmarshalKey(UserInfoName, &ui); err != nil {
+		return nil, err
+	}
+	return &ui, nil
+}
+
+// GetCompartmentID returns the account ID for the given livemode from the
+// legacy OIDC UserInfo stored in the config file.
+// TODO: remove with legacy RAK/OIDC flow.
 func (p *Profile) GetCompartmentID(livemode bool) (string, error) {
 	ui, err := p.GetUserInfo()
 	if err != nil || ui == nil {
@@ -662,8 +742,10 @@ func (p *Profile) GetCompartmentID(livemode bool) (string, error) {
 
 // ResolveCredentials returns the credentials for the given mode. If an OAK
 // token (prefix "oak_") is stored in the keyring and no explicit override is
-// active, it is preferred over the configured API key and the compartment ID
-// and livemode flag are populated. Otherwise it falls back to GetAPIKey.
+// active, it is preferred over the configured API key. For OAK tokens the
+// active context stored in the keyring sets both Stripe-Context and
+// Stripe-Livemode; the livemode parameter is used only for the legacy OIDC
+// fallback and plain API key path.
 func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) {
 	if !p.HasOverrideAPIKey() {
 		uat, err := p.GetUAT()
@@ -671,6 +753,20 @@ func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) 
 			return stripe.Credentials{}, err
 		}
 		if strings.HasPrefix(uat, "oak_") {
+			ac, err := GetActiveContext()
+			if err != nil {
+				return stripe.Credentials{}, err
+			}
+			if ac != nil {
+				if ac.Livemode != livemode {
+					if livemode {
+						return stripe.Credentials{}, fmt.Errorf("your active context is test mode; to access livemode, run 'stripe switch context'")
+					}
+					return stripe.Credentials{}, fmt.Errorf("your active context is livemode; add --live to use livemode, or run 'stripe switch context' to switch to a test mode context")
+				}
+				return stripe.NewOAKCredentials(uat, ac.AccountID, livemode), nil
+			}
+			// TODO: remove with legacy RAK/OIDC flow.
 			compartmentID, err := p.GetCompartmentID(livemode)
 			if err != nil {
 				return stripe.Credentials{}, err

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -19,6 +19,15 @@ import (
 
 var printActiveContextOnce sync.Once
 
+// OAuthTokenRefresher is called by ResolveCredentials when an OAK token is
+// expired or about to expire. It refreshes the token and updates p in-place.
+// Set by the login package via init().
+var OAuthTokenRefresher func(p *Profile) error
+
+// refreshMu serializes concurrent refresh attempts so only one goroutine hits
+// the token endpoint at a time; others re-use the result after the lock.
+var refreshMu sync.Mutex
+
 // AuthorizedAccount represents a Stripe account accessible to an OAuth token.
 type AuthorizedAccount struct {
 	ID    string   `json:"id"`
@@ -57,6 +66,10 @@ type Profile struct {
 	SandboxExpiresAt       string
 	UAT                    string
 	UserInfo               *UserInfo // TODO: remove with legacy RAK/OIDC flow
+
+	// OAuthAccessBaseURL is the access-srv base URL to use for token refresh
+	// and revocation. Set at startup from the --access-base flag; not persisted.
+	OAuthAccessBaseURL string
 }
 
 // config key names
@@ -777,6 +790,21 @@ func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) 
 			return stripe.Credentials{}, err
 		}
 		if strings.HasPrefix(uat, "oak_") {
+			if OAuthTokenRefresher != nil {
+				if t, tErr := GetUATExpiresAt(); tErr == nil && time.Until(t) < 60*time.Second {
+					refreshMu.Lock()
+					// Re-check after acquiring the lock; another goroutine may have
+					// already refreshed, bumping the expiry forward.
+					if t2, tErr2 := GetUATExpiresAt(); tErr2 == nil && time.Until(t2) < 60*time.Second {
+						if refreshErr := OAuthTokenRefresher(p); refreshErr != nil {
+							refreshMu.Unlock()
+							return stripe.Credentials{}, refreshErr
+						}
+						uat = p.UAT
+					}
+					refreshMu.Unlock()
+				}
+			}
 			ac, err := GetActiveContext()
 			if err != nil {
 				return stripe.Credentials{}, err

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -786,7 +786,7 @@ func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) 
 					if livemode {
 						return stripe.Credentials{}, fmt.Errorf("your active context is test mode; to access livemode, run 'stripe switch context'")
 					}
-					return stripe.Credentials{}, fmt.Errorf("your active context is livemode; add --live to use livemode, or run 'stripe switch context' to switch to a test mode context")
+					return stripe.Credentials{}, fmt.Errorf("your active context is livemode; run 'stripe switch context' to select a test mode context, or add --live if you meant to use livemode")
 				}
 				return stripe.NewOAKCredentials(uat, ac.AccountID, livemode), nil
 			}

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -283,20 +284,17 @@ func TestResolveCredentialsOAKLivemodeNoCompartment(t *testing.T) {
 func TestResolveCredentialsOAKLivemodeWithCompartment(t *testing.T) {
 	profilesFile := filepath.Join(t.TempDir(), "config.toml")
 	require.NoError(t, os.WriteFile(profilesFile, []byte{}, 0600))
+	activeCtxJSON, err := json.Marshal(ActiveContext{AccountID: "acct_live123", Livemode: true})
+	require.NoError(t, err)
 	KeyRing = keyring.NewMemoryStore(map[string][]byte{
-		UATKeychainItemKey: []byte("oak_live_1234567890"),
+		UATKeychainItemKey:            []byte("oak_live_1234567890"),
+		OAuthActiveContextKeychainKey: activeCtxJSON,
 	})
 	t.Cleanup(func() {
 		KeyRing = nil
 		viper.Reset()
 	})
 	(&Config{LogLevel: "info", ProfilesFile: profilesFile}).InitConfig()
-	viper.Set(UserInfoName, &UserInfo{
-		Compartments: []Compartment{
-			{CompartmentID: "acct_live123", Livemode: true},
-			{CompartmentID: "acct_test456", Livemode: false},
-		},
-	})
 
 	p := Profile{ProfileName: "default"}
 	creds, err := p.ResolveCredentials(true)

--- a/pkg/login/client_login_test.go
+++ b/pkg/login/client_login_test.go
@@ -82,8 +82,9 @@ func TestLogin(t *testing.T) {
 
 	pollURL = fmt.Sprintf("%s%s", ts.URL, "/stripecli/auth/cliauth_123?secret=cliauth_secret")
 
-	links, err := GetLinks(context.Background(), ts.URL, p.DeviceName)
+	links, useOAuth, err := GetLinks(context.Background(), ts.URL, p.DeviceName, "")
 	require.NoError(t, err)
+	require.False(t, useOAuth)
 	configurer := keys.NewRAKConfigurer(c, afero.NewOsFs())
 	rt := keys.NewRAKTransfer(configurer)
 	auth := NewAuthenticator(rt)
@@ -155,8 +156,9 @@ func TestLoginNoInput(t *testing.T) {
 
 	pollURL = fmt.Sprintf("%s%s", ts.URL, "/stripecli/auth/cliauth_123?secret=cliauth_secret")
 
-	links, err := GetLinks(context.Background(), ts.URL, p.DeviceName)
+	links, useOAuth, err := GetLinks(context.Background(), ts.URL, p.DeviceName, "")
 	require.NoError(t, err)
+	require.False(t, useOAuth)
 	configurer := keys.NewRAKConfigurer(c, afero.NewOsFs())
 	rt := keys.NewRAKTransfer(configurer)
 	auth := NewAuthenticator(rt)

--- a/pkg/login/interactive_login.go
+++ b/pkg/login/interactive_login.go
@@ -46,6 +46,9 @@ func interactiveLoginWithParams(ctx context.Context, cfg *config.Config, input i
 		cfg.Profile.AccountID = account.ID
 	}
 
+	// Clear all stale credentials before saving new ones.
+	_ = cfg.RemoveAuthFields(cfg.Profile.ProfileName)
+
 	profileErr := cfg.Profile.CreateProfile()
 	if profileErr != nil {
 		return profileErr

--- a/pkg/login/keys/configurer.go
+++ b/pkg/login/keys/configurer.go
@@ -43,6 +43,7 @@ func (c *RAKConfigurer) SaveLoginDetails(response *PollAPIKeyResponse) error {
 	c.cfg.Profile.TestModePublishableKey = response.TestModePublishableKey
 	c.cfg.Profile.UAT = response.UAT
 
+	// TODO: remove with legacy RAK/OIDC flow.
 	var compartments []config.Compartment
 	if response.LiveContext != "" {
 		compartments = append(compartments, config.Compartment{
@@ -57,9 +58,7 @@ func (c *RAKConfigurer) SaveLoginDetails(response *PollAPIKeyResponse) error {
 		})
 	}
 	if len(compartments) > 0 {
-		c.cfg.Profile.UserInfo = &config.UserInfo{
-			Compartments: compartments,
-		}
+		c.cfg.Profile.UserInfo = &config.UserInfo{Compartments: compartments}
 	} else {
 		c.cfg.Profile.UserInfo = nil
 	}

--- a/pkg/login/keys/configurer_test.go
+++ b/pkg/login/keys/configurer_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/keyring"
 )
 
-func TestSaveLoginDetails(t *testing.T) {
+func newTestConfig(t *testing.T) *config.Config {
+	t.Helper()
 	profilesFile := filepath.Join(t.TempDir(), "stripe", "config.toml")
 	c := &config.Config{
 		LogLevel: "info",
@@ -22,6 +24,16 @@ func TestSaveLoginDetails(t *testing.T) {
 		ProfilesFile: profilesFile,
 	}
 	c.InitConfig()
+	config.KeyRing = keyring.NewMemoryStore(nil)
+	t.Cleanup(func() {
+		config.KeyRing = nil
+		viper.Reset()
+	})
+	return c
+}
+
+func TestSaveLoginDetails(t *testing.T) {
+	c := newTestConfig(t)
 
 	configurer := NewRAKConfigurer(c, afero.NewOsFs())
 	err := configurer.SaveLoginDetails(&PollAPIKeyResponse{
@@ -36,7 +48,7 @@ func TestSaveLoginDetails(t *testing.T) {
 	require.NoError(t, err)
 
 	v := viper.New()
-	v.SetConfigFile(profilesFile)
+	v.SetConfigFile(c.ProfilesFile)
 
 	err = v.ReadInConfig()
 	require.NoError(t, err)
@@ -50,16 +62,9 @@ func TestSaveLoginDetails(t *testing.T) {
 	assert.Equal(t, "pk_test_1234567890000", v.GetString("tests.test_mode_pub_key"))
 }
 
+// TODO: remove with legacy RAK/OIDC flow.
 func TestSaveLoginDetails_UserInfo(t *testing.T) {
-	profilesFile := filepath.Join(t.TempDir(), "stripe", "config.toml")
-	c := &config.Config{
-		LogLevel: "info",
-		Profile: config.Profile{
-			ProfileName: "tests",
-		},
-		ProfilesFile: profilesFile,
-	}
-	c.InitConfig()
+	c := newTestConfig(t)
 
 	configurer := NewRAKConfigurer(c, afero.NewOsFs())
 	err := configurer.SaveLoginDetails(&PollAPIKeyResponse{
@@ -87,16 +92,9 @@ func TestSaveLoginDetails_UserInfo(t *testing.T) {
 	assert.Equal(t, "acct_test_789", testComp.CompartmentID)
 }
 
+// TODO: remove with legacy RAK/OIDC flow.
 func TestSaveLoginDetails_UserInfoEmpty(t *testing.T) {
-	profilesFile := filepath.Join(t.TempDir(), "stripe", "config.toml")
-	c := &config.Config{
-		LogLevel: "info",
-		Profile: config.Profile{
-			ProfileName: "tests",
-		},
-		ProfilesFile: profilesFile,
-	}
-	c.InitConfig()
+	c := newTestConfig(t)
 
 	configurer := NewRAKConfigurer(c, afero.NewOsFs())
 	err := configurer.SaveLoginDetails(&PollAPIKeyResponse{

--- a/pkg/login/links.go
+++ b/pkg/login/links.go
@@ -19,43 +19,54 @@ type Links struct {
 	VerificationCode string `json:"verification_code"`
 }
 
-// GetLinks provides the URLs for the CLI to continue the login flow
-func GetLinks(ctx context.Context, baseURL string, deviceName string) (*Links, error) {
+// GetLinks provides the URLs for the CLI to continue the login flow.
+//
+// The machineUUID is sent to the server so it can gate individual machines
+// into the OAuth device-code flow via feature flag. When the server responds
+// with a 3xx, the caller should switch to LoginWithDeviceCode instead of
+// proceeding with the legacy RAK flow; in that case GetLinks returns
+// (nil, true, nil).
+func GetLinks(ctx context.Context, baseURL string, deviceName string, machineUUID string) (*Links, bool, error) {
 	parsedBaseURL, err := url.Parse(baseURL)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	client := &stripe.Client{
-		BaseURL: parsedBaseURL,
+		BaseURL:           parsedBaseURL,
+		NoFollowRedirects: true,
 	}
 
 	data := url.Values{}
 	data.Set("client_version", version.Version)
 	data.Set("device_name", deviceName)
+	if machineUUID != "" {
+		data.Set("machine_uuid", machineUUID)
+	}
 
 	res, err := client.PerformRequest(ctx, http.MethodPost, stripeCLIAuthPath, data.Encode(), nil)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-
 	defer res.Body.Close()
+
+	if res.StatusCode >= http.StatusMultipleChoices && res.StatusCode < http.StatusBadRequest {
+		return nil, true, nil
+	}
 
 	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected http status code: %d %s", res.StatusCode, string(bodyBytes))
+		return nil, false, fmt.Errorf("unexpected http status code: %d %s", res.StatusCode, string(bodyBytes))
 	}
 
 	var links Links
-
-	err = json.Unmarshal(bodyBytes, &links)
-	if err != nil {
-		return nil, err
+	if err := json.Unmarshal(bodyBytes, &links); err != nil {
+		return nil, false, err
 	}
 
-	return &links, nil
+	return &links, false, nil
 }

--- a/pkg/login/links_test.go
+++ b/pkg/login/links_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,16 +25,50 @@ func TestGetLinks(t *testing.T) {
 
 		require.NoError(t, r.ParseForm())
 		require.Equal(t, "test", r.PostFormValue("device_name"))
+		require.Equal(t, "uuid-123", r.PostFormValue("machine_uuid"))
 
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(expectedLinks)
+		json.NewEncoder(w).Encode(expectedLinks) //nolint:errcheck
 	}))
 	defer ts.Close()
 
-	links, err := GetLinks(context.Background(), ts.URL, "test")
+	links, useOAuth, err := GetLinks(context.Background(), ts.URL, "test", "uuid-123")
 	require.NoError(t, err)
+	require.False(t, useOAuth)
 	require.Equal(t, expectedLinks, *links)
+}
+
+func TestGetLinksOAuthRedirect(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "uuid-flagged", r.PostFormValue("machine_uuid"))
+
+		http.Redirect(w, r, "https://example.com/oauth", http.StatusFound)
+	}))
+	defer ts.Close()
+
+	links, useOAuth, err := GetLinks(context.Background(), ts.URL, "test", "uuid-flagged")
+	require.NoError(t, err)
+	require.True(t, useOAuth)
+	require.Nil(t, links)
+}
+
+func TestGetLinksNoMachineUUID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Empty(t, r.PostFormValue("machine_uuid"))
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Links{BrowserURL: "https://example.com", PollURL: "https://example.com/poll", VerificationCode: "x"}) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	links, useOAuth, err := GetLinks(context.Background(), ts.URL, "test", "")
+	require.NoError(t, err)
+	require.False(t, useOAuth)
+	require.NotNil(t, links)
 }
 
 func TestGetLinksHTTPStatusError(t *testing.T) {
@@ -44,8 +79,9 @@ func TestGetLinksHTTPStatusError(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	links, err := GetLinks(context.Background(), ts.URL, "test")
+	links, useOAuth, err := GetLinks(context.Background(), ts.URL, "test", "")
 	require.EqualError(t, err, "unexpected http status code: 500 ")
+	require.False(t, useOAuth)
 	require.Empty(t, links)
 }
 
@@ -62,9 +98,10 @@ func TestGetLinksRequestError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	ts.Close()
 
-	links, err := GetLinks(context.Background(), ts.URL, "test")
+	links, useOAuth, err := GetLinks(context.Background(), ts.URL, "test", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), errorString)
+	require.False(t, useOAuth)
 	require.Empty(t, links)
 }
 
@@ -78,11 +115,12 @@ func TestGetLinksParseError(t *testing.T) {
 
 		badLinks := make(map[string]int)
 		badLinks["browser_url"] = 10
-		json.NewEncoder(w).Encode(badLinks)
+		json.NewEncoder(w).Encode(badLinks) //nolint:errcheck
 	}))
 	defer ts.Close()
 
-	links, err := GetLinks(context.Background(), ts.URL, "test")
+	links, useOAuth, err := GetLinks(context.Background(), ts.URL, "test", "")
 	require.EqualError(t, err, "json: cannot unmarshal number into Go struct field Links.browser_url of type string")
+	require.False(t, useOAuth)
 	require.Empty(t, links)
 }

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -24,13 +24,22 @@ func warnIfInsecureStorage() {
 }
 
 // Login is the main entrypoint for logging in to the CLI.
-func Login(ctx context.Context, baseURL string, config *config.Config) error {
-	links, err := GetLinks(ctx, baseURL, config.Profile.DeviceName)
+//
+// When the /stripecli/auth server responds with a 3xx, the machine UUID is
+// enrolled in the OAuth feature flag and the OAuth device-code flow is used
+// instead of the legacy RAK flow. accessBaseURL controls which access-srv
+// environment is used (production by default; QA via --access-base).
+func Login(ctx context.Context, dashboardBaseURL, accessBaseURL string, cfg *config.Config) error {
+	links, useOAuth, err := GetLinks(ctx, dashboardBaseURL, cfg.Profile.DeviceName, cfg.GetMachineUUID())
 	if err != nil {
 		return err
 	}
 
-	configurer := keys.NewRAKConfigurer(config, afero.NewOsFs())
+	if useOAuth {
+		return LoginWithDeviceCode(ctx, accessBaseURL, cfg)
+	}
+
+	configurer := keys.NewRAKConfigurer(cfg, afero.NewOsFs())
 	rt := keys.NewRAKTransfer(configurer)
 	auth := NewAuthenticator(rt)
 	return auth.Login(ctx, links)
@@ -51,9 +60,13 @@ func InitiateLogin(ctx context.Context, baseURL string, cfg *config.Config) erro
 		return err
 	}
 
-	links, err := GetLinks(ctx, baseURL, deviceName)
+	links, useOAuth, err := GetLinks(ctx, baseURL, deviceName, cfg.GetMachineUUID())
 	if err != nil {
 		return err
+	}
+
+	if useOAuth {
+		return fmt.Errorf("OAuth login required for this account; run 'stripe login' (without --non-interactive) to complete browser authorization")
 	}
 
 	out := loginSessionOutput{

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -2,11 +2,9 @@ package login
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/spf13/afero"
@@ -57,19 +55,10 @@ type loginSessionOutput struct {
 	NextStep         string `json:"next_step"`
 }
 
-// oauthContinuation holds the data needed to poll for an OAuth device token.
-// It is base64-encoded and passed to `stripe login --complete` as `oauth:<token>`.
-type oauthContinuation struct {
-	DeviceCode    string `json:"device_code"`
-	Interval      int    `json:"interval"`
-	ExpiresIn     int    `json:"expires_in"`
-	AccessBaseURL string `json:"access_base"`
-}
-
 // InitiateLogin prints JSON with browser_url, verification_code, and a
 // next_step command, then returns. Intended for non-interactive (agent/script)
-// use. For the OAuth device-code flow it calls the device authorization
-// endpoint and encodes the continuation in the next_step token.
+// use. For the OAuth device-code flow it saves pending state to disk and emits
+// `stripe login --complete-device` as the next_step.
 func InitiateLogin(ctx context.Context, baseURL, accessBaseURL string, cfg *config.Config) error {
 	deviceName, err := cfg.Profile.GetDeviceName()
 	if err != nil {
@@ -98,8 +87,8 @@ func InitiateLogin(ctx context.Context, baseURL, accessBaseURL string, cfg *conf
 	return nil
 }
 
-// initiateOAuthDeviceLogin calls the device authorization endpoint, encodes
-// the continuation as a base64 token, and prints the JSON session output.
+// initiateOAuthDeviceLogin calls the device authorization endpoint, saves the
+// pending state to disk, and prints the JSON session output.
 func initiateOAuthDeviceLogin(ctx context.Context, accessBaseURL string) error {
 	clientID := clientIDForAccessBaseURL(accessBaseURL)
 	authResp, err := RequestDeviceCode(ctx, accessBaseURL, clientID)
@@ -107,22 +96,20 @@ func initiateOAuthDeviceLogin(ctx context.Context, accessBaseURL string) error {
 		return fmt.Errorf("failed to request device code: %w", err)
 	}
 
-	cont := oauthContinuation{
+	cont := &oauthContinuation{
 		DeviceCode:    authResp.DeviceCode,
 		Interval:      authResp.Interval,
 		ExpiresIn:     authResp.ExpiresIn,
 		AccessBaseURL: accessBaseURL,
 	}
-	contJSON, err := json.Marshal(cont)
-	if err != nil {
-		return err
+	if err := savePendingDeviceAuth(cont); err != nil {
+		return fmt.Errorf("failed to save pending auth state: %w", err)
 	}
-	contToken := "oauth:" + base64.RawURLEncoding.EncodeToString(contJSON)
 
 	out := loginSessionOutput{
 		BrowserURL:       authResp.VerificationURI,
 		VerificationCode: authResp.UserCode,
-		NextStep:         fmt.Sprintf("stripe login --complete '%s'", contToken),
+		NextStep:         "stripe login --complete-device",
 	}
 	b, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
@@ -132,16 +119,10 @@ func initiateOAuthDeviceLogin(ctx context.Context, accessBaseURL string) error {
 	return nil
 }
 
-// PollForLogin polls until browser auth completes, then saves credentials.
-// Intended as the second step of a non-interactive login flow.
-//
-// For OAuth, pollURL must be of the form "oauth:<base64>" as produced by
-// InitiateLogin; for legacy it is the plain HTTPS poll URL from the dashboard.
+// PollForLogin polls the given legacy poll URL until browser auth completes,
+// then saves credentials. Intended as the second step of a non-interactive
+// legacy login flow. For OAuth, use PollPendingDeviceAuth instead.
 func PollForLogin(ctx context.Context, pollURL string, cfg *config.Config) error {
-	if encoded, ok := strings.CutPrefix(pollURL, "oauth:"); ok {
-		return pollOAuthDeviceLogin(ctx, encoded, cfg)
-	}
-
 	response, account, err := keys.PollForKey(ctx, pollURL, 0, 0)
 	if err != nil {
 		return err
@@ -166,17 +147,15 @@ func PollForLogin(ctx context.Context, pollURL string, cfg *config.Config) error
 	return nil
 }
 
-// pollOAuthDeviceLogin decodes the base64 continuation token and polls the
-// OAuth token endpoint until the user approves in the browser.
-func pollOAuthDeviceLogin(ctx context.Context, encoded string, cfg *config.Config) error {
-	data, err := base64.RawURLEncoding.DecodeString(encoded)
+// PollPendingDeviceAuth loads the OAuth device auth state saved by
+// InitiateLogin and polls the token endpoint until the user approves.
+func PollPendingDeviceAuth(ctx context.Context, cfg *config.Config) error {
+	cont, err := loadPendingDeviceAuth()
 	if err != nil {
-		return fmt.Errorf("invalid OAuth continuation token: %w", err)
+		return err
 	}
-	var cont oauthContinuation
-	if err := json.Unmarshal(data, &cont); err != nil {
-		return fmt.Errorf("invalid OAuth continuation token: %w", err)
-	}
+	// Remove the pending file whether polling succeeds or fails.
+	defer clearPendingDeviceAuth()
 
 	clientID := clientIDForAccessBaseURL(cont.AccessBaseURL)
 	interval := max(time.Duration(cont.Interval)*time.Second, 5*time.Second)
@@ -188,7 +167,7 @@ func pollOAuthDeviceLogin(ctx context.Context, encoded string, cfg *config.Confi
 	tokenResp, err := PollDeviceToken(pollCtx, cont.AccessBaseURL, clientID, cont.DeviceCode, interval)
 	if err != nil {
 		if pollCtx.Err() != nil {
-			return fmt.Errorf("device code expired; please run 'stripe login' again")
+			return fmt.Errorf("device code expired; please run 'stripe login --non-interactive' again")
 		}
 		return err
 	}

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -35,6 +35,9 @@ func Login(ctx context.Context, dashboardBaseURL, accessBaseURL string, cfg *con
 		return err
 	}
 
+	// Clear all stale credentials before saving new ones, regardless of flow.
+	_ = cfg.RemoveAuthFields(cfg.Profile.ProfileName)
+
 	if useOAuth {
 		return LoginWithDeviceCode(ctx, accessBaseURL, cfg)
 	}
@@ -89,6 +92,9 @@ func PollForLogin(ctx context.Context, pollURL string, cfg *config.Config) error
 	if err != nil {
 		return err
 	}
+
+	// Clear all stale credentials before saving new ones.
+	_ = cfg.RemoveAuthFields(cfg.Profile.ProfileName)
 
 	configurer := keys.NewRAKConfigurer(cfg, afero.NewOsFs())
 	if err := configurer.SaveLoginDetails(response); err != nil {

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -2,9 +2,12 @@ package login
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/spf13/afero"
 
@@ -54,10 +57,20 @@ type loginSessionOutput struct {
 	NextStep         string `json:"next_step"`
 }
 
-// InitiateLogin calls GetLinks, prints JSON with browser_url, verification_code,
-// and a next_step command to complete login, then exits. Intended for non-interactive
-// (agent/script) use.
-func InitiateLogin(ctx context.Context, baseURL string, cfg *config.Config) error {
+// oauthContinuation holds the data needed to poll for an OAuth device token.
+// It is base64-encoded and passed to `stripe login --complete` as `oauth:<token>`.
+type oauthContinuation struct {
+	DeviceCode    string `json:"device_code"`
+	Interval      int    `json:"interval"`
+	ExpiresIn     int    `json:"expires_in"`
+	AccessBaseURL string `json:"access_base"`
+}
+
+// InitiateLogin prints JSON with browser_url, verification_code, and a
+// next_step command, then returns. Intended for non-interactive (agent/script)
+// use. For the OAuth device-code flow it calls the device authorization
+// endpoint and encodes the continuation in the next_step token.
+func InitiateLogin(ctx context.Context, baseURL, accessBaseURL string, cfg *config.Config) error {
 	deviceName, err := cfg.Profile.GetDeviceName()
 	if err != nil {
 		return err
@@ -69,7 +82,7 @@ func InitiateLogin(ctx context.Context, baseURL string, cfg *config.Config) erro
 	}
 
 	if useOAuth {
-		return fmt.Errorf("OAuth login required for this account; run 'stripe login' (without --non-interactive) to complete browser authorization")
+		return initiateOAuthDeviceLogin(ctx, accessBaseURL)
 	}
 
 	out := loginSessionOutput{
@@ -85,9 +98,50 @@ func InitiateLogin(ctx context.Context, baseURL string, cfg *config.Config) erro
 	return nil
 }
 
-// PollForLogin polls the given poll URL until browser auth completes, then saves
-// credentials. Intended as the second step of a non-interactive login flow.
+// initiateOAuthDeviceLogin calls the device authorization endpoint, encodes
+// the continuation as a base64 token, and prints the JSON session output.
+func initiateOAuthDeviceLogin(ctx context.Context, accessBaseURL string) error {
+	clientID := clientIDForAccessBaseURL(accessBaseURL)
+	authResp, err := RequestDeviceCode(ctx, accessBaseURL, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to request device code: %w", err)
+	}
+
+	cont := oauthContinuation{
+		DeviceCode:    authResp.DeviceCode,
+		Interval:      authResp.Interval,
+		ExpiresIn:     authResp.ExpiresIn,
+		AccessBaseURL: accessBaseURL,
+	}
+	contJSON, err := json.Marshal(cont)
+	if err != nil {
+		return err
+	}
+	contToken := "oauth:" + base64.RawURLEncoding.EncodeToString(contJSON)
+
+	out := loginSessionOutput{
+		BrowserURL:       authResp.VerificationURI,
+		VerificationCode: authResp.UserCode,
+		NextStep:         fmt.Sprintf("stripe login --complete '%s'", contToken),
+	}
+	b, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
+	return nil
+}
+
+// PollForLogin polls until browser auth completes, then saves credentials.
+// Intended as the second step of a non-interactive login flow.
+//
+// For OAuth, pollURL must be of the form "oauth:<base64>" as produced by
+// InitiateLogin; for legacy it is the plain HTTPS poll URL from the dashboard.
 func PollForLogin(ctx context.Context, pollURL string, cfg *config.Config) error {
+	if encoded, ok := strings.CutPrefix(pollURL, "oauth:"); ok {
+		return pollOAuthDeviceLogin(ctx, encoded, cfg)
+	}
+
 	response, account, err := keys.PollForKey(ctx, pollURL, 0, 0)
 	if err != nil {
 		return err
@@ -108,6 +162,54 @@ func PollForLogin(ctx context.Context, pollURL string, cfg *config.Config) error
 	}
 	fmt.Printf("> %s\n", msg)
 	fmt.Println(ansi.Italic("Please note: this key will expire after 90 days, at which point you'll need to re-authenticate."))
+	warnIfInsecureStorage()
+	return nil
+}
+
+// pollOAuthDeviceLogin decodes the base64 continuation token and polls the
+// OAuth token endpoint until the user approves in the browser.
+func pollOAuthDeviceLogin(ctx context.Context, encoded string, cfg *config.Config) error {
+	data, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return fmt.Errorf("invalid OAuth continuation token: %w", err)
+	}
+	var cont oauthContinuation
+	if err := json.Unmarshal(data, &cont); err != nil {
+		return fmt.Errorf("invalid OAuth continuation token: %w", err)
+	}
+
+	clientID := clientIDForAccessBaseURL(cont.AccessBaseURL)
+	interval := max(time.Duration(cont.Interval)*time.Second, 5*time.Second)
+	expiresIn := max(time.Duration(cont.ExpiresIn)*time.Second, 10*time.Minute)
+
+	pollCtx, cancel := context.WithTimeout(ctx, expiresIn)
+	defer cancel()
+
+	tokenResp, err := PollDeviceToken(pollCtx, cont.AccessBaseURL, clientID, cont.DeviceCode, interval)
+	if err != nil {
+		if pollCtx.Err() != nil {
+			return fmt.Errorf("device code expired; please run 'stripe login' again")
+		}
+		return err
+	}
+
+	// Clear all stale credentials before saving new ones.
+	_ = cfg.RemoveAuthFields(cfg.Profile.ProfileName)
+
+	if err := saveOAuthCredentials(cfg, tokenResp); err != nil {
+		return fmt.Errorf("failed to save credentials: %w", err)
+	}
+
+	accounts, err := ListAuthorizedAccounts(ctx, cont.AccessBaseURL, tokenResp.AccessToken)
+	if err != nil {
+		return fmt.Errorf("failed to fetch account info: %w", err)
+	}
+	activeID, activeLivemode := pickActiveContext(accounts)
+	if err := populateProfileFromAccounts(cfg, accounts, activeID, activeLivemode); err != nil {
+		return fmt.Errorf("failed to save account info: %w", err)
+	}
+
+	printLoginSuccess(accounts, activeID, activeLivemode)
 	warnIfInsecureStorage()
 	return nil
 }

--- a/pkg/login/oauth_accounts.go
+++ b/pkg/login/oauth_accounts.go
@@ -1,0 +1,159 @@
+package login
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+type listAccountsResponse struct {
+	Accounts []config.AuthorizedAccount `json:"accounts"`
+}
+
+// ListAuthorizedAccounts returns the Stripe accounts accessible to accessToken.
+// If the endpoint is unreachable or returns a non-200 response, it falls back
+// to stub data so that callers can be built and tested before the endpoint is live.
+// TODO: remove stub fallback once GET /stripecli/oauth2/token/accounts is available.
+func ListAuthorizedAccounts(ctx context.Context, accessBaseURL, accessToken string) ([]config.AuthorizedAccount, error) {
+	accounts, err := fetchAuthorizedAccounts(ctx, accessBaseURL, accessToken)
+	if err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
+func fetchAuthorizedAccounts(ctx context.Context, accessBaseURL, accessToken string) ([]config.AuthorizedAccount, error) {
+	endpoint := accessBaseURL + accessAPNPath + "/token/accounts"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("accounts request failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var result listAccountsResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse accounts response: %w", err)
+	}
+	return result.Accounts, nil
+}
+
+// PrintAuthorizedContexts fetches the authorized accounts for accessToken and
+// prints them as a formatted list, marking the active context.
+func PrintAuthorizedContexts(ctx context.Context, accessBaseURL, accessToken string) error {
+	accounts, err := ListAuthorizedAccounts(ctx, accessBaseURL, accessToken)
+	if err != nil {
+		return fmt.Errorf("failed to fetch authorized accounts: %w", err)
+	}
+
+	ac, _ := config.GetActiveContext()
+	activeID, activeMode := "", "test"
+	if ac != nil {
+		activeID = ac.AccountID
+		if ac.Livemode {
+			activeMode = "live"
+		}
+	}
+
+	type row struct {
+		name   string
+		id     string
+		mode   string
+		active bool
+	}
+	var rows []row
+	nameW, idW := 0, 0
+	for _, a := range accounts {
+		modes := a.Modes
+		if len(modes) == 0 {
+			modes = []string{"test"}
+		}
+		for _, m := range modes {
+			rows = append(rows, row{
+				name:   a.Name,
+				id:     a.ID,
+				mode:   m,
+				active: a.ID == activeID && m == activeMode,
+			})
+			if len(a.Name) > nameW {
+				nameW = len(a.Name)
+			}
+			if len(a.ID) > idW {
+				idW = len(a.ID)
+			}
+		}
+	}
+
+	color := ansi.Color(os.Stdout)
+	fmt.Printf("Authorized contexts (%d):\n", len(rows))
+	for _, r := range rows {
+		if r.active {
+			fmt.Printf("  %-*s  %-*s  %-7s  %s\n", nameW, r.name, idW, r.id, r.mode, color.Green("● active"))
+		} else {
+			fmt.Printf("  %-*s  %-*s  %s\n", nameW, r.name, idW, r.id, r.mode)
+		}
+	}
+	return nil
+}
+
+// pickActiveContext selects the active account and livemode from the list of
+// authorized accounts. It prefers the first test-mode account; if none is
+// found it falls back to the first account's first mode.
+func pickActiveContext(accounts []config.AuthorizedAccount) (accountID string, livemode bool) {
+	for _, a := range accounts {
+		for _, m := range a.Modes {
+			if m == "test" {
+				return a.ID, false
+			}
+		}
+	}
+	if len(accounts) > 0 {
+		a := accounts[0]
+		if len(a.Modes) > 0 {
+			return a.ID, a.Modes[0] == "live"
+		}
+		return a.ID, false
+	}
+	return "", false
+}
+
+// populateProfileFromAccounts saves the active OAuth context and updates the
+// profile with the active account's display info.
+func populateProfileFromAccounts(cfg *config.Config, accounts []config.AuthorizedAccount, activeID string, activeLivemode bool) error {
+	if len(accounts) == 0 {
+		return fmt.Errorf("no authorized accounts returned")
+	}
+
+	if err := config.SaveActiveContext(activeID, activeLivemode); err != nil {
+		return err
+	}
+
+	cfg.Profile.AccountID = activeID
+	for _, a := range accounts {
+		if a.ID == activeID {
+			cfg.Profile.DisplayName = a.Name
+			break
+		}
+	}
+	return cfg.Profile.CreateProfile()
+}

--- a/pkg/login/oauth_accounts_test.go
+++ b/pkg/login/oauth_accounts_test.go
@@ -1,0 +1,58 @@
+package login
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+func TestFetchAuthorizedAccounts_success(t *testing.T) {
+	want := []config.AuthorizedAccount{
+		{ID: "acct_123", Name: "Test Co", Modes: []string{"test"}},
+		{ID: "acct_456", Name: "Live Co", Modes: []string{"live", "test"}},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/stripecli/oauth2/token/accounts", r.URL.Path)
+		assert.Equal(t, "Bearer oak_test", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listAccountsResponse{Accounts: want}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	got, err := fetchAuthorizedAccounts(context.Background(), srv.URL, "oak_test")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestFetchAuthorizedAccounts_non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := fetchAuthorizedAccounts(context.Background(), srv.URL, "oak_test")
+	assert.ErrorContains(t, err, "404")
+}
+
+func TestListAuthorizedAccounts_returnsRealDataWhenAvailable(t *testing.T) {
+	want := []config.AuthorizedAccount{
+		{ID: "acct_real", Name: "Real Business", Modes: []string{"live", "test"}},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listAccountsResponse{Accounts: want}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	got, err := ListAuthorizedAccounts(context.Background(), srv.URL, "oak_test")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}

--- a/pkg/login/oauth_credentials.go
+++ b/pkg/login/oauth_credentials.go
@@ -106,3 +106,22 @@ func ClearOAuthCredentials(cfg *config.Config) error {
 
 	return nil
 }
+
+// clearOAuthCredentialsForProfile is like ClearOAuthCredentials but operates
+// on a *Profile directly. Used by the token refresher which has no *Config.
+func clearOAuthCredentialsForProfile(p *config.Profile) error {
+	p.UAT = ""
+	if err := p.CreateProfile(); err != nil {
+		return err
+	}
+	for _, key := range []string{
+		OAuthRefreshTokenKeychainKey,
+		config.OAuthActiveContextKeychainKey,
+		config.OAuthUATExpiresAtKeychainKey,
+	} {
+		if err := config.KeyRing.Remove(key); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/login/oauth_credentials.go
+++ b/pkg/login/oauth_credentials.go
@@ -1,0 +1,96 @@
+package login
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/keyring"
+)
+
+// OAuthRefreshTokenKeychainKey is the keyring key for the OAuth refresh token.
+const OAuthRefreshTokenKeychainKey = config.OAuthRefreshTokenKeychainKey
+
+func saveOAuthCredentials(cfg *config.Config, resp *OAuthTokenResponse) error {
+	return UpdateOAuthTokens(cfg, resp)
+}
+
+// UpdateOAuthTokens replaces the stored access token and refresh token after a
+// successful token refresh. If resp.RefreshToken is empty, the refresh token is
+// left unchanged.
+func UpdateOAuthTokens(cfg *config.Config, resp *OAuthTokenResponse) error {
+	cfg.Profile.UAT = resp.AccessToken
+	if err := cfg.Profile.CreateProfile(); err != nil {
+		return err
+	}
+
+	if resp.RefreshToken != "" {
+		if err := config.KeyRing.Set(OAuthRefreshTokenKeychainKey, []byte(resp.RefreshToken), "Stripe CLI OAuth refresh token"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RevokeToken revokes the stored refresh token via the revocation endpoint.
+// Returns nil if no refresh token is stored. Errors from the server are
+// returned to callers, who should log and continue with credential cleanup.
+func RevokeToken(ctx context.Context, accessBaseURL string) error {
+	if config.KeyRing == nil {
+		return nil
+	}
+	refreshTokenBytes, err := config.KeyRing.Get(config.OAuthRefreshTokenKeychainKey)
+	if err != nil {
+		if errors.Is(err, keyring.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	data := url.Values{}
+	data.Set("token", string(refreshTokenBytes))
+	data.Set("client_id", clientIDForAccessBaseURL(accessBaseURL))
+
+	endpoint := accessBaseURL + accessAPNPath + "/revoke"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("token revocation failed (status %d)", resp.StatusCode)
+	}
+	return nil
+}
+
+// ClearOAuthCredentials removes the stored access token, refresh token, and
+// compartment data. Call this when the server returns invalid_grant on a
+// refresh attempt.
+func ClearOAuthCredentials(cfg *config.Config) error {
+	cfg.Profile.UAT = ""
+	if err := cfg.Profile.CreateProfile(); err != nil {
+		return err
+	}
+
+	if err := config.KeyRing.Remove(OAuthRefreshTokenKeychainKey); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+		return err
+	}
+
+	if err := config.KeyRing.Remove(config.OAuthActiveContextKeychainKey); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/login/oauth_credentials.go
+++ b/pkg/login/oauth_credentials.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/keyring"
@@ -30,6 +31,13 @@ func UpdateOAuthTokens(cfg *config.Config, resp *OAuthTokenResponse) error {
 
 	if resp.RefreshToken != "" {
 		if err := config.KeyRing.Set(OAuthRefreshTokenKeychainKey, []byte(resp.RefreshToken), "Stripe CLI OAuth refresh token"); err != nil {
+			return err
+		}
+	}
+
+	if resp.ExpiresIn > 0 {
+		expiresAt := time.Now().Add(time.Duration(resp.ExpiresIn) * time.Second)
+		if err := config.SaveUATExpiresAt(expiresAt); err != nil {
 			return err
 		}
 	}
@@ -89,6 +97,10 @@ func ClearOAuthCredentials(cfg *config.Config) error {
 	}
 
 	if err := config.KeyRing.Remove(config.OAuthActiveContextKeychainKey); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+		return err
+	}
+
+	if err := config.KeyRing.Remove(config.OAuthUATExpiresAtKeychainKey); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
 		return err
 	}
 

--- a/pkg/login/oauth_credentials_test.go
+++ b/pkg/login/oauth_credentials_test.go
@@ -1,0 +1,129 @@
+package login
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/keyring"
+)
+
+func setupOAuthTestConfig(t *testing.T) (*config.Config, func()) {
+	t.Helper()
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	viper.SetConfigFile(profilesFile)
+	t.Cleanup(viper.Reset)
+
+	cfg := &config.Config{
+		Color:    "auto",
+		LogLevel: "info",
+		Profile: config.Profile{
+			ProfileName: "test",
+		},
+		ProfilesFile: profilesFile,
+	}
+	cfg.InitConfig()
+	config.KeyRing = keyring.NewMemoryStore(nil)
+	return cfg, func() {
+		config.KeyRing = nil
+	}
+}
+
+func TestSaveOAuthCredentials(t *testing.T) {
+	cfg, cleanup := setupOAuthTestConfig(t)
+	defer cleanup()
+
+	resp := &OAuthTokenResponse{
+		AccessToken:  "oaac_test_access",
+		RefreshToken: "oart_test_refresh",
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+	}
+
+	err := saveOAuthCredentials(cfg, resp)
+	require.NoError(t, err)
+
+	uat, err := config.KeyRing.Get(config.UATKeychainItemKey)
+	require.NoError(t, err)
+	assert.Equal(t, "oaac_test_access", string(uat))
+
+	rt, err := config.KeyRing.Get(OAuthRefreshTokenKeychainKey)
+	require.NoError(t, err)
+	assert.Equal(t, "oart_test_refresh", string(rt))
+}
+
+func TestUpdateOAuthTokens_WithNewRefreshToken(t *testing.T) {
+	cfg, cleanup := setupOAuthTestConfig(t)
+	defer cleanup()
+
+	// Seed initial tokens.
+	require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte("oaac_old"), ""))
+	require.NoError(t, config.KeyRing.Set(OAuthRefreshTokenKeychainKey, []byte("oart_old"), ""))
+
+	resp := &OAuthTokenResponse{
+		AccessToken:  "oaac_new",
+		RefreshToken: "oart_new",
+	}
+	require.NoError(t, UpdateOAuthTokens(cfg, resp))
+
+	uat, err := config.KeyRing.Get(config.UATKeychainItemKey)
+	require.NoError(t, err)
+	assert.Equal(t, "oaac_new", string(uat))
+
+	rt, err := config.KeyRing.Get(OAuthRefreshTokenKeychainKey)
+	require.NoError(t, err)
+	assert.Equal(t, "oart_new", string(rt))
+}
+
+func TestUpdateOAuthTokens_NoRefreshToken(t *testing.T) {
+	cfg, cleanup := setupOAuthTestConfig(t)
+	defer cleanup()
+
+	// Seed initial tokens.
+	require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte("oaac_old"), ""))
+	require.NoError(t, config.KeyRing.Set(OAuthRefreshTokenKeychainKey, []byte("oart_old"), ""))
+
+	// Response with no refresh token — old RT must be preserved.
+	resp := &OAuthTokenResponse{
+		AccessToken: "oaac_new",
+		// RefreshToken intentionally absent
+	}
+	require.NoError(t, UpdateOAuthTokens(cfg, resp))
+
+	uat, err := config.KeyRing.Get(config.UATKeychainItemKey)
+	require.NoError(t, err)
+	assert.Equal(t, "oaac_new", string(uat))
+
+	rt, err := config.KeyRing.Get(OAuthRefreshTokenKeychainKey)
+	require.NoError(t, err)
+	assert.Equal(t, "oart_old", string(rt), "refresh token must not change when response omits it")
+}
+
+func TestClearOAuthCredentials(t *testing.T) {
+	cfg, cleanup := setupOAuthTestConfig(t)
+	defer cleanup()
+
+	// Seed tokens.
+	require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte("oaac_to_clear"), ""))
+	require.NoError(t, config.KeyRing.Set(OAuthRefreshTokenKeychainKey, []byte("oart_to_clear"), ""))
+
+	require.NoError(t, ClearOAuthCredentials(cfg))
+
+	_, err := config.KeyRing.Get(config.UATKeychainItemKey)
+	assert.Error(t, err, "access token should be removed")
+
+	_, err = config.KeyRing.Get(OAuthRefreshTokenKeychainKey)
+	assert.Error(t, err, "refresh token should be removed")
+}
+
+func TestClearOAuthCredentials_NoExistingTokens(t *testing.T) {
+	cfg, cleanup := setupOAuthTestConfig(t)
+	defer cleanup()
+
+	// Should not error when nothing is present.
+	assert.NoError(t, ClearOAuthCredentials(cfg))
+}

--- a/pkg/login/oauth_device.go
+++ b/pkg/login/oauth_device.go
@@ -1,0 +1,348 @@
+package login
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+const (
+	// DefaultAccessBaseURL is the default (production) base URL for access-srv.
+	DefaultAccessBaseURL = "https://access.stripe.com"
+	// QAAccessBaseURL is the QA base URL for access-srv, used via --access-base.
+	QAAccessBaseURL = "https://qa-access.stripe.com"
+	accessAPNPath   = "/stripecli/oauth2"
+
+	// StripeCLIClientIDProd is the registered OAuth client ID for production.
+	StripeCLIClientIDProd = "oacli_V18aOD6v0hs9CU"
+	// StripeCLIClientIDQA is the registered OAuth client ID for the QA environment.
+	StripeCLIClientIDQA = "oacli_UjA5npk5UKXd9u"
+)
+
+// OAuthError is a structured OAuth error returned by the access-srv token or
+// device-authorization endpoint.
+type OAuthError struct {
+	Code        string
+	Description string
+	HTTPStatus  int
+}
+
+func (e *OAuthError) Error() string {
+	if e.Description != "" {
+		return fmt.Sprintf("%s: %s", e.Code, e.Description)
+	}
+	return e.Code
+}
+
+// DeviceAuthResponse holds the device authorization endpoint response.
+type DeviceAuthResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+// OAuthTokenResponse holds the token endpoint response.
+type OAuthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	Scope        string `json:"scope"`
+}
+
+type tokenErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// RequestDeviceCode calls the device authorization endpoint and returns the response.
+func RequestDeviceCode(ctx context.Context, accessBaseURL, clientID string) (*DeviceAuthResponse, error) {
+	data := url.Values{}
+	data.Set("client_id", clientID)
+	data.Set("scope", "stripecli")
+
+	resp, err := doPostForm(ctx, accessBaseURL+accessAPNPath+"/device/authorization", data)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("device authorization request failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var authResp DeviceAuthResponse
+	if err := json.Unmarshal(body, &authResp); err != nil {
+		return nil, fmt.Errorf("failed to parse device authorization response: %w", err)
+	}
+	return &authResp, nil
+}
+
+// PollDeviceToken polls the token endpoint until the user approves, ctx is
+// canceled or times out, or a terminal error is returned.
+//
+// Callers should create ctx with a deadline matching DeviceAuthResponse.ExpiresIn
+// to automatically stop polling when the device code expires.
+func PollDeviceToken(ctx context.Context, accessBaseURL, clientID, deviceCode string, interval time.Duration) (*OAuthTokenResponse, error) {
+	endpoint := accessBaseURL + accessAPNPath + "/token"
+	data := url.Values{}
+	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+	data.Set("client_id", clientID)
+	data.Set("device_code", deviceCode)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		resp, err := doPostForm(ctx, endpoint, data)
+		if err != nil {
+			return nil, err
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			var tokenResp OAuthTokenResponse
+			if err := json.Unmarshal(body, &tokenResp); err != nil {
+				return nil, fmt.Errorf("failed to parse token response: %w", err)
+			}
+			return &tokenResp, nil
+		}
+
+		var errResp tokenErrorResponse
+		if jsonErr := json.Unmarshal(body, &errResp); jsonErr != nil || errResp.Error == "" {
+			return nil, fmt.Errorf("token request failed (status %d): %s", resp.StatusCode, string(body))
+		}
+
+		oauthErr := &OAuthError{Code: errResp.Error, Description: errResp.ErrorDescription, HTTPStatus: resp.StatusCode}
+
+		var wait time.Duration
+		switch errResp.Error {
+		case "authorization_pending":
+			wait = interval
+		case "slow_down":
+			wait = interval * 2
+		default:
+			return nil, oauthErr
+		}
+		t := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return nil, ctx.Err()
+		case <-t.C:
+		}
+	}
+}
+
+// clientIDForAccessBaseURL returns the OAuth client ID registered for the given
+// access base URL. QA and production each have a distinct client ID.
+func clientIDForAccessBaseURL(accessBaseURL string) string {
+	if accessBaseURL == QAAccessBaseURL {
+		return StripeCLIClientIDQA
+	}
+	return StripeCLIClientIDProd
+}
+
+// LoginWithDeviceCode runs the full OAuth 2.1 device-code flow and saves credentials.
+func LoginWithDeviceCode(ctx context.Context, accessBaseURL string, cfg *config.Config) error {
+	clientID := clientIDForAccessBaseURL(accessBaseURL)
+	authResp, err := RequestDeviceCode(ctx, accessBaseURL, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to request device code: %w", err)
+	}
+
+	color := ansi.Color(os.Stdout)
+	fmt.Printf("Your pairing code is: %s\n", color.Bold(authResp.UserCode))
+	fmt.Printf("To authorize the CLI, visit: %s\n", authResp.VerificationURI)
+
+	if !isSSH() && canOpenBrowser() {
+		fmt.Printf("Press Enter to open the browser (^C to quit)\n")
+		go func() {
+			fmt.Scanln() //nolint:errcheck
+			if err := openBrowser(authResp.VerificationURI); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to open browser: %s\n", err)
+			}
+		}()
+	}
+
+	interval := max(time.Duration(authResp.Interval)*time.Second, 5*time.Second)
+	expiresIn := max(time.Duration(authResp.ExpiresIn)*time.Second, 10*time.Minute)
+
+	pollCtx, cancel := context.WithTimeout(ctx, expiresIn)
+	defer cancel()
+
+	tokenResp, err := PollDeviceToken(pollCtx, accessBaseURL, clientID, authResp.DeviceCode, interval)
+	if err != nil {
+		if pollCtx.Err() != nil {
+			return fmt.Errorf("device code expired; please run 'stripe login --oauth' again")
+		}
+		return err
+	}
+
+	if err := saveOAuthCredentials(cfg, tokenResp); err != nil {
+		return fmt.Errorf("failed to save credentials: %w", err)
+	}
+
+	accounts, err := ListAuthorizedAccounts(ctx, accessBaseURL, tokenResp.AccessToken)
+	if err != nil {
+		return fmt.Errorf("failed to fetch account info: %w", err)
+	}
+	activeID, activeLivemode := pickActiveContext(accounts)
+	if err := populateProfileFromAccounts(cfg, accounts, activeID, activeLivemode); err != nil {
+		return fmt.Errorf("failed to save account info: %w", err)
+	}
+
+	printLoginSuccess(accounts, activeID, activeLivemode)
+	warnIfInsecureStorage()
+	return nil
+}
+
+type contextRow struct {
+	name   string
+	mode   string
+	id     string
+	active bool
+}
+
+func buildContextRows(accounts []config.AuthorizedAccount, activeID string, activeLivemode bool) []contextRow {
+	activeMode := "test"
+	if activeLivemode {
+		activeMode = "live"
+	}
+	var rows []contextRow
+	for _, a := range accounts {
+		modes := a.Modes
+		if len(modes) == 0 {
+			modes = []string{"test"}
+		}
+		for _, m := range modes {
+			rows = append(rows, contextRow{
+				name:   a.Name,
+				mode:   m,
+				id:     a.ID,
+				active: a.ID == activeID && m == activeMode,
+			})
+		}
+	}
+	return rows
+}
+
+func printLoginSuccess(accounts []config.AuthorizedAccount, activeID string, activeLivemode bool) {
+	color := ansi.Color(os.Stdout)
+	rows := buildContextRows(accounts, activeID, activeLivemode)
+
+	if len(rows) == 0 {
+		fmt.Printf("%s Done! The Stripe CLI is configured with your OAuth credentials.\n", color.Green("✓"))
+		return
+	}
+
+	if len(rows) == 1 {
+		r := rows[0]
+		ctx := fmt.Sprintf("%s · %s", r.name, r.mode)
+		fmt.Printf("%s Done! The Stripe CLI is authorized for %s (%s)\n", color.Green("✓"), ctx, r.id)
+		fmt.Printf("  Active context: %s\n\n", ctx)
+		fmt.Println("Run 'stripe reauth' to change permissions or authorize access to additional accounts or sandboxes.")
+		return
+	}
+
+	fmt.Printf("%s Done! The Stripe CLI is authorized for %d contexts.\n\n", color.Green("✓"), len(rows))
+
+	nameW, modeW, idW := 0, 0, 0
+	for _, r := range rows {
+		if len(r.name) > nameW {
+			nameW = len(r.name)
+		}
+		if len(r.mode) > modeW {
+			modeW = len(r.mode)
+		}
+		if len(r.id) > idW {
+			idW = len(r.id)
+		}
+	}
+
+	for _, r := range rows {
+		if r.active {
+			fmt.Printf("  %-*s  %-*s  %-*s  %s active\n", nameW, r.name, modeW, r.mode, idW, r.id, color.Green("●"))
+		} else {
+			fmt.Printf("  %-*s  %-*s  %s\n", nameW, r.name, modeW, r.mode, r.id)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Run 'stripe switch context' to change your active context.")
+	fmt.Println("Run 'stripe reauth' to change permissions or authorize access to additional accounts or sandboxes.")
+}
+
+// RefreshAccessToken exchanges a refresh token for a new access token.
+// On success, callers must persist the returned OAuthTokenResponse.RefreshToken
+// (replacing the previously stored value) before discarding the old token.
+// If the response does not include a refresh token, the caller must require a
+// new interactive login when the access token next expires.
+//
+// On invalid_grant, callers should clear stored credentials and start a new
+// device authorization flow.
+func RefreshAccessToken(ctx context.Context, accessBaseURL, clientID, refreshToken string) (*OAuthTokenResponse, error) {
+	data := url.Values{}
+	data.Set("grant_type", "refresh_token")
+	data.Set("refresh_token", refreshToken)
+	data.Set("client_id", clientID)
+
+	resp, err := doPostForm(ctx, accessBaseURL+accessAPNPath+"/token", data)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		var tokenResp OAuthTokenResponse
+		if err := json.Unmarshal(body, &tokenResp); err != nil {
+			return nil, fmt.Errorf("failed to parse refresh token response: %w", err)
+		}
+		return &tokenResp, nil
+	}
+
+	var errResp tokenErrorResponse
+	if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.Error != "" {
+		return nil, &OAuthError{Code: errResp.Error, Description: errResp.ErrorDescription, HTTPStatus: resp.StatusCode}
+	}
+
+	return nil, fmt.Errorf("refresh token request failed (status %d): %s", resp.StatusCode, string(body))
+}
+
+func doPostForm(ctx context.Context, endpoint string, data url.Values) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return http.DefaultClient.Do(req)
+}

--- a/pkg/login/oauth_device.go
+++ b/pkg/login/oauth_device.go
@@ -198,7 +198,7 @@ func LoginWithDeviceCode(ctx context.Context, accessBaseURL string, cfg *config.
 	tokenResp, err := PollDeviceToken(pollCtx, accessBaseURL, clientID, authResp.DeviceCode, interval)
 	if err != nil {
 		if pollCtx.Err() != nil {
-			return fmt.Errorf("device code expired; please run 'stripe login --oauth' again")
+			return fmt.Errorf("device code expired; please run 'stripe login' again")
 		}
 		return err
 	}

--- a/pkg/login/oauth_device_test.go
+++ b/pkg/login/oauth_device_test.go
@@ -1,0 +1,306 @@
+package login
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+func TestRequestDeviceCode_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/stripecli/oauth2/device/authorization", r.URL.Path)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "test-client-id", r.FormValue("client_id"))
+		assert.Equal(t, "stripecli", r.FormValue("scope"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(DeviceAuthResponse{ //nolint:errcheck
+			DeviceCode:      "dev-code-123",
+			UserCode:        "ABCD-EFGH",
+			VerificationURI: "https://qa-access.stripe.com/stripecli/oauth2/device",
+			ExpiresIn:       300,
+			Interval:        5,
+		})
+	}))
+	defer ts.Close()
+
+	resp, err := RequestDeviceCode(context.Background(), ts.URL, "test-client-id")
+	require.NoError(t, err)
+	assert.Equal(t, "dev-code-123", resp.DeviceCode)
+	assert.Equal(t, "ABCD-EFGH", resp.UserCode)
+	assert.Equal(t, "https://qa-access.stripe.com/stripecli/oauth2/device", resp.VerificationURI)
+	assert.Equal(t, 5, resp.Interval)
+}
+
+func TestRequestDeviceCode_NonOK(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("not found")) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	_, err := RequestDeviceCode(context.Background(), ts.URL, "test-client-id")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestPollDeviceToken_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:device_code", r.FormValue("grant_type"))
+		assert.Equal(t, "device-code", r.FormValue("device_code"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(OAuthTokenResponse{ //nolint:errcheck
+			AccessToken:  "oaac_test_access",
+			RefreshToken: "oart_test_refresh",
+			TokenType:    "Bearer",
+			ExpiresIn:    3600,
+		})
+	}))
+	defer ts.Close()
+
+	resp, err := PollDeviceToken(context.Background(), ts.URL, "client-id", "device-code", 1*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "oaac_test_access", resp.AccessToken)
+	assert.Equal(t, "oart_test_refresh", resp.RefreshToken)
+}
+
+func TestPollDeviceToken_AuthorizationPending(t *testing.T) {
+	var callCount int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n < 3 {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(tokenErrorResponse{Error: "authorization_pending"}) //nolint:errcheck
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(OAuthTokenResponse{AccessToken: "oaac_final", RefreshToken: "oart_final"}) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	resp, err := PollDeviceToken(context.Background(), ts.URL, "client-id", "device-code", 1*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "oaac_final", resp.AccessToken)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&callCount))
+}
+
+func TestPollDeviceToken_SlowDown(t *testing.T) {
+	var callCount int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(tokenErrorResponse{Error: "slow_down"}) //nolint:errcheck
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(OAuthTokenResponse{AccessToken: "oaac_final", RefreshToken: "oart_final"}) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	resp, err := PollDeviceToken(context.Background(), ts.URL, "client-id", "device-code", 1*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "oaac_final", resp.AccessToken)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&callCount))
+}
+
+func TestPollDeviceToken_ExpiredToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(tokenErrorResponse{Error: "expired_token"}) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	_, err := PollDeviceToken(context.Background(), ts.URL, "client-id", "device-code", 1*time.Millisecond)
+	require.Error(t, err)
+	var oauthErr *OAuthError
+	require.True(t, errors.As(err, &oauthErr))
+	assert.Equal(t, "expired_token", oauthErr.Code)
+	assert.Equal(t, http.StatusBadRequest, oauthErr.HTTPStatus)
+}
+
+func TestPollDeviceToken_AccessDenied(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(tokenErrorResponse{Error: "access_denied"}) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	_, err := PollDeviceToken(context.Background(), ts.URL, "client-id", "device-code", 1*time.Millisecond)
+	require.Error(t, err)
+	var oauthErr *OAuthError
+	require.True(t, errors.As(err, &oauthErr))
+	assert.Equal(t, "access_denied", oauthErr.Code)
+}
+
+func TestPollDeviceToken_InvalidGrant(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(tokenErrorResponse{Error: "invalid_grant", ErrorDescription: "permissions no longer valid"}) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	_, err := PollDeviceToken(context.Background(), ts.URL, "client-id", "device-code", 1*time.Millisecond)
+	require.Error(t, err)
+	var oauthErr *OAuthError
+	require.True(t, errors.As(err, &oauthErr))
+	assert.Equal(t, "invalid_grant", oauthErr.Code)
+	assert.Equal(t, "permissions no longer valid", oauthErr.Description)
+}
+
+func TestPollDeviceToken_InvalidClient(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(tokenErrorResponse{Error: "invalid_client"}) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	_, err := PollDeviceToken(context.Background(), ts.URL, "client-id", "device-code", 1*time.Millisecond)
+	require.Error(t, err)
+	var oauthErr *OAuthError
+	require.True(t, errors.As(err, &oauthErr))
+	assert.Equal(t, "invalid_client", oauthErr.Code)
+	assert.Equal(t, http.StatusUnauthorized, oauthErr.HTTPStatus)
+}
+
+func TestPollDeviceToken_ContextCancelled(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(tokenErrorResponse{Error: "authorization_pending"}) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := PollDeviceToken(ctx, ts.URL, "client-id", "device-code", 1*time.Millisecond)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestRefreshAccessToken_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/stripecli/oauth2/token", r.URL.Path)
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "refresh_token", r.FormValue("grant_type"))
+		assert.Equal(t, "oart_old_refresh", r.FormValue("refresh_token"))
+		assert.Equal(t, "test-client-id", r.FormValue("client_id"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(OAuthTokenResponse{ //nolint:errcheck
+			AccessToken:  "oaac_new_access",
+			RefreshToken: "oart_new_refresh",
+			TokenType:    "Bearer",
+			ExpiresIn:    3600,
+		})
+	}))
+	defer ts.Close()
+
+	resp, err := RefreshAccessToken(context.Background(), ts.URL, "test-client-id", "oart_old_refresh")
+	require.NoError(t, err)
+	assert.Equal(t, "oaac_new_access", resp.AccessToken)
+	assert.Equal(t, "oart_new_refresh", resp.RefreshToken)
+}
+
+func TestLoginWithDeviceCodeFailsWhenAccountsFetchFails(t *testing.T) {
+	origCanOpenBrowser := canOpenBrowser
+	canOpenBrowser = func() bool { return false }
+	t.Cleanup(func() { canOpenBrowser = origCanOpenBrowser })
+
+	cfg, cleanup := setupOAuthTestConfig(t)
+	defer cleanup()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/stripecli/oauth2/device/authorization":
+			json.NewEncoder(w).Encode(DeviceAuthResponse{ //nolint:errcheck
+				DeviceCode:      "device-code",
+				UserCode:        "ABCD-EFGH",
+				VerificationURI: "https://example.com/verify",
+				ExpiresIn:       30,
+				Interval:        1,
+			})
+		case "/stripecli/oauth2/token":
+			json.NewEncoder(w).Encode(OAuthTokenResponse{ //nolint:errcheck
+				AccessToken:  "oaac_test_access",
+				RefreshToken: "oart_test_refresh",
+				TokenType:    "Bearer",
+				ExpiresIn:    3600,
+			})
+		case "/stripecli/oauth2/token/accounts":
+			http.Error(w, "unavailable", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	err := LoginWithDeviceCode(context.Background(), ts.URL, cfg)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to fetch account info")
+
+	_, keyErr := config.KeyRing.Get(config.OAuthActiveContextKeychainKey)
+	assert.Error(t, keyErr)
+}
+
+func TestRefreshAccessToken_NoRefreshTokenInResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(OAuthTokenResponse{ //nolint:errcheck
+			AccessToken: "oaac_new_access",
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+			// RefreshToken intentionally absent
+		})
+	}))
+	defer ts.Close()
+
+	resp, err := RefreshAccessToken(context.Background(), ts.URL, "test-client-id", "oart_old_refresh")
+	require.NoError(t, err)
+	assert.Equal(t, "oaac_new_access", resp.AccessToken)
+	assert.Empty(t, resp.RefreshToken)
+}
+
+func TestRefreshAccessToken_InvalidGrant(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(tokenErrorResponse{Error: "invalid_grant", ErrorDescription: "Invalid refresh token"}) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	_, err := RefreshAccessToken(context.Background(), ts.URL, "test-client-id", "oart_bad")
+	require.Error(t, err)
+	var oauthErr *OAuthError
+	require.True(t, errors.As(err, &oauthErr))
+	assert.Equal(t, "invalid_grant", oauthErr.Code)
+	assert.Equal(t, "Invalid refresh token", oauthErr.Description)
+}

--- a/pkg/login/oauth_pending.go
+++ b/pkg/login/oauth_pending.go
@@ -1,0 +1,55 @@
+package login
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+// oauthContinuation holds the data needed to poll for an OAuth device token.
+// It is written to disk by InitiateLogin and read by PollPendingDeviceAuth.
+type oauthContinuation struct {
+	DeviceCode    string `json:"device_code"`
+	Interval      int    `json:"interval"`
+	ExpiresIn     int    `json:"expires_in"`
+	AccessBaseURL string `json:"access_base"`
+}
+
+func pendingDeviceAuthPath() string {
+	return filepath.Join(filepath.Dir(config.CredentialsFilePath()), "oauth_pending.json")
+}
+
+func savePendingDeviceAuth(cont *oauthContinuation) error {
+	path := pendingDeviceAuthPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(cont)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+func loadPendingDeviceAuth() (*oauthContinuation, error) {
+	data, err := os.ReadFile(pendingDeviceAuthPath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, errors.New("no pending OAuth login found; run 'stripe login --non-interactive' first")
+		}
+		return nil, err
+	}
+	var cont oauthContinuation
+	if err := json.Unmarshal(data, &cont); err != nil {
+		return nil, fmt.Errorf("invalid pending OAuth state: %w", err)
+	}
+	return &cont, nil
+}
+
+func clearPendingDeviceAuth() {
+	_ = os.Remove(pendingDeviceAuthPath())
+}

--- a/pkg/login/oauth_reauth.go
+++ b/pkg/login/oauth_reauth.go
@@ -1,0 +1,76 @@
+package login
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const reauthPath = accessAPNPath + "/token/reauth"
+
+type reauthResponse struct {
+	ReauthURL string `json:"reauth_url"`
+}
+
+// Reauth fetches a reauthentication URL for the active OAuth session and
+// directs the user to it. If a browser is available it is opened automatically;
+// otherwise the URL is printed for the user to visit manually.
+func Reauth(ctx context.Context, accessBaseURL, accessToken string) error {
+	reauthURL, err := fetchReauthURL(ctx, accessBaseURL, accessToken)
+	if err != nil {
+		return err
+	}
+
+	if !isSSH() && canOpenBrowser() {
+		fmt.Println("Opening the Stripe Dashboard to re-authorize the CLI...")
+		fmt.Printf("If the browser does not open automatically, visit:\n  %s\n", reauthURL)
+		if err := openBrowser(reauthURL); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to open browser: %s\n", err)
+		}
+	} else {
+		fmt.Printf("Visit the following URL to re-authorize the CLI:\n  %s\n", reauthURL)
+	}
+	return nil
+}
+
+func fetchReauthURL(ctx context.Context, accessBaseURL, accessToken string) (string, error) {
+	endpoint := accessBaseURL + reauthPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var r reauthResponse
+		if err := json.Unmarshal(body, &r); err != nil {
+			return "", fmt.Errorf("failed to parse reauth response: %w", err)
+		}
+		if r.ReauthURL == "" {
+			return "", fmt.Errorf("reauth response missing reauth_url")
+		}
+		return r.ReauthURL, nil
+	case http.StatusUnauthorized:
+		return "", fmt.Errorf("session expired or revoked; run 'stripe login' to authenticate again")
+	case http.StatusBadRequest:
+		return "", fmt.Errorf("invalid reauth request (invalid_request); check your configuration")
+	default:
+		return "", fmt.Errorf("reauth request failed (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+}

--- a/pkg/login/oauth_refresh.go
+++ b/pkg/login/oauth_refresh.go
@@ -1,0 +1,114 @@
+package login
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"time"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/keyring"
+)
+
+func init() {
+	config.OAuthTokenRefresher = refreshOAuthToken
+}
+
+// refreshOAuthToken exchanges the stored refresh token for a new access token
+// and updates p in-place. On invalid_grant it clears all OAuth credentials so
+// the next ResolveCredentials call surfaces an actionable re-login error.
+func refreshOAuthToken(p *config.Profile) error {
+	if config.KeyRing == nil {
+		return errors.New("keyring unavailable; run 'stripe login' to re-authenticate")
+	}
+
+	refreshTokenBytes, err := config.KeyRing.Get(config.OAuthRefreshTokenKeychainKey)
+	if err != nil {
+		if errors.Is(err, keyring.ErrKeyNotFound) {
+			return errors.New("session expired; run 'stripe login' to re-authenticate")
+		}
+		return err
+	}
+
+	accessBaseURL := p.OAuthAccessBaseURL
+	if accessBaseURL == "" {
+		accessBaseURL = DefaultAccessBaseURL
+	}
+	clientID := clientIDForAccessBaseURL(accessBaseURL)
+
+	tokenResp, err := doRefreshToken(context.Background(), accessBaseURL, clientID, string(refreshTokenBytes))
+	if err != nil {
+		var oauthErr *OAuthError
+		if errors.As(err, &oauthErr) && oauthErr.Code == "invalid_grant" {
+			// Token is invalid or consumed; clear credentials so the user gets a
+			// clear "run stripe login" error on the next attempt rather than an
+			// opaque 401 from the Stripe API.
+			_ = clearOAuthCredentialsForProfile(p)
+			return errors.New("session expired; run 'stripe login' to re-authenticate")
+		}
+		return fmt.Errorf("failed to refresh session: %w", err)
+	}
+
+	p.UAT = tokenResp.AccessToken
+	if err := p.CreateProfile(); err != nil {
+		return err
+	}
+
+	if tokenResp.RefreshToken != "" {
+		if err := config.KeyRing.Set(config.OAuthRefreshTokenKeychainKey, []byte(tokenResp.RefreshToken), "Stripe CLI OAuth refresh token"); err != nil {
+			return err
+		}
+	} else {
+		// Per spec: no refresh token in response means the submitted token was
+		// consumed and no replacement was issued. Remove it so the next expiry
+		// triggers a re-login rather than another invalid_grant attempt.
+		_ = config.KeyRing.Remove(config.OAuthRefreshTokenKeychainKey)
+	}
+
+	if tokenResp.ExpiresIn > 0 {
+		expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+		if err := config.SaveUATExpiresAt(expiresAt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// doRefreshToken calls the token endpoint with grant_type=refresh_token.
+func doRefreshToken(ctx context.Context, accessBaseURL, clientID, refreshToken string) (*OAuthTokenResponse, error) {
+	endpoint := accessBaseURL + accessAPNPath + "/token"
+
+	data := url.Values{}
+	data.Set("grant_type", "refresh_token")
+	data.Set("refresh_token", refreshToken)
+	data.Set("client_id", clientID)
+
+	resp, err := doPostForm(ctx, endpoint, data)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		var errResp tokenErrorResponse
+		if jsonErr := json.Unmarshal(body, &errResp); jsonErr == nil && errResp.Error != "" {
+			return nil, &OAuthError{Code: errResp.Error, Description: errResp.ErrorDescription, HTTPStatus: resp.StatusCode}
+		}
+		return nil, fmt.Errorf("token refresh failed (status %d)", resp.StatusCode)
+	}
+
+	var tokenResp OAuthTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse refresh response: %w", err)
+	}
+	return &tokenResp, nil
+}

--- a/pkg/login/switch_context.go
+++ b/pkg/login/switch_context.go
@@ -1,0 +1,274 @@
+package login
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+// SwitchContext updates the active OAuth context. If accountID is non-empty
+// it selects that account directly (test mode by default, live if livemode is
+// true). Otherwise it shows an interactive list.
+func SwitchContext(ctx context.Context, accessBaseURL string, cfg *config.Config, accountID string, livemode bool) error {
+	uat, err := cfg.Profile.GetUAT()
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(uat, "oak_") {
+		return fmt.Errorf("not logged in with OAuth; run 'stripe login' first")
+	}
+
+	accounts, err := ListAuthorizedAccounts(ctx, accessBaseURL, uat)
+	if err != nil {
+		return fmt.Errorf("failed to fetch authorized accounts: %w", err)
+	}
+
+	if accountID != "" {
+		return switchByID(cfg, accounts, accountID, livemode)
+	}
+	return runSwitchContextTUI(cfg, accounts)
+}
+
+func switchByID(cfg *config.Config, accounts []config.AuthorizedAccount, accountID string, livemode bool) error {
+	wantMode := "test"
+	if livemode {
+		wantMode = "live"
+	}
+	for _, a := range accounts {
+		if a.ID != accountID {
+			continue
+		}
+		for _, m := range a.Modes {
+			if m == wantMode {
+				return applyContext(cfg, a, m)
+			}
+		}
+		if livemode {
+			return fmt.Errorf("account %s is not authorized for livemode", accountID)
+		}
+		return fmt.Errorf("account %s is not authorized for test mode; use --live to switch to livemode", accountID)
+	}
+	return fmt.Errorf("account %s not found in your authorized accounts", accountID)
+}
+
+func applyContext(cfg *config.Config, account config.AuthorizedAccount, mode string) error {
+	livemode := mode == "live"
+	if err := config.SaveActiveContext(account.ID, livemode); err != nil {
+		return err
+	}
+	// Preserve the existing UAT: writeProfile removes the keychain entry when UAT is empty.
+	uat, _ := cfg.Profile.GetUAT()
+	cfg.Profile.UAT = uat
+	cfg.Profile.AccountID = account.ID
+	cfg.Profile.DisplayName = account.Name
+	if err := cfg.Profile.CreateProfile(); err != nil {
+		return err
+	}
+	fmt.Printf("Active context: %s · %s (%s)\n", account.Name, mode, account.ID)
+	return nil
+}
+
+// --- TUI ---
+
+type switchRow struct {
+	isSeparator    bool
+	isSectionLabel bool
+	label          string
+	name           string
+	id             string
+	mode           string
+	active         bool
+}
+
+func (r switchRow) selectable() bool {
+	return !r.isSeparator && !r.isSectionLabel
+}
+
+type switchContextModel struct {
+	rows   []switchRow
+	cursor int
+	nameW  int
+	idW    int
+	done   bool
+	quit   bool
+}
+
+func buildSwitchRows(accounts []config.AuthorizedAccount, activeID, activeMode string) (rows []switchRow, nameW, idW int) {
+	var liveRows, sandboxRows []switchRow
+	for _, a := range accounts {
+		for _, m := range a.Modes {
+			row := switchRow{
+				name:   a.Name,
+				id:     a.ID,
+				mode:   m,
+				active: a.ID == activeID && m == activeMode,
+			}
+			if len(a.Name) > nameW {
+				nameW = len(a.Name)
+			}
+			if len(a.ID) > idW {
+				idW = len(a.ID)
+			}
+			if m == "live" {
+				liveRows = append(liveRows, row)
+			} else {
+				sandboxRows = append(sandboxRows, row)
+			}
+		}
+	}
+
+	rows = append(rows, liveRows...)
+	if len(sandboxRows) > 0 {
+		if len(rows) > 0 {
+			rows = append(rows, switchRow{isSeparator: true})
+		}
+		rows = append(rows, switchRow{isSectionLabel: true, label: "Sandboxes"})
+		rows = append(rows, sandboxRows...)
+	}
+	return rows, nameW, idW
+}
+
+func newSwitchContextModel(accounts []config.AuthorizedAccount) switchContextModel {
+	activeID, activeMode := "", "test"
+	if ac, _ := config.GetActiveContext(); ac != nil {
+		activeID = ac.AccountID
+		if ac.Livemode {
+			activeMode = "live"
+		}
+	}
+
+	rows, nameW, idW := buildSwitchRows(accounts, activeID, activeMode)
+
+	m := switchContextModel{rows: rows, nameW: nameW, idW: idW, cursor: -1}
+	for i, r := range rows {
+		if !r.selectable() {
+			continue
+		}
+		if m.cursor == -1 {
+			m.cursor = i
+		}
+		if r.active {
+			m.cursor = i
+			break
+		}
+	}
+	if m.cursor == -1 {
+		m.cursor = 0
+	}
+	return m
+}
+
+func (m switchContextModel) Init() tea.Cmd { return nil }
+
+func (m switchContextModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return m, nil
+	}
+	switch {
+	case key.Code == tea.KeyUp || key.Code == 'k':
+		for i := m.cursor - 1; i >= 0; i-- {
+			if m.rows[i].selectable() {
+				m.cursor = i
+				break
+			}
+		}
+	case key.Code == tea.KeyDown || key.Code == 'j':
+		for i := m.cursor + 1; i < len(m.rows); i++ {
+			if m.rows[i].selectable() {
+				m.cursor = i
+				break
+			}
+		}
+	case key.Code == tea.KeyEnter:
+		m.done = true
+		return m, tea.Quit
+	case key.Code == tea.KeyEscape || key.Code == 'q' || (key.Code == 'c' && key.Mod == tea.ModCtrl):
+		m.quit = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+var (
+	switchHeaderStyle  = lipgloss.NewStyle().Faint(true)
+	switchDividerStyle = lipgloss.NewStyle().Faint(true)
+	switchSectionStyle = lipgloss.NewStyle().Faint(true)
+	switchCursorStyle  = lipgloss.NewStyle().Bold(true)
+	switchActiveStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+)
+
+func (m switchContextModel) View() tea.View {
+	var sb strings.Builder
+
+	// pointer(2) + name(nameW) + sep(2) + id(idW) + sep(2) = nameW+idW+6 before mode
+	// Header "Account" starts at col 2 (after pointer space), "Mode" at nameW+idW+6
+	header := fmt.Sprintf("  %-*sMode", m.nameW+m.idW+4, "Account")
+	sb.WriteString(switchHeaderStyle.Render(header))
+	sb.WriteByte('\n')
+
+	divLen := 2 + m.nameW + 2 + m.idW + 2 + 7 + 2 + 8 // ends after "● active"
+	sb.WriteString(switchDividerStyle.Render(strings.Repeat("─", divLen)))
+	sb.WriteByte('\n')
+
+	for i, r := range m.rows {
+		switch {
+		case r.isSeparator:
+			sb.WriteString(switchDividerStyle.Render("──"))
+			sb.WriteByte('\n')
+		case r.isSectionLabel:
+			sb.WriteString(switchSectionStyle.Render(r.label))
+			sb.WriteByte('\n')
+		default:
+			pointer := "  "
+			if i == m.cursor {
+				pointer = "▶ "
+			}
+			activeMarker := ""
+			if r.active {
+				activeMarker = "  " + switchActiveStyle.Render("● active")
+			}
+			line := fmt.Sprintf("%s%-*s  %-*s  %-7s%s", pointer, m.nameW, r.name, m.idW, r.id, r.mode, activeMarker)
+			line = strings.TrimRight(line, " ")
+			if i == m.cursor {
+				line = switchCursorStyle.Render(line)
+			}
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+	}
+
+	sb.WriteString("\n↑↓ to navigate · enter to select · esc to cancel")
+	return tea.NewView(sb.String())
+}
+
+func runSwitchContextTUI(cfg *config.Config, accounts []config.AuthorizedAccount) error {
+	if len(accounts) == 0 {
+		return fmt.Errorf("no authorized accounts found")
+	}
+	m := newSwitchContextModel(accounts)
+
+	final, err := tea.NewProgram(m).Run()
+	if err != nil {
+		return fmt.Errorf("context selector: %w", err)
+	}
+	result, ok := final.(switchContextModel)
+	if !ok || result.quit || !result.done {
+		return nil
+	}
+	if result.cursor < 0 || result.cursor >= len(result.rows) {
+		return nil
+	}
+	sel := result.rows[result.cursor]
+	for _, a := range accounts {
+		if a.ID == sel.id {
+			return applyContext(cfg, a, sel.mode)
+		}
+	}
+	return fmt.Errorf("selected account not found")
+}

--- a/pkg/logout/logout.go
+++ b/pkg/logout/logout.go
@@ -2,49 +2,79 @@
 package logout
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"strings"
 
+	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/login"
 )
 
-// Logout function is used to clear the credentials set for the current Profile
-func Logout(config *config.Config) error {
-	liveKey, _ := config.Profile.GetAPIKey(true)
-	testKey, _ := config.Profile.GetAPIKey(false)
+// Logout clears credentials for the current profile. For OAuth sessions it
+// also revokes the token before clearing.
+func Logout(ctx context.Context, accessBaseURL string, cfg *config.Config) error {
+	liveKey, _ := cfg.Profile.GetAPIKey(true)
+	testKey, _ := cfg.Profile.GetAPIKey(false)
+	uat, _ := cfg.Profile.GetUAT()
 
-	if liveKey == "" && testKey == "" {
+	if liveKey == "" && testKey == "" && uat == "" && !hasStoredOAuthData() {
 		fmt.Println("You are already logged out.")
 		return nil
 	}
 
-	fmt.Println("Logging out...")
-
-	profileName := config.Profile.ProfileName
-
-	err := config.RemoveAuthFields(profileName)
-	if err != nil {
-		return err
+	if strings.HasPrefix(uat, "oak_") {
+		if err := login.RevokeToken(ctx, accessBaseURL); err != nil {
+			// Log but don't block — credentials should still be cleared.
+			fmt.Fprintf(os.Stderr, "Warning: token revocation failed: %s\n", err)
+		}
+		if err := cfg.RemoveAuthFields(cfg.Profile.ProfileName); err != nil {
+			return err
+		}
+		color := ansi.Color(os.Stdout)
+		fmt.Printf("%s Logged out of all contexts and revoked session.\n", color.Green("✓"))
+		return nil
 	}
 
+	fmt.Println("Logging out...")
+	if err := cfg.RemoveAuthFields(cfg.Profile.ProfileName); err != nil {
+		return err
+	}
+	profileName := cfg.Profile.ProfileName
 	if profileName == "default" {
 		fmt.Println("Credentials have been cleared for the default project.")
 	} else {
 		fmt.Printf("Credentials have been cleared for %s.\n", profileName)
 	}
-
 	return nil
 }
 
-// All function is used to clear the credentials on all profiles
-func All(cfg *config.Config) error {
-	fmt.Println("Logging out...")
+func hasStoredOAuthData() bool {
+	if config.KeyRing == nil {
+		return false
+	}
+	for _, key := range []string{config.OAuthRefreshTokenKeychainKey, config.OAuthActiveContextKeychainKey} {
+		if _, err := config.KeyRing.Get(key); err == nil {
+			return true
+		}
+	}
+	return false
+}
 
-	err := cfg.RemoveAllAuthFields()
-	if err != nil {
-		return err
+// All clears credentials for all profiles.
+func All(ctx context.Context, accessBaseURL string, cfg *config.Config) error {
+	uat, _ := cfg.Profile.GetUAT()
+	if strings.HasPrefix(uat, "oak_") {
+		if err := login.RevokeToken(ctx, accessBaseURL); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: token revocation failed: %s\n", err)
+		}
 	}
 
+	fmt.Println("Logging out...")
+	if err := cfg.RemoveAllAuthFields(); err != nil {
+		return err
+	}
 	fmt.Println("Credentials have been cleared for all projects.")
-
 	return nil
 }

--- a/pkg/logout/logout_test.go
+++ b/pkg/logout/logout_test.go
@@ -1,0 +1,48 @@
+package logout
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/keyring"
+)
+
+func TestLogoutClearsOAuthCredentials(t *testing.T) {
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	cfg := &config.Config{
+		LogLevel: "info",
+		Profile: config.Profile{
+			ProfileName: "default",
+		},
+		ProfilesFile: profilesFile,
+	}
+	cfg.InitConfig()
+
+	activeCtxJSON, err := json.Marshal(config.ActiveContext{AccountID: "acct_123", Livemode: false})
+	require.NoError(t, err)
+
+	config.KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		config.UATKeychainItemKey:            []byte("oaac_test_access"),
+		config.OAuthRefreshTokenKeychainKey:  []byte("oart_test_refresh"),
+		config.OAuthActiveContextKeychainKey: activeCtxJSON,
+	})
+	t.Cleanup(func() {
+		config.KeyRing = nil
+		viper.Reset()
+	})
+
+	require.NoError(t, Logout(t.Context(), "https://access.stripe.com", cfg))
+
+	_, err = config.KeyRing.Get(config.UATKeychainItemKey)
+	assert.Error(t, err)
+	_, err = config.KeyRing.Get(config.OAuthRefreshTokenKeychainKey)
+	assert.Error(t, err)
+	_, err = config.KeyRing.Get(config.OAuthActiveContextKeychainKey)
+	assert.Error(t, err)
+}

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -343,6 +343,28 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 
 	if resp.StatusCode == 401 || (errOnStatus && resp.StatusCode >= 300) {
 		requestError := compileRequestError(body, resp.StatusCode)
+
+		// For OAK tokens, "unauthorized" means the token was manually revoked
+		// or otherwise invalidated server-side. Attempt a transparent refresh
+		// and retry the request once with the new token.
+		if resp.StatusCode == 401 && requestError.ErrorCode == "unauthorized" &&
+			rb.Profile != nil && config.OAuthTokenRefresher != nil {
+			uat, _ := rb.Profile.GetUAT()
+			if strings.HasPrefix(uat, "oak_") {
+				if refreshErr := config.OAuthTokenRefresher(rb.Profile); refreshErr != nil {
+					return []byte{}, refreshErr
+				}
+				newCreds, credErr := rb.Profile.ResolveCredentials(rb.Livemode)
+				if credErr != nil {
+					return []byte{}, credErr
+				}
+				if sc, ok := client.(*stripe.Client); ok {
+					sc.Credentials = newCreds
+				}
+				return rb.performRequest(ctx, client, path, params, data, errOnStatus, additionalConfigure)
+			}
+		}
+
 		return []byte{}, requestError
 	}
 

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -145,6 +145,8 @@ func (rb *Base) RunRequestsCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	rb.Profile.PrintActiveContextBanner()
+
 	if len(args) > 1 {
 		return fmt.Errorf("this command only supports one argument. Run with the --help flag to see usage and examples")
 	}

--- a/pkg/rpcservice/login.go
+++ b/pkg/rpcservice/login.go
@@ -2,6 +2,7 @@ package rpcservice
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/stripe/stripe-cli/pkg/login"
 	"github.com/stripe/stripe-cli/pkg/stripe"
@@ -15,9 +16,13 @@ var getLinks = login.GetLinks
 func (srv *RPCService) Login(ctx context.Context, req *rpc.LoginRequest) (*rpc.LoginResponse, error) {
 	var err error
 
-	links, err = getLinks(ctx, stripe.DefaultDashboardBaseURL, srv.cfg.UserCfg.Profile.DeviceName)
+	var useOAuth bool
+	links, useOAuth, err = getLinks(ctx, stripe.DefaultDashboardBaseURL, srv.cfg.UserCfg.Profile.DeviceName, srv.cfg.UserCfg.GetMachineUUID())
 	if err != nil {
 		return nil, err
+	}
+	if useOAuth {
+		return nil, fmt.Errorf("OAuth login required; use 'stripe login' in a terminal to complete browser authorization")
 	}
 
 	return &rpc.LoginResponse{

--- a/pkg/rpcservice/login_test.go
+++ b/pkg/rpcservice/login_test.go
@@ -15,12 +15,12 @@ import (
 )
 
 func TestLoginReturnsURLAndPairingCode(t *testing.T) {
-	getLinks = func(ctx context.Context, baseURL string, deviceName string) (*login.Links, error) {
+	getLinks = func(ctx context.Context, baseURL string, deviceName string, machineUUID string) (*login.Links, bool, error) {
 		return &login.Links{
 			BrowserURL:       "foo",
 			PollURL:          "bar",
 			VerificationCode: "baz",
-		}, nil
+		}, false, nil
 	}
 
 	ctx := withAuth(context.Background())
@@ -44,8 +44,8 @@ func TestLoginReturnsURLAndPairingCode(t *testing.T) {
 }
 
 func TestLoginReturnsFailsWhenGetLinksFails(t *testing.T) {
-	getLinks = func(ctx context.Context, baseURL string, deviceName string) (*login.Links, error) {
-		return nil, errors.New("Failed to get links")
+	getLinks = func(ctx context.Context, baseURL string, deviceName string, machineUUID string) (*login.Links, bool, error) {
+		return nil, false, errors.New("Failed to get links")
 	}
 
 	ctx := withAuth(context.Background())

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -123,6 +123,9 @@ type Client struct {
 	// Defaults to the standard set of relevant for Stripe headers.
 	VerbosePrintableHeaders []string
 
+	// When true, 3xx responses are returned directly instead of being followed.
+	NoFollowRedirects bool
+
 	// Cached HTTP client, lazily created the first time the Client is used to
 	// send a request.
 	httpClient *http.Client
@@ -175,6 +178,11 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 
 	if c.httpClient == nil {
 		c.httpClient = newHTTPClient(c.Verbose, c.VerbosePrintableHeaders, os.Getenv("STRIPE_CLI_UNIX_SOCKET"))
+		if c.NoFollowRedirects {
+			c.httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			}
+		}
 	}
 
 	if ctx != nil {


### PR DESCRIPTION
Implements the OAuth login flow. This requires a flag on the server to be enabled in order to work.
- Updates `stripe login` to do OAuth
- Updates `stripe logout` to revoke the OAuth access token and clear the credentials locally
- Adds `stripe switch context` to switch between accounts, sandboxes, and test mode
  - Updates `stripe login switch` to be an alias for this command
- Updates `stripe login list` to show the authorized contexts
- Adds `stripe reauth` to authorize more contexts
- Prints a message showing the active context when running resource commands, raw http commands, fixtures, and triggers
