### PR TITLE
Replace confusing '*' with '--all-thin' in INFO message

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -365,14 +365,13 @@ func Init(ctx context.Context, cfg *Config) (*Proxy, error) {
 
 	if len(cfg.ThinEvents) > 0 {
 		for _, event := range cfg.ThinEvents {
+			if event == "*" {
+				cfg.Log.Infof("--all-thin is only supported in the CLI; thin event destinations do not support selecting all event types\n")
+				continue
+			}
 			if _, found := validThinEvents[event]; !found {
-				// If not found in validThinEvents, check in validPreviewThinEvents
 				if _, foundInPreview := validPreviewThinEvents[event]; !foundInPreview {
-					if event == "*" {
-						cfg.Log.Infof("* is only supported in the CLI, thin event destinations do not support selecting all event types\n")
-					} else {
-						cfg.Log.Warningf("You're attempting to listen for \"%s\", which isn't a valid thin event or preview event\n", event)
-					}
+					cfg.Log.Warningf("You're attempting to listen for \"%s\", which isn't a valid thin event or preview event\n", event)
 				}
 			}
 		}


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Fix the confusing INFO message when user inputs the command `stripe listen --all-thin`
Before: 
```
INFO * is only supported in the CLI, thin event destinations do not support selecting all event types
```
After
```
INFO --all-thin is only supported in the CLI; thin event destinations do not support selecting all event types
```