### PR TITLE
Add categories to reported CLI errors

### DIFF
--- a/pkg/errorcategory/category.go
+++ b/pkg/errorcategory/category.go
@@ -1,0 +1,58 @@
+// Package errorcategory attaches stable categories to errors without changing
+// their messages or unwrapping behavior.
+package errorcategory
+
+import "errors"
+
+// Category identifies the source of an error.
+type Category string
+
+const (
+	UserInput  Category = "user_input"
+	Auth       Category = "auth"
+	Network    Category = "network"
+	API        Category = "api"
+	Filesystem Category = "filesystem"
+	Internal   Category = "internal"
+	Panic      Category = "panic"
+)
+
+// Categorized is implemented by errors with an explicit category.
+type Categorized interface {
+	error
+	ErrorCategory() Category
+}
+
+type categorizedError struct {
+	err      error
+	category Category
+}
+
+func (e categorizedError) Error() string {
+	return e.err.Error()
+}
+
+func (e categorizedError) Unwrap() error {
+	return e.err
+}
+
+func (e categorizedError) ErrorCategory() Category {
+	return e.category
+}
+
+// With returns an error with an explicit category. A nil error remains nil.
+func With(err error, category Category) error {
+	if err == nil {
+		return nil
+	}
+	return categorizedError{err: err, category: category}
+}
+
+// Get returns the first explicit category in err's unwrap tree.
+func Get(err error) (Category, bool) {
+	var categorized Categorized
+	if !errors.As(err, &categorized) {
+		return "", false
+	}
+	return categorized.ErrorCategory(), true
+}

--- a/pkg/errorcategory/category_test.go
+++ b/pkg/errorcategory/category_test.go
@@ -1,0 +1,57 @@
+package errorcategory
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testError struct {
+	message string
+}
+
+func (e *testError) Error() string {
+	return e.message
+}
+
+func TestWith(t *testing.T) {
+	target := &testError{message: "unchanged message"}
+	err := With(target, Auth)
+
+	require.EqualError(t, err, target.Error())
+	require.ErrorIs(t, err, target)
+
+	var typed *testError
+	require.ErrorAs(t, err, &typed)
+	require.Same(t, target, typed)
+}
+
+func TestWithNil(t *testing.T) {
+	require.NoError(t, With(nil, Internal))
+}
+
+func TestGet(t *testing.T) {
+	target := errors.New("target")
+	err := fmt.Errorf("outer: %w", With(fmt.Errorf("inner: %w", target), UserInput))
+
+	category, ok := Get(err)
+	require.True(t, ok)
+	require.Equal(t, UserInput, category)
+	require.ErrorIs(t, err, target)
+}
+
+func TestGetWithoutCategory(t *testing.T) {
+	category, ok := Get(errors.New("uncategorized"))
+	require.False(t, ok)
+	require.Empty(t, category)
+}
+
+func TestGetUsesOutermostCategory(t *testing.T) {
+	err := With(With(errors.New("nested"), Network), API)
+
+	category, ok := Get(err)
+	require.True(t, ok)
+	require.Equal(t, API, category)
+}

--- a/pkg/reporting/classify.go
+++ b/pkg/reporting/classify.go
@@ -1,0 +1,72 @@
+package reporting
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+	"os"
+
+	"github.com/spf13/pflag"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/requests"
+)
+
+func classifyError(err error) errorcategory.Category {
+	if category, ok := errorcategory.Get(err); ok {
+		return category
+	}
+
+	var flagNotFound *pflag.NotExistError
+	if errors.As(err, &flagNotFound) {
+		return errorcategory.UserInput
+	}
+
+	var flagValueRequired *pflag.ValueRequiredError
+	if errors.As(err, &flagValueRequired) {
+		return errorcategory.UserInput
+	}
+
+	if statusCode, ok := requestErrorStatusCode(err); ok {
+		if statusCode == 401 || statusCode == 403 {
+			return errorcategory.Auth
+		}
+		return errorcategory.API
+	}
+
+	var pathError *os.PathError
+	if errors.As(err, &pathError) {
+		return errorcategory.Filesystem
+	}
+
+	var urlError *url.Error
+	if errors.As(err, &urlError) {
+		return errorcategory.Network
+	}
+
+	var networkError net.Error
+	if errors.As(err, &networkError) {
+		return errorcategory.Network
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return errorcategory.UserInput
+	}
+
+	return errorcategory.Internal
+}
+
+func requestErrorStatusCode(err error) (int, bool) {
+	var requestError requests.RequestError
+	if errors.As(err, &requestError) {
+		return requestError.StatusCode, true
+	}
+
+	var requestErrorPointer *requests.RequestError
+	if errors.As(err, &requestErrorPointer) {
+		return requestErrorPointer.StatusCode, true
+	}
+
+	return 0, false
+}

