### PR TITLE
Disable q quit keybind when command palette is open

### DIFF
--- a/pkg/docs/tui/model.go
+++ b/pkg/docs/tui/model.go
@@ -399,7 +399,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 
 	if m.palette.Visible() {
 		switch {
-		case key.Matches(msg, m.keys.Quit):
+		case key.Matches(msg, m.keys.Quit) && msg.String() != "q":
 			qm, qcmd := m.beginQuit()
 			return qm.(Model), qcmd
 		case msg.String() == "esc":

--- a/pkg/docs/tui/model_test.go
+++ b/pkg/docs/tui/model_test.go
@@ -331,6 +331,23 @@ func TestUpdate_PaletteQuitsOnCtrlC(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
+func TestUpdate_PaletteQuitKeyDoesNotQuit(t *testing.T) {
+	m := New(WithPage(Page{Content: []byte("# Test\n\nBody")}))
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model := result.(Model)
+
+	// Open the palette
+	result, _ = model.Update(tea.KeyPressMsg{Code: '>', Text: ">"})
+	model = result.(Model)
+	assert.True(t, model.palette.Visible())
+
+	// Pressing q should not quit when the palette is open
+	result, _ = model.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	model = result.(Model)
+	assert.False(t, model.quitting)
+	assert.True(t, model.palette.Visible())
+}
+
 func TestUpdate_PaletteGatesInput(t *testing.T) {
 	r, err := markdown.NewRenderer()
 	require.NoError(t, err)


### PR DESCRIPTION
 ### Summary

Typing q in the palette should be treated as text input, not a quit command. Control sequences like ctrl+c still quit as expected since they don't conflict with palette text entry.

<img width="800" height="335" alt="CleanShot 2026-08-11 at 15 39 06" src="https://github.com/user-attachments/assets/eeb2e176-f809-4e16-bc61-a3ae6b641324" />
