### PR TITLE
coop: bundle a version-locked stripe-coop Agent Skill

### DIFF
--- a/pkg/cmd/coop/coop_agent_followup.go
+++ b/pkg/cmd/coop/coop_agent_followup.go
@@ -83,6 +83,7 @@ func runCoopNextActionWithStore(store helpers.Store, sessionID, completed string
 			coop.Continue(coop.NextActionCommand(sessionID, "")),
 		)
 	}
+	resp.ProtocolVersion = coop.CurrentProtocolVersion
 	return outputJSON(resp)
 }
 
@@ -141,7 +142,7 @@ func runCoopStartFollowup(cmd *cobra.Command, parentSessionID, actionID, target 
 		return outputAgentError(fmt.Errorf("writing guided follow-up session: %w", err))
 	}
 
-	return outputJSON(newCoopAgentGuidedActionResponse(action, session))
+	return outputAgentResponse(newCoopAgentGuidedActionResponse(action, session), nil)
 }
 
 func validateFollowupParent(parent *coop.Session, actionID string) error {

--- a/pkg/cmd/coop/coop_agent_protocol.go
+++ b/pkg/cmd/coop/coop_agent_protocol.go
@@ -126,6 +126,7 @@ func outputAgentResponse(resp coop.CommandResponse, err error) error {
 	if validationErr := resp.Validate(); validationErr != nil {
 		resp = protocolFailure("invalid Co-op protocol response: " + validationErr.Error())
 	}
+	resp.ProtocolVersion = coop.CurrentProtocolVersion
 	if !resp.OK {
 		if resp.Recovery == nil {
 			resp.Recovery = defaultAgentRecovery()

--- a/pkg/cmd/coop/coop_blueprint_api_test.go
+++ b/pkg/cmd/coop/coop_blueprint_api_test.go
@@ -92,9 +92,12 @@ func TestCoopRecommendRequiresAll(t *testing.T) {
 	command.SilenceErrors = true
 	command.SilenceUsage = true
 
-	err := command.Execute()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "requires --all")
+	var err error
+	stderr := captureStderr(t, func() { err = command.Execute() })
+	require.ErrorIs(t, err, RenderedError{})
+	assert.Contains(t, stderr, "requires --all")
+	assert.Contains(t, stderr, `"recovery"`)
+	assert.Contains(t, stderr, "stripe coop recommend --all")
 	assert.Zero(t, repository.listCalls)
 }
 

--- a/pkg/cmd/coop/coop_harness.go
+++ b/pkg/cmd/coop/coop_harness.go
@@ -304,7 +304,10 @@ func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApp
 		envPrefix = adapter.envPrefix(autoApprove)
 	}
 
-	script := fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s %s\n",
+	// The env prefix must precede the `exec` keyword: bash only treats
+	// KEY=value words as assignments before the command word, and `exec` is
+	// the command word here.
+	script := fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\n%sexec %s %s\n",
 		shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath),
 		envPrefix, shellQuote(agent.path), strings.Join(args, " "))
 

--- a/pkg/cmd/coop/coop_harness.go
+++ b/pkg/cmd/coop/coop_harness.go
@@ -1,0 +1,342 @@
+package coopcmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"charm.land/huh/v2"
+
+	"github.com/stripe/stripe-cli/pkg/coop/skill"
+)
+
+// harnessAdapter describes how one coding harness is detected, taught the
+// bundled stripe-coop skill, and launched. Everything harness-specific lives
+// here; the skill content itself stays portable.
+//
+// Verified against official harness documentation, July 2026.
+type harnessAdapter struct {
+	// id is the stable identifier accepted by --agent.
+	id          string
+	displayName string
+	// executables are the PATH candidates that select this adapter.
+	executables []string
+	// skillDir returns the harness's user-level skill directory for the
+	// bundled stripe-coop skill, relative to the user's home directory.
+	skillDir func(home string) string
+	// activationLine is the first line of every launch prompt. It uses the
+	// harness's documented explicit skill activation syntax.
+	activationLine string
+	// promptClause places the launch prompt on the command line. It must
+	// reference the shell variable "$prompt" exactly once, and may include a
+	// leading subcommand (e.g. `run -t "$prompt"` for Goose).
+	promptClause string
+	// approvalArgs returns the flags implementing the developer's permission
+	// choice, and extraArgs returns unconditional flags.
+	approvalArgs func(autoApprove bool) string
+	extraArgs    string
+	// envPrefix returns a `KEY=value ` script prefix for harnesses that are
+	// configured through the environment rather than flags.
+	envPrefix func(autoApprove bool) string
+	// bypassLabel names the harness's unrestricted mode in the permission
+	// prompt.
+	bypassLabel string
+	// interactiveLaunch reports whether launching with an initial prompt
+	// leaves the developer in an interactive conversation. Harnesses without
+	// it cannot run the conversational no-blueprint discovery flow.
+	interactiveLaunch bool
+	// notes describes capability limitations surfaced to the developer.
+	notes string
+}
+
+// agentsSkillsDir is the cross-harness skills directory from the Agent Skills
+// standard, read by Codex, OpenCode, Roo Code, OpenHands, and Goose.
+func agentsSkillsDir(home string) string {
+	return filepath.Join(home, ".agents", "skills")
+}
+
+var harnessRegistry = []*harnessAdapter{
+	{
+		id:                "claude",
+		displayName:       "Claude Code",
+		executables:       []string{"claude"},
+		skillDir:          func(home string) string { return filepath.Join(home, ".claude", "skills") },
+		activationLine:    "Use the /stripe-coop skill.",
+		promptClause:      `"$prompt"`,
+		extraArgs:         "--agents " + shellQuote(claudeCoopAgents),
+		approvalArgs:      flagWhenBypassed("--dangerously-skip-permissions"),
+		bypassLabel:       "Bypass permissions — skip safety checks (isolated environments only)",
+		interactiveLaunch: true,
+	},
+	{
+		id:                "codex",
+		displayName:       "Codex",
+		executables:       []string{"codex"},
+		skillDir:          agentsSkillsDir,
+		activationLine:    "Use the $stripe-coop skill.",
+		promptClause:      `"$prompt"`,
+		approvalArgs:      flagWhenBypassed("--dangerously-bypass-approvals-and-sandbox"),
+		bypassLabel:       "Bypass approvals and sandbox — skip safety checks (isolated environments only)",
+		interactiveLaunch: true,
+	},
+	{
+		id:                "opencode",
+		displayName:       "OpenCode",
+		executables:       []string{"opencode"},
+		skillDir:          agentsSkillsDir,
+		activationLine:    "Use the stripe-coop skill.",
+		promptClause:      `--prompt "$prompt"`,
+		approvalArgs:      flagWhenBypassed("--auto"),
+		bypassLabel:       "Auto-approve permissions — skip approval prompts (isolated environments only)",
+		interactiveLaunch: true,
+	},
+	{
+		id:                "cline",
+		displayName:       "Cline",
+		executables:       []string{"cline"},
+		skillDir:          func(home string) string { return filepath.Join(home, ".cline", "skills") },
+		activationLine:    "Use the /stripe-coop skill.",
+		promptClause:      `"$prompt"`,
+		approvalArgs:      flagWhenBypassed("--yolo"),
+		bypassLabel:       "Auto-approve all actions (--yolo) — skip safety checks (isolated environments only)",
+		interactiveLaunch: false,
+		notes:             "Cline runs the launch prompt as a one-shot task, so the conversational no-blueprint discovery flow is unavailable.",
+	},
+	{
+		id:             "roo",
+		displayName:    "Roo Code",
+		executables:    []string{"roo"},
+		skillDir:       agentsSkillsDir,
+		activationLine: "Use the stripe-coop skill.",
+		promptClause:   `"$prompt"`,
+		// Roo's CLI auto-approves by default; normal mode opts back into
+		// manual approval.
+		approvalArgs: func(autoApprove bool) string {
+			if autoApprove {
+				return ""
+			}
+			return "--require-approval"
+		},
+		bypassLabel:       "Auto-approve all actions (Roo default) — skip safety checks (isolated environments only)",
+		interactiveLaunch: true,
+		notes:             "Roo Code was discontinued in May 2026; its skill support is frozen at the final release.",
+	},
+	{
+		id:                "openhands",
+		displayName:       "OpenHands",
+		executables:       []string{"openhands"},
+		skillDir:          agentsSkillsDir,
+		activationLine:    "Use the stripe-coop skill.",
+		promptClause:      `-t "$prompt"`,
+		approvalArgs:      flagWhenBypassed("--always-approve"),
+		bypassLabel:       "Always approve actions — skip confirmation prompts (isolated environments only)",
+		interactiveLaunch: true,
+	},
+	{
+		id:             "goose",
+		displayName:    "Goose",
+		executables:    []string{"goose"},
+		skillDir:       agentsSkillsDir,
+		activationLine: "Use the stripe-coop skill.",
+		promptClause:   `run -t "$prompt"`,
+		// Goose's permission model is the GOOSE_MODE environment variable
+		// (its default is autonomous).
+		envPrefix: func(autoApprove bool) string {
+			if autoApprove {
+				return "GOOSE_MODE=auto "
+			}
+			return "GOOSE_MODE=approve "
+		},
+		bypassLabel:       "Autonomous mode (GOOSE_MODE=auto) — skip approval prompts (isolated environments only)",
+		interactiveLaunch: false,
+		notes:             "goose run executes the launch prompt without an interactive conversation, so the no-blueprint discovery flow is unavailable.",
+	},
+}
+
+func flagWhenBypassed(flag string) func(bool) string {
+	return func(autoApprove bool) string {
+		if autoApprove {
+			return flag
+		}
+		return ""
+	}
+}
+
+// genericAdapter wraps an unrecognized --agent command. It launches with a
+// positional prompt and receives no skill install, so its prompt falls back to
+// the full self-contained lifecycle instructions.
+func genericAdapter(command string) *harnessAdapter {
+	return &harnessAdapter{
+		id:                command,
+		displayName:       command,
+		executables:       []string{command},
+		activationLine:    "",
+		promptClause:      `"$prompt"`,
+		approvalArgs:      func(bool) string { return "" },
+		interactiveLaunch: true,
+		notes:             "Unknown agent: launched with a positional prompt and without the managed stripe-coop skill.",
+	}
+}
+
+func harnessByID(id string) *harnessAdapter {
+	for _, adapter := range harnessRegistry {
+		if adapter.id == id {
+			return adapter
+		}
+		for _, executable := range adapter.executables {
+			if executable == id {
+				return adapter
+			}
+		}
+	}
+	return nil
+}
+
+type agentInfo struct {
+	adapter *harnessAdapter
+	path    string
+}
+
+var (
+	lookPath    = exec.LookPath
+	userHomeDir = os.UserHomeDir
+)
+
+func (rc *coopRunCmd) detectAgent() (*agentInfo, error) {
+	if rc.agent != "" {
+		path, err := lookPath(rc.agent)
+		if err != nil {
+			return nil, fmt.Errorf("agent %q not found in PATH", rc.agent)
+		}
+		adapter := harnessByID(rc.agent)
+		if adapter == nil {
+			adapter = harnessByID(filepath.Base(rc.agent))
+		}
+		if adapter == nil {
+			adapter = genericAdapter(rc.agent)
+		}
+		return &agentInfo{adapter: adapter, path: path}, nil
+	}
+
+	var found []*agentInfo
+	for _, adapter := range harnessRegistry {
+		if path, err := lookPathAny(adapter.executables); err == nil {
+			found = append(found, &agentInfo{adapter: adapter, path: path})
+		}
+	}
+
+	switch len(found) {
+	case 0:
+		return nil, fmt.Errorf("no AI agent found in PATH.\n  Install Claude Code: https://docs.anthropic.com/en/docs/claude-code\n  Or specify a custom agent: --agent=<command>")
+	case 1:
+		return found[0], nil
+	}
+
+	options := make([]huh.Option[string], 0, len(found))
+	for _, agent := range found {
+		options = append(options, huh.NewOption(agent.adapter.displayName, agent.adapter.id))
+	}
+	var choice string
+	if err := selectString("Multiple agents detected. Which would you like to use?", options, &choice); err != nil {
+		return nil, err
+	}
+	for _, agent := range found {
+		if agent.adapter.id == choice {
+			return agent, nil
+		}
+	}
+	return found[0], nil
+}
+
+func lookPathAny(candidates []string) (string, error) {
+	var err error
+	for _, candidate := range candidates {
+		var path string
+		if path, err = lookPath(candidate); err == nil {
+			return path, nil
+		}
+	}
+	if err == nil {
+		err = exec.ErrNotFound
+	}
+	return "", err
+}
+
+func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) (bool, error) {
+	if agent.adapter.bypassLabel == "" {
+		return false, nil
+	}
+	var choice string
+	err := selectString(fmt.Sprintf("Permission mode for %s:", agent.adapter.displayName),
+		[]huh.Option[string]{
+			huh.NewOption("Normal — agent asks before running commands", "normal"),
+			huh.NewOption(agent.adapter.bypassLabel, "bypass"),
+		},
+		&choice,
+	)
+	if err != nil {
+		return false, err
+	}
+	return choice == "bypass", nil
+}
+
+// buildAgentCmd writes a self-deleting launcher script that reads the prompt
+// file and exec's the harness with its adapter-specific arguments.
+func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApprove bool) (string, error) {
+	launcherPath := promptPath + ".sh"
+	adapter := agent.adapter
+
+	args := make([]string, 0, 3)
+	if adapter.extraArgs != "" {
+		args = append(args, adapter.extraArgs)
+	}
+	if adapter.approvalArgs != nil {
+		if approval := adapter.approvalArgs(autoApprove); approval != "" {
+			args = append(args, approval)
+		}
+	}
+	args = append(args, adapter.promptClause)
+
+	envPrefix := ""
+	if adapter.envPrefix != nil {
+		envPrefix = adapter.envPrefix(autoApprove)
+	}
+
+	script := fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s %s\n",
+		shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath),
+		envPrefix, shellQuote(agent.path), strings.Join(args, " "))
+
+	if err := os.WriteFile(launcherPath, []byte(script), 0700); err != nil {
+		return "", fmt.Errorf("creating agent launcher: %w", err)
+	}
+	return launcherPath, nil
+}
+
+// harnessSkillTarget returns the full stripe-coop install path for a harness,
+// or "" when the harness has no managed skill location.
+func harnessSkillTarget(adapter *harnessAdapter) (string, error) {
+	if adapter.skillDir == nil {
+		return "", nil
+	}
+	home, err := userHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(adapter.skillDir(home), skill.Name), nil
+}
+
+// ensureHarnessCoopSkill installs or refreshes the bundled stripe-coop skill
+// for the selected harness. It reports whether launch prompts may rely on the
+// skill being present.
+func ensureHarnessCoopSkill(adapter *harnessAdapter) (bool, error) {
+	target, err := harnessSkillTarget(adapter)
+	if err != nil || target == "" {
+		return false, err
+	}
+	if _, err := skill.Install(target); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/cmd/coop/coop_harness_test.go
+++ b/pkg/cmd/coop/coop_harness_test.go
@@ -3,7 +3,9 @@ package coopcmd
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -272,6 +274,31 @@ func TestCompactDiscoveryPromptCarriesOnlyDynamicContext(t *testing.T) {
 	assert.NotContains(t, prompt, "await-review")
 	assert.NotContains(t, prompt, stripeAgentGuidanceStart)
 	assert.Less(t, len(prompt), 600)
+}
+
+// TestGooseLauncherScriptExecutesWithEnvMode runs the generated goose
+// launcher for real: the GOOSE_MODE assignment must precede `exec` or bash
+// tries to execute a program literally named "GOOSE_MODE=...".
+func TestGooseLauncherScriptExecutesWithEnvMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("launcher execution requires a POSIX shell")
+	}
+
+	fakeGoose := filepath.Join(t.TempDir(), "goose")
+	outFile := filepath.Join(t.TempDir(), "out")
+	require.NoError(t, os.WriteFile(fakeGoose, []byte("#!/bin/sh\necho \"$GOOSE_MODE|$@\" > "+shellQuote(outFile)+"\n"), 0o700))
+
+	promptPath := filepath.Join(t.TempDir(), "prompt")
+	require.NoError(t, os.WriteFile(promptPath, []byte("the prompt"), 0o600))
+
+	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(
+		&agentInfo{adapter: harnessByID("goose"), path: fakeGoose}, promptPath, true)
+	require.NoError(t, err)
+
+	require.NoError(t, exec.Command("bash", launcherPath).Run())
+	captured, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	assert.Equal(t, "auto|run -t the prompt\n", string(captured))
 }
 
 // TestAgentResponsesCarryProtocolVersion pins the wire-visible protocol

