### PR TITLE
Fix help example that mixes snapshot and thin events to same destination

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -72,7 +72,9 @@ Stripe account.`,
 		Example: `stripe listen
   stripe listen --all-snapshot --forward-to localhost:3000/events
   stripe listen --all-thin --forward-to localhost:3000/events
-  stripe listen --events charge.captured,v1.billing.meter.no_meter_found \
+  stripe listen --events charge.captured,customer.created \
+    --forward-to localhost:3000/events
+  stripe listen --events v1.billing.meter.no_meter_found \
     --forward-to localhost:3000/events
   stripe listen --all-thin --events-from @accounts \
     --forward-to localhost:3000/events`,


### PR DESCRIPTION
### Summary
The example 'stripe listen --events charge.captured,v1.billing.meter.no_meter_found --forward-to ...' is invalid in v2 since mixing snapshot and thin events to the same forwarding destination is now rejected. Split into two separate examples: one for snapshot events and one for thin events.

### Testing
 - [x] `./stripe-v2 listen --help` shows valid examples only
<img width="581" height="259" alt="Screenshot 2026-08-10 at 3 02 59 PM" src="https://github.com/user-attachments/assets/adfa0de4-eeae-4ea7-9645-9a9aad735027" />
