### PR TITLE
Add back navigation to the docs tui

### DIFF
--- a/pkg/docs/tui/keys.go
+++ b/pkg/docs/tui/keys.go
@@ -16,6 +16,7 @@ type KeyMap struct {
 	Search        key.Binding
 	Reference     key.Binding
 	OpenInBrowser key.Binding
+	Back          key.Binding
 	Enter         key.Binding
 }
 
@@ -29,7 +30,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down},
 		{k.PageUp, k.PageDown},
-		{k.OpenInBrowser},
+		{k.OpenInBrowser, k.Back},
 		{k.Search, k.Palette, k.Reference},
 		{k.Quit},
 	}
@@ -77,6 +78,11 @@ func DefaultKeyMap() KeyMap {
 		OpenInBrowser: key.NewBinding(
 			key.WithKeys("o"),
 			key.WithHelp("o", "open in browser"),
+		),
+		Back: key.NewBinding(
+			key.WithKeys("backspace"),
+			key.WithHelp("⌫", "back"),
+			key.WithDisabled(),
 		),
 		Enter: key.NewBinding(
 			key.WithKeys("enter"),

--- a/pkg/docs/tui/keys_test.go
+++ b/pkg/docs/tui/keys_test.go
@@ -22,7 +22,7 @@ func TestKeyMap_FullHelp(t *testing.T) {
 	assert.Len(t, groups, 5)
 	assert.Equal(t, []key.Binding{km.Up, km.Down}, groups[0])
 	assert.Equal(t, []key.Binding{km.PageUp, km.PageDown}, groups[1])
-	assert.Equal(t, []key.Binding{km.OpenInBrowser}, groups[2])
+	assert.Equal(t, []key.Binding{km.OpenInBrowser, km.Back}, groups[2])
 	assert.Equal(t, []key.Binding{km.Search, km.Palette, km.Reference}, groups[3])
 	assert.Equal(t, []key.Binding{km.Quit}, groups[4])
 }

--- a/pkg/docs/tui/model.go
+++ b/pkg/docs/tui/model.go
@@ -46,6 +46,11 @@ type pageLoadedMsg struct {
 	doc  *markdown.Document
 }
 
+type historyEntry struct {
+	page Page
+	doc  *markdown.Document
+}
+
 // Model is the top-level Bubble Tea model for the docs TUI.
 type Model struct {
 	// Components
@@ -62,9 +67,10 @@ type Model struct {
 	adaptiveWordWrap bool
 
 	// Content
-	page  Page
-	doc   *markdown.Document
-	title string
+	page    Page
+	doc     *markdown.Document
+	title   string
+	history []historyEntry
 
 	// Initial palette input (set via WithPaletteInput)
 	initialQuery string
@@ -251,9 +257,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case pageLoadedMsg:
-		return m.updateWithPage(Page{Content: msg.page.Content, URL: msg.page.URL}, msg.doc, m.ready)
+		return m.updateWithPage(Page{Content: msg.page.Content, URL: msg.page.URL}, msg.doc, m.ready, true)
 	case pageReadyMsg:
-		return m.updateWithPage(msg.page, msg.doc, true)
+		return m.updateWithPage(msg.page, msg.doc, true, true)
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -341,7 +347,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // updateWithPage updates the model with a newly fetched page, replacing the
 // current content, title, and link palette.
-func (m Model) updateWithPage(page Page, doc *markdown.Document, render bool) (Model, tea.Cmd) {
+func (m Model) updateWithPage(page Page, doc *markdown.Document, render, push bool) (Model, tea.Cmd) {
+	if push && !m.isLanding() {
+		m.history = append(m.history, historyEntry{page: m.page, doc: m.doc})
+		m.keys.Back.SetEnabled(true)
+	}
 	m.loading = false
 	m.page = page
 	m.doc = doc
@@ -452,8 +462,20 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 		} else {
 			_ = m.page.Open(context.Background())
 		}
+	case key.Matches(msg, m.keys.Back):
+		return m.handleBack()
 	}
 	return m, nil
+}
+
+func (m Model) handleBack() (Model, tea.Cmd) {
+	if len(m.history) == 0 {
+		return m, nil
+	}
+	last := m.history[len(m.history)-1]
+	m.history = m.history[:len(m.history)-1]
+	m.keys.Back.SetEnabled(len(m.history) > 0)
+	return m.updateWithPage(last.page, last.doc, true, false)
 }
 
 // View renders the current model state to the terminal.

--- a/pkg/docs/tui/model_test.go
+++ b/pkg/docs/tui/model_test.go
@@ -108,6 +108,7 @@ func TestNew_Defaults(t *testing.T) {
 	assert.True(t, m.keys.Help.Enabled())
 	assert.True(t, m.keys.Palette.Enabled())
 	assert.True(t, m.keys.OpenInBrowser.Enabled())
+	assert.False(t, m.keys.Back.Enabled())
 }
 
 func TestNew_WithOptions(t *testing.T) {
@@ -484,6 +485,107 @@ func TestUpdate_PageReadyMsg(t *testing.T) {
 	assert.Equal(t, "New Page", model.title)
 	assert.Equal(t, newDoc, model.doc)
 	assert.NotEmpty(t, model.viewport.GetContent())
+}
+
+func TestUpdate_BackWithEmptyHistoryIsNoOp(t *testing.T) {
+	page := Page{Content: []byte("# Original"), URL: &url.URL{Path: "/original"}}
+	m := New(WithPage(page))
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	model := result.(Model)
+
+	assert.False(t, model.keys.Back.Enabled())
+	assert.Empty(t, model.history)
+	assert.Equal(t, page, model.page)
+	assert.Equal(t, "Original", model.title)
+}
+
+func TestUpdate_BackRestoresPreviousPage(t *testing.T) {
+	r, err := markdown.NewRenderer()
+	require.NoError(t, err)
+
+	originalPage := Page{Content: []byte("# Original\n\nOriginal body"), URL: &url.URL{Path: "/original"}}
+	m := New(WithRenderer(r), WithPage(originalPage))
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model := result.(Model)
+	originalDoc := model.doc
+	originalContent := model.viewport.GetContent()
+
+	newDoc, err := markdown.Parse([]byte("# New Page\n\nNew body"))
+	require.NoError(t, err)
+	newPage := Page{Content: []byte("# New Page\n\nNew body"), URL: &url.URL{Path: "/new"}}
+	result, _ = model.Update(pageReadyMsg{page: newPage, doc: newDoc})
+	model = result.(Model)
+
+	assert.True(t, model.keys.Back.Enabled())
+	assert.Len(t, model.history, 1)
+	assert.Equal(t, "New Page", model.title)
+	assert.NotEqual(t, originalContent, model.viewport.GetContent())
+
+	result, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	model = result.(Model)
+
+	assert.Equal(t, originalPage, model.page)
+	assert.Same(t, originalDoc, model.doc)
+	assert.Equal(t, "Original", model.title)
+	assert.Equal(t, originalContent, model.viewport.GetContent())
+	assert.Empty(t, model.history)
+	assert.False(t, model.keys.Back.Enabled())
+}
+
+func TestUpdate_BackNavigatesMultipleHistoryEntries(t *testing.T) {
+	pageA := Page{Content: []byte("# Page A"), URL: &url.URL{Path: "/a"}}
+	m := New(WithPage(pageA))
+	docA := m.doc
+
+	docB, err := markdown.Parse([]byte("# Page B"))
+	require.NoError(t, err)
+	pageB := Page{Content: []byte("# Page B"), URL: &url.URL{Path: "/b"}}
+	result, _ := m.Update(pageReadyMsg{page: pageB, doc: docB})
+	model := result.(Model)
+
+	docC, err := markdown.Parse([]byte("# Page C"))
+	require.NoError(t, err)
+	pageC := Page{Content: []byte("# Page C"), URL: &url.URL{Path: "/c"}}
+	result, _ = model.Update(pageReadyMsg{page: pageC, doc: docC})
+	model = result.(Model)
+
+	require.Len(t, model.history, 2)
+	assert.True(t, model.keys.Back.Enabled())
+
+	result, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	model = result.(Model)
+	assert.Equal(t, pageB, model.page)
+	assert.Same(t, docB, model.doc)
+	assert.Equal(t, "Page B", model.title)
+	assert.True(t, model.keys.Back.Enabled())
+
+	result, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	model = result.(Model)
+	assert.Equal(t, pageA, model.page)
+	assert.Same(t, docA, model.doc)
+	assert.Equal(t, "Page A", model.title)
+	assert.Empty(t, model.history)
+	assert.False(t, model.keys.Back.Enabled())
+}
+
+func TestUpdate_NavigationFromLandingDoesNotAddHistory(t *testing.T) {
+	m := New()
+	result, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model := result.(Model)
+	require.NotNil(t, cmd)
+
+	doc, err := markdown.Parse([]byte("# Documentation"))
+	require.NoError(t, err)
+	page := Page{Content: []byte("# Documentation"), URL: &url.URL{Path: "/"}}
+
+	result, _ = model.Update(pageReadyMsg{page: page, doc: doc})
+	model = result.(Model)
+
+	assert.Equal(t, page, model.page)
+	assert.Same(t, doc, model.doc)
+	assert.Empty(t, model.history)
+	assert.False(t, model.keys.Back.Enabled())
 }
 
 func TestView_ProgressBar_IndeterminateWhenPageLoading(t *testing.T) {


### PR DESCRIPTION
 ### Summary and motivation

Adds a backspace navigation stack to the docs tui so readers can return after following links or search results. The binding is enabled and shown in help only when history is available, and landing-page navigation is excluded from the stack.

<img width="800" height="335" alt="CleanShot 2026-08-11 at 15 29 12" src="https://github.com/user-attachments/assets/52fbaa6c-aae5-41ad-961b-3369b125c8e8" />

