### PR TITLE
Add MinCoreVersion compatibility guard for plugins

### DIFF
--- a/pkg/cmd/plugin/auto_update.go
+++ b/pkg/cmd/plugin/auto_update.go
@@ -26,10 +26,10 @@ func NewAutoUpdateCmd(cfg *config.Config) *AutoUpdateCmd {
 	ac.Cmd = &cobra.Command{
 		Use:   "auto-update [plugin]",
 		Short: "Enable or disable automatic updates for a plugin",
-		Long: `Enable or disable automatic background updates for a plugin.
+		Long: `Enable or disable automatic updates for a plugin.
 
-By default, automatic updates are disabled. When disabled, the CLI will not check
-for or download newer versions automatically.
+By default, automatic updates are disabled. When disabled, the CLI will notify you
+about newer versions but will not download them automatically.
 Omit the plugin name to apply the setting globally to all plugins.`,
 		Example: `stripe plugin auto-update --enable
   stripe plugin auto-update --disable

--- a/pkg/cmd/plugin/list.go
+++ b/pkg/cmd/plugin/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/plugins"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
+	cliversion "github.com/stripe/stripe-cli/pkg/version"
 )
 
 // ListCmd is the struct used for configuring the plugin list command.
@@ -67,7 +68,7 @@ func (lc *ListCmd) runListCmd(cmd *cobra.Command, args []string) error {
 	availablePlugins := make([]plugins.Plugin, 0, len(pluginList.Plugins))
 	nameWidth := 0
 	for _, plugin := range pluginList.Plugins {
-		if plugin.Shortname == "" || plugin.LookUpLatestVersion() == "" {
+		if plugin.Shortname == "" || plugin.LookUpLatestCompatibleVersion(cliversion.Version) == "" {
 			continue
 		}
 		availablePlugins = append(availablePlugins, plugin)

--- a/pkg/cmd/plugin/list_test.go
+++ b/pkg/cmd/plugin/list_test.go
@@ -15,9 +15,14 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/plugins"
+	cliversion "github.com/stripe/stripe-cli/pkg/version"
 )
 
 func TestListCmdPrintsAvailablePlugins(t *testing.T) {
+	origVersion := cliversion.Version
+	cliversion.Version = "1.0.0"
+	defer func() { cliversion.Version = origVersion }()
+
 	cfg, _, cleanup := setupPluginCommandTest(t)
 	defer cleanup()
 
@@ -78,6 +83,7 @@ func assertListOutput(t *testing.T, rendered string) {
 	} else {
 		require.NotContains(t, rendered, "windows-only")
 	}
+	require.NotContains(t, rendered, "incompatible")
 	require.Contains(t, rendered, "Run `stripe plugin install <name>` to install a plugin.")
 
 	assert.Less(t, strings.Index(rendered, "apps"), strings.Index(rendered, "projects"))
@@ -133,6 +139,19 @@ func testListPluginList() plugins.PluginList {
 						Arch:    runtime.GOARCH,
 						OS:      runtime.GOOS,
 						Version: "3.0.0",
+					},
+				},
+			},
+			{
+				Shortname: "incompatible",
+				Shortdesc: "Requires a newer Stripe CLI",
+				Binary:    "stripe-cli-incompatible",
+				Releases: []plugins.Release{
+					{
+						Arch:           runtime.GOARCH,
+						OS:             runtime.GOOS,
+						Version:        "1.0.0",
+						MinCoreVersion: "99.0.0",
 					},
 				},
 			},

--- a/pkg/config/plugin_configs.go
+++ b/pkg/config/plugin_configs.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/spf13/viper"
+
 const (
 	// PluginConfigGlobalScope is used as the scope when a setting applies to all plugins.
 	PluginConfigGlobalScope = "__global"
@@ -26,4 +28,17 @@ func isPluginConfigSection(v interface{}) bool {
 // Example: PluginConfigKey("apps", "updates") to read or set the updates setting for the "apps" plugin
 func PluginConfigKey(scope, field string) string {
 	return "plugin_configs." + scope + "." + field
+}
+
+// PluginAutoUpdateEnabled reports whether automatic updates are enabled for a
+// plugin. A plugin-specific setting takes precedence over the global setting.
+// Automatic updates default to disabled when neither setting is present.
+func (c *Config) PluginAutoUpdateEnabled(pluginName string) bool {
+	pluginKey := PluginConfigKey(pluginName, PluginConfigUpdatesField)
+	if viper.IsSet(pluginKey) {
+		return viper.GetString(pluginKey) == "on"
+	}
+
+	globalKey := PluginConfigKey(PluginConfigGlobalScope, PluginConfigUpdatesField)
+	return viper.GetString(globalKey) == "on"
 }

--- a/pkg/config/plugin_configs_test.go
+++ b/pkg/config/plugin_configs_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginAutoUpdateEnabled(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	cfg := &Config{}
+	globalKey := PluginConfigKey(PluginConfigGlobalScope, PluginConfigUpdatesField)
+	pluginKey := PluginConfigKey("apps", PluginConfigUpdatesField)
+
+	require.False(t, cfg.PluginAutoUpdateEnabled("apps"), "updates should default to disabled")
+
+	viper.Set(globalKey, "on")
+	require.True(t, cfg.PluginAutoUpdateEnabled("apps"), "global enable should apply")
+
+	viper.Set(pluginKey, "off")
+	require.False(t, cfg.PluginAutoUpdateEnabled("apps"), "plugin disable should override global enable")
+
+	viper.Set(globalKey, "off")
+	viper.Set(pluginKey, "on")
+	require.True(t, cfg.PluginAutoUpdateEnabled("apps"), "plugin enable should override global disable")
+}

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -23,9 +23,11 @@ import (
 	"github.com/stripe/stripe-cli/pkg/plugins/proto"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
+	cliversion "github.com/stripe/stripe-cli/pkg/version"
 
 	hclog "github.com/hashicorp/go-hclog"
 	hcplugin "github.com/hashicorp/go-plugin"
+	goversion "github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
@@ -63,10 +65,11 @@ type PluginList struct {
 
 // Release is the type that holds release data for a specific build of a plugin
 type Release struct {
-	Arch    string `toml:"Arch" json:"arch"`
-	OS      string `toml:"OS" json:"os"`
-	Version string `toml:"Version" json:"version"`
-	Sum     string `toml:"Sum" json:"sum,omitempty"`
+	Arch           string `toml:"Arch" json:"arch"`
+	OS             string `toml:"OS" json:"os"`
+	Version        string `toml:"Version" json:"version"`
+	Sum            string `toml:"Sum" json:"sum,omitempty"`
+	MinCoreVersion string `toml:"MinCoreVersion,omitempty" json:"min_core_version,omitempty"`
 }
 
 // getPluginInterface computes the correct metadata needed for starting the hcplugin client
@@ -212,6 +215,48 @@ func (p *Plugin) LookUpLatestVersion() string {
 	}
 
 	return version
+}
+
+// isCompatibleWithCore reports whether this release can run on the given CLI core version.
+// Returns true if MinCoreVersion is empty, coreVersion is "master" (dev builds are never blocked),
+// or coreVersion >= MinCoreVersion. Fails open on parse errors.
+func (r Release) isCompatibleWithCore(coreVersion string) bool {
+	if r.MinCoreVersion == "" {
+		return true
+	}
+	if coreVersion == "master" {
+		return true
+	}
+
+	minV, err := goversion.NewVersion(r.MinCoreVersion)
+	if err != nil {
+		return true
+	}
+	coreV, err := goversion.NewVersion(coreVersion)
+	if err != nil {
+		return true
+	}
+
+	return coreV.GreaterThanOrEqual(minV)
+}
+
+// LookUpLatestCompatibleVersion returns the highest release version for the current OS/arch
+// that is compatible with the given CLI core version. Returns empty string if no compatible
+// release is found.
+func (p *Plugin) LookUpLatestCompatibleVersion(coreVersion string) string {
+	opsystem := runtime.GOOS
+	arch := runtime.GOARCH
+
+	var best string
+	for _, pkg := range p.Releases {
+		if pkg.OS == opsystem && pkg.Arch == arch && pkg.isCompatibleWithCore(coreVersion) {
+			if best == "" || comparePluginVersions(pkg.Version, best) > 0 {
+				best = pkg.Version
+			}
+		}
+	}
+
+	return best
 }
 
 // getReleaseForVersion finds the release object for a specific version on the current platform
@@ -586,6 +631,17 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 			version = resolvedPlugin.Version
 			if err := resolvedPlugin.Install(ctx, config, fs, stripe.DefaultAPIBaseURL, dashboardBaseURL); err != nil {
 				return err
+			}
+		}
+	}
+
+	if !isLocalDevelopmentVersion(version) {
+		if release := p.getReleaseForVersion(version); release != nil {
+			if !release.isCompatibleWithCore(cliversion.Version) {
+				return fmt.Errorf(
+					"plugin %s v%s requires Stripe CLI >= %s (you have %s); run `stripe upgrade` to update the CLI",
+					p.Shortname, version, release.MinCoreVersion, cliversion.Version,
+				)
 			}
 		}
 	}

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -259,6 +259,19 @@ func (p *Plugin) LookUpLatestCompatibleVersion(coreVersion string) string {
 	return best
 }
 
+func (p *Plugin) validateCoreCompatibility(version, coreVersion string) error {
+	release := p.getReleaseForVersion(version)
+	if release == nil || release.isCompatibleWithCore(coreVersion) {
+		return nil
+	}
+
+	return errorcategory.Errorf(
+		errorcategory.UserInput,
+		"plugin %s v%s requires Stripe CLI >= %s (you have %s); upgrade the Stripe CLI: https://docs.stripe.com/stripe-cli/upgrade",
+		p.Shortname, version, release.MinCoreVersion, coreVersion,
+	)
+}
+
 // getReleaseForVersion finds the release object for a specific version on the current platform
 func (p *Plugin) getReleaseForVersion(version string) *Release {
 	return p.getRelease(version, runtime.GOOS, runtime.GOARCH)
@@ -330,11 +343,11 @@ func (p *Plugin) InstalledVersion(config config.IConfig, fs afero.Fs) string {
 
 // Install installs the plugin of the given version.
 func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, apiBaseURL, dashboardBaseURL string) error {
-	return p.install(ctx, cfg, fs, version, apiBaseURL, dashboardBaseURL, "", false)
+	return p.install(ctx, cfg, fs, version, apiBaseURL, dashboardBaseURL, "", false, os.Stdout)
 }
 
-func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, apiBaseURL, dashboardBaseURL, resolvedBinaryURL string, skipMetadataLookup bool) error {
-	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)
+func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, apiBaseURL, dashboardBaseURL, resolvedBinaryURL string, skipMetadataLookup bool, output io.Writer) error {
+	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), output)
 
 	creds, _ := cfg.GetProfile().ResolveCredentialsForAnyMode(false)
 	apiKey := creds.Token
@@ -371,7 +384,7 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 		} else {
 			pluginFromMetadata, err := p.pluginFromMetadata(pluginMetadata.PluginManifest)
 			if err != nil {
-				ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
+				ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), output)
 				return err
 			}
 