--- a/pkg/reporting/classify_test.go
+++ b/pkg/reporting/classify_test.go
@@ -1,0 +1,61 @@
+package reporting
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/requests"
+)
+
+type testNetworkError struct{}
+
+func (testNetworkError) Error() string   { return "network error" }
+func (testNetworkError) Timeout() bool   { return false }
+func (testNetworkError) Temporary() bool { return true }
+
+func TestClassifyError(t *testing.T) {
+	unknownFlag := func() error {
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		return flags.Parse([]string{"--unknown"})
+	}()
+	missingFlagValue := func() error {
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		flags.String("name", "", "")
+		return flags.Parse([]string{"--name"})
+	}()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected errorcategory.Category
+	}{
+		{name: "explicit", err: errorcategory.With(errors.New("input"), errorcategory.UserInput), expected: errorcategory.UserInput},
+		{name: "explicit takes precedence", err: errorcategory.With(&os.PathError{Op: "open", Path: "file", Err: errors.New("failed")}, errorcategory.Auth), expected: errorcategory.Auth},
+		{name: "unknown flag", err: unknownFlag, expected: errorcategory.UserInput},
+		{name: "missing flag value", err: missingFlagValue, expected: errorcategory.UserInput},
+		{name: "API unauthorized", err: requests.RequestError{StatusCode: 401}, expected: errorcategory.Auth},
+		{name: "API forbidden", err: &requests.RequestError{StatusCode: 403}, expected: errorcategory.Auth},
+		{name: "API client error", err: requests.RequestError{StatusCode: 400}, expected: errorcategory.API},
+		{name: "API server error", err: requests.RequestError{StatusCode: 500}, expected: errorcategory.API},
+		{name: "filesystem", err: &os.PathError{Op: "open", Path: "file", Err: errors.New("failed")}, expected: errorcategory.Filesystem},
+		{name: "URL", err: &url.Error{Op: "Get", URL: "https://example.com", Err: errors.New("failed")}, expected: errorcategory.Network},
+		{name: "network", err: testNetworkError{}, expected: errorcategory.Network},
+		{name: "canceled", err: context.Canceled, expected: errorcategory.UserInput},
+		{name: "wrapped", err: fmt.Errorf("outer: %w", &os.PathError{Op: "open", Path: "file", Err: errors.New("failed")}), expected: errorcategory.Filesystem},
+		{name: "fallback", err: errors.New("unexpected"), expected: errorcategory.Internal},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, classifyError(test.err))
+		})
+	}
+}

--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	sentry "github.com/getsentry/sentry-go"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 )
 
 var accountIDProvider func() (string, error)
@@ -40,6 +42,7 @@ func Init(dsn, release string) error {
 // CaptureException reports err to the error reporting backend.
 func CaptureException(err error) {
 	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetTag("error_category", string(classifyError(err)))
 		if accountIDProvider != nil {
 			if accountID, _ := accountIDProvider(); accountID != "" {
 				scope.SetTag("account_id", accountID)
@@ -69,7 +72,10 @@ func CaptureException(err error) {
 // RecoverAndReport captures a recovered panic value to the error reporting backend.
 // The caller is responsible for re-panicking and calling Flush before the process exits.
 func RecoverAndReport(r any) {
-	sentry.CurrentHub().Recover(r)
+	sentry.CurrentHub().WithScope(func(scope *sentry.Scope) {
+		scope.SetTag("error_category", string(errorcategory.Panic))
+		sentry.CurrentHub().Recover(r)
+	})
 }
 
 // Flush blocks until all buffered events are delivered or the timeout elapses.

--- a/pkg/reporting/reporting_test.go
+++ b/pkg/reporting/reporting_test.go
@@ -1,0 +1,62 @@
+package reporting
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sentry "github.com/getsentry/sentry-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+)
+
+func TestCaptureExceptionSetsErrorCategory(t *testing.T) {
+	transport, restore := bindTestClient(t)
+	defer restore()
+
+	CaptureException(context.Canceled)
+
+	events := transport.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, string(errorcategory.UserInput), events[0].Tags["error_category"])
+}
+
+func TestRecoverAndReportSetsIsolatedPanicCategory(t *testing.T) {
+	transport, restore := bindTestClient(t)
+	defer restore()
+
+	RecoverAndReport("panic value")
+	CaptureException(errors.New("ordinary error"))
+
+	events := transport.Events()
+	require.Len(t, events, 2)
+	require.Equal(t, string(errorcategory.Panic), events[0].Tags["error_category"])
+	require.Equal(t, string(errorcategory.Internal), events[1].Tags["error_category"])
+}
+
+func bindTestClient(t *testing.T) (*sentry.MockTransport, func()) {
+	t.Helper()
+
+	transport := &sentry.MockTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:        "https://public@localhost/1",
+		Transport:  transport,
+		BeforeSend: scrubEvent,
+	})
+	require.NoError(t, err)
+
+	hub := sentry.CurrentHub()
+	previousClient := hub.Client()
+	previousAccountIDProvider := accountIDProvider
+	previousCommandPath := commandPath
+	hub.BindClient(client)
+	accountIDProvider = nil
+	commandPath = ""
+
+	return transport, func() {
+		hub.BindClient(previousClient)
+		accountIDProvider = previousAccountIDProvider
+		commandPath = previousCommandPath
+	}
+}

--- a/pkg/validators/cmds.go
+++ b/pkg/validators/cmds.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 )
 
 func getCommandPath(cmd *cobra.Command) string {
@@ -29,7 +31,7 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 	)
 
 	if len(args) > 0 {
-		return errors.New(errorMessage)
+		return errorcategory.With(errors.New(errorMessage), errorcategory.UserInput)
 	}
 
 	return nil
@@ -54,7 +56,7 @@ func ExactArgs(num int) cobra.PositionalArgs {
 		)
 
 		if len(args) != num {
-			return errors.New(errorMessage)
+			return errorcategory.With(errors.New(errorMessage), errorcategory.UserInput)
 		}
 		return nil
 	}
