### PR TITLE
support listen for our internal dev environments

### DIFF
--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -218,10 +218,20 @@ func sendTelemetryEvent(ctx context.Context, requestID string, livemode bool) {
 	}
 }
 
+func expandUnixSocket(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home + path[1:]
+		}
+	}
+	return path
+}
+
 func newHTTPClient(verbose bool, printableHeaders []string, unixSocket string) *http.Client {
 	var httpTransport http.RoundTripper
 
 	if unixSocket != "" {
+		unixSocket = expandUnixSocket(unixSocket)
 		dialFunc := func(network, addr string) (net.Conn, error) {
 			return net.Dial("unix", unixSocket)
 		}

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -2,9 +2,12 @@
 package websocket
 
 import (
+	"bufio"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -647,43 +650,94 @@ func expandUnixSocket(path string) string {
 	return path
 }
 
+// wsIsDevHost reports whether host should be routed through the unix socket
+// proxy (stripeproxy) rather than HTTPS_PROXY. Dev environment hosts on
+// *.dev.stripe.me are only reachable via stripeproxy; public hosts use the
+// HTTP proxy.
+func wsIsDevHost(host string) bool {
+	return strings.HasSuffix(host, ".dev.stripe.me")
+}
+
+// wsDialThroughProxy opens a TCP tunnel to addr through an HTTP CONNECT proxy.
+func wsDialThroughProxy(ctx context.Context, proxyURL *url.URL, addr string) (net.Conn, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", proxyURL.Host)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", addr, addr); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: "CONNECT"})
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		conn.Close()
+		return nil, fmt.Errorf("proxy CONNECT %s: %s", addr, resp.Status)
+	}
+	return conn, nil
+}
+
 func newWebSocketDialer(unixSocket string) *ws.Dialer {
-	// When HTTPS_PROXY is set, use it for WebSocket regardless of STRIPE_CLI_UNIX_SOCKET.
-	// The WebSocket server may be on a different host than the API base and unreachable
-	// via the unix socket proxy (which typically only routes dev API traffic).
 	httpsProxy := os.Getenv("HTTPS_PROXY")
 	if httpsProxy == "" {
 		httpsProxy = os.Getenv("https_proxy")
 	}
 
-	if unixSocket != "" && httpsProxy == "" {
-		unixSocket = expandUnixSocket(unixSocket)
-		// NetDialTLSContext tells gorilla that TLS is already handled externally,
-		// so it skips wrapping wss:// connections with tls.Client(). This matches
-		// the HTTP transport's DialTLS behavior: both send a plain connection to
-		// the unix socket proxy and let it handle TLS termination/forwarding.
-		dialFunc := func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return (&net.Dialer{}).DialContext(ctx, "unix", unixSocket)
-		}
-		return &ws.Dialer{
-			HandshakeTimeout:  10 * time.Second,
-			NetDialContext:    dialFunc,
-			NetDialTLSContext: dialFunc,
-			Subprotocols:      subprotocols[:],
-		}
-	}
+	if unixSocket != "" {
+		expandedSocket := expandUnixSocket(unixSocket)
 
-	if unixSocket != "" && httpsProxy != "" {
-		// Both unix socket and HTTPS proxy are set. Use HTTPS_PROXY for all WebSocket
-		// connections regardless of scheme. http.ProxyFromEnvironment only returns
-		// HTTPS_PROXY for https:// (wss://) requests, so ws:// connections from
-		// --no-wss would bypass the proxy and connect directly. Force HTTPS_PROXY
-		// for both schemes so --no-wss works correctly.
+		if httpsProxy == "" {
+			// Only unix socket: route all WebSocket through it. NetDialTLSContext
+			// tells gorilla TLS is handled externally (by the proxy), so it skips
+			// tls.Client() wrapping and sends a plain connection to stripeproxy.
+			dialFunc := func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", expandedSocket)
+			}
+			return &ws.Dialer{
+				HandshakeTimeout:  10 * time.Second,
+				NetDialContext:    dialFunc,
+				NetDialTLSContext: dialFunc,
+				Subprotocols:      subprotocols[:],
+			}
+		}
+
+		// Both unix socket and HTTPS proxy are set. Route by host:
+		//   *.dev.stripe.me → unix socket (stripeproxy), no TLS wrapping
+		//   everything else → HTTPS_PROXY via HTTP CONNECT, with TLS for wss://
 		if proxyURL, err := url.Parse(httpsProxy); err == nil {
 			return &ws.Dialer{
 				HandshakeTimeout: 10 * time.Second,
-				Proxy:            func(*http.Request) (*url.URL, error) { return proxyURL, nil },
-				Subprotocols:     subprotocols[:],
+				NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					host, _, _ := net.SplitHostPort(addr)
+					if wsIsDevHost(host) {
+						return (&net.Dialer{}).DialContext(ctx, "unix", expandedSocket)
+					}
+					return wsDialThroughProxy(ctx, proxyURL, addr)
+				},
+				// NetDialTLSContext is set so gorilla skips its own tls.Client() call.
+				// We do TLS ourselves for non-dev wss:// connections; dev connections
+				// get a plain unix socket and let stripeproxy handle TLS forwarding.
+				NetDialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					host, _, _ := net.SplitHostPort(addr)
+					if wsIsDevHost(host) {
+						return (&net.Dialer{}).DialContext(ctx, "unix", expandedSocket)
+					}
+					conn, err := wsDialThroughProxy(ctx, proxyURL, addr)
+					if err != nil {
+						return nil, err
+					}
+					tlsConn := tls.Client(conn, &tls.Config{ServerName: host})
+					if err := tlsConn.HandshakeContext(ctx); err != nil {
+						conn.Close()
+						return nil, err
+					}
+					return tlsConn, nil
+				},
+				Subprotocols: subprotocols[:],
 			}
 		}
 	}

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -637,25 +637,44 @@ var nullEventHandler = EventHandlerFunc(func(IncomingMessage) {})
 // Private functions
 //
 
