### PR TITLE
Hide docs landing logo on short terminals

### DIFF
--- a/pkg/docs/tui/model.go
+++ b/pkg/docs/tui/model.go
@@ -625,25 +625,23 @@ func (m Model) fetchPageCmd(dest *url.URL) tea.Cmd {
 // Landing animation
 
 func (m Model) landing() string {
-	logo := m.shape.view(m.styles.LandingDotBright, m.styles.LandingDotMid, m.styles.LandingDotDim)
 	title := m.styles.LandingTitle.Render("stripe docs")
 	subtitle := m.styles.LandingSubtitle.Render("Search, browse, and read Stripe documentation from the terminal")
-
-	block := lipgloss.JoinVertical(
-		lipgloss.Center,
-		logo,
-		"",
-		title,
-		subtitle,
-	)
 
 	bodyHeight := m.height - statusBarHeight
 	if m.help.ShowAll {
 		helpView := lipgloss.NewStyle().PaddingTop(1).PaddingBottom(1).Render(m.help.View(m.keys))
 		bodyHeight -= strings.Count(helpView, "\n") + 1
 	}
+	bodyHeight = max(1, bodyHeight)
 
-	out := lipgloss.Place(m.width, max(1, bodyHeight), lipgloss.Center, lipgloss.Center, block)
+	block := lipgloss.JoinVertical(lipgloss.Center, title, subtitle)
+	if bodyHeight >= paraHeight+1+lipgloss.Height(block) {
+		logo := m.shape.view(m.styles.LandingDotBright, m.styles.LandingDotMid, m.styles.LandingDotDim)
+		block = lipgloss.JoinVertical(lipgloss.Center, logo, "", title, subtitle)
+	}
+
+	out := lipgloss.Place(m.width, bodyHeight, lipgloss.Center, lipgloss.Center, block)
 	out += "\n" + m.status()
 	if m.help.ShowAll {
 		helpView := lipgloss.NewStyle().PaddingTop(1).PaddingBottom(1).Render(m.help.View(m.keys))


### PR DESCRIPTION
 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

The animated logo is a fixed ~20-row shape that doesn't shrink with the terminal, so on short windows (<~25 rows) it pushed the status bar off screen. Dropping it when there isn't room keeps the status bar and help row visible.

**Before**
<img width="800" height="523" alt="CleanShot 2026-08-12 at 16 26 00" src="https://github.com/user-attachments/assets/16aebb39-473f-417b-b62b-8e27cd3a6847" />


**After**
<img width="800" height="453" alt="CleanShot 2026-08-12 at 16 24 10" src="https://github.com/user-attachments/assets/c69c1db7-29fa-442e-a130-661f46c9ab6a" />