@@ -79,7 +81,7 @@ func MaximumNArgs(num int) cobra.PositionalArgs {
 		)
 
 		if len(args) > num {
-			return errors.New(errorMessage)
+			return errorcategory.With(errors.New(errorMessage), errorcategory.UserInput)
 		}
 		return nil
 	}

--- a/pkg/validators/cmds.go
+++ b/pkg/validators/cmds.go
@@ -21,6 +21,10 @@ func getCommandPath(cmd *cobra.Command) string {
 	return commandPath
 }
 
+func userInputError(message string) error {
+	return errorcategory.With(errors.New(message), errorcategory.UserInput)
+}
+
 // NoArgs is a validator for commands to print an error when an argument is provided
 func NoArgs(cmd *cobra.Command, args []string) error {
 	commandPath := getCommandPath(cmd)
@@ -31,7 +35,7 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 	)
 
 	if len(args) > 0 {
-		return errorcategory.With(errors.New(errorMessage), errorcategory.UserInput)
+		return userInputError(errorMessage)
 	}
 
 	return nil
@@ -56,7 +60,7 @@ func ExactArgs(num int) cobra.PositionalArgs {
 		)
 
 		if len(args) != num {
-			return errorcategory.With(errors.New(errorMessage), errorcategory.UserInput)
+			return userInputError(errorMessage)
 		}
 		return nil
 	}
@@ -81,7 +85,7 @@ func MaximumNArgs(num int) cobra.PositionalArgs {
 		)
 
 		if len(args) > num {
-			return errorcategory.With(errors.New(errorMessage), errorcategory.UserInput)
+			return userInputError(errorMessage)
 		}
 		return nil
 	}

