### PR TITLE
Fix fixture .env injection allowing transport hijack via STRIPE_CLI_UNIX_SOCKET

### DIFF
--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -368,13 +368,16 @@ func (fxt *Fixture) makeRequest(ctx context.Context, data FixtureRequest, apiVer
 	}
 
 	path, err := parsers.ParsePath(data.Path, fxt.Responses)
+	if err != nil {
+		return make([]byte, 0), err
+	}
+
+	if !stripe.IsValidAPIPath(path) {
+		return make([]byte, 0), fmt.Errorf("fixture path %q is not a valid Stripe API path (must start with /v1/ or /v2/)", data.Path)
+	}
 
 	if fxt.unsupportedAPIKey(path) {
 		return make([]byte, 0), fmt.Errorf("this trigger must be run with a secret API key (starts with 'sk_')")
-	}
-
-	if err != nil {
-		return make([]byte, 0), err
 	}
 
 	params, err := fxt.createParams(data.Params, apiVersion, path, data.Method)

--- a/pkg/fixtures/fixtures_test.go
+++ b/pkg/fixtures/fixtures_test.go
@@ -400,6 +400,46 @@ func TestUpdateEnvRefusesSymlink(t *testing.T) {
 	require.Equal(t, "ORIGINAL=1\n", string(victimContents))
 }
 