-func newWebSocketDialer(unixSocket string) *ws.Dialer {
-	var dialer *ws.Dialer
+func expandUnixSocket(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home + path[1:]
+		}
+	}
+	return path
+}
 
-	if unixSocket != "" {
-		dialFunc := func(network, addr string) (net.Conn, error) {
-			return net.Dial("unix", unixSocket)
+func newWebSocketDialer(unixSocket string) *ws.Dialer {
+	// When HTTPS_PROXY is set, use it for WebSocket regardless of STRIPE_CLI_UNIX_SOCKET.
+	// The WebSocket server may be on a different host than the API base and unreachable
+	// via the unix socket proxy (which typically only routes dev API traffic).
+	httpsProxy := os.Getenv("HTTPS_PROXY")
+	if httpsProxy == "" {
+		httpsProxy = os.Getenv("https_proxy")
+	}
+
+	if unixSocket != "" && httpsProxy == "" {
+		unixSocket = expandUnixSocket(unixSocket)
+		// NetDialTLSContext tells gorilla that TLS is already handled externally,
+		// so it skips wrapping wss:// connections with tls.Client(). This matches
+		// the HTTP transport's DialTLS behavior: both send a plain connection to
+		// the unix socket proxy and let it handle TLS termination/forwarding.
+		dialFunc := func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", unixSocket)
 		}
-		dialer = &ws.Dialer{
-			HandshakeTimeout: 10 * time.Second,
-			NetDial:          dialFunc,
-			Subprotocols:     subprotocols[:],
-		}
-	} else {
-		dialer = &ws.Dialer{
-			HandshakeTimeout: 10 * time.Second,
-			Proxy:            http.ProxyFromEnvironment,
-			Subprotocols:     subprotocols[:],
+		return &ws.Dialer{
+			HandshakeTimeout:  10 * time.Second,
+			NetDialContext:    dialFunc,
+			NetDialTLSContext: dialFunc,
+			Subprotocols:      subprotocols[:],
 		}
 	}
 
-	return dialer
+	return &ws.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+		Proxy:            http.ProxyFromEnvironment,
+		Subprotocols:     subprotocols[:],
+	}
 }

--- a/pkg/websocket/client.go
+++ b/pkg/websocket/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -669,6 +670,21 @@ func newWebSocketDialer(unixSocket string) *ws.Dialer {
 			NetDialContext:    dialFunc,
 			NetDialTLSContext: dialFunc,
 			Subprotocols:      subprotocols[:],
+		}
+	}
+
+	if unixSocket != "" && httpsProxy != "" {
+		// Both unix socket and HTTPS proxy are set. Use HTTPS_PROXY for all WebSocket
+		// connections regardless of scheme. http.ProxyFromEnvironment only returns
+		// HTTPS_PROXY for https:// (wss://) requests, so ws:// connections from
+		// --no-wss would bypass the proxy and connect directly. Force HTTPS_PROXY
+		// for both schemes so --no-wss works correctly.
+		if proxyURL, err := url.Parse(httpsProxy); err == nil {
+			return &ws.Dialer{
+				HandshakeTimeout: 10 * time.Second,
+				Proxy:            func(*http.Request) (*url.URL, error) { return proxyURL, nil },
+				Subprotocols:     subprotocols[:],
+			}
 		}
 	}
 


### PR DESCRIPTION
### Summary

Fixes an issue where we can't run `stripe listen` end-to-end with our internal dev environments. This is because a single request can be routed through different environments these days, and each one requires a different kind of proxy. The problem is we are only supporting one or the other but not both at the same time.

Tested in our internal environments here: https://docs.google.com/document/d/1FRJa_2kGiGJpPOWd2sElZtUaCtKDjrjqAnTiUphwRb4/edit?tab=t.0