--- a/pkg/cmd/coop/coop_harness_test.go
+++ b/pkg/cmd/coop/coop_harness_test.go
@@ -1,0 +1,310 @@
+package coopcmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/skill"
+)
+
+func testAgent(t *testing.T, id string) *agentInfo {
+	t.Helper()
+	adapter := harnessByID(id)
+	require.NotNil(t, adapter, "unknown harness %q", id)
+	return &agentInfo{adapter: adapter, path: "/usr/local/bin/" + adapter.executables[0]}
+}
+
+func buildLauncherScript(t *testing.T, id string, autoApprove bool) string {
+	t.Helper()
+	promptPath := filepath.Join(t.TempDir(), "prompt")
+	require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
+
+	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(testAgent(t, id), promptPath, autoApprove)
+	require.NoError(t, err)
+	launcher, err := os.ReadFile(launcherPath)
+	require.NoError(t, err)
+	return string(launcher)
+}
+
+func TestHarnessRegistryCoversSupportedHarnesses(t *testing.T) {
+	want := []string{"claude", "codex", "opencode", "cline", "roo", "openhands", "goose"}
+	require.Len(t, harnessRegistry, len(want))
+	for _, id := range want {
+		require.NotNil(t, harnessByID(id), "missing harness %s", id)
+	}
+}
+
+func TestHarnessSkillInstallDirectories(t *testing.T) {
+	home := "/home/dev"
+	tests := map[string]string{
+		"claude":    "/home/dev/.claude/skills",
+		"codex":     "/home/dev/.agents/skills",
+		"opencode":  "/home/dev/.agents/skills",
+		"cline":     "/home/dev/.cline/skills",
+		"roo":       "/home/dev/.agents/skills",
+		"openhands": "/home/dev/.agents/skills",
+		"goose":     "/home/dev/.agents/skills",
+	}
+	for id, wantDir := range tests {
+		adapter := harnessByID(id)
+		require.NotNil(t, adapter, id)
+		require.NotNil(t, adapter.skillDir, "%s must have a managed skill directory", id)
+		assert.Equal(t, filepath.FromSlash(wantDir), adapter.skillDir(home), id)
+	}
+}
+
+func TestHarnessActivationTokens(t *testing.T) {
+	tests := map[string]string{
+		"claude":    "Use the /stripe-coop skill.",
+		"codex":     "Use the $stripe-coop skill.",
+		"opencode":  "Use the stripe-coop skill.",
+		"cline":     "Use the /stripe-coop skill.",
+		"roo":       "Use the stripe-coop skill.",
+		"openhands": "Use the stripe-coop skill.",
+		"goose":     "Use the stripe-coop skill.",
+	}
+	for id, want := range tests {
+		assert.Equal(t, want, harnessByID(id).activationLine, id)
+	}
+}
+
+func TestHarnessLaunchArgumentConstruction(t *testing.T) {
+	tests := []struct {
+		id          string
+		autoApprove bool
+		contains    []string
+		notContains []string
+	}{
+		{
+			id: "opencode", autoApprove: true,
+			contains:    []string{`--auto --prompt "$prompt"`},
+			notContains: []string{"--dangerously"},
+		},
+		{
+			id: "opencode", autoApprove: false,
+			contains:    []string{`--prompt "$prompt"`},
+			notContains: []string{"--auto "},
+		},
+		{
+			id: "cline", autoApprove: true,
+			contains: []string{`--yolo "$prompt"`},
+		},
+		{
+			id: "cline", autoApprove: false,
+			notContains: []string{"--yolo"},
+		},
+		{
+			id: "roo", autoApprove: false,
+			contains: []string{`--require-approval "$prompt"`},
+		},
+		{
+			id: "roo", autoApprove: true,
+			notContains: []string{"--require-approval"},
+		},
+		{
+			id: "openhands", autoApprove: true,
+			contains: []string{`--always-approve -t "$prompt"`},
+		},
+		{
+			id: "openhands", autoApprove: false,
+			contains:    []string{`-t "$prompt"`},
+			notContains: []string{"--always-approve"},
+		},
+		{
+			id: "goose", autoApprove: true,
+			contains: []string{`GOOSE_MODE=auto `, `run -t "$prompt"`},
+		},
+		{
+			id: "goose", autoApprove: false,
+			contains: []string{`GOOSE_MODE=approve `, `run -t "$prompt"`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			script := buildLauncherScript(t, tt.id, tt.autoApprove)
+			assert.Contains(t, script, "exec ")
+			assert.Contains(t, script, `"$prompt"`)
+			for _, want := range tt.contains {
+				assert.Contains(t, script, want)
+			}
+			for _, unwanted := range tt.notContains {
+				assert.NotContains(t, script, unwanted)
+			}
+		})
+	}
+}
+
+func TestDetectAgentPrefersExplicitFlagAndKnownAdapters(t *testing.T) {
+	originalLookPath := lookPath
+	lookPath = func(file string) (string, error) {
+		if file == "opencode" {
+			return "/opt/bin/opencode", nil
+		}
+		return "", errors.New("not found")
+	}
+	t.Cleanup(func() { lookPath = originalLookPath })
+
+	agent, err := (&coopRunCmd{agent: "opencode"}).detectAgent()
+	require.NoError(t, err)
+	assert.Equal(t, "opencode", agent.adapter.id)
+	assert.Equal(t, "/opt/bin/opencode", agent.path)
+
+	// Auto-detection finds the single installed harness without prompting.
+	agent, err = (&coopRunCmd{}).detectAgent()
+	require.NoError(t, err)
+	assert.Equal(t, "opencode", agent.adapter.id)
+}
+
+func TestDetectAgentFallsBackToGenericAdapterForUnknownCommand(t *testing.T) {
+	originalLookPath := lookPath
+	lookPath = func(file string) (string, error) {
+		if file == "my-agent" {
+			return "/opt/bin/my-agent", nil
+		}
+		return "", errors.New("not found")
+	}
+	t.Cleanup(func() { lookPath = originalLookPath })
+
+	agent, err := (&coopRunCmd{agent: "my-agent"}).detectAgent()
+	require.NoError(t, err)
+	assert.Equal(t, "my-agent", agent.adapter.id)
+	assert.Nil(t, agent.adapter.skillDir, "unknown agents receive no managed skill install")
+	assert.True(t, agent.adapter.interactiveLaunch)
+
+	script := func() string {
+		promptPath := filepath.Join(t.TempDir(), "prompt")
+		require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
+		launcherPath, err := (&coopRunCmd{}).buildAgentCmd(agent, promptPath, true)
+		require.NoError(t, err)
+		launcher, err := os.ReadFile(launcherPath)
+		require.NoError(t, err)
+		return string(launcher)
+	}()
+	assert.Contains(t, script, `'/opt/bin/my-agent' "$prompt"`)
+}
+
+func TestEnsureHarnessCoopSkillInstallsIntoHarnessDirectory(t *testing.T) {
+	home := t.TempDir()
+	originalHome := userHomeDir
+	userHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { userHomeDir = originalHome })
+
+	for _, id := range []string{"codex", "claude"} {
+		installed, err := ensureHarnessCoopSkill(harnessByID(id))
+		require.NoError(t, err, id)
+		assert.True(t, installed, id)
+	}
+
+	for _, dir := range []string{
+		filepath.Join(home, ".agents", "skills", skill.Name),
+		filepath.Join(home, ".claude", "skills", skill.Name),
+	} {
+		_, err := os.Stat(filepath.Join(dir, "SKILL.md"))
+		require.NoError(t, err)
+		_, err = os.Stat(filepath.Join(dir, skill.ManifestFileName))
+		require.NoError(t, err)
+	}
+
+	// Second run is an idempotent no-op that still reports the skill ready.
+	installed, err := ensureHarnessCoopSkill(harnessByID("codex"))
+	require.NoError(t, err)
+	assert.True(t, installed)
+}
+
+func TestEnsureCoopSkillForFallsBackOnUnmanagedSkill(t *testing.T) {
+	rc := &coopRunCmd{installCoopSkill: func(*harnessAdapter) (bool, error) {
+		return false, skill.ErrUnmanagedSkill
+	}}
+	ready := rc.ensureCoopSkillFor(nil, testAgent(t, "codex"))
+	assert.False(t, ready)
+
+	prompt := rc.buildAgentPrompt(testAgent(t, "codex"), "")
+	assert.NotContains(t, prompt, "$stripe-coop", "fallback prompt must not rely on the skill")
+	assert.Contains(t, prompt, "production-grade Stripe integration")
+}
+
+func TestCompactSessionPromptCarriesOnlyDynamicContext(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	rc := &coopRunCmd{language: "python", coopSkillReady: true}
+	session, err := rc.startSessionQuietly(commandTestBlueprint(t))
+	require.NoError(t, err)
+
+	prompt, err := rc.buildAgentPromptForSession(testAgent(t, "codex"), session)
+	require.NoError(t, err)
+
+	assert.Contains(t, prompt, "Use the $stripe-coop skill.")
+	assert.Contains(t, prompt, "Session: "+session.ID)
+	assert.Contains(t, prompt, "Integration: ")
+	assert.Contains(t, prompt, "Language: python")
+	assert.Contains(t, prompt, "stripe coop agent start-work --session="+session.ID+" --step=1")
+	assert.NotContains(t, prompt, "<") // no unresolved placeholders
+
+	// The stable lifecycle contract lives in the skill, not the prompt.
+	assert.NotContains(t, prompt, "await-review")
+	assert.NotContains(t, prompt, "report-check")
+	assert.NotContains(t, prompt, stripeAgentGuidanceStart)
+	assert.NotContains(t, prompt, "pm_card_visa")
+	assert.NotContains(t, prompt, "sandbox create")
+	assert.Less(t, len(prompt), 800)
+
+	claudePrompt, err := rc.buildAgentPromptForSession(testAgent(t, "claude"), session)
+	require.NoError(t, err)
+	assert.Contains(t, claudePrompt, "Use the /stripe-coop skill.")
+}
+
+func TestCompactDiscoveryPromptCarriesOnlyDynamicContext(t *testing.T) {
+	rc := &coopRunCmd{language: "python", coopSkillReady: true}
+	prompt := rc.buildAgentPrompt(testAgent(t, "codex"), "")
+
+	assert.Contains(t, prompt, "Use the $stripe-coop skill.")
+	assert.Contains(t, prompt, "No blueprint is selected.")
+	assert.Contains(t, prompt, "gather only developer intent that cannot be inferred")
+	assert.Contains(t, prompt, "stripe coop recommend --all")
+	assert.Contains(t, prompt, "Language hint: python.")
+	assert.NotContains(t, prompt, "await-review")
+	assert.NotContains(t, prompt, stripeAgentGuidanceStart)
+	assert.Less(t, len(prompt), 600)
+}
+
+// TestAgentResponsesCarryProtocolVersion pins the wire-visible protocol
+// version stamp on both success and failure output paths.
+func TestAgentResponsesCarryProtocolVersion(t *testing.T) {
+	output := captureStdout(t, func() {
+		require.NoError(t, outputAgentResponse(coop.CommandResponse{
+			OK:      true,
+			Message: "done",
+		}, nil))
+	})
+	assert.Contains(t, output, `"protocol_version": 1`)
+
+	stderr := captureStderr(t, func() {
+		err := outputAgentResponse(coop.CommandResponse{}, errors.New("boom"))
+		require.ErrorIs(t, err, RenderedError{})
+	})
+	assert.Contains(t, stderr, `"protocol_version": 1`)
+}
+
+// TestSkillDocumentsEveryAgentSubcommand keeps the bundled skill's command
+// reference in lockstep with the registered `stripe coop agent` subcommands.
+func TestSkillDocumentsEveryAgentSubcommand(t *testing.T) {
+	files, err := skill.Files()
+	require.NoError(t, err)
+	commandAPI := string(files["references/command-api.md"])
+
+	agentCmd := newCoopAgentCmd().cmd
+	subcommands := agentCmd.Commands()
+	require.NotEmpty(t, subcommands)
+	for _, sub := range subcommands {
+		name := strings.Fields(sub.Use)[0]
+		assert.Contains(t, commandAPI, "stripe coop agent "+name,
+			"references/command-api.md must document %q", name)
+	}
+}

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -16,11 +16,6 @@ import (
 	"github.com/stripe/stripe-cli/pkg/coop/tui"
 )
 
