### PR TITLE
fix context mismatch from oauth

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -16,6 +17,8 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 	"github.com/stripe/stripe-cli/pkg/proxy"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -138,6 +141,13 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	creds, err := Config.Profile.ResolveCredentials(lc.livemode)
+	var mismatch *config.ActiveContextLivemodeMismatchError
+	if errors.As(err, &mismatch) {
+		if mismatch.ActiveLivemode {
+			return errorcategory.UserInputErrorf("your active context is livemode; add --live to match it, or run 'stripe switch context' to select a test mode context")
+		}
+		return errorcategory.UserInputErrorf("your active context is test mode; remove --live to match it, or run 'stripe switch context' to select a livemode context")
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 	"github.com/stripe/stripe-cli/pkg/logtailing"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -173,10 +174,10 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if ac, acErr := config.GetActiveContext(); acErr == nil && ac != nil && ac.Livemode {
-		return fmt.Errorf("'stripe logs tail' only works in test mode, but your active context is livemode; run 'stripe switch context' to select a test mode context")
+		return errorcategory.UserInputErrorf("'stripe logs tail' only works in test mode, but your active context is livemode; run 'stripe switch context' to select a test mode context")
 	}
 
-	creds, err := tailCmd.cfg.Profile.ResolveCredentialsIgnoringActiveContext(false)
+	creds, err := tailCmd.cfg.Profile.ResolveCredentials(false)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -172,7 +172,11 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	creds, err := tailCmd.cfg.Profile.ResolveCredentials(false)
+	if ac, acErr := config.GetActiveContext(); acErr == nil && ac != nil && ac.Livemode {
+		return fmt.Errorf("'stripe logs tail' only works in test mode, but your active context is livemode; run 'stripe switch context' to select a test mode context")
+	}
+
+	creds, err := tailCmd.cfg.Profile.ResolveCredentialsIgnoringActiveContext(false)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 	"github.com/stripe/stripe-cli/pkg/keyring"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -777,27 +778,32 @@ func (p *Profile) GetCompartmentID(livemode bool) (string, error) {
 	return "", nil
 }
 
+// ActiveContextLivemodeMismatchError indicates that the requested livemode
+// does not match the OAuth active context's livemode. Callers that expose
+// their own mode selection (e.g. a --live flag) can catch this with
+// errors.As and explain how to reconcile it; callers that don't care which
+// mode is used can retry ResolveCredentials(err.ActiveLivemode) to get
+// credentials for whichever mode is actually active.
+type ActiveContextLivemodeMismatchError struct {
+	RequestedLivemode bool
+	ActiveLivemode    bool
+}
+
+func (e *ActiveContextLivemodeMismatchError) Error() string {
+	if e.ActiveLivemode {
+		return "your active context is livemode; run 'stripe switch context' to select a test mode context"
+	}
+	return "your active context is test mode; run 'stripe switch context' to select a livemode context"
+}
+
 // ResolveCredentials returns the credentials for the given mode. If an OAK
 // token (prefix "oak_") is stored in the keyring and no explicit override is
 // active, it is preferred over the configured API key. For OAK tokens the
 // active context stored in the keyring sets both Stripe-Context and
 // Stripe-Livemode; the livemode parameter is used only for the legacy OIDC
-// fallback and plain API key path.
+// fallback and plain API key path. If the active context's livemode differs
+// from the requested livemode, it returns an *ActiveContextLivemodeMismatchError.
 func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) {
-	return p.resolveCredentials(livemode, true)
-}
-
-// ResolveCredentialsIgnoringActiveContext behaves like ResolveCredentials but
-// does not error out when the active context's livemode differs from the
-// requested livemode; it uses the active context's account and livemode
-// as-is instead. This is used by callers (plugin management commands,
-// `stripe logs tail`) that need a usable credential regardless of which mode
-// the user's active context happens to be in.
-func (p *Profile) ResolveCredentialsIgnoringActiveContext(livemode bool) (stripe.Credentials, error) {
-	return p.resolveCredentials(livemode, false)
-}
-
-func (p *Profile) resolveCredentials(livemode bool, enforceActiveContextLivemode bool) (stripe.Credentials, error) {
 	if !p.HasOverrideAPIKey() {
 		uat, err := p.GetUAT()
 		if err != nil {
@@ -824,16 +830,11 @@ func (p *Profile) resolveCredentials(livemode bool, enforceActiveContextLivemode
 				return stripe.Credentials{}, err
 			}
 			if ac != nil {
-				if !enforceActiveContextLivemode {
-					// The Stripe-Livemode header must reflect the active
-					// context's actual mode, not the caller-requested mode.
-					return stripe.NewOAKCredentials(uat, ac.AccountID, ac.Livemode), nil
-				}
 				if ac.Livemode != livemode {
-					if livemode {
-						return stripe.Credentials{}, fmt.Errorf("your active context is test mode; to access livemode, run 'stripe switch context'")
-					}
-					return stripe.Credentials{}, fmt.Errorf("your active context is livemode; run 'stripe switch context' to select a test mode context, or add --live if you meant to use livemode")
+					return stripe.Credentials{}, errorcategory.With(&ActiveContextLivemodeMismatchError{
+						RequestedLivemode: livemode,
+						ActiveLivemode:    ac.Livemode,
+					}, errorcategory.UserInput)
 				}
 				return stripe.NewOAKCredentials(uat, ac.AccountID, livemode), nil
 			}
@@ -843,7 +844,7 @@ func (p *Profile) resolveCredentials(livemode bool, enforceActiveContextLivemode
 				return stripe.Credentials{}, err
 			}
 			if livemode && compartmentID == "" {
-				return stripe.Credentials{}, fmt.Errorf("you're logged in to a sandbox; to access livemode, reauthenticate with 'stripe login' and select your live account")
+				return stripe.Credentials{}, errorcategory.UserInputErrorf("you're logged in to a sandbox; to access livemode, reauthenticate with 'stripe login' and select your live account")
 			}
 			return stripe.NewOAKCredentials(uat, compartmentID, livemode), nil
 		}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -784,6 +784,20 @@ func (p *Profile) GetCompartmentID(livemode bool) (string, error) {
 // Stripe-Livemode; the livemode parameter is used only for the legacy OIDC
 // fallback and plain API key path.
 func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) {
+	return p.resolveCredentials(livemode, true)
+}
+
+// ResolveCredentialsIgnoringActiveContext behaves like ResolveCredentials but
+// does not error out when the active context's livemode differs from the
+// requested livemode; it uses the active context's account and livemode
+// as-is instead. This is used by callers (plugin management commands,
+// `stripe logs tail`) that need a usable credential regardless of which mode
+// the user's active context happens to be in.
+func (p *Profile) ResolveCredentialsIgnoringActiveContext(livemode bool) (stripe.Credentials, error) {
+	return p.resolveCredentials(livemode, false)
+}
+
+func (p *Profile) resolveCredentials(livemode bool, enforceActiveContextLivemode bool) (stripe.Credentials, error) {
 	if !p.HasOverrideAPIKey() {
 		uat, err := p.GetUAT()
 		if err != nil {
@@ -810,6 +824,11 @@ func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) 
 				return stripe.Credentials{}, err
 			}
 			if ac != nil {
+				if !enforceActiveContextLivemode {
+					// The Stripe-Livemode header must reflect the active
+					// context's actual mode, not the caller-requested mode.
+					return stripe.NewOAKCredentials(uat, ac.AccountID, ac.Livemode), nil
+				}
 				if ac.Livemode != livemode {
 					if livemode {
 						return stripe.Credentials{}, fmt.Errorf("your active context is test mode; to access livemode, run 'stripe switch context'")

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 	"github.com/stripe/stripe-cli/pkg/keyring"
 )
 
@@ -298,6 +299,40 @@ func TestResolveCredentialsOAKLivemodeWithCompartment(t *testing.T) {
 
 	p := Profile{ProfileName: "default"}
 	creds, err := p.ResolveCredentials(true)
+	require.NoError(t, err)
+	require.Equal(t, "oak_live_1234567890", creds.Token)
+}
+
+func TestResolveCredentialsOAKLivemodeMismatchReturnsTypedError(t *testing.T) {
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(profilesFile, []byte{}, 0600))
+	activeCtxJSON, err := json.Marshal(ActiveContext{AccountID: "acct_live123", Livemode: true})
+	require.NoError(t, err)
+	KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		UATKeychainItemKey:            []byte("oak_live_1234567890"),
+		OAuthActiveContextKeychainKey: activeCtxJSON,
+	})
+	t.Cleanup(func() {
+		KeyRing = nil
+		viper.Reset()
+	})
+	(&Config{LogLevel: "info", ProfilesFile: profilesFile}).InitConfig()
+
+	p := Profile{ProfileName: "default"}
+	_, err = p.ResolveCredentials(false)
+	require.Error(t, err)
+
+	var mismatch *ActiveContextLivemodeMismatchError
+	require.ErrorAs(t, err, &mismatch)
+	require.False(t, mismatch.RequestedLivemode)
+	require.True(t, mismatch.ActiveLivemode)
+
+	category, ok := errorcategory.Get(err)
+	require.True(t, ok)
+	require.Equal(t, errorcategory.UserInput, category)
+
+	// Retrying with the active context's actual mode succeeds.
+	creds, err := p.ResolveCredentials(mismatch.ActiveLivemode)
 	require.NoError(t, err)
 	require.Equal(t, "oak_live_1234567890", creds.Token)
 }

--- a/pkg/errorcategory/category.go
+++ b/pkg/errorcategory/category.go
@@ -2,7 +2,10 @@
 // their messages or unwrapping behavior.
 package errorcategory
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // Category identifies the source of an error.
 type Category string
@@ -46,6 +49,11 @@ func With(err error, category Category) error {
 		return nil
 	}
 	return categorizedError{err: err, category: category}
+}
+
+// UserInputErrorf formats an error categorized as UserInput.
+func UserInputErrorf(format string, args ...any) error {
+	return With(fmt.Errorf(format, args...), UserInput)
 }
 
 // Get returns the first explicit category in err's unwrap tree.

--- a/pkg/errorcategory/category_test.go
+++ b/pkg/errorcategory/category_test.go
@@ -48,6 +48,16 @@ func TestGetWithoutCategory(t *testing.T) {
 	require.Empty(t, category)
 }
 
+func TestUserInputErrorf(t *testing.T) {
+	err := UserInputErrorf("invalid %s: %q", "value", "foo")
+
+	require.EqualError(t, err, `invalid value: "foo"`)
+
+	category, ok := Get(err)
+	require.True(t, ok)
+	require.Equal(t, UserInput, category)
+}
+
 func TestGetUsesOutermostCategory(t *testing.T) {
 	err := With(With(errors.New("nested"), Network), API)
 

--- a/pkg/login/oauth_accounts.go
+++ b/pkg/login/oauth_accounts.go
@@ -16,6 +16,17 @@ type listAccountsResponse struct {
 	Accounts []config.AuthorizedAccount `json:"accounts"`
 }
 
+// stubAuthorizedAccounts is returned by ListAuthorizedAccounts while the
+// GET /stripecli/oauth2/token/accounts endpoint is unavailable.
+// TODO: remove once the accounts endpoint is live.
+var stubAuthorizedAccounts = []config.AuthorizedAccount{
+	{
+		ID:    "acct_1NRKwLLJDmqA11cn",
+		Name:  "acct_1NRKwLLJDmqA11cn",
+		Modes: []string{"live"},
+	},
+}
+
 // ListAuthorizedAccounts returns the Stripe accounts accessible to accessToken.
 // If the endpoint is unreachable or returns a non-200 response, it falls back
 // to stub data so that callers can be built and tested before the endpoint is live.
@@ -23,7 +34,7 @@ type listAccountsResponse struct {
 func ListAuthorizedAccounts(ctx context.Context, accessBaseURL, accessToken string) ([]config.AuthorizedAccount, error) {
 	accounts, err := fetchAuthorizedAccounts(ctx, accessBaseURL, accessToken)
 	if err != nil {
-		return nil, err
+		return stubAuthorizedAccounts, nil
 	}
 	return accounts, nil
 }

--- a/pkg/login/oauth_accounts.go
+++ b/pkg/login/oauth_accounts.go
@@ -16,27 +16,9 @@ type listAccountsResponse struct {
 	Accounts []config.AuthorizedAccount `json:"accounts"`
 }
 
-// stubAuthorizedAccounts is returned by ListAuthorizedAccounts while the
-// GET /stripecli/oauth2/token/accounts endpoint is unavailable.
-// TODO: remove once the accounts endpoint is live.
-var stubAuthorizedAccounts = []config.AuthorizedAccount{
-	{
-		ID:    "acct_1NRKwLLJDmqA11cn",
-		Name:  "acct_1NRKwLLJDmqA11cn",
-		Modes: []string{"live"},
-	},
-}
-
 // ListAuthorizedAccounts returns the Stripe accounts accessible to accessToken.
-// If the endpoint is unreachable or returns a non-200 response, it falls back
-// to stub data so that callers can be built and tested before the endpoint is live.
-// TODO: remove stub fallback once GET /stripecli/oauth2/token/accounts is available.
 func ListAuthorizedAccounts(ctx context.Context, accessBaseURL, accessToken string) ([]config.AuthorizedAccount, error) {
-	accounts, err := fetchAuthorizedAccounts(ctx, accessBaseURL, accessToken)
-	if err != nil {
-		return stubAuthorizedAccounts, nil
-	}
-	return accounts, nil
+	return fetchAuthorizedAccounts(ctx, accessBaseURL, accessToken)
 }
 
 func fetchAuthorizedAccounts(ctx context.Context, accessBaseURL, accessToken string) ([]config.AuthorizedAccount, error) {

--- a/pkg/login/oauth_device_test.go
+++ b/pkg/login/oauth_device_test.go
@@ -228,7 +228,7 @@ func TestRefreshAccessToken_Success(t *testing.T) {
 	assert.Equal(t, "oart_new_refresh", resp.RefreshToken)
 }
 
-func TestLoginWithDeviceCodeFailsWhenAccountsFetchFails(t *testing.T) {
+func TestLoginWithDeviceCodeFallsBackToStubAccountsWhenAccountsFetchFails(t *testing.T) {
 	origCanOpenBrowser := canOpenBrowser
 	canOpenBrowser = func() bool { return false }
 	t.Cleanup(func() { canOpenBrowser = origCanOpenBrowser })
@@ -263,11 +263,13 @@ func TestLoginWithDeviceCodeFailsWhenAccountsFetchFails(t *testing.T) {
 	defer ts.Close()
 
 	err := LoginWithDeviceCode(context.Background(), ts.URL, cfg)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "failed to fetch account info")
+	require.NoError(t, err)
 
-	_, keyErr := config.KeyRing.Get(config.OAuthActiveContextKeychainKey)
-	assert.Error(t, keyErr)
+	ac, acErr := config.GetActiveContext()
+	require.NoError(t, acErr)
+	require.NotNil(t, ac)
+	assert.Equal(t, "acct_1NRKwLLJDmqA11cn", ac.AccountID)
+	assert.True(t, ac.Livemode)
 }
 
 func TestRefreshAccessToken_NoRefreshTokenInResponse(t *testing.T) {

--- a/pkg/login/oauth_device_test.go
+++ b/pkg/login/oauth_device_test.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/stripe/stripe-cli/pkg/config"
 )
 
 func TestRequestDeviceCode_Success(t *testing.T) {
@@ -228,7 +226,7 @@ func TestRefreshAccessToken_Success(t *testing.T) {
 	assert.Equal(t, "oart_new_refresh", resp.RefreshToken)
 }
 
-func TestLoginWithDeviceCodeFallsBackToStubAccountsWhenAccountsFetchFails(t *testing.T) {
+func TestLoginWithDeviceCodeFailsWhenAccountsFetchFails(t *testing.T) {
 	origCanOpenBrowser := canOpenBrowser
 	canOpenBrowser = func() bool { return false }
 	t.Cleanup(func() { canOpenBrowser = origCanOpenBrowser })
@@ -263,13 +261,8 @@ func TestLoginWithDeviceCodeFallsBackToStubAccountsWhenAccountsFetchFails(t *tes
 	defer ts.Close()
 
 	err := LoginWithDeviceCode(context.Background(), ts.URL, cfg)
-	require.NoError(t, err)
-
-	ac, acErr := config.GetActiveContext()
-	require.NoError(t, acErr)
-	require.NotNil(t, ac)
-	assert.Equal(t, "acct_1NRKwLLJDmqA11cn", ac.AccountID)
-	assert.True(t, ac.Livemode)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch account info")
 }
 
 func TestRefreshAccessToken_NoRefreshTokenInResponse(t *testing.T) {

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -291,7 +291,7 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, apiBaseURL, dashboardBaseURL, resolvedBinaryURL string, skipMetadataLookup bool) error {
 	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)
 
-	creds, _ := cfg.GetProfile().ResolveCredentials(false)
+	creds, _ := cfg.GetProfile().ResolveCredentialsIgnoringActiveContext(false)
 	apiKey := creds.Token
 	pluginToInstall := p
 	pluginDownloadURL := resolvedBinaryURL

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -291,7 +291,7 @@ func (p *Plugin) Install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, version string, apiBaseURL, dashboardBaseURL, resolvedBinaryURL string, skipMetadataLookup bool) error {
 	spinner := ansi.StartNewSpinner(ansi.Faint(fmt.Sprintf("installing '%s' v%s...", p.Shortname, version)), os.Stdout)
 
-	creds, _ := cfg.GetProfile().ResolveCredentialsIgnoringActiveContext(false)
+	creds, _ := resolveCredentialsForAnyMode(cfg.GetProfile(), false)
 	apiKey := creds.Token
 	pluginToInstall := p
 	pluginDownloadURL := resolvedBinaryURL

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -324,7 +324,7 @@ func PersistInstalledPluginState(config config.IConfig, fs afero.Fs, plugin Plug
 // ListPlugins fetches the live plugin list visible to the current caller for
 // the current platform using the list-plugins API endpoints.
 func ListPlugins(ctx context.Context, config config.IConfig, apiBaseURL, dashboardBaseURL string) (PluginList, error) {
-	creds, err := config.GetProfile().ResolveCredentials(false)
+	creds, err := config.GetProfile().ResolveCredentialsIgnoringActiveContext(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return PluginList{}, err
 	}
@@ -372,7 +372,7 @@ func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.I
 		dashboardBaseURL = stripe.DashboardBaseURLForAPIBaseURL(apiBaseURL)
 	}
 
-	creds, err := config.GetProfile().ResolveCredentials(false)
+	creds, err := config.GetProfile().ResolveCredentialsIgnoringActiveContext(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return err
 	}
@@ -507,7 +507,7 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 		return nil, err
 	}
 
-	creds, err := config.GetProfile().ResolveCredentials(false)
+	creds, err := config.GetProfile().ResolveCredentialsIgnoringActiveContext(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return nil, err
 	}
@@ -558,7 +558,7 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 		return nil, err
 	}
 
-	creds, err := config.GetProfile().ResolveCredentials(false)
+	creds, err := config.GetProfile().ResolveCredentialsIgnoringActiveContext(false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return nil, err
 	}

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -32,6 +32,19 @@ import (
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
+// resolveCredentialsForAnyMode resolves credentials for livemode, but if that
+// doesn't match the OAuth active context, resolves credentials for whichever
+// mode is actually active instead of failing. Plugin management commands
+// don't expose their own mode selection, so any usable credential will do.
+func resolveCredentialsForAnyMode(profile *config.Profile, livemode bool) (stripe.Credentials, error) {
+	creds, err := profile.ResolveCredentials(livemode)
+	var mismatch *config.ActiveContextLivemodeMismatchError
+	if errors.As(err, &mismatch) {
+		return profile.ResolveCredentials(mismatch.ActiveLivemode)
+	}
+	return creds, err
+}
+
 type installedPluginStateSnapshot struct {
 	installedPlugins []string
 	localMetadata    []byte
@@ -324,7 +337,7 @@ func PersistInstalledPluginState(config config.IConfig, fs afero.Fs, plugin Plug
 // ListPlugins fetches the live plugin list visible to the current caller for
 // the current platform using the list-plugins API endpoints.
 func ListPlugins(ctx context.Context, config config.IConfig, apiBaseURL, dashboardBaseURL string) (PluginList, error) {
-	creds, err := config.GetProfile().ResolveCredentialsIgnoringActiveContext(false)
+	creds, err := resolveCredentialsForAnyMode(config.GetProfile(), false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return PluginList{}, err
 	}
@@ -372,7 +385,7 @@ func BackfillMissingInstalledPluginMetadata(ctx context.Context, config config.I
 		dashboardBaseURL = stripe.DashboardBaseURLForAPIBaseURL(apiBaseURL)
 	}
 
-	creds, err := config.GetProfile().ResolveCredentialsIgnoringActiveContext(false)
+	creds, err := resolveCredentialsForAnyMode(config.GetProfile(), false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return err
 	}
@@ -507,7 +520,7 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 		return nil, err
 	}
 
-	creds, err := config.GetProfile().ResolveCredentialsIgnoringActiveContext(false)
+	creds, err := resolveCredentialsForAnyMode(config.GetProfile(), false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return nil, err
 	}
@@ -558,7 +571,7 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 		return nil, err
 	}
 
-	creds, err := config.GetProfile().ResolveCredentialsIgnoringActiveContext(false)
+	creds, err := resolveCredentialsForAnyMode(config.GetProfile(), false)
 	if err != nil && !errors.Is(err, validators.ErrAPIKeyNotConfigured) {
 		return nil, err
 	}

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 	"github.com/stripe/stripe-cli/pkg/fsutil"
 	"github.com/stripe/stripe-cli/pkg/parsers"
 	"github.com/stripe/stripe-cli/pkg/stripe"
@@ -227,8 +228,18 @@ func (rb *Base) InitFlags() {
 }
 
 // ResolveCredentials returns Credentials for this request using the associated profile.
+// If the requested mode doesn't match the OAuth active context, it returns an
+// error explaining how to reconcile it using the --live flag these commands expose.
 func (rb *Base) ResolveCredentials() (stripe.Credentials, error) {
-	return rb.Profile.ResolveCredentials(rb.Livemode)
+	creds, err := rb.Profile.ResolveCredentials(rb.Livemode)
+	var mismatch *config.ActiveContextLivemodeMismatchError
+	if errors.As(err, &mismatch) {
+		if mismatch.ActiveLivemode {
+			return stripe.Credentials{}, errorcategory.UserInputErrorf("your active context is livemode; add --live to match it, or run 'stripe switch context' to select a test mode context")
+		}
+		return stripe.Credentials{}, errorcategory.UserInputErrorf("your active context is test mode; remove --live to match it, or run 'stripe switch context' to select a livemode context")
+	}
+	return creds, err
 }
 
 // MakeMultiPartRequest will make a multipart/form-data request to the Stripe API with the specific variables given to it.

--- a/pkg/requests/plugin.go
+++ b/pkg/requests/plugin.go
@@ -71,7 +71,7 @@ func GetPluginMetadata(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVer
 		APIBaseURL:     metadataBaseURL,
 	}
 
-	resolvedCreds, err := base.ResolveCredentials()
+	resolvedCreds, err := profile.ResolveCredentialsIgnoringActiveContext(base.Livemode)
 	if err != nil {
 		resolvedCreds = stripe.NewAPIKeyCredentials(apiKey)
 	}
@@ -121,7 +121,7 @@ func GetPluginList(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVersion
 		APIBaseURL:     listBaseURL,
 	}
 
-	resolvedCreds, err := base.ResolveCredentials()
+	resolvedCreds, err := profile.ResolveCredentialsIgnoringActiveContext(base.Livemode)
 	if err != nil {
 		resolvedCreds = stripe.NewAPIKeyCredentials(apiKey)
 	}

--- a/pkg/requests/plugin.go
+++ b/pkg/requests/plugin.go
@@ -3,6 +3,7 @@ package requests
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -11,6 +12,24 @@ import (
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 )
+
+// resolveCredentialsForAnyMode resolves credentials for livemode, but if that
+// doesn't match the OAuth active context, resolves credentials for whichever
+// mode is actually active instead of failing. Plugin metadata/list requests
+// don't expose their own mode selection, so any usable credential will do.
+func resolveCredentialsForAnyMode(profile *config.Profile, livemode bool, apiKey string) stripe.Credentials {
+	creds, err := profile.ResolveCredentials(livemode)
+	var mismatch *config.ActiveContextLivemodeMismatchError
+	if errors.As(err, &mismatch) {
+		if retried, retryErr := profile.ResolveCredentials(mismatch.ActiveLivemode); retryErr == nil {
+			return retried
+		}
+	}
+	if err != nil {
+		return stripe.NewAPIKeyCredentials(apiKey)
+	}
+	return creds
+}
 
 // PluginMetadata contains plugin-specific manifest and binary information.
 type PluginMetadata struct {
@@ -71,10 +90,7 @@ func GetPluginMetadata(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVer
 		APIBaseURL:     metadataBaseURL,
 	}
 
-	resolvedCreds, err := profile.ResolveCredentialsIgnoringActiveContext(base.Livemode)
-	if err != nil {
-		resolvedCreds = stripe.NewAPIKeyCredentials(apiKey)
-	}
+	resolvedCreds := resolveCredentialsForAnyMode(profile, base.Livemode, apiKey)
 
 	resp, err := base.MakeRequest(ctx, resolvedCreds, metadataPath, params, map[string]interface{}{
 		"plugin":  pluginName,
@@ -121,10 +137,7 @@ func GetPluginList(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVersion
 		APIBaseURL:     listBaseURL,
 	}
 
-	resolvedCreds, err := profile.ResolveCredentialsIgnoringActiveContext(base.Livemode)
-	if err != nil {
-		resolvedCreds = stripe.NewAPIKeyCredentials(apiKey)
-	}
+	resolvedCreds := resolveCredentialsForAnyMode(profile, base.Livemode, apiKey)
 
 	resp, err := base.MakeRequest(ctx, resolvedCreds, listPath, params, map[string]interface{}{
 		"os":   os,


### PR DESCRIPTION
### Summary
Fixes `logs tail` and `plugin install` so that it works as expected.

When logging in with OAuth, you have to pick what account and livemode you want to target. If you picked livemode: 

1. Some commands require a --live flag (e.g. listen, resource commands)
2. Some don't support livemode (e.g logs tail)
3. Some don't care what mode you're in (e.g. plugin install)

Previously we assumed every command fit into (1), so this addresses (2) and (3).

### Testing

### When active context is test mode

#### Resource command
```
./stripe payment_intents create --amount 2000 --currency usd
▸ Running in Tomer's Chicken n' Waffles (v1 Workbench) · test (acct_1NRKwLLJDmqA11cn)
{
...
}
```
```
./stripe payment_intents create --amount 2000 --currency usd --live
▸ Running in Tomer's Chicken n' Waffles (v1 Workbench) · test (acct_1NRKwLLJDmqA11cn)
your active context is test mode; remove --live to match it, or run 'stripe switch context' to select a livemode context
```

#### listen
```
./stripe listen       
> Ready! You are using Stripe API Version [2022-11-15]. Your webhook signing secret is ...
```
```
./stripe listen --live        
your active context is test mode; remove --live to match it, or run 'stripe switch context' to select a livemode context
```
```

#### logs tail
./stripe logs tail       
> Ready! You're now waiting to receive API request logs (^C to quit)
```

#### plugin install
```
./stripe plugin install apps  
✔ installation of v1.17.4 complete.
```

### When active context is live mode

#### Resource command
```
./stripe payment_intents create --amount 2000 --currency usd       
▸ Running in Tomer's Chicken n' Waffles (v1 Workbench) · live (acct_1NRKwLLJDmqA11cn)
your active context is livemode; add --live to match it, or run 'stripe switch context' to select a test mode context
```
```
./stripe payment_intents create --amount 2000 --currency usd --live
▸ Running in Tomer's Chicken n' Waffles (v1 Workbench) · live (acct_1NRKwLLJDmqA11cn)
{
...
}
```

#### listen
```
./stripe listen                                                    
your active context is livemode; add --live to match it, or run 'stripe switch context' to select a test mode context
```

This is a bug on the server, I have a fix going out there.
```
./stripe listen --live
[Thu, 13 Aug 2026 10:02:27 PDT] FATAL Error while authenticating with Stripe: Authorization failed, status=403, body={
  "error": {
    "message": "Live mode secret keys (sk_live_...) are not supported for this operation. To listen for live mode events, use `stripe listen --live` instead.",
    "type": "invalid_request_error"
  }
}
```

#### logs tail
```
./stripe logs tail    
'stripe logs tail' only works in test mode, but your active context is livemode; run 'stripe switch context' to select a test mode context
```

#### plugin install
```
./stripe plugin install apps  
✔ installation of v1.17.4 complete.
```