+func TestMakeRequestRejectsPathTraversal(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	serverCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		serverCalled = true
+	}))
+	defer ts.Close()
+
+	fxt := &Fixture{
+		Fs:          fs,
+		Credentials: stripe.NewAPIKeyCredentials("rk_test_1234"),
+		BaseURL:     ts.URL,
+		Responses:   make(map[string]gjson.Result),
+	}
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"dot-segment escape", "/v2x/../v1.41/containers/create"},
+		{"non-API prefix", "/docker/containers"},
+		{"version without slash", "/v2x/foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := fxt.makeRequest(context.Background(), FixtureRequest{
+				Name:   "test",
+				Path:   tt.path,
+				Method: "post",
+				Params: map[string]interface{}{},
+			}, "")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "not a valid Stripe API path")
+		})
+	}
+
+	require.False(t, serverCalled, "no request should have been sent for invalid paths")
+}
+
 func TestExecuteReturnsRequestNames(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -389,19 +389,20 @@ func MatchFixtureQuery(value string) (*regexp.Regexp, bool) {
 }
 
 func getEnvVar(key string) (string, error) {
-	// Check if env variable is present
 	envValue := os.Getenv(key)
 	if envValue == "" {
-		// Try to load from .env file
+		// Read .env into a local map without modifying the process environment.
+		// godotenv.Read (unlike Load) never calls os.Setenv, preventing
+		// untrusted .env entries from polluting process-wide state.
 		dir, err := os.Getwd()
 		if err != nil {
 			dir = ""
 		}
-		err = godotenv.Load(path.Join(dir, ".env"))
+		envMap, err := godotenv.Read(path.Join(dir, ".env"))
 		if err != nil {
 			return "", nil
 		}
-		envValue = os.Getenv(key)
+		envValue = envMap[key]
 	}
 	if envValue == "" {
 		fmt.Printf("No value for env var: %s\n", key)

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -408,6 +408,27 @@ func TestParseWithEnvSubstring(t *testing.T) {
 	fs.Remove(envPath)
 }
 
+func TestParseEnvFileDoesNotPolluteProcessEnv(t *testing.T) {
+	fs := afero.NewOsFs()
+	wd, _ := os.Getwd()
+	envPath := path.Join(wd, ".env")
+	afero.WriteFile(fs, envPath, []byte("REQUESTED_KEY=hello\nUNRELATED_SECRET=should_not_leak"), os.ModePerm)
+	defer fs.Remove(envPath)
+
+	data := make(map[string]interface{})
+	data["val"] = "${.env:REQUESTED_KEY}"
+	output, err := ParseToFormData(data, make(map[string]gjson.Result))
+
+	require.NoError(t, err)
+	require.Equal(t, 1, len(output))
+	require.Equal(t, "val=hello", output[0])
+
+	require.Empty(t, os.Getenv("UNRELATED_SECRET"),
+		"getEnvVar must not inject unrelated .env entries into the process environment")
+	require.Empty(t, os.Getenv("REQUESTED_KEY"),
+		"getEnvVar must not inject any .env entries into the process environment")
+}
+
 func TestParseWithTimeNow(t *testing.T) {
 	queryRespMap := map[string]gjson.Result{
 		"cust_bender": gjson.Parse(`{"id": "cust_bend123456789"}`),

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -17,6 +17,11 @@ import (
 	"github.com/stripe/stripe-cli/pkg/useragent"
 )
 
+// unixSocketPath is captured once at package init so that later mutations to
+// the process environment (e.g. via godotenv.Load) cannot redirect the HTTP
+// transport after startup.
+var unixSocketPath = os.Getenv("STRIPE_CLI_UNIX_SOCKET")
+
 // APIVersion is API version used in CLI
 const APIVersion = "2019-03-14"
 
@@ -158,7 +163,6 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 		return nil, err
 	}
 
-	// if path starts with v1
 	if IsV2Path(path) {
 		req.Header.Set("Content-Type", V2ContentType)
 	} else {
@@ -177,7 +181,7 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 	}
 
 	if c.httpClient == nil {
-		c.httpClient = newHTTPClient(c.Verbose, c.VerbosePrintableHeaders, os.Getenv("STRIPE_CLI_UNIX_SOCKET"))
+		c.httpClient = newHTTPClient(c.Verbose, c.VerbosePrintableHeaders, unixSocketPath)
 		if c.NoFollowRedirects {
 			c.httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
 				return http.ErrUseLastResponse
@@ -259,7 +263,17 @@ func newHTTPClient(verbose bool, printableHeaders []string, unixSocket string) *
 	}
 }
 
-// IsV2Path checks if the path is for V1 API
+// IsV2Path reports whether path targets the V2 API.
+// The trailing slash is required to avoid false positives on paths like /v2x/...
 func IsV2Path(path string) bool {
-	return strings.HasPrefix(path, "/"+V2Request)
+	return strings.HasPrefix(path, "/"+V2Request+"/")
+}
+
+// IsValidAPIPath reports whether the resolved URL path is under a recognized
+// Stripe API prefix. This prevents path-traversal attacks (e.g.
+// /v2x/../v1.41/containers/create) from reaching non-Stripe endpoints.
+func IsValidAPIPath(path string) bool {
+	return strings.HasPrefix(path, "/v1/") || strings.HasPrefix(path, "/v1?") ||
+		strings.HasPrefix(path, "/v2/") || strings.HasPrefix(path, "/v2?") ||
+		path == "/v1" || path == "/v2"
 }

--- a/pkg/stripe/url_test.go
+++ b/pkg/stripe/url_test.go
@@ -43,6 +43,31 @@ func TestValidateDashboardBaseURLWorks(t *testing.T) {
 	assert.ErrorIs(t, ValidateDashboardBaseURL("anything_else"), errInvalidDashboardBaseURL)
 }
 
+func TestIsV2PathRequiresTrailingSlash(t *testing.T) {
+	assert.True(t, IsV2Path("/v2/core/events"))
+	assert.True(t, IsV2Path("/v2/billing/meters"))
+
+	// Must not match paths that merely start with /v2 without a trailing slash.
+	// This prevents /v2x/... from being misclassified as V2.
+	assert.False(t, IsV2Path("/v2x/../v1.41/containers/create"))
+	assert.False(t, IsV2Path("/v2x"))
+	assert.False(t, IsV2Path("/v1/charges"))
+	assert.False(t, IsV2Path("/v1/customers"))
+}
+
+func TestIsValidAPIPath(t *testing.T) {
+	assert.True(t, IsValidAPIPath("/v1/charges"))
+	assert.True(t, IsValidAPIPath("/v1/customers/cust_123"))
+	assert.True(t, IsValidAPIPath("/v2/core/events"))
+	assert.True(t, IsValidAPIPath("/v2/billing/meters"))
+
+	// Path traversal attacks must be rejected
+	assert.False(t, IsValidAPIPath("/v1.41/containers/create"))
+	assert.False(t, IsValidAPIPath("/docker/containers"))
+	assert.False(t, IsValidAPIPath("/"))
+	assert.False(t, IsValidAPIPath(""))
+}
+
 func TestDashboardBaseURLForAPIBaseURLWorks(t *testing.T) {
 	assert.Equal(t, "https://dashboard.stripe.com", DashboardBaseURLForAPIBaseURL(""))
 	assert.Equal(t, "https://dashboard.stripe.com", DashboardBaseURLForAPIBaseURL("https://api.stripe.com"))


### PR DESCRIPTION
Three defense-in-depth fixes for a bug bounty report ([SAT-28213](https://security-insights.corp.stripe.com/pathfinder/sats/SAT-28213)) where a malicious fixture + .env file could redirect CLI requests to a local Unix socket (e.g. Docker), leaking credentials as plaintext:

1. Replace godotenv.Load() with godotenv.Read() in getEnvVar() so that resolving one ${.env:KEY} no longer injects every .env entry into the process environment.

2. Capture STRIPE_CLI_UNIX_SOCKET once at package init rather than lazily on first request, making transport configuration immutable after startup.

3. Fix divergent V2 path predicate (IsV2Path now requires trailing slash) and add IsValidAPIPath to reject fixture paths that escape /v1/ or /v2/ via dot-segment traversal (e.g. /v2x/../v1.41/containers/create).


Manually tested -- The PoC now fails with the path validation error instead of reaching Docker

<img width="1217" height="74" alt="Screenshot 2026-08-10 at 5 18 21 PM" src="https://github.com/user-attachments/assets/74b39c20-17c9-4e15-99f8-2175822b0699" />


 ### Reviewers
r? @
cc @stripe/developer-products