-type agentInfo struct {
-	name string // "claude" or "codex"
-	path string
-}
-
 // shellQuote wraps s in POSIX single quotes so it is safe to interpolate into a
 // `bash -c` command line. Unlike strconv.Quote (which produces a Go string
 // literal), single quoting neutralizes shell metacharacters including command
@@ -45,115 +40,6 @@ const (
 	claudeCoopAgents             = `{"coop-cost-effective-worker":{"description":"Use proactively for well-bounded, self-contained exploration, documentation research, test execution, log analysis, and verification tasks when delegation saves main-session context and cost.","prompt":"Work as a focused cost-effective Co-op subagent. Complete only the bounded task you receive, verify your result, and return concise evidence to the main agent. Find and honor applicable repository guidance, including AGENTS.md and CLAUDE.md, before acting. Do not choose or change the Stripe integration or run Co-op lifecycle commands.","model":"haiku"}}`
 )
 
-func (rc *coopRunCmd) detectAgent() (*agentInfo, error) {
-	if rc.agent != "" {
-		path, err := exec.LookPath(rc.agent)
-		if err != nil {
-			return nil, fmt.Errorf("agent %q not found in PATH", rc.agent)
-		}
-		name := rc.agent
-		if strings.Contains(path, "claude") {
-			name = "claude"
-		} else if strings.Contains(path, "codex") {
-			name = "codex"
-		}
-		return &agentInfo{name: name, path: path}, nil
-	}
-
-	claudePath, claudeErr := exec.LookPath("claude")
-	codexPath, codexErr := exec.LookPath("codex")
-
-	hasClaude := claudeErr == nil
-	hasCodex := codexErr == nil
-
-	switch {
-	case hasClaude && hasCodex:
-		var choice string
-		err := selectString("Multiple agents detected. Which would you like to use?",
-			[]huh.Option[string]{
-				huh.NewOption("Claude Code", "claude"),
-				huh.NewOption("Codex", "codex"),
-			},
-			&choice,
-		)
-		if err != nil {
-			return nil, err
-		}
-		if choice == "codex" {
-			return &agentInfo{name: "codex", path: codexPath}, nil
-		}
-		return &agentInfo{name: "claude", path: claudePath}, nil
-
-	case hasClaude:
-		return &agentInfo{name: "claude", path: claudePath}, nil
-	case hasCodex:
-		return &agentInfo{name: "codex", path: codexPath}, nil
-	default:
-		return nil, fmt.Errorf("no AI agent found in PATH.\n  Install Claude Code: https://docs.anthropic.com/en/docs/claude-code\n  Or specify a custom agent: --agent=<command>")
-	}
-}
-
-func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) (bool, error) {
-	var choice string
-
-	var title string
-	var bypassLabel string
-	switch agent.name {
-	case "claude":
-		title = "Permission mode for Claude Code:"
-		bypassLabel = "Bypass permissions — skip safety checks (isolated environments only)"
-	case "codex":
-		title = "Permission mode for Codex:"
-		bypassLabel = "Bypass approvals and sandbox — skip safety checks (isolated environments only)"
-	default:
-		return false, nil
-	}
-
-	err := selectString(title,
-		[]huh.Option[string]{
-			huh.NewOption("Normal — agent asks before running commands", "normal"),
-			huh.NewOption(bypassLabel, "bypass"),
-		},
-		&choice,
-	)
-	if err != nil {
-		return false, err
-	}
-	return choice == "bypass", nil
-}
-
-func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApprove bool) (string, error) {
-	launcherPath := promptPath + ".sh"
-	var script string
-
-	switch agent.name {
-	case "claude":
-		flags := " --agents " + shellQuote(claudeCoopAgents)
-		if autoApprove {
-			flags += " --dangerously-skip-permissions"
-		}
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path), flags)
-
-	case "codex":
-		flags := ""
-		if autoApprove {
-			flags = " --dangerously-bypass-approvals-and-sandbox"
-		}
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path), flags)
-
-	default:
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path))
-	}
-
-	if err := os.WriteFile(launcherPath, []byte(script), 0700); err != nil {
-		return "", fmt.Errorf("creating agent launcher: %w", err)
-	}
-	return launcherPath, nil
-}
-
 func (rc *coopRunCmd) hasTmux() bool {
 	_, err := exec.LookPath("tmux")
 	return err == nil
@@ -164,7 +50,7 @@ func (rc *coopRunCmd) agentPaneCommandBuilder(agent *agentInfo, discoveryPrompt 
 		prompt := discoveryPrompt
 		if session != nil {
 			var err error
-			prompt, err = rc.buildAgentPromptForSession(session)
+			prompt, err = rc.buildAgentPromptForSession(agent, session)
 			if err != nil {
 				return "", nil, err
 			}

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -53,7 +53,7 @@ func TestExplicitBlueprintPromptIsCompactBootstrap(t *testing.T) {
 	session, err := rc.startSessionQuietly(commandTestBlueprint(t))
 	require.NoError(t, err)
 
-	prompt, err := rc.buildAgentPromptForSession(session)
+	prompt, err := rc.buildAgentPromptForSession(testAgent(t, "claude"), session)
 	require.NoError(t, err)
 	assert.Contains(t, prompt, "We will handle coordination and orchestration with you")
 	assert.Contains(t, prompt, "cheaper subagents wherever possible, using your best judgment")
@@ -81,7 +81,7 @@ func TestExplicitBlueprintPromptIsCompactBootstrap(t *testing.T) {
 }
 
 func TestDiscoveryPromptKeepsCoopAsIntegrationAuthority(t *testing.T) {
-	prompt := (&coopRunCmd{language: "go"}).buildAgentPrompt("")
+	prompt := (&coopRunCmd{language: "go"}).buildAgentPrompt(testAgent(t, "claude"), "")
 	assert.Contains(t, prompt, "We will handle coordination and orchestration with you")
 	assert.Contains(t, prompt, "cheaper subagents wherever possible, using your best judgment")
 
@@ -108,7 +108,7 @@ func TestPromptAutoApproveReturnsPromptErrors(t *testing.T) {
 		selectString = originalSelectString
 	})
 
-	autoApprove, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{name: "claude"})
+	autoApprove, err := (&coopRunCmd{}).promptAutoApprove(testAgent(t, "claude"))
 
 	require.ErrorIs(t, err, promptErr)
 	assert.False(t, autoApprove)
@@ -137,7 +137,7 @@ func TestPromptAutoApproveLabelsBypassModeAccurately(t *testing.T) {
 			}
 			t.Cleanup(func() { selectString = originalSelectString })
 
-			bypass, err := (&coopRunCmd{}).promptAutoApprove(&agentInfo{name: tt.agent})
+			bypass, err := (&coopRunCmd{}).promptAutoApprove(testAgent(t, tt.agent))
 
 			require.NoError(t, err)
 			assert.True(t, bypass)
@@ -161,7 +161,7 @@ func TestClaudeLauncherConfiguresCostEffectiveWorkerAndInteractivePrompt(t *test
 	require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
 	rc := &coopRunCmd{}
 
-	launcherPath, err := rc.buildAgentCmd(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, promptPath, true)
+	launcherPath, err := rc.buildAgentCmd(&agentInfo{adapter: harnessByID("claude"), path: "/usr/local/bin/claude"}, promptPath, true)
 	require.NoError(t, err)
 	launcher, err := os.ReadFile(launcherPath)
 	require.NoError(t, err)
@@ -180,7 +180,7 @@ func TestClaudeLauncherNormalModeDoesNotBypassPermissions(t *testing.T) {
 	promptPath := filepath.Join(t.TempDir(), "prompt")
 	require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
 
-	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, promptPath, false)
+	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(&agentInfo{adapter: harnessByID("claude"), path: "/usr/local/bin/claude"}, promptPath, false)
 	require.NoError(t, err)
 	launcher, err := os.ReadFile(launcherPath)
 	require.NoError(t, err)
@@ -194,7 +194,7 @@ func TestCodexLauncherDoesNotReceiveClaudeAgents(t *testing.T) {
 	promptPath := filepath.Join(t.TempDir(), "prompt")
 	require.NoError(t, os.WriteFile(promptPath, []byte("prompt"), 0o600))
 
-	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(&agentInfo{name: "codex", path: "/usr/local/bin/codex"}, promptPath, true)
+	launcherPath, err := (&coopRunCmd{}).buildAgentCmd(&agentInfo{adapter: harnessByID("codex"), path: "/usr/local/bin/codex"}, promptPath, true)
 	require.NoError(t, err)
 	launcher, err := os.ReadFile(launcherPath)
 	require.NoError(t, err)
@@ -380,7 +380,7 @@ func TestAgentPaneCommandShellQuotesLauncherPath(t *testing.T) {
 	t.Setenv("TEMP", tmp)
 
 	rc := &coopRunCmd{}
-	build := rc.agentPaneCommandBuilder(&agentInfo{name: "claude", path: "/usr/local/bin/claude"}, "discovery prompt", false)
+	build := rc.agentPaneCommandBuilder(&agentInfo{adapter: harnessByID("claude"), path: "/usr/local/bin/claude"}, "discovery prompt", false)
 	paneCmd, cleanup, err := build(nil)
 	require.NoError(t, err)
 	require.NotNil(t, cleanup)

--- a/pkg/cmd/coop/coop_recommend.go
+++ b/pkg/cmd/coop/coop_recommend.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/coop"
 )
 
 type coopRecommendCmd struct {
@@ -31,15 +33,27 @@ for the developer's requested integration.`,
 
 func (rc *coopRecommendCmd) runRecommendCmd(cmd *cobra.Command, args []string) error {
 	if !rc.all {
-		return fmt.Errorf("recommend requires --all to list blueprint summaries")
+		return outputCoopError(
+			"recommend requires --all to list blueprint summaries",
+			"List every blueprint summary before choosing one.",
+			coop.Continue("stripe coop recommend --all"),
+		)
 	}
 	repository := coopBlueprintRepository()
 	if repository == nil {
-		return fmt.Errorf("loading blueprints: no blueprint repository configured")
+		return outputCoopError(
+			"loading blueprints: no blueprint repository configured",
+			"Blueprint listing is unavailable in this build; report the environment issue to the developer.",
+			coop.Continue(coop.StatusCommand("")),
+		)
 	}
 	blueprints, err := repository.List(cmd.Context())
 	if err != nil {
-		return fmt.Errorf("loading blueprints: %w", err)
+		return outputCoopError(
+			fmt.Sprintf("loading blueprints: %v", err),
+			"Retry the blueprint listing; if it keeps failing, check network access and authentication.",
+			coop.Continue("stripe coop recommend --all"),
+		)
 	}
 
 	type bpEntry struct {
@@ -73,7 +87,9 @@ func (rc *coopRecommendCmd) runRecommendCmd(cmd *cobra.Command, args []string) e
 	}
 
 	response := map[string]interface{}{
-		"blueprints": catalog,
+		"ok":               true,
+		"protocol_version": coop.CurrentProtocolVersion,
+		"blueprints":       catalog,
 		"agent_instructions": `Review every blueprint summary and pick the best match for the developer's request.
 Consider: what they're building, whether it's one-time or recurring, if it involves platforms/marketplaces.
 If multiple could fit, ask the developer to clarify between the top 2-3 options.

--- a/pkg/cmd/coop/coop_run.go
+++ b/pkg/cmd/coop/coop_run.go
@@ -96,9 +96,7 @@ func (rc *coopAgentRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 		return outputAgentError(fmt.Errorf("writing session: %w", err))
 	}
 
-	resp := newCoopAgentRunResponse(bp, session)
-
-	return outputJSON(resp)
+	return outputAgentResponse(newCoopAgentRunResponse(bp, session), nil)
 }
 
 func (rc *coopAgentRunCmd) ensureStripeSkill() error {

--- a/pkg/cmd/coop/coop_run_test.go
+++ b/pkg/cmd/coop/coop_run_test.go
@@ -230,6 +230,7 @@ func TestCoopStartPreparesOnlyTheNeededAgentSkillState(t *testing.T) {
 			rc.agent = fakeAgent
 			skillCalled := false
 			claudeRootCalled := false
+			coopSkillCalled := false
 			rc.ensureSkill = func() error {
 				skillCalled = true
 				return nil
@@ -237,6 +238,11 @@ func TestCoopStartPreparesOnlyTheNeededAgentSkillState(t *testing.T) {
 			rc.prepareSkillDiscovery = func() error {
 				claudeRootCalled = true
 				return nil
+			}
+			rc.installCoopSkill = func(adapter *harnessAdapter) (bool, error) {
+				coopSkillCalled = true
+				assert.Equal(t, tt.agent, adapter.id)
+				return true, nil
 			}
 			args := []string(nil)
 			if tt.blueprint != "" {
@@ -249,6 +255,7 @@ func TestCoopStartPreparesOnlyTheNeededAgentSkillState(t *testing.T) {
 			require.NoError(t, runErr)
 			assert.Equal(t, tt.wantSkill, skillCalled)
 			assert.Equal(t, tt.wantClaudeRoot, claudeRootCalled)
+			assert.True(t, coopSkillCalled, "coop start must install the managed stripe-coop skill")
 		})
 	}
 }

--- a/pkg/cmd/coop/coop_start.go
+++ b/pkg/cmd/coop/coop_start.go
@@ -2,12 +2,16 @@ package coopcmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stripe/stripe-cli/pkg/coop"
+	coopskill "github.com/stripe/stripe-cli/pkg/coop/skill"
 )
 
 type coopRunCmd struct {
@@ -18,6 +22,10 @@ type coopRunCmd struct {
 	debugAgent            bool
 	ensureSkill           func() error
 	prepareSkillDiscovery func() error
+	installCoopSkill      func(*harnessAdapter) (bool, error)
+	// coopSkillReady reports whether the managed stripe-coop skill is
+	// installed for the selected harness, so launch prompts may be compact.
+	coopSkillReady bool
 }
 
 func newCoopRunCmd() *coopRunCmd {
@@ -26,6 +34,7 @@ func newCoopRunCmd() *coopRunCmd {
 		prepareSkillDiscovery: func() error {
 			return ensureProjectSkillsDiscoveryRoot(claudeProjectDirectory)
 		},
+		installCoopSkill: ensureHarnessCoopSkill,
 	}
 	rc.cmd = &cobra.Command{
 		Use:   "start [blueprint-id]",
@@ -94,23 +103,37 @@ func (rc *coopRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if blueprintID == "" && !agent.adapter.interactiveLaunch {
+		return fmt.Errorf(
+			"%s cannot run the conversational blueprint discovery flow (%s)\n  Pick a blueprint first: stripe coop recommend --all\n  Then run: stripe coop start <blueprint-id>",
+			agent.adapter.displayName, agent.adapter.notes,
+		)
+	}
 
 	autoApprove, err := rc.promptAutoApprove(agent)
 	if err != nil {
 		return err
 	}
+	rc.coopSkillReady = rc.ensureCoopSkillFor(cmd, agent)
 	if blueprintID != "" {
 		if err := rc.ensureStripeSkill(); err != nil {
 			warnRepoStripeBestPracticesSkill(cmd, err)
 		}
-	} else if agent.name == "claude" {
+	} else if agent.adapter.id == "claude" {
 		if err := rc.prepareAgentSkillDiscovery(); err != nil {
 			warnRepoClaudeSkillsDiscovery(cmd, err)
 		}
 	}
+	if note := agent.adapter.notes; note != "" {
+		var out io.Writer = os.Stderr
+		if cmd != nil {
+			out = cmd.ErrOrStderr()
+		}
+		fmt.Fprintf(out, "Note: %s\n", note)
+	}
 	fmt.Println()
 
-	agentPrompt := rc.buildAgentPrompt(blueprintID)
+	agentPrompt := rc.buildAgentPrompt(agent, blueprintID)
 
 	if inTmux {
 		return rc.runInTmuxSplit(stripeBin, agent, agentPrompt, autoApprove, blueprint)
@@ -135,9 +158,36 @@ func (rc *coopRunCmd) prepareAgentSkillDiscovery() error {
 	return ensureProjectSkillsDiscoveryRoot(claudeProjectDirectory)
 }
 
-func (rc *coopRunCmd) buildAgentPrompt(blueprintID string) string {
+// ensureCoopSkillFor installs the bundled stripe-coop skill for the selected
+// harness. Install failures degrade to the full self-contained launch prompt,
+// so they warn instead of blocking the session.
+func (rc *coopRunCmd) ensureCoopSkillFor(cmd *cobra.Command, agent *agentInfo) bool {
+	install := rc.installCoopSkill
+	if install == nil {
+		install = ensureHarnessCoopSkill
+	}
+	installed, err := install(agent.adapter)
+	if err != nil {
+		var out io.Writer = os.Stderr
+		if cmd != nil {
+			out = cmd.ErrOrStderr()
+		}
+		if errors.Is(err, coopskill.ErrUnmanagedSkill) {
+			fmt.Fprintf(out, "Warning: an existing %q skill not managed by the Stripe CLI was left untouched; launching with full instructions instead: %v\n", coopskill.Name, err)
+		} else {
+			fmt.Fprintf(out, "Warning: unable to install the %q skill; launching with full instructions instead: %v\n", coopskill.Name, err)
+		}
+		return false
+	}
+	return installed
+}
+
+func (rc *coopRunCmd) buildAgentPrompt(agent *agentInfo, blueprintID string) string {
 	if blueprintID != "" {
 		return ""
+	}
+	if rc.coopSkillReady {
+		return rc.buildCompactDiscoveryPrompt(agent)
 	}
 
 	langHint := ""
@@ -175,7 +225,7 @@ Important: Run "stripe whoami" first to check auth. If not logged in OR if it sh
 %s`, langHint, coopAgentCoordinationInstructions(), stripeAgentGuidanceInstructions())
 }
 
-func (rc *coopRunCmd) buildAgentPromptForSession(session *coop.Session) (string, error) {
+func (rc *coopRunCmd) buildAgentPromptForSession(agent *agentInfo, session *coop.Session) (string, error) {
 	title := session.Blueprint
 	if session.BlueprintPin != nil && session.BlueprintPin.Title != "" {
 		title = session.BlueprintPin.Title
@@ -185,6 +235,9 @@ func (rc *coopRunCmd) buildAgentPromptForSession(session *coop.Session) (string,
 		session,
 		sessionLifecycleInstructions(fmt.Sprintf("You are building a production-grade Stripe integration: %q", title)),
 	)
+	if rc.coopSkillReady && agent != nil {
+		return rc.buildCompactSessionPrompt(agent, session, title, resp.Next), nil
+	}
 
 	return fmt.Sprintf(`You are running a Stripe co-op integration session. A developer is watching your progress in a live terminal UI.
 
@@ -195,6 +248,35 @@ The session is already created. After the authentication check above, begin by r
 %s
 
 Continue using the agent_prompt and next fields returned by the typed Co-op commands.`, resp.AgentPrompt, resp.Next), nil
+}
+
+// buildCompactSessionPrompt relies on the installed stripe-coop skill for the
+// stable lifecycle and safety contract, so the launch prompt carries only the
+// skill activation and this session's dynamic context.
+func (rc *coopRunCmd) buildCompactSessionPrompt(agent *agentInfo, session *coop.Session, title, next string) string {
+	var prompt strings.Builder
+	fmt.Fprintf(&prompt, "%s\n\n", agent.adapter.activationLine)
+	fmt.Fprintf(&prompt, "Session: %s\n", session.ID)
+	fmt.Fprintf(&prompt, "Integration: %s\n", title)
+	if language := session.Settings["language"]; language != "" {
+		fmt.Fprintf(&prompt, "Language: %s\n", language)
+	}
+	prompt.WriteString("A developer reviews your work live in the Co-op TUI pane.\n\n")
+	fmt.Fprintf(&prompt, "Begin by running exactly:\n%s\n\n", next)
+	prompt.WriteString("If the stripe-coop skill is unavailable, run the command anyway and follow each response's agent_prompt, next, and recovery fields.")
+	return prompt.String()
+}
+
+// buildCompactDiscoveryPrompt is the skill-backed no-blueprint launch prompt.
+func (rc *coopRunCmd) buildCompactDiscoveryPrompt(agent *agentInfo) string {
+	var prompt strings.Builder
+	fmt.Fprintf(&prompt, "%s\n\n", agent.adapter.activationLine)
+	prompt.WriteString("No blueprint is selected. Inspect the project and gather only developer intent that cannot be inferred, then follow the skill's discovery flow starting with `stripe coop recommend --all`.\n")
+	if rc.language != "" {
+		fmt.Fprintf(&prompt, "Language hint: %s.\n", rc.language)
+	}
+	prompt.WriteString("A developer reviews your work live in the Co-op TUI pane.")
+	return prompt.String()
 }
 
 func (rc *coopRunCmd) startSessionQuietly(blueprint *coop.Blueprint) (*coop.Session, error) {

--- a/pkg/cmd/coop/coop_stop.go
+++ b/pkg/cmd/coop/coop_stop.go
@@ -70,10 +70,10 @@ func (sc *coopStopCmd) runStopCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	status := string(session.Status)
-	return outputJSON(coop.CommandResponse{
+	return outputAgentResponse(coop.CommandResponse{
 		OK:        true,
 		SessionID: session.ID,
 		State:     status,
 		Message:   fmt.Sprintf("Session %s: %s", status, session.ID),
-	})
+	}, nil)
 }

--- a/pkg/cmd/coop/coop_test.go
+++ b/pkg/cmd/coop/coop_test.go
@@ -1,10 +1,38 @@
 package coopcmd
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestRecommendFollowsAgentJSONContract keeps recommend on the documented
+// agent contract: structured JSON with ok/protocol_version on success, and a
+// structured recovery error instead of plain text on misuse.
+func TestRecommendFollowsAgentJSONContract(t *testing.T) {
+	rc := newCoopRecommendCmd()
+	rc.all = true
+	output := captureStdout(t, func() {
+		require.NoError(t, rc.runRecommendCmd(rc.cmd, nil))
+	})
+	var payload map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(output), &payload))
+	assert.JSONEq(t, "true", string(payload["ok"]))
+	assert.JSONEq(t, "1", string(payload["protocol_version"]))
+	assert.Contains(t, payload, "blueprints")
+
+	missingAll := newCoopRecommendCmd()
+	stderr := captureStderr(t, func() {
+		err := missingAll.runRecommendCmd(missingAll.cmd, nil)
+		require.ErrorIs(t, err, RenderedError{})
+	})
+	var failure map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(stderr), &failure))
+	assert.JSONEq(t, "false", string(failure["ok"]))
+	assert.Contains(t, failure, "recovery")
+}
 
 func TestCoopCommandDoesNotRegisterLegacyAgentCommands(t *testing.T) {
 	cmd := newCoopCmd().cmd

--- a/pkg/coop/README.md
+++ b/pkg/coop/README.md
@@ -75,7 +75,7 @@ active ──→ completed    (all nodes done/skipped, or "stripe coop stop")
 | `stripe coop agent next-action` | Show post-completion options (blocks until selection) |
 | `stripe coop agent start-followup` | Start an internal guided follow-up session selected from next actions |
 
-Agent commands return `next` only when the value is immediately executable. Commands that still need values return `next_template` with `required_inputs`. Failures use a single `recovery` object containing a hint and one of those continuation forms. Session creation does not front-load the full blueprint: each successful `start-work` response returns an `agent_prompt` for only the current node, plus any relevant `api_request`, `test_requests`, `events`, SDK example, and `required_outputs`. The `--step` flag name is retained for the CLI, but its value is the 1-based node number across the session.
+Agent commands return `next` only when the value is immediately executable. Commands that still need values return `next_template` with `required_inputs`. Failures use a single `recovery` object containing a hint and one of those continuation forms. Every rendered agent response is stamped with `protocol_version` (`coop.CurrentProtocolVersion`) so agents and the bundled skill can detect contract drift. Session creation does not front-load the full blueprint: each successful `start-work` response returns an `agent_prompt` for only the current node, plus any relevant `api_request`, `test_requests`, `events`, SDK example, and `required_outputs`. The `--step` flag name is retained for the CLI, but its value is the 1-based node number across the session.
 
 `report-work` requires a concrete `--note`. Use repeatable `--output` flags for values named by `required_outputs`:
 
@@ -92,6 +92,26 @@ stripe coop agent report-work \
 Values that are valid JSON retain their type; other values are stored as strings. Co-op resolves `${node.<step>.<node>:<field>}` references from these persisted outputs before returning a later node's request.
 
 Skipping an output-producing node also skips later nodes that directly or transitively reference its outputs. Co-op refuses the skip if one of those dependent nodes is already done.
+
+## Bundled Agent Skill and Harness Support
+
+The CLI embeds a version-locked `stripe-coop` Agent Skill (`pkg/coop/skill/stripe-coop/`) that carries the stable lifecycle and safety contract. `stripe coop start` installs or refreshes it in the selected harness's user-level skill directory before launching the agent, then hands the agent a compact prompt that activates the skill and supplies only dynamic session context. `join`, `status`, `stop`, and `recommend` never install anything.
+
+Installs are atomic (staged directory + rename) and idempotent (content-hash manifest, `.stripe-cli-skill.json`). A same-name skill directory without that manifest is treated as user-authored and never overwritten; the launch falls back to the full self-contained prompt instead.
+
+Harness adapters live in `pkg/cmd/coop/coop_harness.go` and define detection, skill directory, activation syntax, launch arguments, and approval flags per harness:
+
+| Harness | Skill directory | Activation | Notes |
+|---------|-----------------|------------|-------|
+| Claude Code | `~/.claude/skills` | `/stripe-coop` | `--agents` subagent config, `--dangerously-skip-permissions` bypass |
+| Codex | `~/.agents/skills` | `$stripe-coop` | `--dangerously-bypass-approvals-and-sandbox` bypass |
+| OpenCode | `~/.agents/skills` | description match | `opencode --prompt`, `--auto` bypass |
+| Cline | `~/.cline/skills` | `/stripe-coop` | one-shot launch; no conversational discovery flow |
+| Roo Code | `~/.agents/skills` | description match | auto-approves by default; `--require-approval` in normal mode |
+| OpenHands | `~/.agents/skills` | description match | `openhands -t`, `--always-approve` bypass |
+| Goose | `~/.agents/skills` | description match | `goose run -t`, `GOOSE_MODE` env; no conversational discovery flow |
+
+Harnesses that cannot hold an interactive conversation from a prompt-seeded launch are rejected for no-blueprint discovery with instructions to pick a blueprint first (`stripe coop start <blueprint-id>`).
 
 ## TUI Keybindings
 

--- a/pkg/coop/commands.go
+++ b/pkg/coop/commands.go
@@ -3,6 +3,7 @@ package coop
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // StatusCommand returns the exact command for inspecting Co-op state.
@@ -40,8 +41,15 @@ func StartWorkCommand(sessionID string, nodeNumber int, note string) string {
 		"stripe coop agent start-work --session=%s --step=%d --note=%s",
 		sessionID,
 		nodeNumber,
-		strconv.Quote(note),
+		strconv.Quote(sanitizeCommandNote(note)),
 	)
+}
+
+// sanitizeCommandNote keeps free text (node titles) safe to embed in an exact
+// `next` command: anything matching the `<...>` placeholder syntax would make
+// response validation reject the command as an unfilled template.
+func sanitizeCommandNote(note string) string {
+	return strings.NewReplacer("<", "", ">", "").Replace(note)
 }
 
 // AwaitReviewCommand returns the exact command for waiting on a node review.

--- a/pkg/coop/commands_test.go
+++ b/pkg/coop/commands_test.go
@@ -20,6 +20,16 @@ func TestExactCoopCommands(t *testing.T) {
 	assert.Equal(t, `stripe coop agent start-followup --session="coop_123" --action="deploy" --target="Vercel"`, StartFollowupCommand("coop_123", "deploy", "Vercel"))
 }
 
+// TestStartWorkCommandSanitizesPlaceholderLookalikes guards node titles like
+// "<PaymentElement>" from producing an exact `next` command that response
+// validation would reject as an unfilled template.
+func TestStartWorkCommandSanitizesPlaceholderLookalikes(t *testing.T) {
+	command := StartWorkCommand("coop_123", 3, "Beginning: Mount the <PaymentElement> component")
+
+	assert.Equal(t, `stripe coop agent start-work --session=coop_123 --step=3 --note="Beginning: Mount the PaymentElement component"`, command)
+	require.NoError(t, CommandResponse{OK: true, Continuation: Continue(command)}.Validate())
+}
+
 func TestReportWorkTemplateDescribesEveryInput(t *testing.T) {
 	continuation := ReportWorkTemplate("coop_123", 2, []RequiredOutput{
 		{Field: "id"},

--- a/pkg/coop/helpers/nextaction.go
+++ b/pkg/coop/helpers/nextaction.go
@@ -36,11 +36,14 @@ type Suggestion struct {
 }
 
 type Response struct {
-	OK          bool         `json:"ok"`
-	SessionID   string       `json:"session_id"`
-	Completed   string       `json:"completed"`
-	Suggestions []Suggestion `json:"suggestions"`
-	AgentPrompt string       `json:"agent_prompt"`
+	OK bool `json:"ok"`
+	// ProtocolVersion is stamped at the output boundary, matching
+	// coop.CommandResponse.
+	ProtocolVersion int          `json:"protocol_version,omitempty"`
+	SessionID       string       `json:"session_id"`
+	Completed       string       `json:"completed"`
+	Suggestions     []Suggestion `json:"suggestions"`
+	AgentPrompt     string       `json:"agent_prompt"`
 	coop.Continuation
 }
 

--- a/pkg/coop/skill/install.go
+++ b/pkg/coop/skill/install.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -70,6 +71,7 @@ func Install(targetDir string) (InstallResult, error) {
 	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return "", fmt.Errorf("creating skills directory: %w", err)
 	}
+	sweepInstallDebris(parent)
 
 	staging, err := stageSkill(parent, files, contentHash)
 	if err != nil {
@@ -84,6 +86,34 @@ func Install(targetDir string) (InstallResult, error) {
 		return ResultUpgraded, nil
 	}
 	return ResultInstalled, nil
+}
+
+// installDebrisMaxAge guards the sweep against deleting a concurrent
+// install's live staging directory: only debris comfortably older than any
+// in-flight install is removed.
+const installDebrisMaxAge = time.Hour
+
+// sweepInstallDebris removes staging/retired directories abandoned by earlier
+// interrupted runs (hard kills between staging and the rename swap, or a
+// retired copy whose removal failed). Best effort: a directory still held open
+// elsewhere is retried on the next install.
+func sweepInstallDebris(parent string) {
+	for _, pattern := range []string{
+		fmt.Sprintf(".%s.staging-*", Name),
+		fmt.Sprintf(".%s.retired-*", Name),
+	} {
+		matches, err := filepath.Glob(filepath.Join(parent, pattern))
+		if err != nil {
+			continue
+		}
+		for _, match := range matches {
+			info, err := os.Lstat(match)
+			if err != nil || time.Since(info.ModTime()) < installDebrisMaxAge {
+				continue
+			}
+			_ = os.RemoveAll(match)
+		}
+	}
 }
 
 // readManifest returns the manifest at dir. os.ErrNotExist means the target

--- a/pkg/coop/skill/install.go
+++ b/pkg/coop/skill/install.go
@@ -1,0 +1,169 @@
+package skill
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+
+	"github.com/stripe/stripe-cli/pkg/version"
+)
+
+// ManifestFileName marks a skill directory as CLI-managed. A same-name skill
+// directory without it is treated as user-authored and never touched.
+const ManifestFileName = ".stripe-cli-skill.json"
+
+const manifestManagedBy = "stripe-cli"
+
+// ErrUnmanagedSkill reports that the install target already holds a skill this
+// CLI does not manage. Callers must not overwrite it.
+var ErrUnmanagedSkill = errors.New("a skill not managed by the Stripe CLI already exists at the target path")
+
+// Manifest records how an installed skill copy was produced so later runs can
+// distinguish "ours, current", "ours, stale", and "not ours".
+type Manifest struct {
+	ManagedBy   string `json:"managed_by"`
+	Skill       string `json:"skill"`
+	CLIVersion  string `json:"cli_version"`
+	ContentHash string `json:"content_hash"`
+}
+
+// InstallResult describes what Install did.
+type InstallResult string
+
+const (
+	ResultInstalled InstallResult = "installed"
+	ResultUpgraded  InstallResult = "upgraded"
+	ResultCurrent   InstallResult = "current"
+)
+
+// Install writes the bundled skill to targetDir (the full skill directory,
+// e.g. ~/.agents/skills/stripe-coop). It is idempotent and atomic:
+//   - an existing CLI-managed copy with the same content hash is left as is;
+//   - a stale CLI-managed copy is replaced via a staged directory and renames,
+//     so a crash never leaves a half-written skill in place;
+//   - anything else at the path returns ErrUnmanagedSkill untouched.
+func Install(targetDir string) (InstallResult, error) {
+	files, err := Files()
+	if err != nil {
+		return "", err
+	}
+	contentHash := hashFiles(files)
+
+	existing, err := readManifest(targetDir)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		// Fresh install below.
+	case err != nil:
+		return "", err
+	case existing.ManagedBy != manifestManagedBy || existing.Skill != Name:
+		return "", fmt.Errorf("%w: %s", ErrUnmanagedSkill, targetDir)
+	case existing.ContentHash == contentHash:
+		return ResultCurrent, nil
+	}
+	upgrading := err == nil
+
+	parent := filepath.Dir(targetDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", fmt.Errorf("creating skills directory: %w", err)
+	}
+
+	staging, err := stageSkill(parent, files, contentHash)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = os.RemoveAll(staging) }()
+
+	if err := swapIntoPlace(staging, targetDir, upgrading); err != nil {
+		return "", err
+	}
+	if upgrading {
+		return ResultUpgraded, nil
+	}
+	return ResultInstalled, nil
+}
+
+// readManifest returns the manifest at dir. os.ErrNotExist means the target
+// directory itself does not exist; a directory without a readable manifest is
+// reported as unmanaged.
+func readManifest(dir string) (Manifest, error) {
+	if _, err := os.Lstat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return Manifest{}, os.ErrNotExist
+		}
+		return Manifest{}, fmt.Errorf("checking existing skill at %s: %w", dir, err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ManifestFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Manifest{}, fmt.Errorf("%w: %s", ErrUnmanagedSkill, dir)
+		}
+		return Manifest{}, fmt.Errorf("reading skill manifest at %s: %w", dir, err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return Manifest{}, fmt.Errorf("%w: %s has an unreadable manifest", ErrUnmanagedSkill, dir)
+	}
+	return manifest, nil
+}
+
+func stageSkill(parent string, files map[string][]byte, contentHash string) (string, error) {
+	staging := filepath.Join(parent, fmt.Sprintf(".%s.staging-%s", Name, uuid.New().String()[:8]))
+	for path, contents := range files {
+		destination := filepath.Join(staging, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+			_ = os.RemoveAll(staging)
+			return "", fmt.Errorf("staging skill directory: %w", err)
+		}
+		if err := os.WriteFile(destination, contents, 0o644); err != nil {
+			_ = os.RemoveAll(staging)
+			return "", fmt.Errorf("staging skill file %s: %w", path, err)
+		}
+	}
+	manifest, err := json.MarshalIndent(Manifest{
+		ManagedBy:   manifestManagedBy,
+		Skill:       Name,
+		CLIVersion:  version.Version,
+		ContentHash: contentHash,
+	}, "", "  ")
+	if err != nil {
+		_ = os.RemoveAll(staging)
+		return "", fmt.Errorf("encoding skill manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, ManifestFileName), append(manifest, '\n'), 0o644); err != nil {
+		_ = os.RemoveAll(staging)
+		return "", fmt.Errorf("staging skill manifest: %w", err)
+	}
+	return staging, nil
+}
+
+// swapIntoPlace renames staging to target. When replacing an existing managed
+// copy the old directory is moved aside first (rename onto an existing
+// directory fails on some platforms) and restored if the final rename fails.
+func swapIntoPlace(staging, target string, replaceExisting bool) error {
+	if !replaceExisting {
+		if err := os.Rename(staging, target); err != nil {
+			return fmt.Errorf("installing skill at %s: %w", target, err)
+		}
+		return nil
+	}
+
+	retired := filepath.Join(filepath.Dir(target), fmt.Sprintf(".%s.retired-%s", Name, uuid.New().String()[:8]))
+	if err := os.Rename(target, retired); err != nil {
+		return fmt.Errorf("retiring stale skill at %s: %w", target, err)
+	}
+	if err := os.Rename(staging, target); err != nil {
+		if restoreErr := os.Rename(retired, target); restoreErr != nil {
+			return errors.Join(
+				fmt.Errorf("installing skill at %s: %w", target, err),
+				fmt.Errorf("restoring previous skill: %w", restoreErr),
+			)
+		}
+		return fmt.Errorf("installing skill at %s: %w", target, err)
+	}
+	_ = os.RemoveAll(retired)
+	return nil
+}

--- a/pkg/coop/skill/install_test.go
+++ b/pkg/coop/skill/install_test.go
@@ -1,0 +1,144 @@
+package skill
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func skillTarget(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "skills", Name)
+}
+
+func readInstalledManifest(t *testing.T, target string) Manifest {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(target, ManifestFileName))
+	require.NoError(t, err)
+	var manifest Manifest
+	require.NoError(t, json.Unmarshal(data, &manifest))
+	return manifest
+}
+
+func TestInstallWritesSkillAndManifest(t *testing.T) {
+	target := skillTarget(t)
+
+	result, err := Install(target)
+	require.NoError(t, err)
+	assert.Equal(t, ResultInstalled, result)
+
+	files, err := Files()
+	require.NoError(t, err)
+	for path, contents := range files {
+		installed, err := os.ReadFile(filepath.Join(target, filepath.FromSlash(path)))
+		require.NoError(t, err)
+		assert.Equal(t, contents, installed)
+	}
+
+	manifest := readInstalledManifest(t, target)
+	assert.Equal(t, "stripe-cli", manifest.ManagedBy)
+	assert.Equal(t, Name, manifest.Skill)
+	assert.NotEmpty(t, manifest.CLIVersion)
+	hash, err := ContentHash()
+	require.NoError(t, err)
+	assert.Equal(t, hash, manifest.ContentHash)
+}
+
+func TestInstallIsIdempotent(t *testing.T) {
+	target := skillTarget(t)
+
+	_, err := Install(target)
+	require.NoError(t, err)
+	info, err := os.Stat(filepath.Join(target, "SKILL.md"))
+	require.NoError(t, err)
+
+	result, err := Install(target)
+	require.NoError(t, err)
+	assert.Equal(t, ResultCurrent, result)
+
+	unchanged, err := os.Stat(filepath.Join(target, "SKILL.md"))
+	require.NoError(t, err)
+	assert.Equal(t, info.ModTime(), unchanged.ModTime(), "a current install must not rewrite files")
+}
+
+func TestInstallUpgradesStaleManagedCopy(t *testing.T) {
+	target := skillTarget(t)
+	_, err := Install(target)
+	require.NoError(t, err)
+
+	// Simulate a copy installed by an older CLI: same manifest shape, stale
+	// hash, stale content, plus a file the old version shipped.
+	manifest := readInstalledManifest(t, target)
+	manifest.ContentHash = "stale"
+	manifest.CLIVersion = "0.0.1"
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(target, ManifestFileName), data, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("old"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(target, "obsolete.md"), []byte("old"), 0o644))
+
+	result, err := Install(target)
+	require.NoError(t, err)
+	assert.Equal(t, ResultUpgraded, result)
+
+	files, err := Files()
+	require.NoError(t, err)
+	installed, err := os.ReadFile(filepath.Join(target, "SKILL.md"))
+	require.NoError(t, err)
+	assert.Equal(t, files["SKILL.md"], installed)
+	_, err = os.Stat(filepath.Join(target, "obsolete.md"))
+	assert.True(t, os.IsNotExist(err), "upgrade must remove files the new skill no longer ships")
+
+	hash, err := ContentHash()
+	require.NoError(t, err)
+	assert.Equal(t, hash, readInstalledManifest(t, target).ContentHash)
+}
+
+func TestInstallRefusesUnmanagedSameNameSkill(t *testing.T) {
+	target := skillTarget(t)
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	userSkill := []byte("---\nname: stripe-coop\n---\nuser-authored\n")
+	require.NoError(t, os.WriteFile(filepath.Join(target, "SKILL.md"), userSkill, 0o644))
+
+	_, err := Install(target)
+	require.ErrorIs(t, err, ErrUnmanagedSkill)
+
+	preserved, err := os.ReadFile(filepath.Join(target, "SKILL.md"))
+	require.NoError(t, err)
+	assert.Equal(t, userSkill, preserved, "user-authored skill must be left untouched")
+}
+
+func TestInstallRefusesForeignManagedSkill(t *testing.T) {
+	target := skillTarget(t)
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	foreign, err := json.Marshal(Manifest{ManagedBy: "someone-else", Skill: Name})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(target, ManifestFileName), foreign, 0o644))
+
+	_, err = Install(target)
+	require.ErrorIs(t, err, ErrUnmanagedSkill)
+}
+
+func TestInstallRefusesCorruptManifest(t *testing.T) {
+	target := skillTarget(t)
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(target, ManifestFileName), []byte("{not json"), 0o644))
+
+	_, err := Install(target)
+	require.ErrorIs(t, err, ErrUnmanagedSkill)
+}
+
+func TestInstallLeavesNoStagingDebris(t *testing.T) {
+	target := skillTarget(t)
+	_, err := Install(target)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(filepath.Dir(target))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, Name, entries[0].Name())
+}

