### PR TITLE
Detect Codex Desktop invocations

### DIFF
--- a/pkg/cmd/templates_test.go
+++ b/pkg/cmd/templates_test.go
@@ -51,7 +51,7 @@ func TestIsAIAgent_Detected(t *testing.T) {
 
 func TestIsAIAgent_NotDetected(t *testing.T) {
 	// Ensure none of the agent env vars are set
-	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
+	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
 		t.Setenv(key, "")
 	}
 	assert.False(t, isAIAgent())
@@ -138,7 +138,7 @@ func TestAIAgentHelp_SubcommandOnly(t *testing.T) {
 }
 
 func TestAIAgentHelp_NotDetected(t *testing.T) {
-	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
+	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
 		t.Setenv(key, "")
 	}
 

--- a/pkg/cmd/unknown_cmd_telemetry_test.go
+++ b/pkg/cmd/unknown_cmd_telemetry_test.go
@@ -35,6 +35,7 @@ func (m *mockUnknownCmdTelemetryClient) SendEvent(_ context.Context, eventName s
 func TestRecordUnknownCommand_NotInAgentEnv(t *testing.T) {
 	t.Setenv("CLAUDECODE", "")
 	t.Setenv("CURSOR_AGENT", "")
+	t.Setenv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "")
 	t.Setenv("CODEX_SANDBOX", "")
 	t.Setenv("CODEX_THREAD_ID", "")
 	t.Setenv("CODEX_SANDBOX_NETWORK_DISABLED", "")

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -275,15 +275,20 @@ func TestAIAgentDetection_AllAgents(t *testing.T) {
 	tests := []struct {
 		name     string
 		envVar   string
+		envValue string
 		expected string
 	}{
-		{"Antigravity", "ANTIGRAVITY_CLI_ALIAS", "antigravity"},
-		{"Claude Code", "CLAUDECODE", "claude_code"},
-		{"Cline", "CLINE_ACTIVE", "cline"},
-		{"Codex CLI", "CODEX_SANDBOX", "codex_cli"},
-		{"Cursor", "CURSOR_AGENT", "cursor"},
-		{"Gemini CLI", "GEMINI_CLI", "gemini_cli"},
-		{"Open Code", "OPENCODE", "open_code"},
+		{"Antigravity", "ANTIGRAVITY_CLI_ALIAS", "true", "antigravity"},
+		{"Claude Code", "CLAUDECODE", "true", "claude_code"},
+		{"Cline", "CLINE_ACTIVE", "true", "cline"},
+		{"Codex Desktop", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "Codex Desktop", "codex_desktop"},
+		{"Codex CLI sandbox", "CODEX_SANDBOX", "true", "codex_cli"},
+		{"Codex CLI thread", "CODEX_THREAD_ID", "thread-id", "codex_cli"},
+		{"Codex CLI sandbox network", "CODEX_SANDBOX_NETWORK_DISABLED", "true", "codex_cli"},
+		{"Codex CLI CI", "CODEX_CI", "true", "codex_cli"},
+		{"Cursor", "CURSOR_AGENT", "true", "cursor"},
+		{"Gemini CLI", "GEMINI_CLI", "true", "gemini_cli"},
+		{"Open Code", "OPENCODE", "true", "open_code"},
 	}
 
 	for _, tt := range tests {
@@ -291,7 +296,7 @@ func TestAIAgentDetection_AllAgents(t *testing.T) {
 			// Mock env getter that returns only the specific env var being tested
 			getEnv := func(key string) string {
 				if key == tt.envVar {
-					return "true"
+					return tt.envValue
 				}
 				return ""
 			}
@@ -299,6 +304,22 @@ func TestAIAgentDetection_AllAgents(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestAIAgentDetection_CodexDesktopPriority(t *testing.T) {
+	getEnv := func(key string) string {
+		switch key {
+		case "CODEX_INTERNAL_ORIGINATOR_OVERRIDE":
+			return "Codex Desktop"
+		case "CODEX_THREAD_ID":
+			return "thread-id"
+		default:
+			return ""
+		}
+	}
+
+	result := useragent.DetectAIAgent(getEnv)
+	require.Equal(t, "codex_desktop", result)
 }
 
 func TestAIAgentDetection_Priority(t *testing.T) {

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -59,7 +59,7 @@ func TestAuthorize(t *testing.T) {
 
 func TestUserAgent(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Regexp(t, regexp.MustCompile(`^Stripe/v1 stripe-cli/\w+$`), r.Header.Get("User-Agent"))
+		require.Regexp(t, regexp.MustCompile(`^Stripe/v1 stripe-cli/\w+( AIAgent/\w+)?$`), r.Header.Get("User-Agent"))
 		w.Write([]byte(`{}`))
 	}))
 	defer ts.Close()

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -107,6 +107,10 @@ func DetectAIAgent(getEnv func(string) string) string {
 	if getEnv("CLINE_ACTIVE") != "" {
 		return "cline"
 	}
+	// Codex Desktop also sets the generic Codex env vars, so check its originator first.
+	if getEnv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE") == "Codex Desktop" {
+		return "codex_desktop"
+	}
 	if getEnv("CODEX_SANDBOX") != "" || getEnv("CODEX_THREAD_ID") != "" || getEnv("CODEX_SANDBOX_NETWORK_DISABLED") != "" || getEnv("CODEX_CI") != "" {
 		return "codex_cli"
 	}


### PR DESCRIPTION
### Summary

- report commands launched by Codex Desktop as `codex_desktop` when `CODEX_INTERNAL_ORIGINATOR_OVERRIDE=Codex Desktop`
- check the desktop origin before generic Codex signals because Desktop also sets `CODEX_THREAD_ID` and `CODEX_CI`
- add coverage for every Codex environment signal and allow the intentional AI-agent suffix in the Stripe auth User-Agent test

`CODEX_INTERNAL_ORIGINATOR_OVERRIDE` is internal rather than a documented public contract, but it is currently the only inherited signal that distinguishes Desktop from the Codex CLI. Matching the exact `Codex Desktop` value keeps the detection narrow.

### Testing

- `make test`
- `make lint`