### PR TITLE
Validate plugin binary name from manifest before use

### DIFF
--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -455,6 +455,9 @@ func (p *Plugin) verifychecksumAndSavePlugin(pluginData []byte, config config.IC
 	if err != nil {
 		return err
 	}
+	if err := ValidatePluginBinaryName(p.Binary); err != nil {
+		return err
+	}
 	pluginFilePath := filepath.Join(pluginDir, p.Binary)
 	pluginFilePath += GetBinaryExtension()
 
@@ -592,6 +595,9 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 
 	pluginDir, err := p.getPluginInstallPath(config, version)
 	if err != nil {
+		return err
+	}
+	if err := ValidatePluginBinaryName(p.Binary); err != nil {
 		return err
 	}
 	pluginBinaryPath := filepath.Join(pluginDir, p.Binary)

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -1250,3 +1250,52 @@ func TestVerifyChecksumAndSavePluginRefusesSymlinkedParent(t *testing.T) {
 	_, err = os.Stat(filepath.Join(victimDir, "plugins", "appA", "2.0.1", "stripe-cli-app-a"+GetBinaryExtension()))
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
+
+func TestVerifyChecksumAndSavePluginRejectsTraversalBinary(t *testing.T) {
+	manifestContent, err := os.ReadFile("./test_artifacts/plugins.toml")
+	require.NoError(t, err)
+
+	var pluginList PluginList
+	_, err = toml.Decode(string(manifestContent), &pluginList)
+	require.NoError(t, err)
+
+	var plugin Plugin
+	for _, candidate := range pluginList.Plugins {
+		if candidate.Shortname == "appA" {
+			plugin = candidate
+			break
+		}
+	}
+	require.Equal(t, "appA", plugin.Shortname)
+
+	tempDir := t.TempDir()
+	config := &CustomTestConfig{customConfigPath: tempDir}
+	fs := afero.NewOsFs()
+
+	// A hostile manifest sets the binary name to a path that climbs out of the
+	// plugin install directory (<config>/plugins/appA/2.0.1).
+	plugin.Binary = filepath.Join("..", "..", "..", "escaped-binary")
+	escapedPath := filepath.Join(tempDir, "escaped-binary"+GetBinaryExtension())
+
+	err = plugin.verifychecksumAndSavePlugin([]byte("hello, I am appA_2.0.1"), config, fs, "2.0.1")
+	require.ErrorContains(t, err, "invalid plugin binary name")
+
+	_, statErr := os.Stat(escapedPath)
+	require.ErrorIs(t, statErr, os.ErrNotExist, "binary must not be written outside the plugin directory")
+}
+
+func TestValidatePluginBinaryName(t *testing.T) {
+	require.NoError(t, ValidatePluginBinaryName("stripe-cli-app-a"))
+
+	for _, name := range []string{
+		"",
+		".",
+		"..",
+		"../../../../tmp/x",
+		`..\..\x`,
+		"sub/binary",
+		"/abs/binary",
+	} {
+		require.Error(t, ValidatePluginBinaryName(name), "expected %q to be rejected", name)
+	}
+}

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -75,6 +75,28 @@ func ValidatePluginShortname(pluginName string) error {
 	}
 }
 
+// ValidatePluginBinaryName rejects binary names from the server manifest that
+// could escape the plugin install directory when joined onto local filesystem
+// paths.
+func ValidatePluginBinaryName(binaryName string) error {
+	switch {
+	case binaryName == "":
+		return errors.New("plugin binary name cannot be empty")
+	case binaryName == "." || binaryName == "..":
+		return fmt.Errorf("invalid plugin binary name %q", binaryName)
+	case filepath.IsAbs(binaryName):
+		return fmt.Errorf("invalid plugin binary name %q", binaryName)
+	case strings.ContainsAny(binaryName, `/\`):
+		return fmt.Errorf("invalid plugin binary name %q", binaryName)
+	case filepath.Clean(binaryName) != binaryName:
+		return fmt.Errorf("invalid plugin binary name %q", binaryName)
+	case filepath.Base(binaryName) != binaryName:
+		return fmt.Errorf("invalid plugin binary name %q", binaryName)
+	default:
+		return nil
+	}
+}
+
 // Install installs the resolved plugin version. If the metadata lookup already
 // resolved a concrete binary URL, it reuses that result and skips a second
 // metadata request. Otherwise it retries metadata during install so cached


### PR DESCRIPTION
Plugin binary names come from the remote plugin manifest and are joined into filesystem paths for download and execution without validation. A crafted or MITM'd manifest could use path traversal in that name to write or run a binary outside the plugin directory. This validates the binary name before it is used as a path component.