--- a/pkg/coop/skill/install_test.go
+++ b/pkg/coop/skill/install_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -130,6 +131,33 @@ func TestInstallRefusesCorruptManifest(t *testing.T) {
 
 	_, err := Install(target)
 	require.ErrorIs(t, err, ErrUnmanagedSkill)
+}
+
+func TestInstallSweepsAbandonedDebrisButKeepsFreshStaging(t *testing.T) {
+	target := skillTarget(t)
+	parent := filepath.Dir(target)
+	require.NoError(t, os.MkdirAll(parent, 0o755))
+
+	stale := filepath.Join(parent, "."+Name+".staging-dead1234")
+	retired := filepath.Join(parent, "."+Name+".retired-dead5678")
+	fresh := filepath.Join(parent, "."+Name+".staging-live1234")
+	for _, dir := range []string{stale, retired, fresh} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("debris"), 0o644))
+	}
+	old := time.Now().Add(-2 * installDebrisMaxAge)
+	require.NoError(t, os.Chtimes(stale, old, old))
+	require.NoError(t, os.Chtimes(retired, old, old))
+
+	_, err := Install(target)
+	require.NoError(t, err)
+
+	for _, gone := range []string{stale, retired} {
+		_, statErr := os.Lstat(gone)
+		assert.True(t, os.IsNotExist(statErr), "%s must be swept", gone)
+	}
+	_, statErr := os.Lstat(fresh)
+	assert.NoError(t, statErr, "a fresh staging dir (possible concurrent install) must be kept")
 }
 
 func TestInstallLeavesNoStagingDebris(t *testing.T) {

--- a/pkg/coop/skill/skill.go
+++ b/pkg/coop/skill/skill.go
@@ -17,7 +17,11 @@ import (
 // Name is the skill directory and frontmatter name.
 const Name = "stripe-coop"
 
-//go:embed all:stripe-coop
+// The pattern deliberately has no `all:` prefix: dot/underscore files present
+// on the build machine (.DS_Store, editor swap files) must never be embedded
+// and shipped into user skill directories.
+//
+//go:embed stripe-coop
 var embedded embed.FS
 
 // Files returns the bundled skill files keyed by path relative to the skill

--- a/pkg/coop/skill/skill.go
+++ b/pkg/coop/skill/skill.go
@@ -1,0 +1,76 @@
+// Package skill bundles the stripe-coop Agent Skill inside the CLI binary and
+// installs it into coding-harness skill directories. The skill teaches an
+// agent how to operate the Co-op command protocol, so it is version-locked to
+// this binary: it is embedded at build time and never downloaded at launch.
+package skill
+
+import (
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+// Name is the skill directory and frontmatter name.
+const Name = "stripe-coop"
+
+//go:embed all:stripe-coop
+var embedded embed.FS
+
+// Files returns the bundled skill files keyed by path relative to the skill
+// directory (e.g. "SKILL.md", "references/command-api.md").
+func Files() (map[string][]byte, error) {
+	files := map[string][]byte{}
+	err := fs.WalkDir(embedded, Name, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		contents, err := embedded.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading embedded skill file %s: %w", path, err)
+		}
+		files[strings.TrimPrefix(path, Name+"/")] = contents
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := files["SKILL.md"]; !ok {
+		return nil, fmt.Errorf("embedded skill is missing SKILL.md")
+	}
+	return files, nil
+}
+
+// ContentHash returns a stable hash of every bundled file path and content.
+// Two binaries bundling identical skill content produce identical hashes, so
+// installs are idempotent across CLI versions that did not change the skill.
+func ContentHash() (string, error) {
+	files, err := Files()
+	if err != nil {
+		return "", err
+	}
+	return hashFiles(files), nil
+}
+
+func hashFiles(files map[string][]byte) string {
+	paths := make([]string, 0, len(files))
+	for path := range files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	digest := sha256.New()
+	for _, path := range paths {
+		digest.Write([]byte(path))
+		digest.Write([]byte{0})
+		digest.Write(files[path])
+		digest.Write([]byte{0})
+	}
+	return hex.EncodeToString(digest.Sum(nil))
+}

--- a/pkg/coop/skill/skill_test.go
+++ b/pkg/coop/skill/skill_test.go
@@ -1,0 +1,148 @@
+package skill
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundledSkillHasCompleteLayout(t *testing.T) {
+	files, err := Files()
+	require.NoError(t, err)
+
+	for _, path := range []string{
+		"SKILL.md",
+		"references/command-api.md",
+		"references/node-contracts.md",
+		"references/recovery.md",
+	} {
+		assert.Contains(t, files, path)
+		assert.NotEmpty(t, files[path], "%s must not be empty", path)
+	}
+
+	// The skill stays lean: no README/changelog/install docs duplicating the
+	// CLI-managed install flow.
+	for path := range files {
+		lower := strings.ToLower(path)
+		assert.NotContains(t, lower, "readme")
+		assert.NotContains(t, lower, "changelog")
+		assert.NotContains(t, lower, "install")
+	}
+}
+
+func TestBundledSkillFrontmatterIsValid(t *testing.T) {
+	files, err := Files()
+	require.NoError(t, err)
+	frontmatter := skillFrontmatter(t, string(files["SKILL.md"]))
+
+	name, ok := frontmatter["name"]
+	require.True(t, ok, "frontmatter must declare name")
+	assert.Equal(t, Name, name, "frontmatter name must match the skill directory name")
+	assert.LessOrEqual(t, len(name), 64)
+	assert.Regexp(t, `^[a-z0-9]+(-[a-z0-9]+)*$`, name)
+
+	description, ok := frontmatter["description"]
+	require.True(t, ok, "frontmatter must declare description")
+	assert.NotEmpty(t, description)
+	assert.LessOrEqual(t, len(description), 1024, "description exceeds the agentskills spec limit")
+
+	// The description gates activation: it must scope the skill to Co-op
+	// sessions and away from ordinary Stripe development.
+	assert.Contains(t, description, "stripe coop")
+	assert.Contains(t, description, "coop_")
+	assert.Contains(t, description, "Do not use for ordinary Stripe coding outside Co-op")
+}
+
+func TestBundledSkillReferenceIntegrity(t *testing.T) {
+	files, err := Files()
+	require.NoError(t, err)
+
+	body := string(files["SKILL.md"])
+	for _, reference := range []string{
+		"references/command-api.md",
+		"references/node-contracts.md",
+		"references/recovery.md",
+	} {
+		assert.Contains(t, body, reference, "SKILL.md must point at %s", reference)
+	}
+
+	// Every references/... mention across the skill resolves to a bundled file.
+	for path, contents := range files {
+		for _, line := range strings.Split(string(contents), "\n") {
+			for _, token := range strings.Fields(line) {
+				token = strings.Trim(token, "`()[].,:;")
+				if !strings.HasPrefix(token, "references/") {
+					continue
+				}
+				assert.Contains(t, files, token, "%s mentions missing reference %q", path, token)
+			}
+		}
+	}
+}
+
+func TestBundledSkillCoversLifecycleContract(t *testing.T) {
+	files, err := Files()
+	require.NoError(t, err)
+	skillBody := string(files["SKILL.md"])
+	allContent := skillBody + string(files["references/command-api.md"]) +
+		string(files["references/node-contracts.md"]) + string(files["references/recovery.md"])
+
+	for _, command := range []string{
+		"start-work", "report-check", "report-work", "skip",
+		"await-review", "resume", "next-action", "start-followup",
+	} {
+		assert.Contains(t, skillBody, command, "SKILL.md must name control command %s", command)
+	}
+	for _, nodeType := range []string{
+		"apiRequest", "asyncHandler", "uiComponent", "testHelper",
+		"cliCommand", "dashboard", "setUpWebhooks",
+	} {
+		assert.Contains(t, allContent, nodeType)
+	}
+	for _, contract := range []string{
+		"${node",                           // reference resolution
+		"pm_card_visa",                     // card-number safety
+		"raw request body",                 // webhook signature verification
+		"one node at a time",               // pacing
+		"stripe sandbox create --from-git", // auth bootstrap
+		"heartbeat",                        // never touch internal state
+	} {
+		assert.Contains(t, allContent, contract)
+	}
+}
+
+func TestContentHashIsStableAndContentSensitive(t *testing.T) {
+	first, err := ContentHash()
+	require.NoError(t, err)
+	second, err := ContentHash()
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Len(t, first, 64)
+
+	files, err := Files()
+	require.NoError(t, err)
+	baseline := hashFiles(files)
+	files["SKILL.md"] = append(files["SKILL.md"], '\n')
+	assert.NotEqual(t, baseline, hashFiles(files))
+}
+
+// skillFrontmatter parses the simple key: value YAML frontmatter block.
+func skillFrontmatter(t *testing.T, body string) map[string]string {
+	t.Helper()
+	require.True(t, strings.HasPrefix(body, "---\n"), "SKILL.md must start with frontmatter")
+	rest := body[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	require.Greater(t, end, 0, "frontmatter must be terminated")
+
+	frontmatter := map[string]string{}
+	for _, line := range strings.Split(rest[:end], "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		frontmatter[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return frontmatter
+}

--- a/pkg/coop/skill/stripe-coop/SKILL.md
+++ b/pkg/coop/skill/stripe-coop/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: stripe-coop
+description: Operate an active Stripe CLI Co-op integration session. Use when a prompt or command mentions `stripe coop`, a `coop_*` session, or building a Stripe integration through Co-op's live human-review TUI. Follow the typed command protocol, implement one node at a time, and stop at review boundaries. Do not use for ordinary Stripe coding outside Co-op.
+---
+
+# Stripe Co-op
+
+Co-op pairs you with a human developer to build a Stripe integration in their
+application. The human watches and reviews your progress live in a terminal UI.
+You drive the session through typed `stripe coop` CLI commands that return JSON.
+
+**The deliverable is a working integration in the user's application** — not a
+sequence of successful CLI commands. CLI commands are for setup, test data, and
+verification; the implementation lives in the user's codebase unless a node is
+explicitly a `cliCommand`.
+
+## Core rules
+
+1. **Work one node at a time.** Never work ahead of the current node.
+2. **The current node's `agent_prompt` is the task source of truth.** Follow it
+   over your own assumptions.
+3. **Use only the typed control commands** (`start-work`, `report-check`,
+   `report-work`, `skip`, `await-review`, `resume`, `next-action`,
+   `start-followup`). Never invent state transitions, and never edit Co-op
+   session JSON, heartbeat files, or any internal Co-op state directly.
+4. **Follow the `next` field.** Every response tells you what to run next.
+   `next` is an exact command — run it verbatim. `next_template` +
+   `required_inputs` means you must substitute real values first; never run a
+   command that still contains `<...>` placeholders.
+5. **Stop at review boundaries.** When told to await review, run
+   `await-review` and block. React to the decision the CLI returns; do not ask
+   the human to re-type feedback that is already in the response.
+6. **Report honestly.** Run meaningful checks; pass `--passed` only for results
+   you actually observed. Report the main implementation file with useful
+   line/snippet/note detail.
+7. **Skip only genuinely inapplicable nodes**, with a concrete `--note` reason.
+
+## Starting
+
+- **No blueprint selected yet:** inspect the project first (language,
+  framework, existing Stripe code). Ask the developer only for intent or
+  constraints you cannot infer from the code. Then run
+  `stripe coop recommend --all`, pick the best blueprint, confirm your choice
+  with the developer in plain language, and run
+  `stripe coop run <blueprint-id> --language=<lang>`.
+- **Session already created:** run the exact bootstrap command you were given
+  (usually `stripe coop agent start-work ...`) and follow each response.
+
+In both cases, check API access before creating or working a session: run
+`stripe whoami`. If not authenticated, or it shows "Test mode key: not
+available", run `stripe sandbox create --from-git`. The claim URL appears in
+the developer's TUI automatically.
+
+## Working a node
+
+1. `start-work` → read `agent_prompt`, plus the structured context:
+   `api_request`, `test_requests`, `events`, and `sdk_example` describe the
+   exact API call, test fixtures, webhook events, and SDK usage for this node.
+   See `references/node-contracts.md` for node types and how to interpret each
+   field.
+2. Implement in the user's app, matching its existing conventions, framework,
+   and dependency choices. Exercise the real application code when practical,
+   not just direct API calls.
+3. Verify, then `report-check` each meaningful check (short `--check` label,
+   long output in `--detail`).
+4. `report-work` with `--file`, `--lines`/`--snippet` and a concrete `--note`.
+   Supply every `required_outputs` value via `--output` — later nodes resolve
+   `${node...}` references from them (see `references/node-contracts.md`).
+5. Run the response's `next` command. At review boundaries, prepare the
+   developer first: for UI or server work keep the server running, and give the
+   URL to open, the action to take, and the expected result.
+
+Review, rejection, timeout, and wake-up handling: `references/recovery.md`.
+Full command and response reference: `references/command-api.md`.
+
+## After completion
+
+When all nodes are done, run `next-action` and wait for the developer's
+choice. Any follow-up work must go through `start-followup` — do not start
+free-form work on a completed session.
+
+## Safety
+
+- Never hardcode secret keys, webhook secrets, or Stripe-shaped fake secrets
+  in code, tests, or fallbacks. Read secrets from environment variables or the
+  project's existing secret-management convention.
+- Verify webhook signatures against the **raw request body** with the official
+  SDK helpers.
+- Never put full card numbers in application code, tests, or API calls. Use
+  supported test PaymentMethod IDs (e.g. `pm_card_visa`) or official Stripe
+  test helpers; collect real card details only through hosted/official
+  client-side components.
+- Keep CLI test-helper parameters (fixtures, triggers, test clocks) out of
+  application code — they belong to test setup, not the integration.

--- a/pkg/coop/skill/stripe-coop/SKILL.md
+++ b/pkg/coop/skill/stripe-coop/SKILL.md
@@ -76,8 +76,11 @@ Full command and response reference: `references/command-api.md`.
 ## After completion
 
 When all nodes are done, run `next-action` and wait for the developer's
-choice. Any follow-up work must go through `start-followup` — do not start
-free-form work on a completed session.
+choice. Act only on what its response returns: some selections come back with
+an `agent_prompt` to carry out directly, while guided actions (deploys) tell
+you to run `start-followup`, which creates a new reviewed session. Do not
+start free-form work on a completed session outside what `next-action`
+returns.
 
 ## Safety
 

--- a/pkg/coop/skill/stripe-coop/references/command-api.md
+++ b/pkg/coop/skill/stripe-coop/references/command-api.md
@@ -1,8 +1,11 @@
 # Co-op command API
 
-All agent-facing commands print a single JSON object. Successful responses go
-to stdout; failures go to stderr with a non-zero exit code but still contain
-structured JSON.
+`stripe coop run`, `stripe coop recommend --all`, and every
+`stripe coop agent` command print a single JSON object. Successful responses
+go to stdout; failures go to stderr with a non-zero exit code but still
+contain structured JSON. (`stripe coop status` is the exception: it prints a
+human-readable summary, or the raw session object with `--json` — neither
+carries `ok`/`protocol_version`.)
 
 ## Response shape
 
@@ -65,7 +68,7 @@ issue, and continue with the recovery continuation.
 |---|---|
 | `stripe coop recommend --all` | List blueprint summaries for selection. Add `--include-testing` to include testing blueprints. |
 | `stripe coop run <blueprint-id>` | Create a session from a blueprint. Flags: `--language`, repeatable `--setting key=value` and `--param key=value`, `--parent-session`, `--parent-step`. |
-| `stripe coop status [--session=<id>] [--json]` | Inspect session progress. Read-only. |
+| `stripe coop status [--session=<id>] [--json]` | Inspect session progress. Read-only. `--json` prints the raw session object (including each node's recorded `outputs`), not the agent response shape. |
 | `stripe coop stop [--session=<id>]` | End a session (normally the human's decision). |
 | `stripe coop join <id>` | Human-facing live TUI. Not for agents. |
 
@@ -117,8 +120,11 @@ an `id` — that `id` is the value for `--action` on `start-followup` and later
 for `--completed`; the response's `next`/`agent_prompt` name the selected one.
 
 ### `stripe coop agent start-followup --session=<parent-id> --action=<action-id> [--target=...]`
-Starts a guided follow-up session for an action offered by `next-action`.
-This is the only way to begin follow-up work after completion.
+Starts a guided follow-up session for a guided action offered by
+`next-action` (deploy actions). Run it only when a `next-action` response
+directs you to; other selections (e.g. writing a summary) arrive as an
+`agent_prompt` in the `next-action` response itself and are done directly,
+then recorded with `next-action --completed=<action-id>`.
 
 ## Stripe documentation lookup
 

--- a/pkg/coop/skill/stripe-coop/references/command-api.md
+++ b/pkg/coop/skill/stripe-coop/references/command-api.md
@@ -1,0 +1,135 @@
+# Co-op command API
+
+All agent-facing commands print a single JSON object. Successful responses go
+to stdout; failures go to stderr with a non-zero exit code but still contain
+structured JSON.
+
+## Response shape
+
+```json
+{
+  "ok": true,
+  "protocol_version": 1,
+  "session_id": "coop_abc123",
+  "node": 3,
+  "state": "active",
+  "message": "Started: Create a PaymentIntent",
+  "next": "stripe coop agent report-check --session=coop_abc123 --step=3 ...",
+  "next_template": "stripe coop agent report-work --session=coop_abc123 --step=3 --note=\"<what you did>\"",
+  "required_inputs": [{"name": "note", "flag": "--note", "description": "..."}],
+  "wait_timeout_seconds": 300,
+  "required_outputs": [{"source": "", "field": "id"}],
+  "agent_prompt": "Current node 3 of 9 ...",
+  "api_request": {"method": "post", "path": "/v1/payment_intents", "params": {}},
+  "test_requests": [],
+  "events": [],
+  "sdk_example": "..."
+}
+```
+
+Field semantics:
+
+- `next` — an exact command. Run it verbatim; it never contains placeholders.
+- `next_template` + `required_inputs` — a command template. Substitute a real
+  value for every `<...>` placeholder before running. Never execute a command
+  that still contains `<` `>`.
+- Exactly one of `next` / `next_template` is set when a continuation exists.
+- `wait_timeout_seconds` — the command in `next` blocks up to this many
+  seconds. Give your shell tool at least one minute more than this so the
+  structured timeout response can arrive (e.g. 300s wait → 360s shell budget).
+- `agent_prompt` — the task contract for the current node.
+- `required_outputs` — values you must report with `--output` on
+  `report-work` (see node-contracts.md).
+
+Failure shape:
+
+```json
+{
+  "ok": false,
+  "protocol_version": 1,
+  "error": "what went wrong",
+  "recovery": {
+    "hint": "how to proceed",
+    "next": "stripe coop status"
+  }
+}
+```
+
+`recovery` always contains a `hint` and either `next` or `next_template` (with
+`required_inputs`), following the same rules as above. Read the hint, fix the
+issue, and continue with the recovery continuation.
+
+## Session commands
+
+| Command | Purpose |
+|---|---|
+| `stripe coop recommend --all` | List blueprint summaries for selection. Add `--include-testing` to include testing blueprints. |
+| `stripe coop run <blueprint-id>` | Create a session from a blueprint. Flags: `--language`, repeatable `--setting key=value` and `--param key=value`, `--parent-session`, `--parent-step`. |
+| `stripe coop status [--session=<id>] [--json]` | Inspect session progress. Read-only. |
+| `stripe coop stop [--session=<id>]` | End a session (normally the human's decision). |
+| `stripe coop join <id>` | Human-facing live TUI. Not for agents. |
+
+## Agent lifecycle commands
+
+All take `--session=<id>` and (except `resume`, `next-action`,
+`start-followup`) a 1-based `--step=<n>` task number.
+
+### `stripe coop agent start-work --session=<id> --step=<n> --note="..."`
+Marks the node active and returns the node's `agent_prompt`, structured
+context, and `required_outputs`. Safe to replay: re-running on an active node
+just returns the current contract.
+
+### `stripe coop agent report-check --session=<id> --step=<n> --check="..." [--detail="..."] [--passed]`
+Records one verification. `--check` is a one-line label the reviewer sees;
+put command output and reasoning in `--detail`. Pass `--passed` only if you
+observed the expected result. Report at least one meaningful check before
+`report-work` on every non-skipped reviewable node; failed or partial checks
+are reported without `--passed` plus an explanation of the limitation.
+
+### `stripe coop agent report-work --session=<id> --step=<n> --note="..." [--file=...] [--lines=a-b] [--snippet=...] [--output field=value]...`
+Reports the implementation. `--note` is required. `--file` should be the main
+implementation file in the user's app (not README/package files unless the
+node is documentation-only). Every entry in `required_outputs` must be
+supplied as `--output field=value` or `--output source:field=value`; values
+may be raw strings or JSON. Moves the node to review (or done for
+informational nodes) and returns what to do next.
+
+### `stripe coop agent skip --session=<id> --step=<n> --note="<reason>"`
+Skips a genuinely inapplicable node. Nodes that depend on its outputs are
+skipped with it; skipping fails if a dependent node is already done.
+
+### `stripe coop agent await-review --session=<id> --step=<n>`
+Blocks until the developer confirms or requests changes, up to
+`wait_timeout_seconds` (currently 300s). Only run it when a response tells
+you to. See recovery.md for timeout, confirmation, and rejection handling.
+
+### `stripe coop agent resume --session=<id>`
+Read-only: reports the current lifecycle continuation after a wake-up or lost
+context. Run it when the TUI injects a resume prompt, then run the returned
+non-empty `next` exactly; an empty continuation means another handoff already
+advanced the session — continue your current work.
+
+### `stripe coop agent next-action --session=<id> [--completed=<action-id>]`
+After session completion, waits (up to 10 minutes per call) for the
+developer's next-action choice, or records a finished follow-up with
+`--completed`. Re-run on timeout. The response lists `suggestions`, each with
+an `id` — that `id` is the value for `--action` on `start-followup` and later
+for `--completed`; the response's `next`/`agent_prompt` name the selected one.
+
+### `stripe coop agent start-followup --session=<parent-id> --action=<action-id> [--target=...]`
+Starts a guided follow-up session for an action offered by `next-action`.
+This is the only way to begin follow-up work after completion.
+
+## Stripe documentation lookup
+
+When Stripe behavior, parameters, or events are ambiguous, consult current
+docs through the CLI instead of guessing:
+
+```
+stripe docs search "<question>" --non-interactive --no-pager
+stripe docs <result-path> --non-interactive --no-pager
+stripe docs api <resource-or-event> --non-interactive --no-pager
+```
+
+Treat current CLI documentation as authoritative over model memory. Do not use
+docs to choose or switch integrations — the blueprint owns that decision.

--- a/pkg/coop/skill/stripe-coop/references/node-contracts.md
+++ b/pkg/coop/skill/stripe-coop/references/node-contracts.md
@@ -54,7 +54,9 @@ only a direct CLI/API call.
 ## Outputs and `${node...}` references
 
 Later nodes reference earlier results with
-`${node.<step-key>.<node-key>[:...]:<field>}` placeholders. Co-op resolves
+`${node.<step-key>.<node-key>[.<source>]:<field>}` placeholders — the
+reference part is dot-separated (an optional source segment after the node
+key), and a single colon separates it from the field. Co-op resolves
 them from outputs you report, so:
 
 - `start-work` lists `required_outputs` for the current node — the values

--- a/pkg/coop/skill/stripe-coop/references/node-contracts.md
+++ b/pkg/coop/skill/stripe-coop/references/node-contracts.md
@@ -1,0 +1,81 @@
+# Node contracts
+
+A blueprint is a sequence of steps; each step contains nodes. Nodes are
+addressed by a 1-based `--step` task number across the whole session. The
+`start-work` response for a node carries everything below.
+
+## Node types
+
+- `apiRequest` — implement app code that makes this Stripe API call using the
+  official SDK or the project's existing Stripe client pattern. Decide from the
+  task whether the call belongs in runtime code, a setup/seed script, or
+  one-time provisioning. The CLI is for inspection, temporary test data, and
+  verifying the app code — not the implementation.
+- `asyncHandler` — implement the app's webhook/async handler for every event
+  listed in `events`. Read the raw request body, verify the Stripe signature
+  with the official SDK helpers and the webhook secret from the environment,
+  branch on each listed event type, and act on the data the app needs. Test
+  with `stripe listen --forward-to localhost:<actual-app-port>/webhook` and
+  `stripe trigger <event>` when the event has a supported trigger; otherwise
+  exercise the app flow that emits it. Do not assume port 4242.
+- `uiComponent` — build or update the user-facing surface that starts,
+  redirects to, or displays this part of the flow. Verify it through the
+  running app, and give the developer the URL, the action to take, and the
+  expected result.
+- `testHelper` — verify the integration end to end. `test_requests` advance
+  Stripe test state (test clocks, test helpers, fixtures) and are run as test
+  setup — their parameters belong to the test harness, never to application
+  code.
+- `cliCommand` — run the requested CLI command and report its concrete result.
+  The only node type where no app code may be required.
+- `dashboard` — complete the requested Stripe Dashboard configuration and
+  verify the resulting state (via API/CLI where possible).
+- `setUpWebhooks` — configure the requested webhook destination and verify the
+  application receives the listed events.
+
+For `apiRequest`, `asyncHandler`, and `uiComponent`, a node is complete only
+when the app has working code for the behavior, wired into the app's existing
+routes/services/conventions, and verification exercised the app code — not
+only a direct CLI/API call.
+
+## Structured context fields
+
+- `api_request` — `{method, path, params}` for the exact Stripe call. Params
+  may contain `${node...}` references already resolved to real values.
+- `sdk_example` — a code snippet for the call in the session's language. A
+  starting point: adapt it to the project's conventions.
+- `test_requests` — API fixtures (`{method, path, params}`) to run as test
+  setup for `testHelper` nodes. Execute them as test tooling — the Stripe CLI
+  (e.g. `stripe post /v1/test_helpers/... -d key=value`) or a short test
+  script — never as application code.
+- `events` — the webhook event types an `asyncHandler` must handle, with any
+  payload details.
+
+## Outputs and `${node...}` references
+
+Later nodes reference earlier results with
+`${node.<step-key>.<node-key>[:...]:<field>}` placeholders. Co-op resolves
+them from outputs you report, so:
+
+- `start-work` lists `required_outputs` for the current node — the values
+  later nodes need. Each has an optional `source` (a named/numbered request
+  result; empty means the node's primary result) and a `field` path.
+- Report each one on `report-work` with `--output field=value` or
+  `--output source:field=value`. Values must be the **real observed values**
+  (IDs, URLs, keys of created objects) — never placeholders or invented data.
+  `report-work` fails until all required outputs are supplied.
+- If a resolved value appears in a later node's context, use it as-is. Never
+  ship an unresolved `${node...}` or `${env...}` placeholder into application
+  code, config, or a command. If a `${node...}` placeholder reaches you
+  unresolved, look the value up in the recorded outputs of the referenced node
+  via `stripe coop status --session=<id> --json` (each node's `outputs` map),
+  or report the missing `--output` on that node first. `${env...}` values come
+  from the environment (`${env:livemode}` is `false` in test-mode sessions).
+
+## Reviews
+
+Nodes in a step are reviewed together as a step. `report-work` tells you
+whether to continue the step or await review. Auto-confirmed (informational)
+nodes skip human review — continue immediately. Before awaiting review, run
+the node's verification command when one is given, keep useful servers
+running, and share concrete actions and expected results for the developer.

--- a/pkg/coop/skill/stripe-coop/references/recovery.md
+++ b/pkg/coop/skill/stripe-coop/references/recovery.md
@@ -1,0 +1,63 @@
+# Reviews, timeouts, and recovery
+
+## Await-review
+
+Run `stripe coop agent await-review` only when a response's `next` says to.
+It blocks until the developer decides, up to `wait_timeout_seconds`
+(currently 300 seconds). Always give your shell tool at least one minute more
+than `wait_timeout_seconds` (e.g. 360s) so the structured timeout response
+can arrive instead of the harness killing the command.
+
+Possible outcomes (`state` field):
+
+- `confirmed` — the step was approved. Run the returned `next` command.
+- `timeout` — nobody decided yet. This is normal: re-run the same
+  `await-review` command and keep waiting. Do not treat a timeout as
+  rejection or move on.
+- `rejected` (or a message saying changes were requested) — the response
+  `message` contains the developer's feedback and the `next` command points
+  at the node to redo. Use that feedback directly; never ask the developer to
+  repeat feedback that is already in the response. Redo the affected work
+  from the feedback, re-verify, and report again.
+- "already …" — the node moved on while you were away (e.g. a wake-up
+  handled it). Follow the returned `next`.
+
+## Wake-ups and `resume`
+
+While you are blocked (or after your await timed out), the TUI may inject a
+message telling you human input updated the session. Respond by running the
+exact `stripe coop agent resume --session=<id>` command it gives. `resume` is
+read-only and safe to repeat. If its JSON has a non-empty `next`, run that
+command exactly; if the continuation is empty, another handoff already
+advanced the session — continue your current work.
+
+Use `resume` too whenever you lose track of session state (restarts, context
+loss): it returns the single correct continuation for the current state.
+
+## Completion and follow-ups
+
+When every node is done, run
+`stripe coop agent next-action --session=<id>`. It waits up to 10 minutes per
+call for the developer to choose; on timeout, re-run it. When the developer
+selects follow-up work, the response tells you to run
+`stripe coop agent start-followup --session=<parent> --action=<id>`, which
+creates a new guided session — work it with the same node lifecycle. After
+finishing a follow-up, record it with
+`next-action --completed=<action-id>` on the parent session.
+
+## Errors
+
+Every failure response contains `error` plus `recovery.hint` and a recovery
+continuation. Read the hint, fix the cause, and continue from the recovery
+command — usually `stripe coop status` to re-inspect state. Do not retry a
+failed command unchanged, and never work around a failure by editing Co-op's
+session files, heartbeat files, or any internal state on disk. If the session
+is aborted or unrecoverable, tell the developer and stop.
+
+## Authentication problems
+
+If commands fail with authentication errors, run `stripe whoami`. If not
+authenticated or test-mode keys are unavailable, run
+`stripe sandbox create --from-git` — the claim URL surfaces in the
+developer's TUI automatically. Never paste secret keys into files or shell
+history to work around auth.

--- a/pkg/coop/skill/stripe-coop/references/recovery.md
+++ b/pkg/coop/skill/stripe-coop/references/recovery.md
@@ -38,12 +38,14 @@ loss): it returns the single correct continuation for the current state.
 
 When every node is done, run
 `stripe coop agent next-action --session=<id>`. It waits up to 10 minutes per
-call for the developer to choose; on timeout, re-run it. When the developer
-selects follow-up work, the response tells you to run
+call for the developer to choose; on timeout, re-run it. The response for the
+selected action is the instruction: either an `agent_prompt` to carry out
+directly (e.g. writing a summary), or — for guided actions like deploys — a
+`next` command telling you to run
 `stripe coop agent start-followup --session=<parent> --action=<id>`, which
-creates a new guided session — work it with the same node lifecycle. After
-finishing a follow-up, record it with
-`next-action --completed=<action-id>` on the parent session.
+creates a new guided session worked with the same node lifecycle. Either way,
+record the finished action with `next-action --completed=<action-id>` on the
+parent session.
 
 ## Errors
 

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -17,6 +17,12 @@ type NodeState string
 
 const (
 	CurrentSessionSchemaVersion = 4
+
+	// CurrentProtocolVersion identifies the agent-facing command response
+	// contract. It is stamped onto every rendered response so agents (and the
+	// bundled stripe-coop skill) can detect contract drift. Bump it only for
+	// wire-visible changes.
+	CurrentProtocolVersion = 1
 )
 
 const (
@@ -318,11 +324,14 @@ type Recovery struct {
 
 // CommandResponse is the JSON output format for agent-facing commands.
 type CommandResponse struct {
-	OK        bool   `json:"ok"`
-	SessionID string `json:"session_id,omitempty"`
-	Node      int    `json:"node,omitempty"`
-	State     string `json:"state,omitempty"`
-	Message   string `json:"message,omitempty"`
+	OK bool `json:"ok"`
+	// ProtocolVersion is stamped at the output boundary; responses built
+	// internally leave it zero.
+	ProtocolVersion int    `json:"protocol_version,omitempty"`
+	SessionID       string `json:"session_id,omitempty"`
+	Node            int    `json:"node,omitempty"`
+	State           string `json:"state,omitempty"`
+	Message         string `json:"message,omitempty"`
 	Continuation
 	RequiredOutputs []RequiredOutput          `json:"required_outputs,omitempty"`
 	AgentPrompt     string                    `json:"agent_prompt,omitempty"`


### PR DESCRIPTION
## What

Bundles a version-locked `stripe-coop` Agent Skill inside the CLI binary and installs it into the selected coding harness before `stripe coop start` launches an agent. The skill carries Co-op's stable lifecycle and safety contract, so launch prompts shrink to skill activation plus the dynamic session context.

## Why

The lifecycle contract was re-sent in full on every launch prompt and every command response. Moving it into a skill that the agent loads on demand keeps the prompt focused on the user's project and integration intent, and gives us one portable place to teach agents the protocol.

The skill is embedded (`go:embed`) rather than downloaded: it is part of the Co-op protocol and must stay compatible with the exact CLI version, so it deliberately does not reuse the network-backed `pkg/agentskills` installer.

## How it works

- **Skill** — `pkg/coop/skill/stripe-coop/`: `SKILL.md` plus `references/{command-api,node-contracts,recovery}.md`. The frontmatter description scopes activation to Co-op sessions and away from ordinary Stripe development.
- **Install** — atomic (staged directory + rename) and idempotent (sha256 content hash in a `.stripe-cli-skill.json` manifest). A same-name skill directory without that manifest is treated as user-authored and never overwritten; the launch falls back to the previous self-contained prompt. Abandoned staging/retired directories older than an hour are swept.
- **Harness adapters** — `pkg/cmd/coop/coop_harness.go` replaces the old name/path switch. Each adapter declares executables, skill directory, activation syntax, launch arguments, approval flags, and capability limits.
- **Scope** — only `stripe coop start` installs. `join`, `status`, `stop`, and `recommend` do not. `coop run` and command responses stay self-contained for agents invoked directly.

## Harness support

Verified against current official harness docs (July 2026):

| Harness | Skill directory | Activation | Notes |
|---|---|---|---|
| Claude Code | `~/.claude/skills` | `/stripe-coop` | `--dangerously-skip-permissions` bypass |
| Codex | `~/.agents/skills` | `$stripe-coop` | `--dangerously-bypass-approvals-and-sandbox` bypass |
| OpenCode | `~/.agents/skills` | description match | `opencode --prompt`, `--auto` |
| Cline | `~/.cline/skills` | `/stripe-coop` | one-shot launch; no conversational discovery |
| Roo Code | `~/.agents/skills` | description match | auto-approves by default; discontinued May 2026 |
| OpenHands | `~/.agents/skills` | description match | `openhands -t`, `--always-approve` |
| Goose | `~/.agents/skills` | description match | `goose run -t`, `GOOSE_MODE` env; no conversational discovery |

Harnesses that cannot hold an interactive conversation from a prompt-seeded launch are rejected for no-blueprint discovery with an actionable message rather than silently launching into a broken flow. Unknown `--agent` values get a generic positional-prompt launcher, no skill install, and the full fallback prompt.

## Protocol

Adds `protocol_version` to rendered agent responses so agents can detect contract drift. `recommend` now emits `ok`/`protocol_version` and structured recovery errors instead of plain text. `start-work` notes strip angle brackets so node titles like `<PaymentElement>` cannot trip the placeholder validator.

## Testing

- `go test ./pkg/coop/... ./pkg/cmd/coop -count=1` — green
- `golangci-lint run` — 0 issues; `go build ./...`; `git diff --check` clean
- skill-creator `quick_validate.py` — valid
- New coverage: embed layout/frontmatter/reference integrity, install atomicity/idempotence/upgrade/unmanaged-refusal/debris-sweep, per-harness skill dirs and activation tokens, launch-arg construction, compact-prompt content and size caps, protocol-version stamping, and a lockstep test that every registered `stripe coop agent` subcommand is documented in the bundled `command-api.md`
- The Goose launcher test executes the generated script against a fake binary rather than asserting on substrings

An adversarial multi-agent review of this branch surfaced 8 confirmed findings, all fixed in the second commit — most notably that the Goose launcher placed the env assignment after `exec`, so `bash` tried to run a program literally named `GOOSE_MODE=auto` and the harness could never start.

## Follow-ups (not in this PR)

- Give `${node...}` outputs a typed schema in blueprints instead of free-form `field=value` JSON
- Real-agent end-to-end pass of the skill (this branch has a doc-comprehension forward-test only)
- Cline's docs disagree on `--yolo` vs `--auto-approve`; worth re-verifying before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
