### PR TITLE
Enable merge queue CI triggers for v2 branch

### DIFF
--- a/.github/workflows/canary-test.yml
+++ b/.github/workflows/canary-test.yml
@@ -2,9 +2,11 @@ name: Canary Tests
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, v2]
   push:
-    branches: [master]
+    branches: [master, v2]
+  merge_group:
+    branches: [master, v2]
   workflow_call:
     inputs:
       run_api_tests:

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     paths:
     - 'goreleaser/**'
+  merge_group:
+    paths:
+    - '.goreleaser/**'
 
 jobs:
   build-linux:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 on:
   push:
   pull_request:
+  merge_group:
 name: Test
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `merge_group` event triggers to CI workflows so they run when PRs enter the merge queue targeting `v2`.
- Add `v2` to the branch filters in `canary-test.yml` (was previously `master`-only for `pull_request`/`push`).

## Workflows changed
| File | Change |
|------|--------|
| `canary-test.yml` | Added `v2` to `pull_request`/`push` branches, added `merge_group` trigger |
| `test.yml` | Added `merge_group` trigger (no branch filter needed — already runs on all) |
| `test-snapshot.yml` | Added `merge_group` trigger with `.goreleaser/**` path filter |

## After merging — GitHub repo settings required
1. Go to **Settings → Rules → Rulesets** (or Branch Protection Rules) for the `v2` branch
2. Enable **"Require merge queue"**
3. Set required status checks to match what `master` requires (e.g. `Test`, `Canary Tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)