@@ -380,8 +393,13 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 		}
 	}
 
+	if err := pluginToInstall.validateCoreCompatibility(version, cliversion.Version); err != nil {
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), output)
+		return err
+	}
+
 	if pluginDownloadURL == "" {
-		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stdout)
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), output)
 		if metadataLookupErr != nil {
 			return fmt.Errorf("could not resolve download URL for plugin '%s' v%s: failed to fetch plugin metadata: %w", p.Shortname, version, metadataLookupErr)
 		}
@@ -389,8 +407,8 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 	}
 
 	// Pull down bin, verify, and save to disk
-	if err := pluginToInstall.downloadAndSavePlugin(cfg, pluginDownloadURL, fs, version); err != nil {
-		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), os.Stdout)
+	if err := pluginToInstall.downloadAndSavePlugin(ctx, cfg, pluginDownloadURL, fs, version); err != nil {
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), output)
 		return err
 	}
 
@@ -407,14 +425,14 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 			}).Debugf("could not clean up plugin after local metadata write failure: %s", cleanupErr)
 		}
 
-		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), os.Stdout)
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s': %s", p.Shortname, err)), output)
 		return err
 	}
 
 	// Once the plugin is successfully downloaded, clean up other versions
 	p.cleanUpPluginPath(cfg, fs, version)
 
-	ansi.StopSpinner(spinner, "", os.Stdout)
+	ansi.StopSpinner(spinner, "", output)
 
 	return nil
 }
@@ -477,8 +495,8 @@ func (p *Plugin) Uninstall(ctx context.Context, config config.IConfig, fs afero.
 	return nil
 }
 