--- a/pkg/validators/cmds_test.go
+++ b/pkg/validators/cmds_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 )
 
 func TestNoArgs(t *testing.T) {
@@ -21,6 +23,7 @@ func TestNoArgsWithArgs(t *testing.T) {
 
 	result := NoArgs(c, args)
 	require.EqualError(t, result, "`c` does not take any positional arguments. See `c --help` for supported flags and usage")
+	requireErrorCategory(t, result, errorcategory.UserInput)
 }
 
 func TestExactArgs(t *testing.T) {
@@ -37,6 +40,7 @@ func TestExactArgsTooMany(t *testing.T) {
 
 	result := ExactArgs(1)(c, args)
 	require.EqualError(t, result, "`c` requires exactly 1 positional argument. See `c --help` for supported flags and usage")
+	requireErrorCategory(t, result, errorcategory.UserInput)
 }
 
 func TestExactArgsTooManyMoreThan1(t *testing.T) {
@@ -45,4 +49,20 @@ func TestExactArgsTooManyMoreThan1(t *testing.T) {
 
 	result := ExactArgs(2)(c, args)
 	require.EqualError(t, result, "`c` requires exactly 2 positional arguments. See `c --help` for supported flags and usage")
+	requireErrorCategory(t, result, errorcategory.UserInput)
+}
+
+func TestMaximumNArgsTooMany(t *testing.T) {
+	c := &cobra.Command{Use: "c"}
+	err := MaximumNArgs(1)(c, []string{"foo", "bar"})
+
+	require.EqualError(t, err, "`c` accepts at maximum 1 positional argument. See `c --help` for supported flags and usage")
+	requireErrorCategory(t, err, errorcategory.UserInput)
+}
+
+func requireErrorCategory(t *testing.T, err error, expected errorcategory.Category) {
+	t.Helper()
+	category, ok := errorcategory.Get(err)
+	require.True(t, ok)
+	require.Equal(t, expected, category)
 }

--- a/pkg/validators/validate.go
+++ b/pkg/validators/validate.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 )
 
 // ArgValidator is an argument validator. It accepts a string and returns an
@@ -14,9 +16,9 @@ type ArgValidator func(string) error
 
 var (
 	// ErrAPIKeyNotConfigured is the error returned when the loaded profile is missing the api key property
-	ErrAPIKeyNotConfigured = errors.New("you have not configured API keys yet")
+	ErrAPIKeyNotConfigured = errorcategory.With(errors.New("you have not configured API keys yet"), errorcategory.Auth)
 	// ErrPubKeyNotConfigured is the error returned when the loaded profile is missing the publishable key property
-	ErrPubKeyNotConfigured = errors.New("you have not configured publishable keys yet")
+	ErrPubKeyNotConfigured = errorcategory.With(errors.New("you have not configured publishable keys yet"), errorcategory.Auth)
 	// ErrDeviceNameNotConfigured is the error returned when the loaded profile is missing the device name property
 	ErrDeviceNameNotConfigured = errors.New("you have not configured your device name yet")
 	// ErrAccountIDNotConfigured is the error returned when the loaded profile is missing the account_id property
@@ -50,21 +52,25 @@ func CallNonEmpty(validator ArgValidator, value string) error {
 	return validator(value)
 }
 
+func authError(message string) error {
+	return errorcategory.With(errors.New(message), errorcategory.Auth)
+}
+
 // APIKey validates that a string looks like an API key.
 func APIKey(input string) error {
 	if len(input) == 0 {
 		return ErrAPIKeyNotConfigured
 	} else if len(input) < 12 {
-		return errors.New("the API key provided is too short, it must be at least 12 characters long")
+		return authError("the API key provided is too short, it must be at least 12 characters long")
 	}
 
 	keyParts := strings.Split(input, "_")
 	if len(keyParts) < 3 {
-		return errors.New("you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
+		return authError("you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
 	}
 
 	if keyParts[0] != "sk" && keyParts[0] != "rk" && keyParts[0] != "rkcs" {
-		return errors.New("the CLI only supports using a secret or restricted key")
+		return authError("the CLI only supports using a secret or restricted key")
 	}
 
 	return nil
@@ -75,16 +81,16 @@ func APIKeyNotRestricted(input string) error {
 	if len(input) == 0 {
 		return ErrAPIKeyNotConfigured
 	} else if len(input) < 12 {
-		return errors.New("the API key provided is too short, it must be at least 12 characters long")
+		return authError("the API key provided is too short, it must be at least 12 characters long")
 	}
 
 	keyParts := strings.Split(input, "_")
 	if len(keyParts) < 3 {
-		return errors.New("you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
+		return authError("you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
 	}
 
 	if keyParts[0] != "sk" || keyParts[0] == "rk" {
-		return errors.New("this CLI command only supports using a secret key. Please re-run using the --api-key flag override with your secret API key")
+		return authError("this CLI command only supports using a secret key. Please re-run using the --api-key flag override with your secret API key")
 	}
 
 	return nil

--- a/pkg/validators/validate_test.go
+++ b/pkg/validators/validate_test.go
@@ -5,26 +5,34 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 )
 
 func TestNoKey(t *testing.T) {
 	err := APIKey("")
 	require.EqualError(t, err, "you have not configured API keys yet")
+	require.True(t, err == ErrAPIKeyNotConfigured)
+	require.ErrorIs(t, err, ErrAPIKeyNotConfigured)
+	requireErrorCategory(t, err, errorcategory.Auth)
 }
 
 func TestKeyTooShort(t *testing.T) {
 	err := APIKey("123")
 	require.EqualError(t, err, "the API key provided is too short, it must be at least 12 characters long")
+	requireErrorCategory(t, err, errorcategory.Auth)
 }
 
 func TestLegacyAPIKeys(t *testing.T) {
 	err := APIKey("sk_123457890abcdef")
 	require.EqualError(t, err, "you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
+	requireErrorCategory(t, err, errorcategory.Auth)
 }
 
 func TestPublishableAPIKey(t *testing.T) {
 	err := APIKey("pk_test_12345")
 	require.EqualError(t, err, "the CLI only supports using a secret or restricted key")
+	requireErrorCategory(t, err, errorcategory.Auth)
 }
 
 func TestLivemodeAPIKey(t *testing.T) {


### PR DESCRIPTION
### Summary
Adds a stable `error_category` tag to reported CLI errors and recovered panics, classifying recognizable flag, API, filesystem, network, cancellation, and validation failures while preserving existing error messages, exit behavior, and event capture.