### PR TITLE
Capture agent host and self-reported agent identifiers in telemetry

### DIFF
--- a/pkg/cmd/templates_test.go
+++ b/pkg/cmd/templates_test.go
@@ -51,7 +51,7 @@ func TestIsAIAgent_Detected(t *testing.T) {
 
 func TestIsAIAgent_NotDetected(t *testing.T) {
 	// Ensure none of the agent env vars are set
-	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
+	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
 		t.Setenv(key, "")
 	}
 	assert.False(t, isAIAgent())
@@ -138,7 +138,7 @@ func TestAIAgentHelp_SubcommandOnly(t *testing.T) {
 }
 
 func TestAIAgentHelp_NotDetected(t *testing.T) {
-	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
+	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
 		t.Setenv(key, "")
 	}
 

--- a/pkg/cmd/unknown_cmd_telemetry_test.go
+++ b/pkg/cmd/unknown_cmd_telemetry_test.go
@@ -35,6 +35,7 @@ func (m *mockUnknownCmdTelemetryClient) SendEvent(_ context.Context, eventName s
 func TestRecordUnknownCommand_NotInAgentEnv(t *testing.T) {
 	t.Setenv("CLAUDECODE", "")
 	t.Setenv("CURSOR_AGENT", "")
+	t.Setenv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "")
 	t.Setenv("CODEX_SANDBOX", "")
 	t.Setenv("CODEX_THREAD_ID", "")
 	t.Setenv("CODEX_SANDBOX_NETWORK_DISABLED", "")

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -51,7 +51,8 @@ type CLIAnalyticsEventMetadata struct {
 	GeneratedResource bool   `url:"generated_resource"`          // whether or not this was a generated resource
 	AIAgent           string `url:"ai_agent,omitempty"`          // the AI coding agent that invoked the CLI, if any
 	AIAgentRaw        string `url:"ai_agent_raw,omitempty"`      // the agent's self-reported AI_AGENT/AGENT value; unvalidated, prefer ai_agent for grouping
-	AgentHost         string `url:"agent_host,omitempty"`        // the application hosting the agent (desktop, IDE, SDK), when reported
+	AgentHost         string `url:"agent_host,omitempty"`        // the application hosting the agent, as reported by the agent
+	AgentHostKind     string `url:"agent_host_kind,omitempty"`   // coarse category for agent_host: desktop, terminal, ide, remote, sdk, mcp, chat, or ci
 	MacAppBundleID    string `url:"mac_app_bundle_id,omitempty"` // bundle ID of the macOS app that launched the process tree, if any
 	InstallMethod     string `url:"install_method,omitempty"`    // how the CLI was installed
 	InTmux            bool   `url:"in_tmux"`                     // whether the CLI was invoked from within tmux
@@ -82,6 +83,8 @@ type NoOpTelemetryClient struct {
 
 // NewEventMetadata initializes an instance of CLIAnalyticsEventContext
 func NewEventMetadata() *CLIAnalyticsEventMetadata {
+	agentHost := useragent.DetectAgentHost(os.Getenv)
+
 	return &CLIAnalyticsEventMetadata{
 		InvocationID:   uuid.NewString(),
 		CLIVersion:     version.Version,
@@ -89,7 +92,8 @@ func NewEventMetadata() *CLIAnalyticsEventMetadata {
 		Arch:           runtime.GOARCH,
 		AIAgent:        useragent.DetectAIAgent(os.Getenv),
 		AIAgentRaw:     useragent.DetectAIAgentRaw(os.Getenv),
-		AgentHost:      useragent.DetectAgentHost(os.Getenv),
+		AgentHost:      agentHost,
+		AgentHostKind:  useragent.AgentHostKind(agentHost),
 		MacAppBundleID: useragent.DetectMacAppBundleID(os.Getenv),
 		InstallMethod: useragent.DetectInstallMethod(
 			os.Getenv,

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -37,27 +37,26 @@ const DefaultTelemetryEndpoint = "https://r.stripe.com/0"
 
 // CLIAnalyticsEventMetadata is the structure that holds telemetry data context that is ultimately sent to the Stripe Analytics Service.
 type CLIAnalyticsEventMetadata struct {
-	InvocationID      string `url:"invocation_id"`               // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
-	UserAgent         string `url:"user_agent"`                  // the application that is used to create this request
-	CommandPath       string `url:"command_path"`                // the command or gRPC method that initiated this request
-	CommandFlags      string `url:"command_flags"`               // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
-	PluginName        string `url:"plugin_name,omitempty"`       // the plugin being installed, when relevant
-	PluginVersion     string `url:"plugin_version,omitempty"`    // the version of the plugin being installed/uninstalled/upgraded
-	Merchant          string `url:"merchant"`                    // the merchant ID: ex. acct_xxxx
-	CLIVersion        string `url:"cli_version"`                 // the version of the CLI
-	OS                string `url:"os"`                          // the OS of the system
-	Arch              string `url:"arch"`                        // the CPU architecture of the system
-	MachineUUID       string `url:"machine_uuid,omitempty"`      // the persistent machine UUID
-	GeneratedResource bool   `url:"generated_resource"`          // whether or not this was a generated resource
-	AIAgent           string `url:"ai_agent,omitempty"`          // the AI coding agent that invoked the CLI, if any
-	AIAgentRaw        string `url:"ai_agent_raw,omitempty"`      // the agent's self-reported AI_AGENT/AGENT value; unvalidated, prefer ai_agent for grouping
-	AgentHost         string `url:"agent_host,omitempty"`        // the application hosting the agent, as reported by the agent
-	AgentHostKind     string `url:"agent_host_kind,omitempty"`   // coarse category for agent_host: desktop, terminal, ide, remote, sdk, mcp, chat, or ci
-	MacAppBundleID    string `url:"mac_app_bundle_id,omitempty"` // bundle ID of the macOS app that launched the process tree, if any
-	InstallMethod     string `url:"install_method,omitempty"`    // how the CLI was installed
-	InTmux            bool   `url:"in_tmux"`                     // whether the CLI was invoked from within tmux
-	InScreen          bool   `url:"in_screen"`                   // whether the CLI was invoked from within GNU Screen
-	TerminalProgram   string `url:"terminal_program,omitempty"`  // the terminal program that invoked the CLI, if any
+	InvocationID      string `url:"invocation_id"`              // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
+	UserAgent         string `url:"user_agent"`                 // the application that is used to create this request
+	CommandPath       string `url:"command_path"`               // the command or gRPC method that initiated this request
+	CommandFlags      string `url:"command_flags"`              // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
+	PluginName        string `url:"plugin_name,omitempty"`      // the plugin being installed, when relevant
+	PluginVersion     string `url:"plugin_version,omitempty"`   // the version of the plugin being installed/uninstalled/upgraded
+	Merchant          string `url:"merchant"`                   // the merchant ID: ex. acct_xxxx
+	CLIVersion        string `url:"cli_version"`                // the version of the CLI
+	OS                string `url:"os"`                         // the OS of the system
+	Arch              string `url:"arch"`                       // the CPU architecture of the system
+	MachineUUID       string `url:"machine_uuid,omitempty"`     // the persistent machine UUID
+	GeneratedResource bool   `url:"generated_resource"`         // whether or not this was a generated resource
+	AIAgent           string `url:"ai_agent,omitempty"`         // the AI coding agent that invoked the CLI, if any
+	AIAgentRaw        string `url:"ai_agent_raw,omitempty"`     // the agent's self-reported AI_AGENT/AGENT value; unvalidated, prefer ai_agent for grouping
+	AgentHost         string `url:"agent_host,omitempty"`       // the application hosting the agent, as reported by the agent
+	AgentHostKind     string `url:"agent_host_kind,omitempty"`  // coarse category for agent_host: desktop, terminal, ide, remote, sdk, mcp, chat, or ci
+	InstallMethod     string `url:"install_method,omitempty"`   // how the CLI was installed
+	InTmux            bool   `url:"in_tmux"`                    // whether the CLI was invoked from within tmux
+	InScreen          bool   `url:"in_screen"`                  // whether the CLI was invoked from within GNU Screen
+	TerminalProgram   string `url:"terminal_program,omitempty"` // the terminal program that invoked the CLI, if any
 }
 
 // TelemetryClient is an interface that can send two types of events: an API request, and just general events.
@@ -86,15 +85,14 @@ func NewEventMetadata() *CLIAnalyticsEventMetadata {
 	agentHost := useragent.DetectAgentHost(os.Getenv)
 
 	return &CLIAnalyticsEventMetadata{
-		InvocationID:   uuid.NewString(),
-		CLIVersion:     version.Version,
-		OS:             runtime.GOOS,
-		Arch:           runtime.GOARCH,
-		AIAgent:        useragent.DetectAIAgent(os.Getenv),
-		AIAgentRaw:     useragent.DetectAIAgentRaw(os.Getenv),
-		AgentHost:      agentHost,
-		AgentHostKind:  useragent.AgentHostKind(agentHost),
-		MacAppBundleID: useragent.DetectMacAppBundleID(os.Getenv),
+		InvocationID:  uuid.NewString(),
+		CLIVersion:    version.Version,
+		OS:            runtime.GOOS,
+		Arch:          runtime.GOARCH,
+		AIAgent:       useragent.DetectAIAgent(os.Getenv),
+		AIAgentRaw:    useragent.DetectAIAgentRaw(os.Getenv),
+		AgentHost:     agentHost,
+		AgentHostKind: useragent.AgentHostKind(agentHost),
 		InstallMethod: useragent.DetectInstallMethod(
 			os.Getenv,
 			os.Executable,

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -50,7 +50,6 @@ type CLIAnalyticsEventMetadata struct {
 	MachineUUID       string `url:"machine_uuid,omitempty"`     // the persistent machine UUID
 	GeneratedResource bool   `url:"generated_resource"`         // whether or not this was a generated resource
 	AIAgent           string `url:"ai_agent,omitempty"`         // the AI coding agent that invoked the CLI, if any
-	AIAgentRaw        string `url:"ai_agent_raw,omitempty"`     // self-reported AI_AGENT/AGENT value, only when ai_agent did not recognize the agent
 	AgentHostKind     string `url:"agent_host_kind,omitempty"`  // where the agent ran: desktop, terminal, ide, remote, sdk, mcp, chat, ci, or other
 	AgentVersion      string `url:"agent_version,omitempty"`    // the agent's own version, when it reports one
 	InstallMethod     string `url:"install_method,omitempty"`   // how the CLI was installed
@@ -82,24 +81,12 @@ type NoOpTelemetryClient struct {
 
 // NewEventMetadata initializes an instance of CLIAnalyticsEventContext
 func NewEventMetadata() *CLIAnalyticsEventMetadata {
-	aiAgent := useragent.DetectAIAgent(os.Getenv)
-
-	// Only report the self-reported identifier when we failed to recognize the agent.
-	// For a known agent it would duplicate ai_agent; the case it exists for is an agent
-	// we have not shipped support for naming itself, which is a discovery signal rather
-	// than a column to group by.
-	aiAgentRaw := ""
-	if aiAgent == "" {
-		aiAgentRaw = useragent.DetectAIAgentRaw(os.Getenv)
-	}
-
 	return &CLIAnalyticsEventMetadata{
 		InvocationID:  uuid.NewString(),
 		CLIVersion:    version.Version,
 		OS:            runtime.GOOS,
 		Arch:          runtime.GOARCH,
-		AIAgent:       aiAgent,
-		AIAgentRaw:    aiAgentRaw,
+		AIAgent:       useragent.DetectAIAgent(os.Getenv),
 		AgentHostKind: useragent.DetectAgentHostKind(os.Getenv),
 		AgentVersion:  useragent.DetectAgentVersion(os.Getenv),
 		InstallMethod: useragent.DetectInstallMethod(

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -50,9 +50,9 @@ type CLIAnalyticsEventMetadata struct {
 	MachineUUID       string `url:"machine_uuid,omitempty"`     // the persistent machine UUID
 	GeneratedResource bool   `url:"generated_resource"`         // whether or not this was a generated resource
 	AIAgent           string `url:"ai_agent,omitempty"`         // the AI coding agent that invoked the CLI, if any
-	AIAgentRaw        string `url:"ai_agent_raw,omitempty"`     // the agent's self-reported AI_AGENT/AGENT value; unvalidated, prefer ai_agent for grouping
-	AgentHost         string `url:"agent_host,omitempty"`       // the application hosting the agent, as reported by the agent
-	AgentHostKind     string `url:"agent_host_kind,omitempty"`  // coarse category for agent_host: desktop, terminal, ide, remote, sdk, mcp, chat, or ci
+	AIAgentRaw        string `url:"ai_agent_raw,omitempty"`     // self-reported AI_AGENT/AGENT value, only when ai_agent did not recognize the agent
+	AgentHostKind     string `url:"agent_host_kind,omitempty"`  // where the agent ran: desktop, terminal, ide, remote, sdk, mcp, chat, ci, or other
+	AgentVersion      string `url:"agent_version,omitempty"`    // the agent's own version, when it reports one
 	InstallMethod     string `url:"install_method,omitempty"`   // how the CLI was installed
 	InTmux            bool   `url:"in_tmux"`                    // whether the CLI was invoked from within tmux
 	InScreen          bool   `url:"in_screen"`                  // whether the CLI was invoked from within GNU Screen
@@ -82,17 +82,26 @@ type NoOpTelemetryClient struct {
 
 // NewEventMetadata initializes an instance of CLIAnalyticsEventContext
 func NewEventMetadata() *CLIAnalyticsEventMetadata {
-	agentHost := useragent.DetectAgentHost(os.Getenv)
+	aiAgent := useragent.DetectAIAgent(os.Getenv)
+
+	// Only report the self-reported identifier when we failed to recognize the agent.
+	// For a known agent it would duplicate ai_agent; the case it exists for is an agent
+	// we have not shipped support for naming itself, which is a discovery signal rather
+	// than a column to group by.
+	aiAgentRaw := ""
+	if aiAgent == "" {
+		aiAgentRaw = useragent.DetectAIAgentRaw(os.Getenv)
+	}
 
 	return &CLIAnalyticsEventMetadata{
 		InvocationID:  uuid.NewString(),
 		CLIVersion:    version.Version,
 		OS:            runtime.GOOS,
 		Arch:          runtime.GOARCH,
-		AIAgent:       useragent.DetectAIAgent(os.Getenv),
-		AIAgentRaw:    useragent.DetectAIAgentRaw(os.Getenv),
-		AgentHost:     agentHost,
-		AgentHostKind: useragent.AgentHostKind(agentHost),
+		AIAgent:       aiAgent,
+		AIAgentRaw:    aiAgentRaw,
+		AgentHostKind: useragent.DetectAgentHostKind(os.Getenv),
+		AgentVersion:  useragent.DetectAgentVersion(os.Getenv),
 		InstallMethod: useragent.DetectInstallMethod(
 			os.Getenv,
 			os.Executable,

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -37,23 +37,26 @@ const DefaultTelemetryEndpoint = "https://r.stripe.com/0"
 
 // CLIAnalyticsEventMetadata is the structure that holds telemetry data context that is ultimately sent to the Stripe Analytics Service.
 type CLIAnalyticsEventMetadata struct {
-	InvocationID      string `url:"invocation_id"`              // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
-	UserAgent         string `url:"user_agent"`                 // the application that is used to create this request
-	CommandPath       string `url:"command_path"`               // the command or gRPC method that initiated this request
-	CommandFlags      string `url:"command_flags"`              // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
-	PluginName        string `url:"plugin_name,omitempty"`      // the plugin being installed, when relevant
-	PluginVersion     string `url:"plugin_version,omitempty"`   // the version of the plugin being installed/uninstalled/upgraded
-	Merchant          string `url:"merchant"`                   // the merchant ID: ex. acct_xxxx
-	CLIVersion        string `url:"cli_version"`                // the version of the CLI
-	OS                string `url:"os"`                         // the OS of the system
-	Arch              string `url:"arch"`                       // the CPU architecture of the system
-	MachineUUID       string `url:"machine_uuid,omitempty"`     // the persistent machine UUID
-	GeneratedResource bool   `url:"generated_resource"`         // whether or not this was a generated resource
-	AIAgent           string `url:"ai_agent,omitempty"`         // the AI coding agent that invoked the CLI, if any
-	InstallMethod     string `url:"install_method,omitempty"`   // how the CLI was installed
-	InTmux            bool   `url:"in_tmux"`                    // whether the CLI was invoked from within tmux
-	InScreen          bool   `url:"in_screen"`                  // whether the CLI was invoked from within GNU Screen
-	TerminalProgram   string `url:"terminal_program,omitempty"` // the terminal program that invoked the CLI, if any
+	InvocationID      string `url:"invocation_id"`               // The invocation id is unique to each context object and represents all events coming from one command / gRPC method call
+	UserAgent         string `url:"user_agent"`                  // the application that is used to create this request
+	CommandPath       string `url:"command_path"`                // the command or gRPC method that initiated this request
+	CommandFlags      string `url:"command_flags"`               // Comma-separated list of flags that were passed to the command (only includes flag names, not their values)
+	PluginName        string `url:"plugin_name,omitempty"`       // the plugin being installed, when relevant
+	PluginVersion     string `url:"plugin_version,omitempty"`    // the version of the plugin being installed/uninstalled/upgraded
+	Merchant          string `url:"merchant"`                    // the merchant ID: ex. acct_xxxx
+	CLIVersion        string `url:"cli_version"`                 // the version of the CLI
+	OS                string `url:"os"`                          // the OS of the system
+	Arch              string `url:"arch"`                        // the CPU architecture of the system
+	MachineUUID       string `url:"machine_uuid,omitempty"`      // the persistent machine UUID
+	GeneratedResource bool   `url:"generated_resource"`          // whether or not this was a generated resource
+	AIAgent           string `url:"ai_agent,omitempty"`          // the AI coding agent that invoked the CLI, if any
+	AIAgentRaw        string `url:"ai_agent_raw,omitempty"`      // the agent's self-reported AI_AGENT/AGENT value; unvalidated, prefer ai_agent for grouping
+	AgentHost         string `url:"agent_host,omitempty"`        // the application hosting the agent (desktop, IDE, SDK), when reported
+	MacAppBundleID    string `url:"mac_app_bundle_id,omitempty"` // bundle ID of the macOS app that launched the process tree, if any
+	InstallMethod     string `url:"install_method,omitempty"`    // how the CLI was installed
+	InTmux            bool   `url:"in_tmux"`                     // whether the CLI was invoked from within tmux
+	InScreen          bool   `url:"in_screen"`                   // whether the CLI was invoked from within GNU Screen
+	TerminalProgram   string `url:"terminal_program,omitempty"`  // the terminal program that invoked the CLI, if any
 }
 
 // TelemetryClient is an interface that can send two types of events: an API request, and just general events.
@@ -80,11 +83,14 @@ type NoOpTelemetryClient struct {
 // NewEventMetadata initializes an instance of CLIAnalyticsEventContext
 func NewEventMetadata() *CLIAnalyticsEventMetadata {
 	return &CLIAnalyticsEventMetadata{
-		InvocationID: uuid.NewString(),
-		CLIVersion:   version.Version,
-		OS:           runtime.GOOS,
-		Arch:         runtime.GOARCH,
-		AIAgent:      useragent.DetectAIAgent(os.Getenv),
+		InvocationID:   uuid.NewString(),
+		CLIVersion:     version.Version,
+		OS:             runtime.GOOS,
+		Arch:           runtime.GOARCH,
+		AIAgent:        useragent.DetectAIAgent(os.Getenv),
+		AIAgentRaw:     useragent.DetectAIAgentRaw(os.Getenv),
+		AgentHost:      useragent.DetectAgentHost(os.Getenv),
+		MacAppBundleID: useragent.DetectMacAppBundleID(os.Getenv),
 		InstallMethod: useragent.DetectInstallMethod(
 			os.Getenv,
 			os.Executable,

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -335,7 +335,6 @@ func TestAIAgentDetection_AllAgents(t *testing.T) {
 		{"Antigravity", "ANTIGRAVITY_CLI_ALIAS", "true", "antigravity"},
 		{"Claude Code", "CLAUDECODE", "true", "claude_code"},
 		{"Cline", "CLINE_ACTIVE", "true", "cline"},
-		{"Codex Desktop", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "Codex Desktop", "codex_desktop"},
 		{"Codex CLI sandbox", "CODEX_SANDBOX", "true", "codex_cli"},
 		{"Codex CLI thread", "CODEX_THREAD_ID", "thread-id", "codex_cli"},
 		{"Codex CLI sandbox network", "CODEX_SANDBOX_NETWORK_DISABLED", "true", "codex_cli"},
@@ -358,22 +357,6 @@ func TestAIAgentDetection_AllAgents(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 		})
 	}
-}
-
-func TestAIAgentDetection_CodexDesktopPriority(t *testing.T) {
-	getEnv := func(key string) string {
-		switch key {
-		case "CODEX_INTERNAL_ORIGINATOR_OVERRIDE":
-			return "Codex Desktop"
-		case "CODEX_THREAD_ID":
-			return "thread-id"
-		default:
-			return ""
-		}
-	}
-
-	result := useragent.DetectAIAgent(getEnv)
-	require.Equal(t, "codex_desktop", result)
 }
 
 func TestAIAgentDetection_Priority(t *testing.T) {

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -230,8 +230,7 @@ func TestSendEvent_WithAgentHost(t *testing.T) {
 		require.NoError(t, err)
 		bodyString := string(body)
 		require.Contains(t, bodyString, "ai_agent=claude_code")
-		require.Contains(t, bodyString, "ai_agent_raw=claude-code_2-1-222_agent")
-		require.Contains(t, bodyString, "agent_host=claude-desktop")
+		require.Contains(t, bodyString, "agent_version=2.1.222")
 		require.Contains(t, bodyString, "agent_host_kind=desktop")
 	}))
 	defer ts.Close()
@@ -245,9 +244,8 @@ func TestSendEvent_WithAgentHost(t *testing.T) {
 		CommandPath:   "stripe test",
 		Merchant:      "acct_1234",
 		AIAgent:       "claude_code",
-		AIAgentRaw:    "claude-code_2-1-222_agent",
-		AgentHost:     "claude-desktop",
 		AgentHostKind: "desktop",
+		AgentVersion:  "2.1.222",
 	}
 
 	processCtx := stripe.WithEventMetadata(context.Background(), telemetryMetadata)
@@ -261,7 +259,7 @@ func TestSendEvent_OmitsUnsetAgentFields(t *testing.T) {
 		require.NoError(t, err)
 		bodyString := string(body)
 		require.NotContains(t, bodyString, "ai_agent_raw")
-		require.NotContains(t, bodyString, "agent_host")
+		require.NotContains(t, bodyString, "agent_version")
 		require.NotContains(t, bodyString, "agent_host_kind")
 	}))
 	defer ts.Close()
@@ -389,4 +387,40 @@ func TestAIAgentDetection_Priority(t *testing.T) {
 	}
 	result := useragent.DetectAIAgent(getEnv)
 	require.Equal(t, "antigravity", result)
+}
+
+func clearAgentEnv(t *testing.T) {
+	for _, key := range []string{
+		"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE",
+		"CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI",
+		"CURSOR_AGENT", "GEMINI_CLI", "OPENCODE", "OPENCLAW_SHELL",
+		"AI_AGENT", "AGENT", "CLAUDE_CODE_ENTRYPOINT", "__CFBundleIdentifier",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func TestNewEventMetadata_ReportsRawAgentOnlyWhenUnrecognized(t *testing.T) {
+	t.Run("unrecognized agent is reported raw", func(t *testing.T) {
+		clearAgentEnv(t)
+		t.Setenv("AI_AGENT", "goose_9-9-9")
+
+		tel := stripe.NewEventMetadata()
+		require.Empty(t, tel.AIAgent)
+		require.Equal(t, "goose_9-9-9", tel.AIAgentRaw)
+		require.Equal(t, "9.9.9", tel.AgentVersion)
+	})
+
+	t.Run("recognized agent suppresses the raw value", func(t *testing.T) {
+		clearAgentEnv(t)
+		t.Setenv("CLAUDECODE", "1")
+		t.Setenv("AI_AGENT", "claude-code_2-1-222_agent")
+		t.Setenv("CLAUDE_CODE_ENTRYPOINT", "claude-desktop")
+
+		tel := stripe.NewEventMetadata()
+		require.Equal(t, "claude_code", tel.AIAgent)
+		require.Empty(t, tel.AIAgentRaw, "raw value duplicates ai_agent for a known agent")
+		require.Equal(t, "desktop", tel.AgentHostKind)
+		require.Equal(t, "2.1.222", tel.AgentVersion)
+	})
 }

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -224,6 +224,63 @@ func TestSendEvent_WithAIAgent(t *testing.T) {
 	analyticsClient.SendEvent(processCtx, "foo", "bar")
 }
 
+func TestSendEvent_WithAgentHostAndBundleID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		bodyString := string(body)
+		require.Contains(t, bodyString, "ai_agent=claude_code")
+		require.Contains(t, bodyString, "ai_agent_raw=claude-code_2-1-222_agent")
+		require.Contains(t, bodyString, "agent_host=claude-desktop")
+		require.Contains(t, bodyString, "mac_app_bundle_id=com.anthropic.claudefordesktop")
+	}))
+	defer ts.Close()
+	baseURL, _ := url.Parse(ts.URL)
+
+	telemetryMetadata := &stripe.CLIAnalyticsEventMetadata{
+		InvocationID:   "123456",
+		UserAgent:      "Unit Test",
+		CLIVersion:     "master",
+		OS:             "darwin",
+		CommandPath:    "stripe test",
+		Merchant:       "acct_1234",
+		AIAgent:        "claude_code",
+		AIAgentRaw:     "claude-code_2-1-222_agent",
+		AgentHost:      "claude-desktop",
+		MacAppBundleID: "com.anthropic.claudefordesktop",
+	}
+
+	processCtx := stripe.WithEventMetadata(context.Background(), telemetryMetadata)
+	analyticsClient := stripe.AnalyticsTelemetryClient{BaseURL: baseURL, HTTPClient: &http.Client{}}
+	analyticsClient.SendEvent(processCtx, "foo", "bar")
+}
+
+func TestSendEvent_OmitsUnsetAgentFields(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		bodyString := string(body)
+		require.NotContains(t, bodyString, "ai_agent_raw")
+		require.NotContains(t, bodyString, "agent_host")
+		require.NotContains(t, bodyString, "mac_app_bundle_id")
+	}))
+	defer ts.Close()
+	baseURL, _ := url.Parse(ts.URL)
+
+	telemetryMetadata := &stripe.CLIAnalyticsEventMetadata{
+		InvocationID: "123456",
+		UserAgent:    "Unit Test",
+		CLIVersion:   "master",
+		OS:           "linux",
+		CommandPath:  "stripe test",
+		Merchant:     "acct_1234",
+	}
+
+	processCtx := stripe.WithEventMetadata(context.Background(), telemetryMetadata)
+	analyticsClient := stripe.AnalyticsTelemetryClient{BaseURL: baseURL, HTTPClient: &http.Client{}}
+	analyticsClient.SendEvent(processCtx, "foo", "bar")
+}
+
 func TestSkipsSendEventWhenMetadataIsEmpty(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Fail(t, "Did not expect to reach sendData")

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -275,15 +275,20 @@ func TestAIAgentDetection_AllAgents(t *testing.T) {
 	tests := []struct {
 		name     string
 		envVar   string
+		envValue string
 		expected string
 	}{
-		{"Antigravity", "ANTIGRAVITY_CLI_ALIAS", "antigravity"},
-		{"Claude Code", "CLAUDECODE", "claude_code"},
-		{"Cline", "CLINE_ACTIVE", "cline"},
-		{"Codex CLI", "CODEX_SANDBOX", "codex_cli"},
-		{"Cursor", "CURSOR_AGENT", "cursor"},
-		{"Gemini CLI", "GEMINI_CLI", "gemini_cli"},
-		{"Open Code", "OPENCODE", "open_code"},
+		{"Antigravity", "ANTIGRAVITY_CLI_ALIAS", "true", "antigravity"},
+		{"Claude Code", "CLAUDECODE", "true", "claude_code"},
+		{"Cline", "CLINE_ACTIVE", "true", "cline"},
+		{"Codex Desktop", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "Codex Desktop", "codex_desktop"},
+		{"Codex CLI sandbox", "CODEX_SANDBOX", "true", "codex_cli"},
+		{"Codex CLI thread", "CODEX_THREAD_ID", "thread-id", "codex_cli"},
+		{"Codex CLI sandbox network", "CODEX_SANDBOX_NETWORK_DISABLED", "true", "codex_cli"},
+		{"Codex CLI CI", "CODEX_CI", "true", "codex_cli"},
+		{"Cursor", "CURSOR_AGENT", "true", "cursor"},
+		{"Gemini CLI", "GEMINI_CLI", "true", "gemini_cli"},
+		{"Open Code", "OPENCODE", "true", "open_code"},
 	}
 
 	for _, tt := range tests {
@@ -291,7 +296,7 @@ func TestAIAgentDetection_AllAgents(t *testing.T) {
 			// Mock env getter that returns only the specific env var being tested
 			getEnv := func(key string) string {
 				if key == tt.envVar {
-					return "true"
+					return tt.envValue
 				}
 				return ""
 			}
@@ -299,6 +304,22 @@ func TestAIAgentDetection_AllAgents(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestAIAgentDetection_CodexDesktopPriority(t *testing.T) {
+	getEnv := func(key string) string {
+		switch key {
+		case "CODEX_INTERNAL_ORIGINATOR_OVERRIDE":
+			return "Codex Desktop"
+		case "CODEX_THREAD_ID":
+			return "thread-id"
+		default:
+			return ""
+		}
+	}
+
+	result := useragent.DetectAIAgent(getEnv)
+	require.Equal(t, "codex_desktop", result)
 }
 
 func TestAIAgentDetection_Priority(t *testing.T) {

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -258,7 +258,6 @@ func TestSendEvent_OmitsUnsetAgentFields(t *testing.T) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		bodyString := string(body)
-		require.NotContains(t, bodyString, "ai_agent_raw")
 		require.NotContains(t, bodyString, "agent_version")
 		require.NotContains(t, bodyString, "agent_host_kind")
 	}))
@@ -400,27 +399,16 @@ func clearAgentEnv(t *testing.T) {
 	}
 }
 
-func TestNewEventMetadata_ReportsRawAgentOnlyWhenUnrecognized(t *testing.T) {
-	t.Run("unrecognized agent is reported raw", func(t *testing.T) {
-		clearAgentEnv(t)
-		t.Setenv("AI_AGENT", "goose_9-9-9")
+func TestNewEventMetadata_FromObservedDesktopSession(t *testing.T) {
+	// Values observed in a real Claude Desktop session; see TestObservedAgentSessions
+	// in pkg/useragent for the full set and for Codex Desktop.
+	clearAgentEnv(t)
+	t.Setenv("CLAUDECODE", "1")
+	t.Setenv("AI_AGENT", "claude-code_2-1-227_agent")
+	t.Setenv("CLAUDE_CODE_ENTRYPOINT", "claude-desktop")
 
-		tel := stripe.NewEventMetadata()
-		require.Empty(t, tel.AIAgent)
-		require.Equal(t, "goose_9-9-9", tel.AIAgentRaw)
-		require.Equal(t, "9.9.9", tel.AgentVersion)
-	})
-
-	t.Run("recognized agent suppresses the raw value", func(t *testing.T) {
-		clearAgentEnv(t)
-		t.Setenv("CLAUDECODE", "1")
-		t.Setenv("AI_AGENT", "claude-code_2-1-222_agent")
-		t.Setenv("CLAUDE_CODE_ENTRYPOINT", "claude-desktop")
-
-		tel := stripe.NewEventMetadata()
-		require.Equal(t, "claude_code", tel.AIAgent)
-		require.Empty(t, tel.AIAgentRaw, "raw value duplicates ai_agent for a known agent")
-		require.Equal(t, "desktop", tel.AgentHostKind)
-		require.Equal(t, "2.1.222", tel.AgentVersion)
-	})
+	tel := stripe.NewEventMetadata()
+	require.Equal(t, "claude_code", tel.AIAgent)
+	require.Equal(t, "desktop", tel.AgentHostKind)
+	require.Equal(t, "2.1.227", tel.AgentVersion)
 }

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -232,6 +232,7 @@ func TestSendEvent_WithAgentHostAndBundleID(t *testing.T) {
 		require.Contains(t, bodyString, "ai_agent=claude_code")
 		require.Contains(t, bodyString, "ai_agent_raw=claude-code_2-1-222_agent")
 		require.Contains(t, bodyString, "agent_host=claude-desktop")
+		require.Contains(t, bodyString, "agent_host_kind=desktop")
 		require.Contains(t, bodyString, "mac_app_bundle_id=com.anthropic.claudefordesktop")
 	}))
 	defer ts.Close()
@@ -247,6 +248,7 @@ func TestSendEvent_WithAgentHostAndBundleID(t *testing.T) {
 		AIAgent:        "claude_code",
 		AIAgentRaw:     "claude-code_2-1-222_agent",
 		AgentHost:      "claude-desktop",
+		AgentHostKind:  "desktop",
 		MacAppBundleID: "com.anthropic.claudefordesktop",
 	}
 
@@ -262,6 +264,7 @@ func TestSendEvent_OmitsUnsetAgentFields(t *testing.T) {
 		bodyString := string(body)
 		require.NotContains(t, bodyString, "ai_agent_raw")
 		require.NotContains(t, bodyString, "agent_host")
+		require.NotContains(t, bodyString, "agent_host_kind")
 		require.NotContains(t, bodyString, "mac_app_bundle_id")
 	}))
 	defer ts.Close()

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -224,7 +224,7 @@ func TestSendEvent_WithAIAgent(t *testing.T) {
 	analyticsClient.SendEvent(processCtx, "foo", "bar")
 }
 
-func TestSendEvent_WithAgentHostAndBundleID(t *testing.T) {
+func TestSendEvent_WithAgentHost(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
@@ -233,23 +233,21 @@ func TestSendEvent_WithAgentHostAndBundleID(t *testing.T) {
 		require.Contains(t, bodyString, "ai_agent_raw=claude-code_2-1-222_agent")
 		require.Contains(t, bodyString, "agent_host=claude-desktop")
 		require.Contains(t, bodyString, "agent_host_kind=desktop")
-		require.Contains(t, bodyString, "mac_app_bundle_id=com.anthropic.claudefordesktop")
 	}))
 	defer ts.Close()
 	baseURL, _ := url.Parse(ts.URL)
 
 	telemetryMetadata := &stripe.CLIAnalyticsEventMetadata{
-		InvocationID:   "123456",
-		UserAgent:      "Unit Test",
-		CLIVersion:     "master",
-		OS:             "darwin",
-		CommandPath:    "stripe test",
-		Merchant:       "acct_1234",
-		AIAgent:        "claude_code",
-		AIAgentRaw:     "claude-code_2-1-222_agent",
-		AgentHost:      "claude-desktop",
-		AgentHostKind:  "desktop",
-		MacAppBundleID: "com.anthropic.claudefordesktop",
+		InvocationID:  "123456",
+		UserAgent:     "Unit Test",
+		CLIVersion:    "master",
+		OS:            "darwin",
+		CommandPath:   "stripe test",
+		Merchant:      "acct_1234",
+		AIAgent:       "claude_code",
+		AIAgentRaw:    "claude-code_2-1-222_agent",
+		AgentHost:     "claude-desktop",
+		AgentHostKind: "desktop",
 	}
 
 	processCtx := stripe.WithEventMetadata(context.Background(), telemetryMetadata)
@@ -265,7 +263,6 @@ func TestSendEvent_OmitsUnsetAgentFields(t *testing.T) {
 		require.NotContains(t, bodyString, "ai_agent_raw")
 		require.NotContains(t, bodyString, "agent_host")
 		require.NotContains(t, bodyString, "agent_host_kind")
-		require.NotContains(t, bodyString, "mac_app_bundle_id")
 	}))
 	defer ts.Close()
 	baseURL, _ := url.Parse(ts.URL)

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -59,7 +59,7 @@ func TestAuthorize(t *testing.T) {
 
 func TestUserAgent(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Regexp(t, regexp.MustCompile(`^Stripe/v1 stripe-cli/\w+$`), r.Header.Get("User-Agent"))
+		require.Regexp(t, regexp.MustCompile(`^Stripe/v1 stripe-cli/\w+( AIAgent/\w+)?$`), r.Header.Get("User-Agent"))
 		w.Write([]byte(`{}`))
 	}))
 	defer ts.Close()

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -107,10 +107,6 @@ func DetectAIAgent(getEnv func(string) string) string {
 	if getEnv("CLINE_ACTIVE") != "" {
 		return "cline"
 	}
-	// Codex Desktop also sets the generic Codex env vars, so check its originator first.
-	if getEnv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE") == "Codex Desktop" {
-		return "codex_desktop"
-	}
 	if getEnv("CODEX_SANDBOX") != "" || getEnv("CODEX_THREAD_ID") != "" || getEnv("CODEX_SANDBOX_NETWORK_DISABLED") != "" || getEnv("CODEX_CI") != "" {
 		return "codex_cli"
 	}
@@ -129,122 +125,64 @@ func DetectAIAgent(getEnv func(string) string) string {
 	return ""
 }
 
-// detectAIAgentRaw returns the agent's self-reported identifier from the emerging
-// AI_AGENT/AGENT convention, or "" when unset. It is deliberately unexported and never
-// reported as-is: it is unvalidated free text from the environment, and only the
-// version parsed out of it by DetectAgentVersion leaves the machine.
+// DetectAgentHostKind reports where the agent ran: "desktop", "terminal", "ide",
+// "remote", "sdk", "mcp", or "other", and "" when no agent reported a host.
 //
-// AI_AGENT is used by Vercel's detect-agent and set by Claude Code (which
-// deliberately does not overwrite another vendor's value). AGENT is used by Goose,
-// Amp, and Bun, and is being added to Codex. AGENT is the more collision-prone of
-// the two, so it is only consulted as a fallback.
-func detectAIAgentRaw(getEnv func(string) string) string {
-	if agent := sanitizeEnvValue(getEnv("AI_AGENT")); agent != "" {
-		return agent
+// Only the category is exposed. The underlying values are per-vendor spellings that
+// every consumer would otherwise have to enumerate, and the vendor is already carried
+// by DetectAIAgent.
+func DetectAgentHostKind(getEnv func(string) string) string {
+	host := getEnv("CLAUDE_CODE_ENTRYPOINT")
+	if host == "" {
+		// Codex Desktop sets this alongside the generic Codex signals, and it is
+		// currently the only inherited value separating Desktop from the Codex CLI.
+		host = getEnv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE")
 	}
-	return sanitizeEnvValue(getEnv("AGENT"))
-}
-
-// DetectAgentHost returns the application hosting the coding agent, when the agent
-// reports one. This distinguishes a desktop or IDE-hosted agent from the same agent
-// running in a terminal, which DetectAIAgent alone cannot do.
-//
-// Values are not mapped to a fixed set, since the set evolves outside this CLI. Known
-// Claude Code values include "cli", "claude-desktop", "claude-vscode", "mcp",
-// "sdk-ts", "sdk-py", "local-agent", "claude-code-github-action", and several
-// "remote*" variants. Codex Desktop reports "codex-desktop".
-func DetectAgentHost(getEnv func(string) string) string {
-	if host := getEnv("CLAUDE_CODE_ENTRYPOINT"); host != "" {
-		return normalizeAgentHost(host)
-	}
-	// Codex Desktop sets this alongside the generic Codex signals; it is currently the
-	// only inherited value that separates Desktop from the Codex CLI.
-	if host := getEnv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE"); host != "" {
-		return normalizeAgentHost(host)
-	}
-	return detectMacAppHost(getEnv)
-}
-
-// AgentHostKind maps a host returned by DetectAgentHost to a coarse category, or ""
-// when the host is unset or not one we recognize.
-//
-// This is the curated counterpart to the free-form agent_host value, in the same way
-// that DetectAIAgent is curated rather than free text. It exists so that
-// a question like "how many invocations came from a desktop app" is one stable
-// predicate rather than a list of per-vendor spellings that has to be extended every
-// time a vendor ships a new host or renames an existing one.
-func AgentHostKind(host string) string {
 	if host == "" {
 		return ""
 	}
-	// Remote hosts are matched first and by prefix: "remote-desktop" is a remote
-	// session, not the desktop app, so any substring match on "desktop" would
-	// silently conflate the two.
+
+	// Vendors disagree on formatting, and Claude Code disagrees with itself: it ships
+	// both "claude_in_slack" and "claude-in-slack", while Codex reports "Codex Desktop".
+	host = strings.ToLower(strings.TrimSpace(host))
+	host = strings.NewReplacer(" ", "-", "_", "-").Replace(host)
+
+	// Checked first and by prefix: "remote-desktop" is a remote session, not the
+	// desktop app, so matching "desktop" anywhere would silently inflate desktop counts.
 	if host == "remote" || strings.HasPrefix(host, "remote-") {
 		return "remote"
 	}
 	if kind, ok := agentHostKinds[host]; ok {
 		return kind
 	}
-	return agentHostKindOther
-}
-
-// DetectAgentHostKind reports the category of the host that invoked the CLI. This is
-// the single host signal reported in telemetry: the underlying host string is a
-// per-vendor spelling that callers would have to enumerate, whereas the category is a
-// bounded set, and the vendor is already carried by DetectAIAgent.
-func DetectAgentHostKind(getEnv func(string) string) string {
-	return AgentHostKind(DetectAgentHost(getEnv))
+	// Reported rather than dropped, so a host we have not categorized stays
+	// distinguishable from no host at all while the field stays bounded.
+	return "other"
 }
 
 // DetectAgentVersion returns the agent's own version, parsed out of the identifier it
 // reports through the AI_AGENT convention, or "" when absent or unparseable.
 //
-// Claude Code encodes it as "claude-code_2-1-222_agent" (dots written as dashes) and
-// has also used a "claude-code/2.1.222" form. No other agent reports a version this
-// way today, so in practice this is populated for Claude Code and empty elsewhere.
-// The format is undocumented, so this validates what it extracts and reports nothing
-// rather than guessing.
+// Claude Code encodes it as "claude-code_2-1-227_agent" (dots written as dashes) and
+// has also used "claude-code/2.1.227". No other agent reports a version this way today.
+// Both formats are undocumented, so this validates what it extracts and reports nothing
+// rather than guessing: a wrong version is worse than a missing one.
 func DetectAgentVersion(getEnv func(string) string) string {
-	identifier := detectAIAgentRaw(getEnv)
+	identifier := strings.TrimSpace(getEnv("AI_AGENT"))
 	if identifier == "" {
-		return ""
+		// AGENT is the same convention under the name Goose, Amp and Bun use.
+		identifier = strings.TrimSpace(getEnv("AGENT"))
 	}
 
-	// "claude-code/2.1.222" -- everything after the last slash.
 	if idx := strings.LastIndex(identifier, "/"); idx >= 0 {
-		return validVersion(strings.TrimSpace(identifier[idx+1:]))
+		return validVersion(identifier[idx+1:])
 	}
-
-	// "claude-code_2-1-222_agent" -- the first underscore-delimited segment that reads
-	// as a version once dashes are treated as dots.
 	for _, segment := range strings.Split(identifier, "_") {
 		if version := validVersion(strings.ReplaceAll(segment, "-", ".")); version != "" {
 			return version
 		}
 	}
-
 	return ""
-}
-
-// detectMacAppHost identifies the host from the macOS bundle identifier of the app
-// that launched the process tree, for the case where a desktop app invokes the CLI
-// without its coding agent in between -- an MCP server that shells out, for example --
-// and so sets none of the agent environment variables.
-//
-// macOS sets __CFBundleIdentifier when an app bundle launches a process, and child
-// processes inherit it, so it names the GUI app at the root of the session rather than
-// the direct parent. Only bundle IDs we explicitly recognize are mapped; every other
-// value, including terminal emulators, is ignored rather than reported. That keeps this
-// a narrow positive check instead of a general "which app launched us" field, whose
-// value would be unbounded and mostly terminal emulators.
-func detectMacAppHost(getEnv func(string) string) string {
-	// A terminal emulator between the app and the CLI means the session is a terminal
-	// one, whatever app happens to sit at the root of the tree.
-	if DetectTerminalProgram(getEnv) != "" {
-		return ""
-	}
-	return macAppHosts[sanitizeEnvValue(getEnv("__CFBundleIdentifier"))]
 }
 
 //
@@ -273,45 +211,25 @@ var encodedUserAgent string
 // Private constants
 //
 
-// maxEnvValueLength bounds free-form environment values before they are reported,
-// so an unexpected or hostile value cannot bloat a request.
-const maxEnvValueLength = 64
-
-// agentHostKindOther is reported when a host was detected but is not one we
-// categorize. It keeps the field bounded while still making a new or renamed host
-// visible, which reporting "" would not.
-const agentHostKindOther = "other"
+// maxVersionLength bounds a parsed version before it is reported, so an unexpected or
+// hostile value cannot bloat a request.
+const maxVersionLength = 32
 
 //
 // Private variables
 //
 
-// macAppHosts maps the bundle identifiers of desktop apps that can invoke the CLI to
-// the host they correspond to. Deliberately minimal: an unlisted bundle ID reports no
-// host at all, so adding an entry is a decision rather than a default.
-//
-// com.openai.codex is what ChatGPT.app itself ships as, verified against an installed
-// 26.730.61639 build -- OpenAI uses one bundle identifier for the desktop app, so this
-// cannot separate ChatGPT from Codex, only identify the OpenAI desktop app.
-var macAppHosts = map[string]string{
-	"com.anthropic.claudefordesktop": "claude-desktop",
-	"com.openai.codex":               "codex-desktop",
-}
-
 // agentHostKinds categorizes the hosts we know about. "remote*" hosts are handled by
-// prefix in AgentHostKind rather than enumerated here.
+// prefix in DetectAgentHostKind rather than enumerated here.
 var agentHostKinds = map[string]string{
-	"claude-code-github-action": "ci",
-	"claude-desktop":            "desktop",
-	"claude-in-slack":           "chat",
-	"claude-in-teams":           "chat",
-	"claude-vscode":             "ide",
-	"cli":                       "terminal",
-	"codex-desktop":             "desktop",
-	"mcp":                       "mcp",
-	"sdk-cli":                   "sdk",
-	"sdk-py":                    "sdk",
-	"sdk-ts":                    "sdk",
+	"claude-desktop": "desktop",
+	"claude-vscode":  "ide",
+	"cli":            "terminal",
+	"codex-desktop":  "desktop",
+	"mcp":            "mcp",
+	"sdk-cli":        "sdk",
+	"sdk-py":         "sdk",
+	"sdk-ts":         "sdk",
 }
 
 //
@@ -320,55 +238,21 @@ var agentHostKinds = map[string]string{
 
 // validVersion returns the candidate if it is a dot-separated numeric version, and ""
 // otherwise. Deliberately strict: the identifier formats this parses are undocumented,
-// and a wrong version is worse than a missing one.
+// so anything unexpected is dropped rather than guessed at.
 func validVersion(candidate string) string {
-	if candidate == "" || strings.HasPrefix(candidate, ".") || strings.HasSuffix(candidate, ".") {
+	if candidate == "" || len(candidate) > maxVersionLength ||
+		strings.HasPrefix(candidate, ".") || strings.HasSuffix(candidate, ".") ||
+		strings.Contains(candidate, "..") {
 		return ""
 	}
 
-	digits := false
 	for _, r := range candidate {
-		switch {
-		case r >= '0' && r <= '9':
-			digits = true
-		case r == '.':
-		default:
+		if (r < '0' || r > '9') && r != '.' {
 			return ""
 		}
 	}
 
-	if !digits || strings.Contains(candidate, "..") {
-		return ""
-	}
-
 	return candidate
-}
-
-// normalizeAgentHost lowercases a reported host and collapses spaces and underscores
-// to dashes, so that values from different vendors land in one comparable column.
-// Claude Code reports "claude-desktop" while Codex Desktop reports "Codex Desktop",
-// and Claude Code is itself inconsistent: it ships both "claude_in_slack" and
-// "claude-in-slack", alongside dashed values like "claude-vscode".
-func normalizeAgentHost(host string) string {
-	lowered := strings.ToLower(sanitizeEnvValue(host))
-	return strings.NewReplacer(" ", "-", "_", "-").Replace(lowered)
-}
-
-// sanitizeEnvValue trims an environment value, drops anything outside printable
-// ASCII, and truncates the result to maxEnvValueLength.
-func sanitizeEnvValue(value string) string {
-	cleaned := strings.Map(func(r rune) rune {
-		if r < ' ' || r > '~' {
-			return -1
-		}
-		return r
-	}, strings.TrimSpace(value))
-
-	if len(cleaned) > maxEnvValueLength {
-		cleaned = cleaned[:maxEnvValueLength]
-	}
-
-	return cleaned
 }
 
 func init() {

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -146,12 +146,20 @@ func DetectAIAgentRaw(getEnv func(string) string) string {
 // reports one. This distinguishes a desktop or IDE-hosted agent from the same agent
 // running in a terminal, which DetectAIAgent alone cannot do.
 //
-// Values are passed through as reported rather than mapped to a fixed set, since the
-// set evolves outside this CLI. Known Claude Code values include "cli",
-// "claude-desktop", "claude-vscode", "mcp", "sdk-ts", "sdk-py", "local-agent",
-// "claude-code-github-action", and several "remote*" variants.
+// Values are not mapped to a fixed set, since the set evolves outside this CLI. Known
+// Claude Code values include "cli", "claude-desktop", "claude-vscode", "mcp",
+// "sdk-ts", "sdk-py", "local-agent", "claude-code-github-action", and several
+// "remote*" variants. Codex Desktop reports "codex-desktop".
 func DetectAgentHost(getEnv func(string) string) string {
-	return sanitizeEnvValue(getEnv("CLAUDE_CODE_ENTRYPOINT"))
+	if host := getEnv("CLAUDE_CODE_ENTRYPOINT"); host != "" {
+		return normalizeAgentHost(host)
+	}
+	// Codex Desktop sets this alongside the generic Codex signals; it is currently the
+	// only inherited value that separates Desktop from the Codex CLI.
+	if host := getEnv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE"); host != "" {
+		return normalizeAgentHost(host)
+	}
+	return ""
 }
 
 // DetectMacAppBundleID returns the bundle identifier of the macOS application that
@@ -200,6 +208,13 @@ const maxEnvValueLength = 64
 //
 // Private functions
 //
+
+// normalizeAgentHost lowercases and dash-separates a reported host so that values
+// from different vendors land in one comparable column: Claude Code reports
+// "claude-desktop" while Codex Desktop reports "Codex Desktop".
+func normalizeAgentHost(host string) string {
+	return strings.ReplaceAll(strings.ToLower(sanitizeEnvValue(host)), " ", "-")
+}
 
 // sanitizeEnvValue trims an environment value, drops anything outside printable
 // ASCII, and truncates the result to maxEnvValueLength.

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -107,6 +107,10 @@ func DetectAIAgent(getEnv func(string) string) string {
 	if getEnv("CLINE_ACTIVE") != "" {
 		return "cline"
 	}
+	// Codex Desktop also sets the generic Codex env vars, so check its originator first.
+	if getEnv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE") == "Codex Desktop" {
+		return "codex_desktop"
+	}
 	if getEnv("CODEX_SANDBOX") != "" || getEnv("CODEX_THREAD_ID") != "" || getEnv("CODEX_SANDBOX_NETWORK_DISABLED") != "" || getEnv("CODEX_CI") != "" {
 		return "codex_cli"
 	}

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -162,6 +162,24 @@ func DetectAgentHost(getEnv func(string) string) string {
 	return ""
 }
 
+// AgentHostKind maps a host returned by DetectAgentHost to a coarse category, or ""
+// when the host is unset or not one we recognize.
+//
+// This is the curated counterpart to the free-form agent_host value, in the same way
+// that DetectAIAgent is the curated counterpart to DetectAIAgentRaw. It exists so that
+// a question like "how many invocations came from a desktop app" is one stable
+// predicate rather than a list of per-vendor spellings that has to be extended every
+// time a vendor ships a new host or renames an existing one.
+func AgentHostKind(host string) string {
+	// Remote hosts are matched first and by prefix: "remote-desktop" is a remote
+	// session, not the desktop app, so any substring match on "desktop" would
+	// silently conflate the two.
+	if host == "remote" || strings.HasPrefix(host, "remote-") {
+		return "remote"
+	}
+	return agentHostKinds[host]
+}
+
 // DetectMacAppBundleID returns the bundle identifier of the macOS application that
 // launched the process tree, or "" on other platforms and when unset.
 //
@@ -206,14 +224,39 @@ var encodedUserAgent string
 const maxEnvValueLength = 64
 
 //
+// Private variables
+//
+
+// agentHostKinds categorizes the hosts we know about. Hosts absent from this map are
+// still reported verbatim as agent_host; only the coarse category is omitted, so an
+// unrecognized host is a gap in grouping rather than lost data. "remote*" hosts are
+// handled by prefix in AgentHostKind rather than enumerated here.
+var agentHostKinds = map[string]string{
+	"claude-code-github-action": "ci",
+	"claude-desktop":            "desktop",
+	"claude-in-slack":           "chat",
+	"claude-in-teams":           "chat",
+	"claude-vscode":             "ide",
+	"cli":                       "terminal",
+	"codex-desktop":             "desktop",
+	"mcp":                       "mcp",
+	"sdk-cli":                   "sdk",
+	"sdk-py":                    "sdk",
+	"sdk-ts":                    "sdk",
+}
+
+//
 // Private functions
 //
 
-// normalizeAgentHost lowercases and dash-separates a reported host so that values
-// from different vendors land in one comparable column: Claude Code reports
-// "claude-desktop" while Codex Desktop reports "Codex Desktop".
+// normalizeAgentHost lowercases a reported host and collapses spaces and underscores
+// to dashes, so that values from different vendors land in one comparable column.
+// Claude Code reports "claude-desktop" while Codex Desktop reports "Codex Desktop",
+// and Claude Code is itself inconsistent: it ships both "claude_in_slack" and
+// "claude-in-slack", alongside dashed values like "claude-vscode".
 func normalizeAgentHost(host string) string {
-	return strings.ReplaceAll(strings.ToLower(sanitizeEnvValue(host)), " ", "-")
+	lowered := strings.ToLower(sanitizeEnvValue(host))
+	return strings.NewReplacer(" ", "-", "_", "-").Replace(lowered)
 }
 
 // sanitizeEnvValue trims an environment value, drops anything outside printable

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -163,7 +163,7 @@ func DetectAgentHost(getEnv func(string) string) string {
 	if host := getEnv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE"); host != "" {
 		return normalizeAgentHost(host)
 	}
-	return ""
+	return detectMacAppHost(getEnv)
 }
 
 // AgentHostKind maps a host returned by DetectAgentHost to a coarse category, or ""
@@ -184,17 +184,24 @@ func AgentHostKind(host string) string {
 	return agentHostKinds[host]
 }
 
-// DetectMacAppBundleID returns the bundle identifier of the macOS application that
-// launched the process tree, or "" on other platforms and when unset.
+// detectMacAppHost identifies the host from the macOS bundle identifier of the app
+// that launched the process tree, for the case where a desktop app invokes the CLI
+// without its coding agent in between -- an MCP server that shells out, for example --
+// and so sets none of the agent environment variables.
 //
 // macOS sets __CFBundleIdentifier when an app bundle launches a process, and child
-// processes inherit it. That inheritance means it identifies the GUI application at
-// the root of the session rather than the direct parent: launching from a terminal
-// emulator reports that emulator (e.g. "com.apple.Terminal"), and it is absent
-// entirely under ssh, cron, and CI. It is therefore a signal that *some* Mac app
-// started the session, not proof of who invoked the CLI.
-func DetectMacAppBundleID(getEnv func(string) string) string {
-	return sanitizeEnvValue(getEnv("__CFBundleIdentifier"))
+// processes inherit it, so it names the GUI app at the root of the session rather than
+// the direct parent. Only bundle IDs we explicitly recognize are mapped; every other
+// value, including terminal emulators, is ignored rather than reported. That keeps this
+// a narrow positive check instead of a general "which app launched us" field, whose
+// value would be unbounded and mostly terminal emulators.
+func detectMacAppHost(getEnv func(string) string) string {
+	// A terminal emulator between the app and the CLI means the session is a terminal
+	// one, whatever app happens to sit at the root of the tree.
+	if DetectTerminalProgram(getEnv) != "" {
+		return ""
+	}
+	return macAppHosts[sanitizeEnvValue(getEnv("__CFBundleIdentifier"))]
 }
 
 //
@@ -235,6 +242,18 @@ const maxEnvValueLength = 64
 // still reported verbatim as agent_host; only the coarse category is omitted, so an
 // unrecognized host is a gap in grouping rather than lost data. "remote*" hosts are
 // handled by prefix in AgentHostKind rather than enumerated here.
+// macAppHosts maps the bundle identifiers of desktop apps that can invoke the CLI to
+// the host they correspond to. Deliberately minimal: an unlisted bundle ID reports no
+// host at all, so adding an entry is a decision rather than a default.
+//
+// com.openai.codex is what ChatGPT.app itself ships as, verified against an installed
+// 26.730.61639 build -- OpenAI uses one bundle identifier for the desktop app, so this
+// cannot separate ChatGPT from Codex, only identify the OpenAI desktop app.
+var macAppHosts = map[string]string{
+	"com.anthropic.claudefordesktop": "claude-desktop",
+	"com.openai.codex":               "codex-desktop",
+}
+
 var agentHostKinds = map[string]string{
 	"claude-code-github-action": "ci",
 	"claude-desktop":            "desktop",

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -125,6 +125,48 @@ func DetectAIAgent(getEnv func(string) string) string {
 	return ""
 }
 
+// DetectAIAgentRaw returns the agent's self-reported identifier from the emerging
+// AI_AGENT/AGENT convention, or "" when unset. Unlike DetectAIAgent this is not a
+// curated value: any vendor adopting the convention shows up here without a CLI
+// release, at the cost of being unvalidated free text. Prefer DetectAIAgent for
+// grouping and treat this as supplementary.
+//
+// AI_AGENT is used by Vercel's detect-agent and set by Claude Code (which
+// deliberately does not overwrite another vendor's value). AGENT is used by Goose,
+// Amp, and Bun, and is being added to Codex. AGENT is the more collision-prone of
+// the two, so it is only consulted as a fallback.
+func DetectAIAgentRaw(getEnv func(string) string) string {
+	if agent := sanitizeEnvValue(getEnv("AI_AGENT")); agent != "" {
+		return agent
+	}
+	return sanitizeEnvValue(getEnv("AGENT"))
+}
+
+// DetectAgentHost returns the application hosting the coding agent, when the agent
+// reports one. This distinguishes a desktop or IDE-hosted agent from the same agent
+// running in a terminal, which DetectAIAgent alone cannot do.
+//
+// Values are passed through as reported rather than mapped to a fixed set, since the
+// set evolves outside this CLI. Known Claude Code values include "cli",
+// "claude-desktop", "claude-vscode", "mcp", "sdk-ts", "sdk-py", "local-agent",
+// "claude-code-github-action", and several "remote*" variants.
+func DetectAgentHost(getEnv func(string) string) string {
+	return sanitizeEnvValue(getEnv("CLAUDE_CODE_ENTRYPOINT"))
+}
+
+// DetectMacAppBundleID returns the bundle identifier of the macOS application that
+// launched the process tree, or "" on other platforms and when unset.
+//
+// macOS sets __CFBundleIdentifier when an app bundle launches a process, and child
+// processes inherit it. That inheritance means it identifies the GUI application at
+// the root of the session rather than the direct parent: launching from a terminal
+// emulator reports that emulator (e.g. "com.apple.Terminal"), and it is absent
+// entirely under ssh, cron, and CI. It is therefore a signal that *some* Mac app
+// started the session, not proof of who invoked the CLI.
+func DetectMacAppBundleID(getEnv func(string) string) string {
+	return sanitizeEnvValue(getEnv("__CFBundleIdentifier"))
+}
+
 //
 // Private types
 //
@@ -148,8 +190,33 @@ var encodedStripeUserAgent string
 var encodedUserAgent string
 
 //
+// Private constants
+//
+
+// maxEnvValueLength bounds free-form environment values before they are reported,
+// so an unexpected or hostile value cannot bloat a request.
+const maxEnvValueLength = 64
+
+//
 // Private functions
 //
+
+// sanitizeEnvValue trims an environment value, drops anything outside printable
+// ASCII, and truncates the result to maxEnvValueLength.
+func sanitizeEnvValue(value string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		if r < ' ' || r > '~' {
+			return -1
+		}
+		return r
+	}, strings.TrimSpace(value))
+
+	if len(cleaned) > maxEnvValueLength {
+		cleaned = cleaned[:maxEnvValueLength]
+	}
+
+	return cleaned
+}
 
 func init() {
 	initUserAgent()

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -129,17 +129,16 @@ func DetectAIAgent(getEnv func(string) string) string {
 	return ""
 }
 
-// DetectAIAgentRaw returns the agent's self-reported identifier from the emerging
-// AI_AGENT/AGENT convention, or "" when unset. Unlike DetectAIAgent this is not a
-// curated value: any vendor adopting the convention shows up here without a CLI
-// release, at the cost of being unvalidated free text. Prefer DetectAIAgent for
-// grouping and treat this as supplementary.
+// detectAIAgentRaw returns the agent's self-reported identifier from the emerging
+// AI_AGENT/AGENT convention, or "" when unset. It is deliberately unexported and never
+// reported as-is: it is unvalidated free text from the environment, and only the
+// version parsed out of it by DetectAgentVersion leaves the machine.
 //
 // AI_AGENT is used by Vercel's detect-agent and set by Claude Code (which
 // deliberately does not overwrite another vendor's value). AGENT is used by Goose,
 // Amp, and Bun, and is being added to Codex. AGENT is the more collision-prone of
 // the two, so it is only consulted as a fallback.
-func DetectAIAgentRaw(getEnv func(string) string) string {
+func detectAIAgentRaw(getEnv func(string) string) string {
 	if agent := sanitizeEnvValue(getEnv("AI_AGENT")); agent != "" {
 		return agent
 	}
@@ -170,7 +169,7 @@ func DetectAgentHost(getEnv func(string) string) string {
 // when the host is unset or not one we recognize.
 //
 // This is the curated counterpart to the free-form agent_host value, in the same way
-// that DetectAIAgent is the curated counterpart to DetectAIAgentRaw. It exists so that
+// that DetectAIAgent is curated rather than free text. It exists so that
 // a question like "how many invocations came from a desktop app" is one stable
 // predicate rather than a list of per-vendor spellings that has to be extended every
 // time a vendor ships a new host or renames an existing one.
@@ -207,7 +206,7 @@ func DetectAgentHostKind(getEnv func(string) string) string {
 // The format is undocumented, so this validates what it extracts and reports nothing
 // rather than guessing.
 func DetectAgentVersion(getEnv func(string) string) string {
-	identifier := DetectAIAgentRaw(getEnv)
+	identifier := detectAIAgentRaw(getEnv)
 	if identifier == "" {
 		return ""
 	}

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -175,13 +175,57 @@ func DetectAgentHost(getEnv func(string) string) string {
 // predicate rather than a list of per-vendor spellings that has to be extended every
 // time a vendor ships a new host or renames an existing one.
 func AgentHostKind(host string) string {
+	if host == "" {
+		return ""
+	}
 	// Remote hosts are matched first and by prefix: "remote-desktop" is a remote
 	// session, not the desktop app, so any substring match on "desktop" would
 	// silently conflate the two.
 	if host == "remote" || strings.HasPrefix(host, "remote-") {
 		return "remote"
 	}
-	return agentHostKinds[host]
+	if kind, ok := agentHostKinds[host]; ok {
+		return kind
+	}
+	return agentHostKindOther
+}
+
+// DetectAgentHostKind reports the category of the host that invoked the CLI. This is
+// the single host signal reported in telemetry: the underlying host string is a
+// per-vendor spelling that callers would have to enumerate, whereas the category is a
+// bounded set, and the vendor is already carried by DetectAIAgent.
+func DetectAgentHostKind(getEnv func(string) string) string {
+	return AgentHostKind(DetectAgentHost(getEnv))
+}
+
+// DetectAgentVersion returns the agent's own version, parsed out of the identifier it
+// reports through the AI_AGENT convention, or "" when absent or unparseable.
+//
+// Claude Code encodes it as "claude-code_2-1-222_agent" (dots written as dashes) and
+// has also used a "claude-code/2.1.222" form. No other agent reports a version this
+// way today, so in practice this is populated for Claude Code and empty elsewhere.
+// The format is undocumented, so this validates what it extracts and reports nothing
+// rather than guessing.
+func DetectAgentVersion(getEnv func(string) string) string {
+	identifier := DetectAIAgentRaw(getEnv)
+	if identifier == "" {
+		return ""
+	}
+
+	// "claude-code/2.1.222" -- everything after the last slash.
+	if idx := strings.LastIndex(identifier, "/"); idx >= 0 {
+		return validVersion(strings.TrimSpace(identifier[idx+1:]))
+	}
+
+	// "claude-code_2-1-222_agent" -- the first underscore-delimited segment that reads
+	// as a version once dashes are treated as dots.
+	for _, segment := range strings.Split(identifier, "_") {
+		if version := validVersion(strings.ReplaceAll(segment, "-", ".")); version != "" {
+			return version
+		}
+	}
+
+	return ""
 }
 
 // detectMacAppHost identifies the host from the macOS bundle identifier of the app
@@ -234,14 +278,15 @@ var encodedUserAgent string
 // so an unexpected or hostile value cannot bloat a request.
 const maxEnvValueLength = 64
 
+// agentHostKindOther is reported when a host was detected but is not one we
+// categorize. It keeps the field bounded while still making a new or renamed host
+// visible, which reporting "" would not.
+const agentHostKindOther = "other"
+
 //
 // Private variables
 //
 
-// agentHostKinds categorizes the hosts we know about. Hosts absent from this map are
-// still reported verbatim as agent_host; only the coarse category is omitted, so an
-// unrecognized host is a gap in grouping rather than lost data. "remote*" hosts are
-// handled by prefix in AgentHostKind rather than enumerated here.
 // macAppHosts maps the bundle identifiers of desktop apps that can invoke the CLI to
 // the host they correspond to. Deliberately minimal: an unlisted bundle ID reports no
 // host at all, so adding an entry is a decision rather than a default.
@@ -254,6 +299,8 @@ var macAppHosts = map[string]string{
 	"com.openai.codex":               "codex-desktop",
 }
 
+// agentHostKinds categorizes the hosts we know about. "remote*" hosts are handled by
+// prefix in AgentHostKind rather than enumerated here.
 var agentHostKinds = map[string]string{
 	"claude-code-github-action": "ci",
 	"claude-desktop":            "desktop",
@@ -271,6 +318,32 @@ var agentHostKinds = map[string]string{
 //
 // Private functions
 //
+
+// validVersion returns the candidate if it is a dot-separated numeric version, and ""
+// otherwise. Deliberately strict: the identifier formats this parses are undocumented,
+// and a wrong version is worse than a missing one.
+func validVersion(candidate string) string {
+	if candidate == "" || strings.HasPrefix(candidate, ".") || strings.HasSuffix(candidate, ".") {
+		return ""
+	}
+
+	digits := false
+	for _, r := range candidate {
+		switch {
+		case r >= '0' && r <= '9':
+			digits = true
+		case r == '.':
+		default:
+			return ""
+		}
+	}
+
+	if !digits || strings.Contains(candidate, "..") {
+		return ""
+	}
+
+	return candidate
+}
 
 // normalizeAgentHost lowercases a reported host and collapses spaces and underscores
 // to dashes, so that values from different vendors land in one comparable column.

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -197,7 +197,7 @@ func TestAgentHostKind(t *testing.T) {
 		// remote-desktop is a remote session, not the desktop app. A substring match on
 		// "desktop" would report this as desktop and quietly inflate desktop counts.
 		{"remote desktop is remote", "remote-desktop", "remote"},
-		{"unknown host", "some-future-host", ""},
+		{"unknown host reports other", "some-future-host", "other"},
 		{"empty", "", ""},
 	}
 
@@ -214,6 +214,57 @@ func TestAgentHostKind_CoversEveryKnownHost(t *testing.T) {
 	for host, kind := range agentHostKinds {
 		require.Equal(t, kind, AgentHostKind(host), "host %q", host)
 		require.Equal(t, host, normalizeAgentHost(host), "map key %q is not normalized", host)
+	}
+}
+
+func TestDetectAgentVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		envs     map[string]string
+		expected string
+	}{
+		{"claude code underscore form", map[string]string{"AI_AGENT": "claude-code_2-1-222_agent"}, "2.1.222"},
+		{"claude code harness role", map[string]string{"AI_AGENT": "claude-code_2-1-222_harness"}, "2.1.222"},
+		{"claude code slash form", map[string]string{"AI_AGENT": "claude-code/2.1.222"}, "2.1.222"},
+		{"agent fallback var", map[string]string{"AGENT": "goose_1-2-3"}, "1.2.3"},
+		{"no version reported", map[string]string{"AI_AGENT": "goose"}, ""},
+		{"unset", map[string]string{}, ""},
+		// A wrong version is worse than a missing one, so anything that is not a plain
+		// dot-separated number is rejected rather than guessed at.
+		{"non numeric segment rejected", map[string]string{"AI_AGENT": "claude-code_beta_agent"}, ""},
+		{"slash form with junk rejected", map[string]string{"AI_AGENT": "claude-code/v2.1.222"}, ""},
+		{"trailing dot rejected", map[string]string{"AI_AGENT": "claude-code/2.1."}, ""},
+		{"double dot rejected", map[string]string{"AI_AGENT": "claude-code/2..1"}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetectAgentVersion(mapEnv(tt.envs))
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetectAgentHostKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		envs     map[string]string
+		expected string
+	}{
+		{"claude desktop", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop"}, "desktop"},
+		{"codex desktop", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "desktop"},
+		{"desktop via bundle id", map[string]string{"__CFBundleIdentifier": "com.openai.codex"}, "desktop"},
+		{"terminal", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"}, "terminal"},
+		{"remote not desktop", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "remote_desktop"}, "remote"},
+		{"unknown host", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "something-new"}, "other"},
+		{"no host", map[string]string{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetectAgentHostKind(mapEnv(tt.envs))
+			require.Equal(t, tt.expected, result)
+		})
 	}
 }
 

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -147,7 +147,7 @@ func TestDetectAIAgentRaw(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := DetectAIAgentRaw(mapEnv(tt.envs))
+			result := detectAIAgentRaw(mapEnv(tt.envs))
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -327,5 +327,125 @@ func TestMacAppHosts_AllCategorizeAsDesktop(t *testing.T) {
 func mapEnv(envs map[string]string) func(string) string {
 	return func(key string) string {
 		return envs[key]
+	}
+}
+
+// TestObservedAgentSessions pins the detectors against environments captured from real
+// agent sessions, so a vendor changing what it exports shows up here as a failure
+// rather than as a silent gap in reporting.
+func TestObservedAgentSessions(t *testing.T) {
+	tests := []struct {
+		name        string
+		envs        map[string]string
+		agent       string
+		hostKind    string
+		version     string
+		description string
+	}{
+		{
+			name: "claude code in claude desktop, macos",
+			envs: map[string]string{
+				"CLAUDECODE":                  "1",
+				"AI_AGENT":                    "claude-code_2-1-222_agent",
+				"CLAUDE_CODE_ENTRYPOINT":      "claude-desktop",
+				"CLAUDE_AGENT_SDK_VERSION":    "0.3.222",
+				"CLAUDE_CODE_SESSION_ID":      sensitiveSessionID,
+				"CLAUDE_CODE_HOST_SESSION_ID": sensitiveHostID,
+				"__CFBundleIdentifier":        "com.anthropic.claudefordesktop",
+			},
+			agent:    "claude_code",
+			hostKind: "desktop",
+			version:  "2.1.222",
+		},
+		{
+			name: "claude code in claude desktop, windows",
+			envs: map[string]string{
+				"CLAUDECODE":               "1",
+				"AI_AGENT":                 "claude-code_2-1-227_agent",
+				"CLAUDE_CODE_ENTRYPOINT":   "claude-desktop",
+				"CLAUDE_AGENT_SDK_VERSION": "0.3.227",
+				"CLAUDE_CODE_SESSION_ID":   sensitiveSessionID,
+				"CLAUDE_CODE_OAUTH_SCOPES": sensitiveScopes,
+			},
+			agent:       "claude_code",
+			hostKind:    "desktop",
+			version:     "2.1.227",
+			description: "no __CFBundleIdentifier on Windows; the env vars carry it",
+		},
+		{
+			name: "codex desktop, windows",
+			envs: map[string]string{
+				"CODEX_CI":                           "1",
+				"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop",
+				"CODEX_THREAD_ID":                    sensitiveThreadID,
+				"CODEX_PERMISSION_PROFILE":           ":read-only",
+				"CODEX_SANDBOX_NETWORK_DISABLED":     "1",
+			},
+			agent:       "codex_desktop",
+			hostKind:    "desktop",
+			version:     "",
+			description: "Desktop also sets the generic Codex signals, so originator must be checked first",
+		},
+		{
+			name: "codex cli",
+			envs: map[string]string{
+				"CODEX_THREAD_ID": sensitiveThreadID,
+				"CODEX_SANDBOX":   "1",
+			},
+			agent:    "codex_cli",
+			hostKind: "",
+			version:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getEnv := mapEnv(tt.envs)
+			require.Equal(t, tt.agent, DetectAIAgent(getEnv), tt.description)
+			require.Equal(t, tt.hostKind, DetectAgentHostKind(getEnv), tt.description)
+			require.Equal(t, tt.version, DetectAgentVersion(getEnv), tt.description)
+		})
+	}
+}
+
+// Distinctive stand-ins for the per-session values these products export, so
+// TestObservedAgentSessions_NoSensitiveValuesReported can assert none of them reach a
+// reported field.
+const (
+	sensitiveSessionID = "SESSIONID-1111"
+	sensitiveHostID    = "HOSTID-2222"
+	sensitiveThreadID  = "THREADID-3333"
+	sensitiveScopes    = "SCOPES-4444"
+)
+
+func TestObservedAgentSessions_NoSensitiveValuesReported(t *testing.T) {
+	// Session, thread, host and scope values must never leave the machine. Several are
+	// read as presence checks during detection, so assert on what is reported rather
+	// than on what is read.
+	envs := map[string]string{
+		"CLAUDECODE":                         "1",
+		"AI_AGENT":                           "claude-code_2-1-227_agent",
+		"CLAUDE_CODE_ENTRYPOINT":             "claude-desktop",
+		"CLAUDE_CODE_SESSION_ID":             sensitiveSessionID,
+		"CLAUDE_CODE_HOST_SESSION_ID":        sensitiveHostID,
+		"CLAUDE_CODE_OAUTH_SCOPES":           sensitiveScopes,
+		"CODEX_THREAD_ID":                    sensitiveThreadID,
+		"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop",
+		"CODEX_PERMISSION_PROFILE":           ":read-only",
+	}
+	getEnv := mapEnv(envs)
+
+	reported := []string{
+		DetectAIAgent(getEnv),
+		DetectAgentHostKind(getEnv),
+		DetectAgentVersion(getEnv),
+		DetectInstallMethod(getEnv, errExe, noStat),
+		DetectTerminalProgram(getEnv),
+	}
+
+	for _, secret := range []string{sensitiveSessionID, sensitiveHostID, sensitiveThreadID, sensitiveScopes} {
+		for _, value := range reported {
+			require.NotContains(t, value, secret)
+		}
 	}
 }

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -129,91 +129,29 @@ func TestDetectTerminalProgram(t *testing.T) {
 	}
 }
 
-func TestDetectAIAgentRaw(t *testing.T) {
+func TestDetectAgentHostKind(t *testing.T) {
 	tests := []struct {
 		name     string
 		envs     map[string]string
 		expected string
 	}{
-		{"ai_agent", map[string]string{"AI_AGENT": "claude-code_2-1-222_agent"}, "claude-code_2-1-222_agent"},
-		{"agent fallback", map[string]string{"AGENT": "goose"}, "goose"},
-		{"ai_agent wins over agent", map[string]string{"AI_AGENT": "amp", "AGENT": "goose"}, "amp"},
-		{"blank ai_agent falls back", map[string]string{"AI_AGENT": "  ", "AGENT": "goose"}, "goose"},
-		{"unset", map[string]string{}, ""},
-		{"trimmed", map[string]string{"AI_AGENT": "  cursor\n"}, "cursor"},
-		{"non printable stripped", map[string]string{"AI_AGENT": "cur\x00so\tré"}, "cursor"},
-		{"truncated", map[string]string{"AI_AGENT": strings.Repeat("a", 100)}, strings.Repeat("a", 64)},
+		{"claude desktop", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop"}, "desktop"},
+		{"codex desktop, normalized from \"Codex Desktop\"", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "desktop"},
+		{"terminal", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"}, "terminal"},
+		{"ide", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-vscode"}, "ide"},
+		{"sdk", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "sdk-ts"}, "sdk"},
+		// remote-desktop is a remote session, not the desktop app. Matching "desktop"
+		// anywhere would report this as desktop and quietly inflate desktop counts.
+		{"remote desktop is remote", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "remote_desktop"}, "remote"},
+		{"agent env wins over codex", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "terminal"},
+		{"uncategorized host", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "something-new"}, "other"},
+		{"no host", map[string]string{}, ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := detectAIAgentRaw(mapEnv(tt.envs))
-			require.Equal(t, tt.expected, result)
+			require.Equal(t, tt.expected, DetectAgentHostKind(mapEnv(tt.envs)))
 		})
-	}
-}
-
-func TestDetectAgentHost(t *testing.T) {
-	tests := []struct {
-		name     string
-		envs     map[string]string
-		expected string
-	}{
-		{"desktop", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop"}, "claude-desktop"},
-		{"cli", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"}, "cli"},
-		{"mcp", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "mcp"}, "mcp"},
-		{"codex desktop normalized", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "codex-desktop"},
-		{"claude wins over codex", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "cli"},
-		{"underscores collapse to dashes", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude_in_slack"}, "claude-in-slack"},
-		{"both slack spellings agree", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-in-slack"}, "claude-in-slack"},
-		{"unset", map[string]string{}, ""},
-		{"sanitized", map[string]string{"CLAUDE_CODE_ENTRYPOINT": " claude-vscode "}, "claude-vscode"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := DetectAgentHost(mapEnv(tt.envs))
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestAgentHostKind(t *testing.T) {
-	tests := []struct {
-		name     string
-		host     string
-		expected string
-	}{
-		{"claude desktop", "claude-desktop", "desktop"},
-		{"codex desktop", "codex-desktop", "desktop"},
-		{"cli", "cli", "terminal"},
-		{"vscode", "claude-vscode", "ide"},
-		{"mcp", "mcp", "mcp"},
-		{"sdk", "sdk-ts", "sdk"},
-		{"github action", "claude-code-github-action", "ci"},
-		{"slack", "claude-in-slack", "chat"},
-		{"bare remote", "remote", "remote"},
-		{"remote variant", "remote-cowork", "remote"},
-		// remote-desktop is a remote session, not the desktop app. A substring match on
-		// "desktop" would report this as desktop and quietly inflate desktop counts.
-		{"remote desktop is remote", "remote-desktop", "remote"},
-		{"unknown host reports other", "some-future-host", "other"},
-		{"empty", "", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := AgentHostKind(tt.host)
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestAgentHostKind_CoversEveryKnownHost(t *testing.T) {
-	// Every host in the map must categorize, so a typo'd key cannot sit unnoticed.
-	for host, kind := range agentHostKinds {
-		require.Equal(t, kind, AgentHostKind(host), "host %q", host)
-		require.Equal(t, host, normalizeAgentHost(host), "map key %q is not normalized", host)
 	}
 }
 
@@ -235,6 +173,7 @@ func TestDetectAgentVersion(t *testing.T) {
 		{"slash form with junk rejected", map[string]string{"AI_AGENT": "claude-code/v2.1.222"}, ""},
 		{"trailing dot rejected", map[string]string{"AI_AGENT": "claude-code/2.1."}, ""},
 		{"double dot rejected", map[string]string{"AI_AGENT": "claude-code/2..1"}, ""},
+		{"overlong rejected", map[string]string{"AI_AGENT": "claude-code/" + strings.Repeat("1.", 40)}, ""},
 	}
 
 	for _, tt := range tests {
@@ -242,85 +181,6 @@ func TestDetectAgentVersion(t *testing.T) {
 			result := DetectAgentVersion(mapEnv(tt.envs))
 			require.Equal(t, tt.expected, result)
 		})
-	}
-}
-
-func TestDetectAgentHostKind(t *testing.T) {
-	tests := []struct {
-		name     string
-		envs     map[string]string
-		expected string
-	}{
-		{"claude desktop", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop"}, "desktop"},
-		{"codex desktop", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "desktop"},
-		{"desktop via bundle id", map[string]string{"__CFBundleIdentifier": "com.openai.codex"}, "desktop"},
-		{"terminal", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"}, "terminal"},
-		{"remote not desktop", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "remote_desktop"}, "remote"},
-		{"unknown host", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "something-new"}, "other"},
-		{"no host", map[string]string{}, ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := DetectAgentHostKind(mapEnv(tt.envs))
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestDetectAgentHost_MacAppFallback(t *testing.T) {
-	tests := []struct {
-		name     string
-		envs     map[string]string
-		expected string
-	}{
-		{
-			"claude desktop with no agent env",
-			map[string]string{"__CFBundleIdentifier": "com.anthropic.claudefordesktop"},
-			"claude-desktop",
-		},
-		{
-			"chatgpt desktop ships the codex bundle id",
-			map[string]string{"__CFBundleIdentifier": "com.openai.codex"},
-			"codex-desktop",
-		},
-		{
-			// The bundle ID is inherited by the whole process tree, so a terminal
-			// emulator in between makes this a terminal session regardless of which
-			// app sits at the root.
-			"terminal program suppresses the fallback",
-			map[string]string{"__CFBundleIdentifier": "com.anthropic.claudefordesktop", "TERM_PROGRAM": "iTerm.app"},
-			"",
-		},
-		{
-			// Reporting terminal emulators here would make agent_host mostly a list of
-			// terminals, which is the field we chose not to add.
-			"unrecognized bundle id is ignored",
-			map[string]string{"__CFBundleIdentifier": "com.apple.Terminal"},
-			"",
-		},
-		{
-			"agent env wins over bundle id",
-			map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli", "__CFBundleIdentifier": "com.anthropic.claudefordesktop"},
-			"cli",
-		},
-		{"unset", map[string]string{}, ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := DetectAgentHost(mapEnv(tt.envs))
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestMacAppHosts_AllCategorizeAsDesktop(t *testing.T) {
-	// Every app we recognize is a desktop app, so each must reach the desktop
-	// category through the same path a real invocation takes.
-	for bundleID, host := range macAppHosts {
-		require.Equal(t, host, normalizeAgentHost(host), "host %q is not normalized", host)
-		require.Equal(t, "desktop", AgentHostKind(host), "bundle %q", bundleID)
 	}
 }
 
@@ -351,7 +211,6 @@ func TestObservedAgentSessions(t *testing.T) {
 				"CLAUDE_AGENT_SDK_VERSION":    "0.3.222",
 				"CLAUDE_CODE_SESSION_ID":      sensitiveSessionID,
 				"CLAUDE_CODE_HOST_SESSION_ID": sensitiveHostID,
-				"__CFBundleIdentifier":        "com.anthropic.claudefordesktop",
 			},
 			agent:    "claude_code",
 			hostKind: "desktop",
@@ -381,10 +240,10 @@ func TestObservedAgentSessions(t *testing.T) {
 				"CODEX_PERMISSION_PROFILE":           ":read-only",
 				"CODEX_SANDBOX_NETWORK_DISABLED":     "1",
 			},
-			agent:       "codex_desktop",
+			agent:       "codex_cli",
 			hostKind:    "desktop",
 			version:     "",
-			description: "Desktop also sets the generic Codex signals, so originator must be checked first",
+			description: "Desktop also sets the generic Codex signals; the host is what distinguishes it",
 		},
 		{
 			name: "codex cli",

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -217,23 +217,59 @@ func TestAgentHostKind_CoversEveryKnownHost(t *testing.T) {
 	}
 }
 
-func TestDetectMacAppBundleID(t *testing.T) {
+func TestDetectAgentHost_MacAppFallback(t *testing.T) {
 	tests := []struct {
 		name     string
 		envs     map[string]string
 		expected string
 	}{
-		{"claude desktop", map[string]string{"__CFBundleIdentifier": "com.anthropic.claudefordesktop"}, "com.anthropic.claudefordesktop"},
-		{"terminal", map[string]string{"__CFBundleIdentifier": "com.apple.Terminal"}, "com.apple.Terminal"},
-		{"unset elsewhere", map[string]string{}, ""},
-		{"truncated", map[string]string{"__CFBundleIdentifier": strings.Repeat("c", 100)}, strings.Repeat("c", 64)},
+		{
+			"claude desktop with no agent env",
+			map[string]string{"__CFBundleIdentifier": "com.anthropic.claudefordesktop"},
+			"claude-desktop",
+		},
+		{
+			"chatgpt desktop ships the codex bundle id",
+			map[string]string{"__CFBundleIdentifier": "com.openai.codex"},
+			"codex-desktop",
+		},
+		{
+			// The bundle ID is inherited by the whole process tree, so a terminal
+			// emulator in between makes this a terminal session regardless of which
+			// app sits at the root.
+			"terminal program suppresses the fallback",
+			map[string]string{"__CFBundleIdentifier": "com.anthropic.claudefordesktop", "TERM_PROGRAM": "iTerm.app"},
+			"",
+		},
+		{
+			// Reporting terminal emulators here would make agent_host mostly a list of
+			// terminals, which is the field we chose not to add.
+			"unrecognized bundle id is ignored",
+			map[string]string{"__CFBundleIdentifier": "com.apple.Terminal"},
+			"",
+		},
+		{
+			"agent env wins over bundle id",
+			map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli", "__CFBundleIdentifier": "com.anthropic.claudefordesktop"},
+			"cli",
+		},
+		{"unset", map[string]string{}, ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := DetectMacAppBundleID(mapEnv(tt.envs))
+			result := DetectAgentHost(mapEnv(tt.envs))
 			require.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+func TestMacAppHosts_AllCategorizeAsDesktop(t *testing.T) {
+	// Every app we recognize is a desktop app, so each must reach the desktop
+	// category through the same path a real invocation takes.
+	for bundleID, host := range macAppHosts {
+		require.Equal(t, host, normalizeAgentHost(host), "host %q is not normalized", host)
+		require.Equal(t, "desktop", AgentHostKind(host), "bundle %q", bundleID)
 	}
 }
 

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -162,6 +162,8 @@ func TestDetectAgentHost(t *testing.T) {
 		{"desktop", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop"}, "claude-desktop"},
 		{"cli", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"}, "cli"},
 		{"mcp", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "mcp"}, "mcp"},
+		{"codex desktop normalized", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "codex-desktop"},
+		{"claude wins over codex", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "cli"},
 		{"unset", map[string]string{}, ""},
 		{"sanitized", map[string]string{"CLAUDE_CODE_ENTRYPOINT": " claude-vscode "}, "claude-vscode"},
 	}

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -2,6 +2,7 @@ package useragent
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -123,6 +124,71 @@ func TestDetectTerminalProgram(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := DetectTerminalProgram(mapEnv(tt.envs))
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetectAIAgentRaw(t *testing.T) {
+	tests := []struct {
+		name     string
+		envs     map[string]string
+		expected string
+	}{
+		{"ai_agent", map[string]string{"AI_AGENT": "claude-code_2-1-222_agent"}, "claude-code_2-1-222_agent"},
+		{"agent fallback", map[string]string{"AGENT": "goose"}, "goose"},
+		{"ai_agent wins over agent", map[string]string{"AI_AGENT": "amp", "AGENT": "goose"}, "amp"},
+		{"blank ai_agent falls back", map[string]string{"AI_AGENT": "  ", "AGENT": "goose"}, "goose"},
+		{"unset", map[string]string{}, ""},
+		{"trimmed", map[string]string{"AI_AGENT": "  cursor\n"}, "cursor"},
+		{"non printable stripped", map[string]string{"AI_AGENT": "cur\x00so\tré"}, "cursor"},
+		{"truncated", map[string]string{"AI_AGENT": strings.Repeat("a", 100)}, strings.Repeat("a", 64)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetectAIAgentRaw(mapEnv(tt.envs))
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetectAgentHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		envs     map[string]string
+		expected string
+	}{
+		{"desktop", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop"}, "claude-desktop"},
+		{"cli", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"}, "cli"},
+		{"mcp", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "mcp"}, "mcp"},
+		{"unset", map[string]string{}, ""},
+		{"sanitized", map[string]string{"CLAUDE_CODE_ENTRYPOINT": " claude-vscode "}, "claude-vscode"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetectAgentHost(mapEnv(tt.envs))
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetectMacAppBundleID(t *testing.T) {
+	tests := []struct {
+		name     string
+		envs     map[string]string
+		expected string
+	}{
+		{"claude desktop", map[string]string{"__CFBundleIdentifier": "com.anthropic.claudefordesktop"}, "com.anthropic.claudefordesktop"},
+		{"terminal", map[string]string{"__CFBundleIdentifier": "com.apple.Terminal"}, "com.apple.Terminal"},
+		{"unset elsewhere", map[string]string{}, ""},
+		{"truncated", map[string]string{"__CFBundleIdentifier": strings.Repeat("c", 100)}, strings.Repeat("c", 64)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetectMacAppBundleID(mapEnv(tt.envs))
 			require.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -164,6 +164,8 @@ func TestDetectAgentHost(t *testing.T) {
 		{"mcp", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "mcp"}, "mcp"},
 		{"codex desktop normalized", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "codex-desktop"},
 		{"claude wins over codex", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "cli"},
+		{"underscores collapse to dashes", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude_in_slack"}, "claude-in-slack"},
+		{"both slack spellings agree", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-in-slack"}, "claude-in-slack"},
 		{"unset", map[string]string{}, ""},
 		{"sanitized", map[string]string{"CLAUDE_CODE_ENTRYPOINT": " claude-vscode "}, "claude-vscode"},
 	}
@@ -173,6 +175,45 @@ func TestDetectAgentHost(t *testing.T) {
 			result := DetectAgentHost(mapEnv(tt.envs))
 			require.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+func TestAgentHostKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{"claude desktop", "claude-desktop", "desktop"},
+		{"codex desktop", "codex-desktop", "desktop"},
+		{"cli", "cli", "terminal"},
+		{"vscode", "claude-vscode", "ide"},
+		{"mcp", "mcp", "mcp"},
+		{"sdk", "sdk-ts", "sdk"},
+		{"github action", "claude-code-github-action", "ci"},
+		{"slack", "claude-in-slack", "chat"},
+		{"bare remote", "remote", "remote"},
+		{"remote variant", "remote-cowork", "remote"},
+		// remote-desktop is a remote session, not the desktop app. A substring match on
+		// "desktop" would report this as desktop and quietly inflate desktop counts.
+		{"remote desktop is remote", "remote-desktop", "remote"},
+		{"unknown host", "some-future-host", ""},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AgentHostKind(tt.host)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAgentHostKind_CoversEveryKnownHost(t *testing.T) {
+	// Every host in the map must categorize, so a typo'd key cannot sit unnoticed.
+	for host, kind := range agentHostKinds {
+		require.Equal(t, kind, AgentHostKind(host), "host %q", host)
+		require.Equal(t, host, normalizeAgentHost(host), "map key %q is not normalized", host)
 	}
 }
 


### PR DESCRIPTION
> **Supersedes #1889**, which is merged into this branch.

## Why

`DetectAIAgent` can't tell a desktop-hosted agent from a terminal one — Claude Code in Claude Desktop and Claude Code in iTerm both report exactly `ai_agent=claude_code`. The agents already export the answer and we drop it on the floor.

Environments captured from real sessions across both vendors and both platforms:

| variable | Claude Desktop (macOS) | Claude Desktop (Windows) | Codex Desktop (Windows) |
|---|---|---|---|
| `CLAUDECODE` | `1` | `1` | — |
| `CLAUDE_CODE_ENTRYPOINT` | `claude-desktop` | `claude-desktop` | — |
| `AI_AGENT` | `claude-code_2-1-222_agent` | `claude-code_2-1-227_agent` | — |
| `CODEX_INTERNAL_ORIGINATOR_OVERRIDE` | — | — | `Codex Desktop` |
| `CODEX_CI` | — | — | `1` |
| `TERM_PROGRAM` | *(unset)* | *(unset)* | *(unset)* |

Two things these settle. The Claude version format is **stable across builds** — the same parse handles `2-1-222` and `2-1-227` — so `agent_version` isn't over-fit to one sample. And **Codex Desktop sets the generic Codex signals too** (`CODEX_CI=1`), so its originator variable is the only thing separating Desktop from the CLI.

Note the last row: with `TERM_PROGRAM` unset, a desktop-hosted run currently looks identical to a headless or piped terminal run.

## What

Two fields alongside the existing `ai_agent`, whose semantics are unchanged:

| field | values |
|---|---|
| `agent_host_kind` | `desktop`, `terminal`, `ide`, `remote`, `sdk`, `mcp`, `other` |
| `agent_host_raw` | the normalized host underneath the category, e.g. `claude-desktop-3p`, `sdk-ts` |
| `agent_version` | e.g. `2.1.227`, empty when the agent reports none |

```
agent_host_kind=desktop&agent_version=2.1.227&ai_agent=claude_code&...
```

The two host fields split by purpose: **group by `agent_host_kind`, drill into `agent_host_raw`.** Those are per-vendor spellings every consumer would have to enumerate, and the vendor is already carried by `ai_agent` — so `ai_agent` + `agent_host_kind` says "Claude Code, on desktop" in two columns instead of three. A host we don't categorize reports `other`, so a new or renamed host stays visible without the field being unbounded.

**`agent_host_raw` exists because the categories are deliberately coarse, and coarseness is not recoverable after the fact.** `claude-desktop` and `claude-desktop-3p` are both `desktop`; `sdk-ts` and `sdk-py` are both `sdk`. Without the raw value nothing downstream can tell them apart, and data collected without it simply doesn't contain the distinction.

It also solves a release-cycle problem. `agent_host_kind=other` says something is unmapped but not what — identifying it has meant reading a vendor's minified bundle, and mapping it then costs a code change, a release, and users upgrading, so an unmapped host is invisible for months. `claude-desktop-3p` was miscounted exactly that way until a grep happened to surface it. With the raw value it's answerable from the data.

Cardinality stays small: Claude Code ships 25 entrypoint values and Codex a handful. Normalization runs before reporting, so one host can't arrive under several spellings across platforms — a Windows `Codex Web` and a macOS `codex_web` both land as `codex-web`.

Two details worth a reviewer's eye:

- **`remote_desktop` is categorized as `remote`, not `desktop`.** Claude Code's own surface mapping labels `claude-desktop`, `claude-desktop-3p` and `remote_desktop` all as "Claude Desktop", but in the third the session executes remotely, so the CLI runs on the remote host rather than the user's machine — and this field describes where the CLI ran. Remote hosts are matched by prefix *before* the map so a substring match on `desktop` can't put them in the wrong bucket.
- **`agent_version` refuses to guess.** Claude Code encodes the version in `AI_AGENT` as `claude-code_2-1-227_agent` (dots as dashes) and has also used `claude-code/2.1.227`. Neither format is documented, so the parse validates and reports nothing on anything that isn't a plain dot-separated number: `v2.1.227`, `beta`, `2.1.`, `2..1` and overlong values all yield empty.

## What is deliberately not collected

Every reported value is a label from a fixed set, a validated version number, or the normalized host identifier.

| variable | handling |
|---|---|
| `CLAUDE_CODE_SESSION_ID`, `CLAUDE_CODE_HOST_SESSION_ID`, `CLAUDE_CODE_OAUTH_SCOPES`, `CODEX_PERMISSION_PROFILE` | never read |
| `CODEX_THREAD_ID`, `CODEX_SANDBOX_NETWORK_DISABLED`, `CODEX_CI` | presence checks only; values never captured |
| `CLAUDE_CODE_ENTRYPOINT`, `CODEX_INTERNAL_ORIGINATOR_OVERRIDE` | the derived category, plus the normalized value itself |
| `AI_AGENT` | only the parsed version number is reported |

`agent_host_raw` is the one field carrying a value not drawn from a fixed set, and it's worth flagging explicitly for review. It comes from two allowlisted variables whose stated purpose is self-identification — not session, thread, or auth data — and it's normalized, stripped to printable ASCII, and bounded to 32 characters.

`TestObservedAgentSessions_NoSensitiveValuesReported` asserts this on output rather than on access, since several of those variables genuinely are read during detection.

## Relationship to #1889

#1889 is merged here rather than landing separately. Its detection work is kept; its `codex_desktop` `ai_agent` value is not.

Adding `codex_desktop` to the enum would have encoded the host in two places, and made "how many Codex invocations" a list — `ai_agent IN ('codex_cli','codex_desktop')` — that grows with every new Codex host. `CODEX_INTERNAL_ORIGINATOR_OVERRIDE` is also internal and undocumented, so it drives the best-effort `agent_host_kind` rather than a value dashboards group by. Codex Desktop remains fully visible as `agent_host_kind=desktop`.

The cost: a Codex Desktop run reports `ai_agent=codex_cli`. That's the pre-existing wart of a host baked into an agent name; renaming it to `codex` breaks already-shipped data, so it belongs in its own change.

Also from #1889: per-variable Codex test coverage (`TestAIAgentDetection_AllAgents` previously only exercised `CODEX_SANDBOX`), and a fix to `TestUserAgent`, which asserted `^Stripe/v1 stripe-cli/\w+$` but fails whenever the suite is run from a coding agent — `initUserAgent` appends an `AIAgent/...` suffix. That was red on master for anyone running `make test` from Claude Code or Cursor.

## Testing

- `TestObservedAgentSessions` pins the detectors against the four captured environments above, so a vendor changing what it exports fails a test rather than silently degrading reporting.
- `TestObservedAgentSessions_NoSensitiveValuesReported` asserts no session, host, thread or scope value reaches a reported field.
- `agent_host_raw` reported for every host and empty only when no host was reported, including the `claude-desktop` vs `claude-desktop-3p` split, normalization, the 32-character bound, and non-printable stripping.
- Version parsing across both formats plus five rejection cases; host categorization including the `remote-desktop` trap and the `other` bucket.
- Telemetry assertions verified to actually execute via deliberate negative controls — they run inside an `httptest` handler, where a silently-skipped assertion would otherwise pass green.
- Full `go test ./...` green, `make lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
