### PR TITLE
Drop expected errors from Sentry reporting

### DIFF
--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -41,8 +41,13 @@ func Init(dsn, release string) error {
 
 // CaptureException reports err to the error reporting backend.
 func CaptureException(err error) {
+	category := classifyError(err)
+	if !shouldCapture(category) {
+		return
+	}
+
 	sentry.WithScope(func(scope *sentry.Scope) {
-		scope.SetTag("error_category", string(classifyError(err)))
+		scope.SetTag("error_category", string(category))
 		if accountIDProvider != nil {
 			if accountID, _ := accountIDProvider(); accountID != "" {
 				scope.SetTag("account_id", accountID)
@@ -67,6 +72,13 @@ func CaptureException(err error) {
 		scope.SetFingerprint([]string{caller, fmt.Sprintf("%T", root), root.Error()})
 		sentry.CaptureException(err)
 	})
+}
+
+// shouldCapture defines the reporting policy for classified errors. Auth covers
+// expected credential or authorization outcomes, not defects in authentication code;
+// callers can explicitly categorize actionable failures as internal, network, or API.
+func shouldCapture(category errorcategory.Category) bool {
+	return category != errorcategory.UserInput && category != errorcategory.Auth
 }
 
 // RecoverAndReport captures a recovered panic value to the error reporting backend.

--- a/pkg/reporting/reporting_test.go
+++ b/pkg/reporting/reporting_test.go
@@ -3,23 +3,92 @@ package reporting
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	sentry "github.com/getsentry/sentry-go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/requests"
 )
 
-func TestCaptureExceptionSetsErrorCategory(t *testing.T) {
+func TestCaptureExceptionSuppressesExpectedCategories(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "user input", err: context.Canceled},
+		{name: "auth", err: requests.RequestError{StatusCode: 401}},
+		{name: "wrapped user input", err: fmt.Errorf("wrapped: %w", context.Canceled)},
+		{name: "wrapped auth", err: fmt.Errorf("wrapped: %w", requests.RequestError{StatusCode: 403})},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport, restore := bindTestClient(t)
+			defer restore()
+
+			CaptureException(test.err)
+
+			require.Empty(t, transport.Events())
+		})
+	}
+}
+
+func TestCaptureExceptionCapturesActionableCategories(t *testing.T) {
+	categories := []errorcategory.Category{
+		errorcategory.Network,
+		errorcategory.API,
+		errorcategory.Filesystem,
+		errorcategory.Internal,
+	}
+
+	for _, category := range categories {
+		t.Run(string(category), func(t *testing.T) {
+			transport, restore := bindTestClient(t)
+			defer restore()
+
+			CaptureException(errorcategory.With(errors.New("actionable error"), category))
+
+			events := transport.Events()
+			require.Len(t, events, 1)
+			require.Equal(t, string(category), events[0].Tags["error_category"])
+		})
+	}
+}
+
+func TestCaptureExceptionCapturesUnknownErrorsAsInternal(t *testing.T) {
 	transport, restore := bindTestClient(t)
 	defer restore()
 
-	CaptureException(context.Canceled)
+	CaptureException(errors.New("unknown error"))
 
 	events := transport.Events()
 	require.Len(t, events, 1)
-	require.Equal(t, string(errorcategory.UserInput), events[0].Tags["error_category"])
+	require.Equal(t, string(errorcategory.Internal), events[0].Tags["error_category"])
+}
+
+func TestShouldCapture(t *testing.T) {
+	tests := []struct {
+		category errorcategory.Category
+		expected bool
+	}{
+		{category: errorcategory.UserInput, expected: false},
+		{category: errorcategory.Auth, expected: false},
+		{category: errorcategory.Network, expected: true},
+		{category: errorcategory.API, expected: true},
+		{category: errorcategory.Filesystem, expected: true},
+		{category: errorcategory.Internal, expected: true},
+		{category: errorcategory.Panic, expected: true},
+		{category: errorcategory.Category("unknown"), expected: true},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.category), func(t *testing.T) {
+			require.Equal(t, test.expected, shouldCapture(test.category))
+		})
+	}
 }
 
 func TestRecoverAndReportSetsIsolatedPanicCategory(t *testing.T) {


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Skip Sentry capture for errors categorized as user_input or auth