### PR TITLE
Validate fixture api_base before making requests

### DIFF
--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -361,10 +361,15 @@ func (fxt *Fixture) addCustomHeaders(headers map[string]string) func(req *http.R
 }
 
 func (fxt *Fixture) makeRequest(ctx context.Context, data FixtureRequest, apiVersion string) ([]byte, error) {
+	apiBase := fxt.getAPIBase(data)
+	if err := stripe.ValidateAPIBaseURL(apiBase); err != nil {
+		return make([]byte, 0), fmt.Errorf("fixture api_base %q is not an allowed Stripe API base URL: %w", apiBase, err)
+	}
+
 	req := requests.Base{
 		Method:         strings.ToUpper(data.Method),
 		SuppressOutput: true,
-		APIBaseURL:     fxt.getAPIBase(data),
+		APIBaseURL:     apiBase,
 	}
 
 	path, err := parsers.ParsePath(data.Path, fxt.Responses)

--- a/pkg/fixtures/fixtures_test.go
+++ b/pkg/fixtures/fixtures_test.go
@@ -440,6 +440,42 @@ func TestMakeRequestRejectsPathTraversal(t *testing.T) {
 	require.False(t, serverCalled, "no request should have been sent for invalid paths")
 }
 
+func TestMakeRequestRejectsForeignAPIBase(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	var gotAuth string
+	evilCalled := false
+	evil := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		evilCalled = true
+		gotAuth = req.Header.Get("Authorization")
+	}))
+	defer evil.Close()
+
+	// The httptest listener answers on 127.0.0.1, which is allow-listed for tests.
+	// Address the very same server through the "localhost" hostname so the URL is a
+	// host the validator must reject, while still being routable if the guard fails.
+	foreignBase := strings.Replace(evil.URL, "127.0.0.1", "localhost", 1)
+
+	fxt := &Fixture{
+		Fs:          fs,
+		Credentials: stripe.NewAPIKeyCredentials("rk_test_1234"),
+		BaseURL:     "https://api.stripe.com",
+		Responses:   make(map[string]gjson.Result),
+	}
+
+	_, err := fxt.makeRequest(context.Background(), FixtureRequest{
+		Name:    "test",
+		Path:    "/v1/customers",
+		Method:  "post",
+		Params:  map[string]interface{}{},
+		APIBase: foreignBase,
+	}, "")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not an allowed Stripe API base URL")
+	require.False(t, evilCalled, "no request should have been sent to the foreign api_base")
+	require.Empty(t, gotAuth, "API key must never reach a foreign api_base")
+}
+
 func TestExecuteReturnsRequestNames(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {

--- a/pkg/stripe/url.go
+++ b/pkg/stripe/url.go
@@ -9,10 +9,11 @@ import (
 
 const (
 	// DefaultAPIBaseURL is the default base URL for API requests
-	DefaultAPIBaseURL   = "https://api.stripe.com"
-	APIBaseURLRegexp    = `^https:\/\/api\.stripe\.com\/v\d+$`
-	qaAPIBaseURL        = "https://qa-api.stripe.com"
-	devAPIBaseURLRegexp = `http(s)?:\/\/[A-Za-z0-9\-]+.dev.stripe.me`
+	DefaultAPIBaseURL     = "https://api.stripe.com"
+	APIBaseURLRegexp      = `^https:\/\/api\.stripe\.com\/v\d+$`
+	qaAPIBaseURL          = "https://qa-api.stripe.com"
+	meterEventsAPIBaseURL = "https://meter-events.stripe.com"
+	devAPIBaseURLRegexp   = `http(s)?:\/\/[A-Za-z0-9\-]+.dev.stripe.me`
 
 	// DefaultFilesAPIBaseURL is the default base URL for Files API requsts
 	DefaultFilesAPIBaseURL = "https://files.stripe.com/"
@@ -48,7 +49,7 @@ func isValid(url string, exactStrings []string, regexpStrings []string) bool {
 
 // ValidateAPIBaseURL returns an error if apiBaseURL isn't allowed
 func ValidateAPIBaseURL(apiBaseURL string) error {
-	exactStrings := []string{DefaultAPIBaseURL, qaAPIBaseURL, DefaultFilesAPIBaseURL}
+	exactStrings := []string{DefaultAPIBaseURL, qaAPIBaseURL, meterEventsAPIBaseURL, DefaultFilesAPIBaseURL}
 	regexpStrings := []string{APIBaseURLRegexp, devAPIBaseURLRegexp, localhostURLRegexp}
 	if isValid(apiBaseURL, exactStrings, regexpStrings) {
 		return nil


### PR DESCRIPTION
The fixtures runner reads `api_base` from the fixture file and passes it to `MakeRequest` directly, while `RunRequestsCmd` already validates it through `ValidateAPIBaseURL`. That gap lets a fixture point requests carrying the user's API key at an arbitrary host. This applies the same validation on the fixtures path before any request is sent. The meter events API base is added to the allowlist because two built-in triggers (`v1.billing.meter.*`) rely on it.