### PR TITLE
Validate `--events-from` flag and reject invalid values

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -26,6 +26,12 @@ import (
 
 var thinEventPattern = regexp.MustCompile(`^v\d+\.`)
 
+var validEventsFromValues = map[string]bool{
+	"@self":     true,
+	"@accounts": true,
+	"all":       true,
+}
+
 const (
 	webhooksWebSocketFeature     = "webhooks"
 	destinationsWebSocketFeature = "v2_events"
@@ -139,6 +145,10 @@ Stripe account.`,
 // but since it's acting as the core functionality for the cmd above, I'm keeping it close.
 func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	if err := lc.checkRemovedFlags(); err != nil {
+		return err
+	}
+
+	if err := lc.validateEventsFrom(); err != nil {
 		return err
 	}
 
@@ -449,6 +459,13 @@ func splitEventsByType(events []string, allSnapshot, allThin bool) (snapshotEven
 
 func isThinEvent(eventType string) bool {
 	return thinEventPattern.MatchString(eventType)
+}
+
+func (lc *listenCmd) validateEventsFrom() error {
+	if !validEventsFromValues[lc.eventsFrom] {
+		return fmt.Errorf("invalid --events-from value %q: must be one of '@self', '@accounts', or 'all'", lc.eventsFrom)
+	}
+	return nil
 }
 
 // resolveForwardURLs determines the direct and connect forwarding URLs based on

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -325,6 +325,35 @@ func TestValidateForwardingConfig(t *testing.T) {
 	}
 }
 
+func TestValidateEventsFrom(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "@self is valid", value: "@self", wantErr: false},
+		{name: "@accounts is valid", value: "@accounts", wantErr: false},
+		{name: "all is valid", value: "all", wantErr: false},
+		{name: "@everyone is invalid", value: "@everyone", wantErr: true},
+		{name: "empty string is invalid", value: "", wantErr: true},
+		{name: "self without @ is invalid", value: "self", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := newListenCmd()
+			lc.eventsFrom = tt.value
+			err := lc.validateEventsFrom()
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid --events-from value")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestCheckRemovedFlags(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Fix the bug that `--events-from @invalid-flag` was silently accepted by adding a `validateEventsFrom()` method that checks the flag value against the allowed set (@self, @accounts, all) and returns a clear error for anything else. 


### Testing
- [x] Unit tests added and passing (go test ./pkg/cmd/ -run TestValidateEventsFrom)
- [x] Manually tested
```
 ./stripe-v2 listen --events-from @everyone
invalid --events-from value "@everyone": must be one of '@self', '@accounts', or 'all'
```