### PR TITLE
Simplify error message when mixing snapshot and thin events to same destination

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -491,10 +491,10 @@ func (lc *listenCmd) validateForwardingConfig(snapshotEvents, thinEvents []strin
 	hasThin := len(thinEvents) > 0
 	if hasSnapshot && hasThin {
 		if directURL != "" && directURL == forwardThinURL {
-			return fmt.Errorf("cannot forward both snapshot and thin events to the same destination; use --all-snapshot or --all-thin to subscribe to only one type")
+			return fmt.Errorf("cannot forward both snapshot and thin events to the same destination")
 		}
 		if connectURL != "" && connectURL == forwardThinConnectURL {
-			return fmt.Errorf("cannot forward both snapshot and thin events to the same connect destination; use --all-snapshot or --all-thin to subscribe to only one type")
+			return fmt.Errorf("cannot forward both snapshot and thin events to the same connect destination")
 		}
 	}
 


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Remove the misleading suggestion to use `--all-snapshot` or `--all-thin`, which doesn't match the user's intent when they've specified individual events. The error now just states the constraint without suggesting unrelated flags.