-func (p *Plugin) downloadAndSavePlugin(config config.IConfig, pluginDownloadURL string, fs afero.Fs, version string) error {
-	body, err := FetchRemoteResource(pluginDownloadURL)
+func (p *Plugin) downloadAndSavePlugin(ctx context.Context, config config.IConfig, pluginDownloadURL string, fs afero.Fs, version string) error {
+	body, err := fetchRemoteResource(ctx, pluginDownloadURL)
 	if err != nil {
 		return err
 	}
@@ -636,13 +654,8 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 	}
 
 	if !isLocalDevelopmentVersion(version) {
-		if release := p.getReleaseForVersion(version); release != nil {
-			if !release.isCompatibleWithCore(cliversion.Version) {
-				return fmt.Errorf(
-					"plugin %s v%s requires Stripe CLI >= %s (you have %s); run `stripe upgrade` to update the CLI",
-					p.Shortname, version, release.MinCoreVersion, cliversion.Version,
-				)
-			}
+		if err := p.validateCoreCompatibility(version, cliversion.Version); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -1,11 +1,13 @@
 package plugins
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	cliversion "github.com/stripe/stripe-cli/pkg/version"
 )
 
@@ -1325,7 +1328,65 @@ func TestRunRejectsIncompatiblePlugin(t *testing.T) {
 	err := plugin.Run(context.Background(), &cfg.Config, fs, nil, "", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "requires Stripe CLI >= 99.0.0")
-	require.Contains(t, err.Error(), "stripe upgrade")
+	require.Contains(t, err.Error(), "https://docs.stripe.com/stripe-cli/upgrade")
+}
+
+func TestInstallRejectsIncompatiblePluginBeforeReplacingInstalledVersion(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+
+	origVersion := cliversion.Version
+	cliversion.Version = "1.0.0"
+	defer func() { cliversion.Version = origVersion }()
+
+	plugin := Plugin{
+		Shortname: "myplugin",
+		Binary:    "stripe-cli-myplugin",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.0", Sum: "abc123"},
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "2.0.0", Sum: "def456", MinCoreVersion: "2.0.0"},
+		},
+	}
+
+	oldBinary := filepath.Join("/plugins/myplugin/1.0.0", "stripe-cli-myplugin"+GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(oldBinary), 0755))
+	require.NoError(t, afero.WriteFile(fs, oldBinary, []byte("working"), 0755))
+
+	resolved := &ResolvedPluginVersion{
+		Plugin:    &plugin,
+		Version:   "2.0.0",
+		BinaryURL: "https://example.test/myplugin/2.0.0",
+	}
+	err := resolved.install(context.Background(), cfg, fs, stripe.DefaultAPIBaseURL, "", io.Discard)
+	require.ErrorContains(t, err, "requires Stripe CLI >= 2.0.0")
+
+	oldVersionExists, err := afero.Exists(fs, oldBinary)
+	require.NoError(t, err)
+	require.True(t, oldVersionExists)
+	require.False(t, plugin.IsVersionInstalled(cfg, fs, "2.0.0"))
+}
+
+func TestMinCoreVersionTOMLRoundTrip(t *testing.T) {
+	want := PluginList{Plugins: []Plugin{{
+		Shortname: "myplugin",
+		Binary:    "stripe-cli-myplugin",
+		Releases: []Release{{
+			Arch:           runtime.GOARCH,
+			OS:             runtime.GOOS,
+			Version:        "2.0.0",
+			Sum:            "abc123",
+			MinCoreVersion: "1.45.0",
+		}},
+	}}}
+
+	var encoded bytes.Buffer
+	require.NoError(t, toml.NewEncoder(&encoded).Encode(want))
+	require.Contains(t, encoded.String(), `MinCoreVersion = "1.45.0"`)
+
+	got, err := validatePluginManifest(encoded.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, "1.45.0", got.Plugins[0].Releases[0].MinCoreVersion)
 }
 
 func TestRunAllowsCompatiblePlugin(t *testing.T) {

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/requests"
+	cliversion "github.com/stripe/stripe-cli/pkg/version"
 )
 
 type failRemoveAllFs struct {
@@ -1214,6 +1215,193 @@ func TestVerifyChecksumAndSavePluginRefusesSymlink(t *testing.T) {
 	victimContents, err := os.ReadFile(victimFile)
 	require.NoError(t, err)
 	require.Equal(t, "original", string(victimContents))
+}
+
+func TestIsCompatibleWithCore(t *testing.T) {
+	tests := []struct {
+		name           string
+		minCoreVersion string
+		coreVersion    string
+		expected       bool
+	}{
+		{"empty min is always compatible", "", "1.0.0", true},
+		{"master is always compatible", "2.0.0", "master", true},
+		{"core equals min", "1.5.0", "1.5.0", true},
+		{"core greater than min", "1.5.0", "1.6.0", true},
+		{"core less than min", "2.0.0", "1.9.0", false},
+		{"unparseable min fails open", "not-a-version", "1.0.0", true},
+		{"unparseable core fails open", "1.0.0", "not-a-version", true},
+		{"both unparseable fails open", "bad", "also-bad", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := Release{MinCoreVersion: tt.minCoreVersion}
+			require.Equal(t, tt.expected, r.isCompatibleWithCore(tt.coreVersion))
+		})
+	}
+}
+
+func TestLookUpLatestCompatibleVersion(t *testing.T) {
+	plugin := Plugin{
+		Shortname: "test",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.0", MinCoreVersion: ""},
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "2.0.0", MinCoreVersion: "1.5.0"},
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "3.0.0", MinCoreVersion: "2.0.0"},
+		},
+	}
+
+	// Core 1.5.0 can run v1.0.0 and v2.0.0, but not v3.0.0
+	require.Equal(t, "2.0.0", plugin.LookUpLatestCompatibleVersion("1.5.0"))
+
+	// Core 2.0.0 can run all
+	require.Equal(t, "3.0.0", plugin.LookUpLatestCompatibleVersion("2.0.0"))
+
+	// Core 1.0.0 can only run v1.0.0 (no min) and not v2.0.0 or v3.0.0
+	require.Equal(t, "1.0.0", plugin.LookUpLatestCompatibleVersion("1.0.0"))
+
+	// master can run all
+	require.Equal(t, "3.0.0", plugin.LookUpLatestCompatibleVersion("master"))
+}
+
+func TestLookUpLatestCompatibleVersionNoMatch(t *testing.T) {
+	plugin := Plugin{
+		Shortname: "test",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.0", MinCoreVersion: "99.0.0"},
+		},
+	}
+
+	require.Equal(t, "", plugin.LookUpLatestCompatibleVersion("1.0.0"))
+}
+
+func TestLookUpLatestCompatibleVersionIgnoresOtherPlatforms(t *testing.T) {
+	plugin := Plugin{
+		Shortname: "test",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.0", MinCoreVersion: ""},
+			{Arch: "other-arch", OS: "other-os", Version: "9.0.0", MinCoreVersion: ""},
+		},
+	}
+
+	require.Equal(t, "1.0.0", plugin.LookUpLatestCompatibleVersion("1.0.0"))
+}
+
+func TestRunRejectsIncompatiblePlugin(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+
+	t.Setenv("STRIPE_PLUGINS_PATH", "/plugins")
+
+	origVersion := cliversion.Version
+	cliversion.Version = "1.0.0"
+	defer func() { cliversion.Version = origVersion }()
+
+	plugin := Plugin{
+		Shortname:        "incompatible-plugin",
+		Binary:           "stripe-cli-incompatible",
+		MagicCookieValue: "COOKIE",
+		Releases: []Release{
+			{
+				Arch:           runtime.GOARCH,
+				OS:             runtime.GOOS,
+				Version:        "1.0.0",
+				Sum:            "abc123",
+				MinCoreVersion: "99.0.0",
+			},
+		},
+	}
+
+	pluginDir := "/plugins/incompatible-plugin/1.0.0"
+	require.NoError(t, fs.MkdirAll(pluginDir, 0755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(pluginDir, "stripe-cli-incompatible"+GetBinaryExtension()), []byte("bin"), 0755))
+
+	origPluginsPath := PluginsPath
+	PluginsPath = ""
+	defer func() { PluginsPath = origPluginsPath }()
+
+	err := plugin.Run(context.Background(), &cfg.Config, fs, nil, "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires Stripe CLI >= 99.0.0")
+	require.Contains(t, err.Error(), "stripe upgrade")
+}
+
+func TestRunAllowsCompatiblePlugin(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+
+	t.Setenv("STRIPE_PLUGINS_PATH", "/plugins")
+
+	origVersion := cliversion.Version
+	cliversion.Version = "2.0.0"
+	defer func() { cliversion.Version = origVersion }()
+
+	plugin := Plugin{
+		Shortname:        "compatible-plugin",
+		Binary:           "stripe-cli-compatible",
+		MagicCookieValue: "COOKIE",
+		Releases: []Release{
+			{
+				Arch:           runtime.GOARCH,
+				OS:             runtime.GOOS,
+				Version:        "1.0.0",
+				Sum:            "abc123",
+				MinCoreVersion: "1.5.0",
+			},
+		},
+	}
+
+	pluginDir := "/plugins/compatible-plugin/1.0.0"
+	require.NoError(t, fs.MkdirAll(pluginDir, 0755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(pluginDir, "stripe-cli-compatible"+GetBinaryExtension()), []byte("bin"), 0755))
+
+	origPluginsPath := PluginsPath
+	PluginsPath = ""
+	defer func() { PluginsPath = origPluginsPath }()
+
+	// Should pass the compatibility check and fail later at the checksum/handshake stage
+	err := plugin.Run(context.Background(), &cfg.Config, fs, nil, "", "")
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "requires Stripe CLI")
+}
+
+func TestRunSkipsCompatibilityCheckForLocalDev(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	cfg := &TestConfig{}
+	cfg.InitConfig()
+
+	t.Setenv("STRIPE_PLUGINS_PATH", "/plugins")
+
+	plugin := Plugin{
+		Shortname:        "dev-plugin",
+		Binary:           "stripe-cli-dev",
+		MagicCookieValue: "COOKIE",
+		Releases: []Release{
+			{
+				Arch:           runtime.GOARCH,
+				OS:             runtime.GOOS,
+				Version:        "1.0.0",
+				Sum:            "abc123",
+				MinCoreVersion: "99.0.0",
+			},
+		},
+	}
+
+	pluginDir := "/plugins/dev-plugin/local.build.dev"
+	require.NoError(t, fs.MkdirAll(pluginDir, 0755))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(pluginDir, "stripe-cli-dev"+GetBinaryExtension()), []byte("bin"), 0755))
+
+	origPluginsPath := PluginsPath
+	PluginsPath = "/plugins"
+	defer func() { PluginsPath = origPluginsPath }()
+
+	// Should skip compatibility check for local dev and fail at handshake
+	err := plugin.Run(context.Background(), &cfg.Config, fs, nil, "", "")
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "requires Stripe CLI")
 }
 
 func TestVerifyChecksumAndSavePluginRefusesSymlinkedParent(t *testing.T) {

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
+	cliversion "github.com/stripe/stripe-cli/pkg/version"
 )
 
 type installedPluginStateSnapshot struct {
@@ -51,9 +52,28 @@ type ResolvedPluginVersion struct {
 // checkLatestPluginVersionResolver is swappable for test injection.
 var checkLatestPluginVersionResolver = ResolvePluginForUpgrade
 
+// getPluginMetadata is swappable for test injection.
+var getPluginMetadata = requests.GetPluginMetadata
+
+// automaticPluginInstaller is swappable for test injection.
+// Progress goes to stderr so the download is visible without disturbing the
+// stdout the plugin command already produced.
+var automaticPluginInstaller = func(ctx context.Context, resolvedPlugin *ResolvedPluginVersion, config config.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string) error {
+	return resolvedPlugin.install(ctx, config, fs, apiBaseURL, dashboardBaseURL, os.Stderr)
+}
+
 // checkLatestPluginVersionTimeout bounds the best-effort upgrade hint lookup so
 // plugin commands do not hang on exit when the metadata endpoint is slow.
 var checkLatestPluginVersionTimeout = 2 * time.Second
+
+// automaticPluginUpdateTimeout prevents an automatic download from delaying
+// command exit indefinitely.
+var automaticPluginUpdateTimeout = 30 * time.Second
+
+// automaticPluginUpdateRetryInterval throttles automatic updates after a failed
+// attempt. Without it, an update that keeps failing (blocked CDN, bad checksum,
+// slow link) would spend automaticPluginUpdateTimeout on every plugin command.
+var automaticPluginUpdateRetryInterval = 6 * time.Hour
 
 // ValidatePluginShortname rejects names that could escape the plugin install or
 // metadata directories when joined onto local filesystem paths.
@@ -81,6 +101,10 @@ func ValidatePluginShortname(pluginName string) error {
 // metadata request. Otherwise it retries metadata during install so cached
 // local metadata can still recover fresh release details.
 func (r *ResolvedPluginVersion) Install(ctx context.Context, config config.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string) error {
+	return r.install(ctx, config, fs, apiBaseURL, dashboardBaseURL, os.Stdout)
+}
+
+func (r *ResolvedPluginVersion) install(ctx context.Context, config config.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string, output io.Writer) error {
 	switch {
 	case r == nil:
 		return errorcategory.New(errorcategory.Internal, "missing resolved plugin version")
@@ -89,7 +113,7 @@ func (r *ResolvedPluginVersion) Install(ctx context.Context, config config.IConf
 	case r.Version == "":
 		return errorcategory.New(errorcategory.Internal, "missing plugin version")
 	default:
-		return r.Plugin.install(ctx, config, fs, r.Version, apiBaseURL, dashboardBaseURL, r.BinaryURL, r.BinaryURL != "")
+		return r.Plugin.install(ctx, config, fs, r.Version, apiBaseURL, dashboardBaseURL, r.BinaryURL, r.BinaryURL != "", output)
 	}
 }
 
@@ -529,13 +553,16 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 	if cachedErr == nil {
 		resolvedVersion := version
 		if resolvedVersion == "" {
-			resolvedVersion = cachedPlugin.LookUpLatestVersion()
+			resolvedVersion = cachedPlugin.LookUpLatestCompatibleVersion(cliversion.Version)
 		}
 		if resolvedVersion == "" {
-			return nil, errorcategory.Errorf(errorcategory.API, "could not determine latest version for plugin %s", pluginName)
+			return nil, errorcategory.Errorf(errorcategory.API, "plugin %s has no release compatible with Stripe CLI %s on %s/%s", pluginName, cliversion.Version, runtime.GOOS, runtime.GOARCH)
 		}
 		if cachedPlugin.getReleaseForVersion(resolvedVersion) == nil {
 			return nil, errorcategory.Errorf(errorcategory.API, "cached plugin metadata did not include plugin %s version %s for %s/%s", pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
+		}
+		if err := cachedPlugin.validateCoreCompatibility(resolvedVersion, cliversion.Version); err != nil {
+			return nil, err
 		}
 
 		return &ResolvedPluginVersion{
@@ -671,7 +698,14 @@ func selectPluginForUpgrade(localPlugin, manifestPlugin *Plugin) *Plugin {
 		return mergePluginMetadata(manifestPlugin, nil)
 	case manifestPlugin == nil:
 		return mergePluginMetadata(localPlugin, nil)
-	case comparePluginVersions(localPlugin.LookUpLatestVersion(), manifestPlugin.LookUpLatestVersion()) >= 0:
+	// Compare the newest *compatible* release in each source. Comparing the
+	// newest release outright can hand the merge to a source whose latest this
+	// CLI cannot run, and mergePluginMetadata takes Releases from the primary
+	// only, so the other source's compatible releases would be discarded.
+	case comparePluginVersions(
+		localPlugin.LookUpLatestCompatibleVersion(cliversion.Version),
+		manifestPlugin.LookUpLatestCompatibleVersion(cliversion.Version),
+	) >= 0:
 		return mergePluginMetadata(localPlugin, manifestPlugin)
 	default:
 		return mergePluginMetadata(manifestPlugin, localPlugin)
@@ -790,7 +824,7 @@ func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs af
 		basePlugin = &cachedPlugin
 	}
 
-	pluginMetadata, err := requests.GetPluginMetadata(ctx, apiBaseURL, dashboardBaseURL, stripe.APIVersion, apiKey, config.GetProfile(), pluginName, version, runtime.GOOS, runtime.GOARCH)
+	pluginMetadata, err := getPluginMetadata(ctx, apiBaseURL, dashboardBaseURL, stripe.APIVersion, apiKey, config.GetProfile(), pluginName, version, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return nil, err
 	}
@@ -800,15 +834,44 @@ func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs af
 		return nil, err
 	}
 
-	resolvedVersion := version
+	requestedVersion := version
+	resolvedVersion := requestedVersion
 	if resolvedVersion == "" {
-		resolvedVersion = plugin.LookUpLatestVersion()
+		resolvedVersion = plugin.LookUpLatestCompatibleVersion(cliversion.Version)
 	}
 	if resolvedVersion == "" {
-		return nil, errorcategory.Errorf(errorcategory.API, "plugin metadata response did not include a release for %s on %s/%s", pluginName, runtime.GOOS, runtime.GOARCH)
+		return nil, errorcategory.Errorf(errorcategory.API, "plugin %s has no release compatible with Stripe CLI %s on %s/%s", pluginName, cliversion.Version, runtime.GOOS, runtime.GOARCH)
 	}
 	if plugin.getReleaseForVersion(resolvedVersion) == nil {
 		return nil, errorcategory.Errorf(errorcategory.API, "plugin metadata response did not include plugin %s version %s for %s/%s", pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
+	}
+	if err := plugin.validateCoreCompatibility(resolvedVersion, cliversion.Version); err != nil {
+		return nil, err
+	}
+
+	// An unversioned metadata request returns the binary URL for the registry's
+	// latest release. If that release is too new for this CLI, fetch the selected
+	// compatible version explicitly so the URL and checksum refer to the same
+	// artifact.
+	if requestedVersion == "" && resolvedVersion != plugin.LookUpLatestVersion() {
+		exactMetadata, err := getPluginMetadata(ctx, apiBaseURL, dashboardBaseURL, stripe.APIVersion, apiKey, config.GetProfile(), pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
+		if err != nil {
+			return nil, err
+		}
+
+		exactPlugin, err := basePlugin.pluginFromMetadata(exactMetadata.PluginManifest)
+		if err != nil {
+			return nil, err
+		}
+		if exactPlugin.getReleaseForVersion(resolvedVersion) == nil {
+			return nil, errorcategory.Errorf(errorcategory.API, "plugin metadata response did not include plugin %s version %s for %s/%s", pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
+		}
+		if err := exactPlugin.validateCoreCompatibility(resolvedVersion, cliversion.Version); err != nil {
+			return nil, err
+		}
+
+		plugin = exactPlugin
+		pluginMetadata = exactMetadata
 	}
 
 	return &ResolvedPluginVersion{
@@ -839,9 +902,9 @@ func getLatestResolvedPluginVersion(pluginName string, plugin *Plugin) (string, 
 		return "", errorcategory.Errorf(errorcategory.API, "could not determine latest version for plugin %s", pluginName)
 	}
 
-	version := plugin.LookUpLatestVersion()
+	version := plugin.LookUpLatestCompatibleVersion(cliversion.Version)
 	if version == "" {
-		return "", errorcategory.Errorf(errorcategory.API, "could not determine latest version for plugin %s", pluginName)
+		return "", errorcategory.Errorf(errorcategory.API, "plugin %s has no release compatible with Stripe CLI %s on %s/%s", pluginName, cliversion.Version, runtime.GOOS, runtime.GOARCH)
 	}
 
 	return version, nil
@@ -1048,9 +1111,17 @@ func (e *ErrPluginNotFound) Error() string {
 
 // FetchRemoteResource returns the remote resource body
 func FetchRemoteResource(url string) ([]byte, error) {
+	return fetchRemoteResource(context.Background(), url)
+}
+
+func fetchRemoteResource(ctx context.Context, url string) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	t := &requests.TracedTransport{}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 
 	if err != nil {
 		return nil, err
@@ -1089,8 +1160,9 @@ func FetchRemoteResource(url string) ([]byte, error) {
 	return body, nil
 }
 
-// CheckLatestPluginVersion prints an upgrade hint to stderr if live metadata
-// has a newer version of the plugin than what is currently installed.
+// CheckLatestPluginVersion checks live metadata after a successful plugin
+// command. It installs a newer compatible release when automatic updates are
+// enabled, otherwise it prints the existing manual-upgrade hint.
 func CheckLatestPluginVersion(ctx context.Context, config config.IConfig, fs afero.Fs, plugin Plugin, apiBaseURL, dashboardBaseURL string) {
 	if PluginsPath != "" {
 		return
@@ -1109,29 +1181,142 @@ func CheckLatestPluginVersion(ctx context.Context, config config.IConfig, fs afe
 		ctx = context.Background()
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, checkLatestPluginVersionTimeout)
-	defer cancel()
+	lookupCtx, cancel := context.WithTimeout(ctx, checkLatestPluginVersionTimeout)
+	resolvedPlugin, err := checkLatestPluginVersionResolver(lookupCtx, config, fs, plugin.Shortname, apiBaseURL, dashboardBaseURL)
+	cancel()
 
-	resolvedPlugin, err := checkLatestPluginVersionResolver(ctx, config, fs, plugin.Shortname, apiBaseURL, dashboardBaseURL)
 	if err != nil {
+		return
+	}
+	if resolvedPlugin == nil {
 		return
 	}
 
 	latestVersion := resolvedPlugin.Version
 	if latestVersion == "" && resolvedPlugin.Plugin != nil {
-		latestVersion = resolvedPlugin.Plugin.LookUpLatestVersion()
+		latestVersion = resolvedPlugin.Plugin.LookUpLatestCompatibleVersion(cliversion.Version)
 	}
 	if latestVersion == "" {
 		return
 	}
 
-	if comparePluginVersions(installedVersion, latestVersion) < 0 {
-		c := ansi.Color(os.Stderr)
-		msg := fmt.Sprintf(
-			"A newer version of the %s plugin is available (v%s → v%s). Run `stripe plugin upgrade %s` to update.",
-			plugin.Shortname, installedVersion, latestVersion, plugin.Shortname,
-		)
-		fmt.Fprintln(os.Stderr, c.Yellow(msg).String())
+	if comparePluginVersions(installedVersion, latestVersion) >= 0 {
+		return
+	}
+
+	if pluginAutoUpdateEnabled(config, plugin.Shortname) && !autoUpdateOnCooldown(config, fs, plugin.Shortname) {
+		updateCtx, cancelUpdate := context.WithTimeout(ctx, automaticPluginUpdateTimeout)
+		err := automaticPluginInstaller(updateCtx, resolvedPlugin, config, fs, apiBaseURL, dashboardBaseURL)
+		cancelUpdate()
+
+		if err == nil {
+			clearAutoUpdateFailure(config, fs, plugin.Shortname)
+
+			c := ansi.Color(os.Stderr)
+			msg := fmt.Sprintf("Automatically updated the %s plugin (v%s → v%s).", plugin.Shortname, installedVersion, latestVersion)
+			fmt.Fprintln(os.Stderr, c.Green(msg).String())
+			return
+		}
+
+		// A canceled parent context means the user interrupted the command, which
+		// says nothing about whether the update would have succeeded.
+		if ctx.Err() == nil {
+			recordAutoUpdateFailure(config, fs, plugin.Shortname)
+		}
+
+		log.WithFields(log.Fields{
+			"prefix": "plugins.CheckLatestPluginVersion",
+			"plugin": plugin.Shortname,
+			"from":   installedVersion,
+			"to":     latestVersion,
+		}).Debugf("automatic plugin update failed: %s", err)
+	}
+
+	c := ansi.Color(os.Stderr)
+	msg := fmt.Sprintf(
+		"A newer version of the %s plugin is available (v%s → v%s). Run `stripe plugin upgrade %s` to update.",
+		plugin.Shortname, installedVersion, latestVersion, plugin.Shortname,
+	)
+	fmt.Fprintln(os.Stderr, c.Yellow(msg).String())
+}
+
+type pluginAutoUpdateConfig interface {
+	PluginAutoUpdateEnabled(pluginName string) bool
+}
+
+func pluginAutoUpdateEnabled(config config.IConfig, pluginName string) bool {
+	settings, ok := config.(pluginAutoUpdateConfig)
+	if !ok {
+		log.WithFields(log.Fields{
+			"prefix": "plugins.pluginAutoUpdateEnabled",
+			"plugin": pluginName,
+		}).Debugf("config type %T cannot report automatic update settings; treating automatic updates as disabled", config)
+		return false
+	}
+
+	return settings.PluginAutoUpdateEnabled(pluginName)
+}
+
+// autoUpdateFailureStampPath is the marker file recording the last failed
+// automatic update for a plugin. Its modification time drives the retry
+// cooldown, so no contents are needed.
+func autoUpdateFailureStampPath(config config.IConfig, pluginName string) (string, error) {
+	if err := ValidatePluginShortname(pluginName); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(getLocalPluginMetadataDir(config), pluginName+".update-failed"), nil
+}
+
+// autoUpdateOnCooldown reports whether a recent failed automatic update should
+// suppress another attempt.
+func autoUpdateOnCooldown(config config.IConfig, fs afero.Fs, pluginName string) bool {
+	stampPath, err := autoUpdateFailureStampPath(config, pluginName)
+	if err != nil {
+		return false
+	}
+
+	info, err := fs.Stat(stampPath)
+	if err != nil {
+		return false
+	}
+
+	return time.Since(info.ModTime()) < automaticPluginUpdateRetryInterval
+}
+
+func recordAutoUpdateFailure(config config.IConfig, fs afero.Fs, pluginName string) {
+	logger := log.WithFields(log.Fields{
+		"prefix": "plugins.recordAutoUpdateFailure",
+		"plugin": pluginName,
+	})
+
+	stampPath, err := autoUpdateFailureStampPath(config, pluginName)
+	if err != nil {
+		logger.Debugf("could not determine automatic update cooldown path: %s", err)
+		return
+	}
+
+	if err := fs.MkdirAll(filepath.Dir(stampPath), 0755); err != nil {
+		logger.Debugf("could not create plugin metadata directory: %s", err)
+		return
+	}
+
+	if err := afero.WriteFile(fs, stampPath, nil, 0644); err != nil {
+		logger.Debugf("could not record automatic update cooldown: %s", err)
+	}
+}
+
+func clearAutoUpdateFailure(config config.IConfig, fs afero.Fs, pluginName string) {
+	stampPath, err := autoUpdateFailureStampPath(config, pluginName)
+	if err != nil {
+		return
+	}
+
+	if err := fs.Remove(stampPath); err != nil && !os.IsNotExist(err) {
+		log.WithFields(log.Fields{
+			"prefix": "plugins.clearAutoUpdateFailure",
+			"plugin": pluginName,
+		}).Debugf("could not clear automatic update cooldown: %s", err)
 	}
 }
 

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -16,11 +16,13 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
 	cfgpkg "github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
+	cliversion "github.com/stripe/stripe-cli/pkg/version"
 )
 
 // CustomTestConfig is a test config that allows overriding the config folder path.
@@ -500,6 +502,119 @@ func TestResolvePluginForInstallPrefersFresherCachedManifestWhenEndpointFails(t 
 
 	release := resolvedPlugin.Plugin.getReleaseForVersion("1.0.0")
 	require.NotNil(t, release)
+}
+
+func TestResolvePluginForUpgradeFetchesExactLatestCompatibleVersion(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	origVersion := cliversion.Version
+	cliversion.Version = "1.5.0"
+	defer func() { cliversion.Version = origVersion }()
+
+	manifest := fmt.Sprintf(`[[Plugin]]
+  Shortname = "docs"
+  Shortdesc = "Docs plugin"
+  Binary = "stripe-cli-docs"
+  MagicCookieValue = "DOCS-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = %q
+    OS = %q
+    Version = "1.0.0"
+    Sum = "abc123"
+
+  [[Plugin.Release]]
+    Arch = %q
+    OS = %q
+    Version = "2.0.0"
+    Sum = "def456"
+    MinCoreVersion = "2.0.0"
+`, runtime.GOARCH, runtime.GOOS, runtime.GOARCH, runtime.GOOS)
+
+	requestedVersions := []string{}
+	origGetPluginMetadata := getPluginMetadata
+	getPluginMetadata = func(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVersion, apiKey string, profile *cfgpkg.Profile, pluginName, requestedVersion, opsystem, arch string) (requests.PluginMetadata, error) {
+		requestedVersions = append(requestedVersions, requestedVersion)
+
+		binaryVersion := requestedVersion
+		if binaryVersion == "" {
+			binaryVersion = "2.0.0"
+		}
+		return requests.PluginMetadata{
+			BinaryURL:      "https://example.test/docs/" + binaryVersion,
+			PluginManifest: manifest,
+		}, nil
+	}
+	defer func() { getPluginMetadata = origGetPluginMetadata }()
+
+	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "docs", "https://api.example.test", "https://dashboard.example.test")
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", resolvedPlugin.Version)
+	require.Equal(t, "https://example.test/docs/1.0.0", resolvedPlugin.BinaryURL)
+	require.Equal(t, []string{"", "1.0.0"}, requestedVersions)
+}
+
+func TestSelectPluginForUpgradePrefersSourceWithNewestCompatibleRelease(t *testing.T) {
+	origVersion := cliversion.Version
+	cliversion.Version = "1.5.0"
+	defer func() { cliversion.Version = origVersion }()
+
+	newestCompatible := &Plugin{
+		Shortname: "docs",
+		Binary:    "stripe-cli-docs",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.2.0", Sum: "abc123"},
+		},
+	}
+	// Holds the newest release overall, but this CLI can only run 1.1.0 from it.
+	newestOverall := &Plugin{
+		Shortname: "docs",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.1.0", Sum: "def456"},
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "2.0.0", Sum: "ghi789", MinCoreVersion: "2.0.0"},
+		},
+	}
+
+	// mergePluginMetadata takes Releases from the primary source only, so picking
+	// the wrong source silently drops 1.2.0 and downgrades the upgrade to 1.1.0.
+	fromLocal := selectPluginForUpgrade(newestCompatible, newestOverall)
+	require.NotNil(t, fromLocal)
+	require.Equal(t, "1.2.0", fromLocal.LookUpLatestCompatibleVersion(cliversion.Version))
+
+	fromManifest := selectPluginForUpgrade(newestOverall, newestCompatible)
+	require.NotNil(t, fromManifest)
+	require.Equal(t, "1.2.0", fromManifest.LookUpLatestCompatibleVersion(cliversion.Version))
+	require.Equal(t, "stripe-cli-docs", fromManifest.Binary, "the fallback source should still backfill missing fields")
+}
+
+func TestResolvePluginForInstallReportsWhenCachedReleasesNeedNewerCLI(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	origVersion := cliversion.Version
+	cliversion.Version = "1.5.0"
+	defer func() { cliversion.Version = origVersion }()
+
+	require.NoError(t, writeLocalPluginMetadata(config, fs, Plugin{
+		Shortname:        "docs",
+		Binary:           "stripe-cli-docs",
+		MagicCookieValue: "DOCS-COOKIE",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "2.0.0", Sum: "abc123", MinCoreVersion: "2.0.0"},
+		},
+	}))
+
+	origGetPluginMetadata := getPluginMetadata
+	getPluginMetadata = func(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVersion, apiKey string, profile *cfgpkg.Profile, pluginName, requestedVersion, opsystem, arch string) (requests.PluginMetadata, error) {
+		return requests.PluginMetadata{}, errors.New("metadata endpoint unavailable")
+	}
+	defer func() { getPluginMetadata = origGetPluginMetadata }()
+
+	_, err := ResolvePluginForInstall(context.Background(), config, fs, "docs", "", "https://api.example.test", "https://dashboard.example.test")
+	require.ErrorContains(t, err, "plugin docs has no release compatible with Stripe CLI 1.5.0")
 }
 
 func TestResolvePluginForUpgradeUsesMetadataEndpointWhenAvailable(t *testing.T) {
@@ -992,6 +1107,243 @@ func TestCheckLatestPluginVersionPrintsWhenUpgradeAvailable(t *testing.T) {
 	require.Contains(t, output, "v1.0.0")
 	require.Contains(t, output, "v1.1.0")
 	require.Contains(t, output, "stripe plugin upgrade myplugin")
+}
+
+func TestCheckLatestPluginVersionAutomaticallyUpdatesWhenEnabled(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set(cfgpkg.PluginConfigKey(cfgpkg.PluginConfigGlobalScope, cfgpkg.PluginConfigUpdatesField), "on")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	plugin := Plugin{
+		Shortname:        "myplugin",
+		Binary:           "stripe-cli-myplugin",
+		MagicCookieValue: "MY-COOKIE",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.0", Sum: "abc123"},
+		},
+	}
+
+	pluginBinaryPath := fmt.Sprintf("/plugins/myplugin/1.0.0/stripe-cli-myplugin%s", GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("binary"), 0755))
+
+	origResolver := checkLatestPluginVersionResolver
+	origInstaller := automaticPluginInstaller
+	resolved := &ResolvedPluginVersion{
+		Plugin: &Plugin{
+			Shortname: "myplugin",
+			Releases: []Release{
+				{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.1.0", Sum: "def456"},
+			},
+		},
+		Version:   "1.1.0",
+		BinaryURL: "https://example.test/myplugin/1.1.0",
+	}
+	checkLatestPluginVersionResolver = func(ctx context.Context, cfg cfgpkg.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
+		return resolved, nil
+	}
+	installed := false
+	automaticPluginInstaller = func(ctx context.Context, got *ResolvedPluginVersion, cfg cfgpkg.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string) error {
+		require.Same(t, resolved, got)
+		_, hasDeadline := ctx.Deadline()
+		require.True(t, hasDeadline)
+		installed = true
+		return nil
+	}
+	defer func() {
+		checkLatestPluginVersionResolver = origResolver
+		automaticPluginInstaller = origInstaller
+	}()
+
+	output := captureStderr(t, func() {
+		CheckLatestPluginVersion(context.Background(), config, fs, plugin, stripe.DefaultAPIBaseURL, "")
+	})
+
+	require.True(t, installed)
+	require.Contains(t, output, "Automatically updated the myplugin plugin")
+	require.NotContains(t, output, "stripe plugin upgrade")
+}
+
+func TestCheckLatestPluginVersionFallsBackToHintWhenAutomaticUpdateFails(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set(cfgpkg.PluginConfigKey("myplugin", cfgpkg.PluginConfigUpdatesField), "on")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	plugin := Plugin{Shortname: "myplugin", Binary: "stripe-cli-myplugin"}
+	pluginBinaryPath := fmt.Sprintf("/plugins/myplugin/1.0.0/stripe-cli-myplugin%s", GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("binary"), 0755))
+
+	origResolver := checkLatestPluginVersionResolver
+	origInstaller := automaticPluginInstaller
+	checkLatestPluginVersionResolver = func(ctx context.Context, cfg cfgpkg.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
+		return &ResolvedPluginVersion{Plugin: &plugin, Version: "1.1.0"}, nil
+	}
+	automaticPluginInstaller = func(ctx context.Context, resolved *ResolvedPluginVersion, cfg cfgpkg.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string) error {
+		return errors.New("download failed")
+	}
+	defer func() {
+		checkLatestPluginVersionResolver = origResolver
+		automaticPluginInstaller = origInstaller
+	}()
+
+	output := captureStderr(t, func() {
+		CheckLatestPluginVersion(context.Background(), config, fs, plugin, stripe.DefaultAPIBaseURL, "")
+	})
+
+	require.Contains(t, output, "A newer version of the myplugin plugin is available")
+	require.Contains(t, output, "stripe plugin upgrade myplugin")
+}
+
+// setUpAutoUpdateTest installs myplugin v1.0.0 on an in-memory filesystem with
+// automatic updates enabled, and stubs the resolver so v1.1.0 is the latest
+// compatible release.
+func setUpAutoUpdateTest(t *testing.T) (afero.Fs, *TestConfig, Plugin) {
+	t.Helper()
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set(cfgpkg.PluginConfigKey(cfgpkg.PluginConfigGlobalScope, cfgpkg.PluginConfigUpdatesField), "on")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	plugin := Plugin{
+		Shortname:        "myplugin",
+		Binary:           "stripe-cli-myplugin",
+		MagicCookieValue: "MY-COOKIE",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.0", Sum: "abc123"},
+		},
+	}
+
+	pluginBinaryPath := fmt.Sprintf("/plugins/myplugin/1.0.0/stripe-cli-myplugin%s", GetBinaryExtension())
+	require.NoError(t, fs.MkdirAll(filepath.Dir(pluginBinaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, pluginBinaryPath, []byte("binary"), 0755))
+
+	origResolver := checkLatestPluginVersionResolver
+	checkLatestPluginVersionResolver = func(ctx context.Context, cfg cfgpkg.IConfig, fs afero.Fs, pluginName, apiBaseURL, dashboardBaseURL string) (*ResolvedPluginVersion, error) {
+		return &ResolvedPluginVersion{
+			Plugin: &Plugin{
+				Shortname: "myplugin",
+				Releases: []Release{
+					{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.1.0", Sum: "def456"},
+				},
+			},
+			Version:   "1.1.0",
+			BinaryURL: "https://example.test/myplugin/1.1.0",
+		}, nil
+	}
+	t.Cleanup(func() { checkLatestPluginVersionResolver = origResolver })
+
+	return fs, config, plugin
+}
+
+// stubAutomaticPluginInstaller makes automatic updates return installErr and
+// returns a pointer to the number of attempts made.
+func stubAutomaticPluginInstaller(t *testing.T, installErr error) *int {
+	t.Helper()
+
+	attempts := 0
+	orig := automaticPluginInstaller
+	automaticPluginInstaller = func(ctx context.Context, resolved *ResolvedPluginVersion, cfg cfgpkg.IConfig, fs afero.Fs, apiBaseURL, dashboardBaseURL string) error {
+		attempts++
+		return installErr
+	}
+	t.Cleanup(func() { automaticPluginInstaller = orig })
+
+	return &attempts
+}
+
+// writeAutoUpdateFailureStamp records a failed automatic update that happened
+// the given duration ago.
+func writeAutoUpdateFailureStamp(t *testing.T, config cfgpkg.IConfig, fs afero.Fs, pluginName string, age time.Duration) string {
+	t.Helper()
+
+	stampPath, err := autoUpdateFailureStampPath(config, pluginName)
+	require.NoError(t, err)
+	require.NoError(t, fs.MkdirAll(filepath.Dir(stampPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, stampPath, nil, 0644))
+
+	stamped := time.Now().Add(-age)
+	require.NoError(t, fs.Chtimes(stampPath, stamped, stamped))
+
+	return stampPath
+}
+
+func TestCheckLatestPluginVersionSkipsAutomaticUpdateDuringCooldown(t *testing.T) {
+	fs, config, plugin := setUpAutoUpdateTest(t)
+	attempts := stubAutomaticPluginInstaller(t, nil)
+	stampPath := writeAutoUpdateFailureStamp(t, config, fs, plugin.Shortname, time.Minute)
+
+	output := captureStderr(t, func() {
+		CheckLatestPluginVersion(context.Background(), config, fs, plugin, stripe.DefaultAPIBaseURL, "")
+	})
+
+	require.Zero(t, *attempts, "a recent failure should suppress another download attempt")
+	require.Contains(t, output, "A newer version of the myplugin plugin is available")
+	require.Contains(t, output, "stripe plugin upgrade myplugin")
+
+	_, err := fs.Stat(stampPath)
+	require.NoError(t, err, "the cooldown should survive a suppressed attempt")
+}
+
+func TestCheckLatestPluginVersionRetriesAutomaticUpdateAfterCooldown(t *testing.T) {
+	fs, config, plugin := setUpAutoUpdateTest(t)
+	attempts := stubAutomaticPluginInstaller(t, nil)
+	stampPath := writeAutoUpdateFailureStamp(t, config, fs, plugin.Shortname, 2*automaticPluginUpdateRetryInterval)
+
+	output := captureStderr(t, func() {
+		CheckLatestPluginVersion(context.Background(), config, fs, plugin, stripe.DefaultAPIBaseURL, "")
+	})
+
+	require.Equal(t, 1, *attempts)
+	require.Contains(t, output, "Automatically updated the myplugin plugin")
+
+	_, err := fs.Stat(stampPath)
+	require.True(t, os.IsNotExist(err), "a successful update should clear the cooldown")
+}
+
+func TestCheckLatestPluginVersionRecordsCooldownWhenAutomaticUpdateFails(t *testing.T) {
+	fs, config, plugin := setUpAutoUpdateTest(t)
+	attempts := stubAutomaticPluginInstaller(t, errors.New("download failed"))
+
+	captureStderr(t, func() {
+		CheckLatestPluginVersion(context.Background(), config, fs, plugin, stripe.DefaultAPIBaseURL, "")
+	})
+	require.Equal(t, 1, *attempts)
+
+	stampPath, err := autoUpdateFailureStampPath(config, plugin.Shortname)
+	require.NoError(t, err)
+	_, err = fs.Stat(stampPath)
+	require.NoError(t, err, "a failed update should record a cooldown")
+
+	// The next plugin command must not spend the update timeout failing again.
+	captureStderr(t, func() {
+		CheckLatestPluginVersion(context.Background(), config, fs, plugin, stripe.DefaultAPIBaseURL, "")
+	})
+	require.Equal(t, 1, *attempts)
+}
+
+func TestCheckLatestPluginVersionSkipsCooldownWhenCommandInterrupted(t *testing.T) {
+	fs, config, plugin := setUpAutoUpdateTest(t)
+	attempts := stubAutomaticPluginInstaller(t, context.Canceled)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	captureStderr(t, func() {
+		CheckLatestPluginVersion(ctx, config, fs, plugin, stripe.DefaultAPIBaseURL, "")
+	})
+	require.Equal(t, 1, *attempts)
+
+	stampPath, err := autoUpdateFailureStampPath(config, plugin.Shortname)
+	require.NoError(t, err)
+	_, err = fs.Stat(stampPath)
+	require.True(t, os.IsNotExist(err), "an interrupted command should not start a cooldown")
 }
 
 func TestCheckLatestPluginVersionSilentWhenUpToDate(t *testing.T) {


### PR DESCRIPTION
Adds a MinCoreVersion field to plugin releases so plugins can declare the minimum CLI version they require. The runtime guard in Plugin.Run refuses to launch a plugin whose MinCoreVersion exceeds the running CLI, directing the user to run `stripe upgrade`. Dev builds (version "master") and local.build.dev are never blocked. Also adds LookUpLatestCompatibleVersion for use by the upcoming background auto-upgrade feature.


Committed-By-Agent: claude

 ### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
