### PR TITLE
coop: harden the launch path and make the no-tmux experience first-class

### DIFF
--- a/pkg/cmd/coop/coop_agent_resumer.go
+++ b/pkg/cmd/coop/coop_agent_resumer.go
@@ -14,15 +14,24 @@ import (
 
 const coopAgentPaneOption = "@stripe_coop_agent"
 
+// parkedHeartbeatFreshFor classifies the agent as parked in await-review. While
+// parked it refreshes the session heartbeat every 500ms and reads the human's
+// decision from the session file itself; only an agent that has timed out back
+// to its idle prompt needs a keystroke wake-up.
+const parkedHeartbeatFreshFor = 2 * time.Second
+
 var runTmuxOutput = func(args ...string) (string, error) {
 	out, err := exec.Command("tmux", args...).CombinedOutput()
 	return string(out), err
 }
 
 type tmuxAgentResumer struct {
-	tuiPane  string
-	keyDelay time.Duration
-	mu       sync.Mutex
+	tuiPane string
+	// heartbeatAge reports how long ago the agent refreshed the session
+	// heartbeat; nil disables the parked-agent check.
+	heartbeatAge func(sessionID string) (time.Duration, error)
+	keyDelay     time.Duration
+	mu           sync.Mutex
 }
 
 func newTmuxAgentResumer(tuiPane string) *tmuxAgentResumer {
@@ -33,12 +42,29 @@ func (r *tmuxAgentResumer) Notify(sessionID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// A parked agent picks the decision up from the session file on its own.
+	// Injecting keystrokes is only for an agent that has timed out — doing it
+	// while the agent is live would append our prompt to whatever is in its
+	// input box (including a half-typed human message) or blindly submit an
+	// open dialog.
+	if r.heartbeatAge != nil {
+		if age, err := r.heartbeatAge(sessionID); err == nil && age <= parkedHeartbeatFreshFor {
+			return nil
+		}
+	}
+
 	pane, err := r.findAgentPane()
 	if err != nil {
 		return err
 	}
 	resumeCommand := coop.ResumeCommand(sessionID)
 	prompt := fmt.Sprintf("Human input updated Stripe Co-op session %s. Resume neutrally: run exactly `%s`. If its JSON has a non-empty `next`, run that command exactly; otherwise continue your current work.", sessionID, resumeCommand)
+	// Clear any half-typed input first. C-u kills the line in readline-style
+	// inputs and is a no-op in dialogs — unlike Escape, which can dismiss a
+	// dialog the user needed to answer.
+	if err := runTmux("send-keys", "-t", pane, "C-u"); err != nil {
+		return fmt.Errorf("clearing Co-op agent input: %w", err)
+	}
 	if err := runTmux("send-keys", "-t", pane, "-l", prompt); err != nil {
 		return fmt.Errorf("sending Co-op resume prompt: %w", err)
 	}
@@ -54,16 +80,23 @@ func (r *tmuxAgentResumer) Notify(sessionID string) error {
 }
 
 func (r *tmuxAgentResumer) findAgentPane() (string, error) {
-	out, err := runTmuxOutput("list-panes", "-t", r.tuiPane, "-F", "#{pane_id}\t#{@stripe_coop_agent}")
+	out, err := runTmuxOutput("list-panes", "-t", r.tuiPane, "-F", "#{pane_id}\t#{@stripe_coop_agent}\t#{pane_dead}")
 	if err != nil {
 		return "", fmt.Errorf("listing Co-op tmux panes: %w", err)
 	}
 	var panes []string
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		pane, tag, ok := strings.Cut(line, "\t")
-		if ok && strings.TrimSpace(tag) == "1" {
-			panes = append(panes, strings.TrimSpace(pane))
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 || strings.TrimSpace(fields[1]) != "1" {
+			continue
 		}
+		// send-keys into a dead pane (remain-on-exit) succeeds silently and
+		// the decision never reaches an agent. Fail so the TUI surfaces the
+		// manual resume command instead.
+		if len(fields) >= 3 && strings.TrimSpace(fields[2]) == "1" {
+			return "", fmt.Errorf("the Co-op agent pane has exited")
+		}
+		panes = append(panes, strings.TrimSpace(fields[0]))
 	}
 	if len(panes) != 1 {
 		return "", fmt.Errorf("expected one Co-op agent pane, found %d", len(panes))
@@ -75,6 +108,9 @@ func coopTUIOptions() []tui.Option {
 	options := []tui.Option{tui.WithSandboxClaimURL(coopSandboxClaimURL())}
 	if tuiPane := os.Getenv("TMUX_PANE"); tuiPane != "" {
 		resumer := newTmuxAgentResumer(tuiPane)
+		if store, err := coop.NewStore(coopConfigFolder()); err == nil {
+			resumer.heartbeatAge = store.HeartbeatAge
+		}
 		options = append(options, tui.WithReviewDecisionNotifier(resumer.Notify))
 	}
 	return options

--- a/pkg/cmd/coop/coop_agent_resumer.go
+++ b/pkg/cmd/coop/coop_agent_resumer.go
@@ -1,9 +1,11 @@
 package coopcmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -25,13 +27,21 @@ var runTmuxOutput = func(args ...string) (string, error) {
 	return string(out), err
 }
 
+// errAgentBusy reports that the agent is still working, so the decision was
+// left in the session file rather than typed into a live pane. The TUI turns
+// this into the manual resume instructions.
+var errAgentBusy = errors.New("the agent is still working; it will pick up this decision on its own")
+
 type tmuxAgentResumer struct {
 	tuiPane string
 	// heartbeatAge reports how long ago the agent refreshed the session
 	// heartbeat; nil disables the parked-agent check.
 	heartbeatAge func(sessionID string) (time.Duration, error)
-	keyDelay     time.Duration
-	mu           sync.Mutex
+	// agentIsWorking reports whether the session still has a node the agent is
+	// actively implementing; nil disables the busy-agent check.
+	agentIsWorking func(sessionID string) bool
+	keyDelay       time.Duration
+	mu             sync.Mutex
 }
 
 func newTmuxAgentResumer(tuiPane string) *tmuxAgentResumer {
@@ -43,14 +53,21 @@ func (r *tmuxAgentResumer) Notify(sessionID string) error {
 	defer r.mu.Unlock()
 
 	// A parked agent picks the decision up from the session file on its own.
-	// Injecting keystrokes is only for an agent that has timed out — doing it
-	// while the agent is live would append our prompt to whatever is in its
-	// input box (including a half-typed human message) or blindly submit an
-	// open dialog.
+	// Injecting keystrokes is only for an agent that has timed out back to an
+	// idle prompt — doing it while the agent is live would append our prompt
+	// to whatever is in its input box (including a half-typed human message)
+	// or blindly submit an open permission dialog.
 	if r.heartbeatAge != nil {
 		if age, err := r.heartbeatAge(sessionID); err == nil && age <= parkedHeartbeatFreshFor {
 			return nil
 		}
+	}
+	// A stale heartbeat only means "not parked in await-review" — the agent
+	// may be mid-work with a dialog open, since the heartbeat exists only
+	// while parked. Require positive evidence that it stopped working before
+	// typing into its pane.
+	if r.agentIsWorking != nil && r.agentIsWorking(sessionID) {
+		return errAgentBusy
 	}
 
 	pane, err := r.findAgentPane()
@@ -110,10 +127,24 @@ func coopTUIOptions() []tui.Option {
 		resumer := newTmuxAgentResumer(tuiPane)
 		if store, err := coop.NewStore(coopConfigFolder()); err == nil {
 			resumer.heartbeatAge = store.HeartbeatAge
+			resumer.agentIsWorking = func(sessionID string) bool {
+				session, err := store.Read(sessionID)
+				if err != nil {
+					return false
+				}
+				node, _ := session.ActiveNode()
+				return node != nil
+			}
 		}
 		options = append(options, tui.WithReviewDecisionNotifier(resumer.Notify))
 		alerter := &tmuxReviewAlerter{tuiPane: tuiPane}
-		options = append(options, tui.WithReviewAlertNotifier(alerter.Alert))
+		options = append(options,
+			tui.WithReviewAlertNotifier(alerter.Alert),
+			tui.WithExitCleanup(alerter.Restore),
+		)
+		if pin := coopPaneWidthPin(tuiPane); pin != nil {
+			options = append(options, tui.WithResizeHook(pin))
+		}
 	} else {
 		// Outside tmux the terminal still understands BEL, and bubbletea's
 		// focus reporting still works — ring only when the user is elsewhere.
@@ -156,23 +187,110 @@ func withTmuxServerFlags(serverFlags []string, args ...string) []string {
 // tmuxReviewAlerter surfaces "a review is waiting" through tmux itself — the
 // only channel that reaches the user regardless of which pane is active or
 // which terminal draws the status line.
+//
+// In the in-tmux split path this renames a window the user owns, so it
+// captures the window's prior name and automatic-rename setting on first use
+// and puts both back — on clear and on exit. Blindly setting
+// automatic-rename=on would silently override users who keep it off to name
+// windows by hand.
 type tmuxReviewAlerter struct {
 	tuiPane string
+
+	mu              sync.Mutex
+	saved           bool
+	priorName       string
+	priorAutoRename string
+	renamed         bool
 }
 
 // Alert renames the co-op window in tmux's status line while a review waits
-// and rings the terminal bell if the user is looking elsewhere. rename-window
-// disables automatic-rename, so clearing restores automatic naming instead of
-// renaming again.
+// and rings the terminal bell if the user is looking elsewhere.
 func (a *tmuxReviewAlerter) Alert(hasReview, focused bool) {
-	if hasReview {
-		_ = runTmux("rename-window", "-t", a.tuiPane, "coop: REVIEW")
-		if !focused {
-			ringTerminalBell()
-		}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if !hasReview {
+		a.restoreLocked()
 		return
 	}
-	_ = runTmux("set-window-option", "-t", a.tuiPane, "automatic-rename", "on")
+	a.saveWindowStateLocked()
+	if err := runTmux("rename-window", "-t", a.tuiPane, "coop: REVIEW"); err == nil {
+		a.renamed = true
+	}
+	if !focused {
+		ringTerminalBell()
+	}
+}
+
+// Restore puts the window name back. Safe to call when nothing was renamed,
+// so it can run unconditionally on TUI exit.
+func (a *tmuxReviewAlerter) Restore() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.restoreLocked()
+}
+
+func (a *tmuxReviewAlerter) saveWindowStateLocked() {
+	if a.saved {
+		return
+	}
+	// Record before the first rename; rename-window itself turns
+	// automatic-rename off, so reading after would capture our own effect.
+	name, err := runTmuxOutput("display-message", "-p", "-t", a.tuiPane, "#{window_name}")
+	if err != nil {
+		return
+	}
+	auto, err := runTmuxOutput("display-message", "-p", "-t", a.tuiPane, "#{?automatic-rename,on,off}")
+	if err != nil {
+		return
+	}
+	a.priorName = strings.TrimSpace(name)
+	a.priorAutoRename = strings.TrimSpace(auto)
+	a.saved = true
+}
+
+func (a *tmuxReviewAlerter) restoreLocked() {
+	if !a.renamed || !a.saved {
+		return
+	}
+	if a.priorName != "" {
+		_ = runTmux("rename-window", "-t", a.tuiPane, a.priorName)
+	}
+	// rename-window sets automatic-rename off; only re-enable it if that is
+	// how we found the window.
+	if a.priorAutoRename == "on" {
+		_ = runTmux("set-window-option", "-t", a.tuiPane, "automatic-rename", "on")
+	}
+	a.renamed = false
+}
+
+// coopPaneWidthPin re-asserts the launcher's intended TUI pane width after a
+// resize. tmux scales panes proportionally when the terminal changes size, so
+// the fixed width set at launch would otherwise drift — a 200-column window
+// narrowed to 120 takes the TUI from 48 columns to roughly 29, well under
+// what the review card needs. Returns nil unless this process was launched by
+// `coop start`, so a hand-run `coop join` never resizes the user's own pane.
+func coopPaneWidthPin(tuiPane string) func(width, height int) {
+	target, err := strconv.Atoi(os.Getenv(coopTUIWidthEnv))
+	if err != nil || target <= 0 {
+		return nil
+	}
+	return func(width, _ int) {
+		if width == target {
+			return
+		}
+		// Only pin while the window is still wide enough to deserve a split;
+		// otherwise leave the panes alone rather than starving the agent.
+		out, err := runTmuxOutput("display-message", "-p", "-t", tuiPane, "#{window_width}")
+		if err != nil {
+			return
+		}
+		windowWidth, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil || coopTUIPaneWidthFor(windowWidth) == 0 {
+			return
+		}
+		_ = runTmux("resize-pane", "-t", tuiPane, "-x", strconv.Itoa(target))
+	}
 }
 
 // ringTerminalBell writes BEL to the controlling terminal. Harmless under the

--- a/pkg/cmd/coop/coop_agent_resumer.go
+++ b/pkg/cmd/coop/coop_agent_resumer.go
@@ -112,13 +112,27 @@ func coopTUIOptions() []tui.Option {
 			resumer.heartbeatAge = store.HeartbeatAge
 		}
 		options = append(options, tui.WithReviewDecisionNotifier(resumer.Notify))
+		alerter := &tmuxReviewAlerter{tuiPane: tuiPane}
+		options = append(options, tui.WithReviewAlertNotifier(alerter.Alert))
+	} else {
+		// Outside tmux the terminal still understands BEL, and bubbletea's
+		// focus reporting still works — ring only when the user is elsewhere.
+		options = append(options, tui.WithReviewAlertNotifier(func(hasReview, focused bool) {
+			if hasReview && !focused {
+				ringTerminalBell()
+			}
+		}))
 	}
 	return options
 }
 
-func splitCoopAgentPane(args ...string) (string, error) {
-	args = append([]string{"split-window", "-P", "-F", "#{pane_id}"}, args...)
-	out, err := runTmuxOutput(args...)
+// splitCoopAgentPane splits off and tags the agent pane. serverFlags select
+// the tmux server (e.g. -L stripe-coop for the dedicated launcher socket);
+// nil targets the server from $TMUX, which is correct inside an existing
+// session.
+func splitCoopAgentPane(serverFlags []string, args ...string) (string, error) {
+	splitArgs := append(withTmuxServerFlags(serverFlags, "split-window", "-P", "-F", "#{pane_id}"), args...)
+	out, err := runTmuxOutput(splitArgs...)
 	if err != nil {
 		return "", err
 	}
@@ -126,9 +140,44 @@ func splitCoopAgentPane(args ...string) (string, error) {
 	if pane == "" {
 		return "", fmt.Errorf("tmux split-window returned an empty pane ID")
 	}
-	if err := runTmux("set-option", "-p", "-t", pane, coopAgentPaneOption, "1"); err != nil {
-		_ = runTmux("kill-pane", "-t", pane)
+	if err := runTmux(withTmuxServerFlags(serverFlags, "set-option", "-p", "-t", pane, coopAgentPaneOption, "1")...); err != nil {
+		_ = runTmux(withTmuxServerFlags(serverFlags, "kill-pane", "-t", pane)...)
 		return "", fmt.Errorf("tagging Co-op agent pane: %w", err)
 	}
 	return pane, nil
+}
+
+// withTmuxServerFlags prepends tmux server-selection flags (which must come
+// before the subcommand) without aliasing the caller's slice.
+func withTmuxServerFlags(serverFlags []string, args ...string) []string {
+	return append(append([]string(nil), serverFlags...), args...)
+}
+
+// tmuxReviewAlerter surfaces "a review is waiting" through tmux itself — the
+// only channel that reaches the user regardless of which pane is active or
+// which terminal draws the status line.
+type tmuxReviewAlerter struct {
+	tuiPane string
+}
+
+// Alert renames the co-op window in tmux's status line while a review waits
+// and rings the terminal bell if the user is looking elsewhere. rename-window
+// disables automatic-rename, so clearing restores automatic naming instead of
+// renaming again.
+func (a *tmuxReviewAlerter) Alert(hasReview, focused bool) {
+	if hasReview {
+		_ = runTmux("rename-window", "-t", a.tuiPane, "coop: REVIEW")
+		if !focused {
+			ringTerminalBell()
+		}
+		return
+	}
+	_ = runTmux("set-window-option", "-t", a.tuiPane, "automatic-rename", "on")
+}
+
+// ringTerminalBell writes BEL to the controlling terminal. Harmless under the
+// TUI's alt screen; the shipped tmux config passes it through to the outer
+// terminal (bell-action any, visual-bell off).
+func ringTerminalBell() {
+	fmt.Fprint(os.Stderr, "\a")
 }

--- a/pkg/cmd/coop/coop_agent_resumer_test.go
+++ b/pkg/cmd/coop/coop_agent_resumer_test.go
@@ -28,13 +28,38 @@ func TestSplitCoopAgentPaneTagsReturnedPane(t *testing.T) {
 		runTmuxOutput = originalRunTmuxOutput
 	})
 
-	pane, err := splitCoopAgentPane("-h", "bash", "-c", "agent")
+	pane, err := splitCoopAgentPane(nil, "-h", "bash", "-c", "agent")
 
 	require.NoError(t, err)
 	assert.Equal(t, "%7", pane)
 	require.Len(t, calls, 2)
 	assert.Equal(t, []string{"split-window", "-P", "-F", "#{pane_id}", "-h", "bash", "-c", "agent"}, calls[0])
 	assert.Equal(t, []string{"set-option", "-p", "-t", "%7", coopAgentPaneOption, "1"}, calls[1])
+}
+
+func TestSplitCoopAgentPaneTargetsRequestedServer(t *testing.T) {
+	originalRunTmux := runTmux
+	originalRunTmuxOutput := runTmuxOutput
+	var calls [][]string
+	runTmuxOutput = func(args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return "%3\n", nil
+	}
+	runTmux = func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalRunTmuxOutput
+	})
+
+	_, err := splitCoopAgentPane([]string{"-L", coopTmuxSocket}, "-h", "bash", "-c", "agent")
+
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
+	assert.Equal(t, []string{"-L", "stripe-coop"}, calls[0][:2], "split must land on the dedicated socket")
+	assert.Equal(t, []string{"-L", "stripe-coop"}, calls[1][:2], "tagging must target the same server")
 }
 
 func TestTmuxAgentResumerSerializesConcurrentWakeUps(t *testing.T) {

--- a/pkg/cmd/coop/coop_agent_resumer_test.go
+++ b/pkg/cmd/coop/coop_agent_resumer_test.go
@@ -1,9 +1,11 @@
 package coopcmd
 
 import (
+	"errors"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,7 +43,7 @@ func TestTmuxAgentResumerSerializesConcurrentWakeUps(t *testing.T) {
 	var callsMu sync.Mutex
 	var calls [][]string
 	runTmuxOutput = func(args ...string) (string, error) {
-		return "%1\t\n%2\t1\n", nil
+		return "%1\t\t0\n%2\t1\t0\n", nil
 	}
 	runTmux = func(args ...string) error {
 		callsMu.Lock()
@@ -73,11 +75,95 @@ func TestTmuxAgentResumerSerializesConcurrentWakeUps(t *testing.T) {
 
 	callsMu.Lock()
 	defer callsMu.Unlock()
-	require.Len(t, calls, 6)
-	for i := 0; i < len(calls); i += 2 {
-		require.Len(t, calls[i], 5)
-		assert.Equal(t, []string{"send-keys", "-t", "%2", "-l"}, calls[i][:4])
-		assert.True(t, strings.Contains(calls[i][4], "stripe coop agent resume --session=session_"))
-		assert.Equal(t, []string{"send-keys", "-t", "%2", "Enter"}, calls[i+1])
+	require.Len(t, calls, 9)
+	for i := 0; i < len(calls); i += 3 {
+		assert.Equal(t, []string{"send-keys", "-t", "%2", "C-u"}, calls[i])
+		require.Len(t, calls[i+1], 5)
+		assert.Equal(t, []string{"send-keys", "-t", "%2", "-l"}, calls[i+1][:4])
+		assert.True(t, strings.Contains(calls[i+1][4], "stripe coop agent resume --session=session_"))
+		assert.Equal(t, []string{"send-keys", "-t", "%2", "Enter"}, calls[i+2])
 	}
+}
+
+func TestTmuxAgentResumerSkipsInjectionWhileAgentIsParked(t *testing.T) {
+	originalRunTmux := runTmux
+	originalRunTmuxOutput := runTmuxOutput
+	var calls [][]string
+	record := func(args ...string) {
+		calls = append(calls, append([]string(nil), args...))
+	}
+	runTmuxOutput = func(args ...string) (string, error) {
+		record(args...)
+		return "%2\t1\t0\n", nil
+	}
+	runTmux = func(args ...string) error {
+		record(args...)
+		return nil
+	}
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalRunTmuxOutput
+	})
+
+	resumer := newTmuxAgentResumer("%1")
+	resumer.keyDelay = 0
+	resumer.heartbeatAge = func(sessionID string) (time.Duration, error) {
+		assert.Equal(t, "session_parked", sessionID)
+		return 500 * time.Millisecond, nil
+	}
+
+	require.NoError(t, resumer.Notify("session_parked"))
+	assert.Empty(t, calls, "a parked agent reads the decision from the session file; nothing should be injected")
+}
+
+func TestTmuxAgentResumerInjectsWhenHeartbeatMissing(t *testing.T) {
+	originalRunTmux := runTmux
+	originalRunTmuxOutput := runTmuxOutput
+	var calls [][]string
+	runTmuxOutput = func(args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return "%2\t1\t0\n", nil
+	}
+	runTmux = func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalRunTmuxOutput
+	})
+
+	resumer := newTmuxAgentResumer("%1")
+	resumer.keyDelay = 0
+	resumer.heartbeatAge = func(string) (time.Duration, error) {
+		return 0, errors.New("no heartbeat")
+	}
+
+	require.NoError(t, resumer.Notify("session_idle"))
+	require.Len(t, calls, 4) // list-panes, C-u, prompt, Enter
+	assert.Equal(t, []string{"send-keys", "-t", "%2", "C-u"}, calls[1])
+}
+
+func TestTmuxAgentResumerRefusesDeadAgentPane(t *testing.T) {
+	originalRunTmux := runTmux
+	originalRunTmuxOutput := runTmuxOutput
+	var sends [][]string
+	runTmuxOutput = func(args ...string) (string, error) {
+		return "%2\t1\t1\n", nil
+	}
+	runTmux = func(args ...string) error {
+		sends = append(sends, append([]string(nil), args...))
+		return nil
+	}
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalRunTmuxOutput
+	})
+
+	resumer := newTmuxAgentResumer("%1")
+	err := resumer.Notify("session_dead")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exited")
+	assert.Empty(t, sends, "no keystrokes may be sent into a dead pane")
 }

--- a/pkg/cmd/coop/coop_debug_agent_test.go
+++ b/pkg/cmd/coop/coop_debug_agent_test.go
@@ -34,7 +34,8 @@ func TestDebugAgentPaneCommandUsesStripeBinaryAndSession(t *testing.T) {
 	cmd, cleanup, err := rc.debugAgentPaneCommandBuilder("/tmp/stripe bin")(&coop.Session{ID: "coop_123"})
 	require.NoError(t, err)
 	assert.Nil(t, cleanup)
-	assert.Equal(t, "XDG_CONFIG_HOME='/tmp/xdg config' '/tmp/stripe bin' coop debug-agent --session 'coop_123'", cmd)
+	assert.Equal(t, "XDG_CONFIG_HOME='/tmp/xdg config' '/tmp/stripe bin' coop debug-agent --session 'coop_123'", cmd.shell)
+	assert.Equal(t, []string{"/tmp/stripe bin", "coop", "debug-agent", "--session", "coop_123"}, cmd.argv)
 }
 
 func TestCoopDebugAgentRerunsRequestedChanges(t *testing.T) {

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -317,7 +317,10 @@ func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprint *coo
 	shellCmd := shellCommandWithCoopEnv(paneCmd.shell)
 
 	agentWidth := paneWidth - tuiWidth - coopPaneDividerWidth
-	if _, err := splitCoopAgentPane("-h", "-l", strconv.Itoa(agentWidth), "bash", "-c", shellCmd); err != nil {
+	// nil server flags: inside an existing session the split must land on the
+	// user's own server (resolved via $TMUX), never the dedicated socket —
+	// attaching a second server from inside a pane nests silently.
+	if _, err := splitCoopAgentPane(nil, "-h", "-l", strconv.Itoa(agentWidth), "bash", "-c", shellCmd); err != nil {
 		if cleanup != nil {
 			cleanup()
 		}
@@ -338,9 +341,10 @@ func (rc *coopRunCmd) runInNewTmux(stripeBin string, agent *agentInfo, agentProm
 
 func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.Blueprint, buildPaneCmd coopPaneCommandBuilder) error {
 	sessionName := "stripe-coop"
+	serverFlags := []string{"-L", coopTmuxSocket}
 
-	// Check for existing session
-	if err := runTmux("has-session", "-t", sessionName); err == nil {
+	// Check for existing session on the dedicated socket
+	if err := runTmux(withTmuxServerFlags(serverFlags, "has-session", "-t", sessionName)...); err == nil {
 		var choice string
 		if err := selectString("A co-op tmux session already exists. What would you like to do?",
 			[]huh.Option[string]{
@@ -353,13 +357,13 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 		}
 
 		if choice == "attach" {
-			attach := exec.Command("tmux", "attach-session", "-t", sessionName)
+			attach := exec.Command("tmux", withTmuxServerFlags(serverFlags, "attach-session", "-t", sessionName)...)
 			attach.Stdin = os.Stdin
 			attach.Stdout = os.Stdout
 			attach.Stderr = os.Stderr
 			return attach.Run()
 		}
-		killTmuxSession(sessionName)
+		killTmuxSession(serverFlags, sessionName)
 	}
 
 	width, height := coopTmuxSessionDimensions()
@@ -393,8 +397,16 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 	}
 	shellCmd := shellCommandWithCoopEnv(paneCmd.shell)
 
-	if err := runTmux("new-session", "-d", "-s", sessionName, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height),
-		"bash", "-c", tuiCmd); err != nil {
+	// The shipped config only applies when this new-session call starts the
+	// server; -f is ignored on a running server, which can only be a co-op one
+	// on this socket. On write failure, launch with tmux defaults — degraded
+	// but working.
+	newSessionFlags := serverFlags
+	if confPath, err := writeCoopTmuxConf(); err == nil {
+		newSessionFlags = withTmuxServerFlags(serverFlags, "-f", confPath)
+	}
+	if err := runTmux(withTmuxServerFlags(newSessionFlags, "new-session", "-d", "-s", sessionName,
+		"-x", strconv.Itoa(width), "-y", strconv.Itoa(height), "bash", "-c", tuiCmd)...); err != nil {
 		if cleanup != nil {
 			cleanup()
 		}
@@ -403,27 +415,27 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 	}
 
 	agentWidth := width - tuiWidth - coopPaneDividerWidth
-	agentPane, err := splitCoopAgentPane("-h", "-t", sessionName, "-l", strconv.Itoa(agentWidth), "bash", "-c", shellCmd)
+	agentPane, err := splitCoopAgentPane(serverFlags, "-h", "-t", sessionName, "-l", strconv.Itoa(agentWidth), "bash", "-c", shellCmd)
 	if err != nil {
 		if cleanup != nil {
 			cleanup()
 		}
-		killTmuxSession(sessionName)
+		killTmuxSession(serverFlags, sessionName)
 		rc.abortStartedSession(session, "tmux split-window failed")
 		return fmt.Errorf("tmux split-window failed: %w", err)
 	}
 
-	runTmux("select-pane", "-t", agentPane)
+	runTmux(withTmuxServerFlags(serverFlags, "select-pane", "-t", agentPane)...)
 
-	attach := exec.Command("tmux", "attach-session", "-t", sessionName)
+	attach := exec.Command("tmux", withTmuxServerFlags(serverFlags, "attach-session", "-t", sessionName)...)
 	attach.Stdin = os.Stdin
 	attach.Stdout = os.Stdout
 	attach.Stderr = os.Stderr
 	return attach.Run()
 }
 
-func killTmuxSession(sessionName string) {
-	_ = runTmux("kill-session", "-t", sessionName)
+func killTmuxSession(serverFlags []string, sessionName string) {
+	_ = runTmux(withTmuxServerFlags(serverFlags, "kill-session", "-t", sessionName)...)
 }
 
 func coopTmuxSessionDimensions() (int, int) {

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -480,6 +480,9 @@ func (rc *coopRunCmd) runFallbackWithReason(stripeBin string, blueprint *coop.Bl
 	} else {
 		fmt.Printf("Open another terminal and run: %s\n", shellCommandWithCoopEnv(joinBin+" coop join --wait"))
 	}
+	if hint := nativeSplitHint(); hint != "" {
+		fmt.Println(hint)
+	}
 	fmt.Println()
 
 	paneCmd, cleanup, err := buildPaneCmd(session)

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -30,7 +30,16 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-type coopPaneCommandBuilder func(session *coop.Session) (string, func(), error)
+// paneCommand describes the agent launch in each of the two launch modes:
+// shell is interpolated into a tmux pane's command line; argv runs directly in
+// this terminal with no shell, so the fallback works where bash doesn't exist
+// (Windows, minimal containers, NixOS).
+type paneCommand struct {
+	shell string
+	argv  []string
+}
+
+type coopPaneCommandBuilder func(session *coop.Session) (paneCommand, func(), error)
 
 var (
 	selectString = helpers.Select[string]
@@ -140,31 +149,39 @@ func (rc *coopRunCmd) promptAutoApprove(agent *agentInfo) (bool, error) {
 	return choice == "bypass", nil
 }
 
-func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApprove bool) (string, error) {
-	launcherPath := promptPath + ".sh"
-	var script string
-
+// agentFlags returns the per-agent CLI flags as an argv fragment. The tmux
+// launcher script and the direct-exec fallback both build from this so the two
+// launch modes cannot drift.
+func agentFlags(agent *agentInfo, autoApprove bool) []string {
 	switch agent.name {
 	case "claude":
-		flags := " --agents " + shellQuote(claudeCoopAgents)
+		flags := []string{"--agents", claudeCoopAgents}
 		if autoApprove {
-			flags += " --dangerously-skip-permissions"
+			flags = append(flags, "--dangerously-skip-permissions")
 		}
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path), flags)
-
+		return flags
 	case "codex":
-		flags := ""
 		if autoApprove {
-			flags = " --dangerously-bypass-approvals-and-sandbox"
+			return []string{"--dangerously-bypass-approvals-and-sandbox"}
 		}
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path), flags)
-
+		return nil
 	default:
-		script = fmt.Sprintf("#!/bin/bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s \"$prompt\"\n",
-			shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path))
+		return nil
 	}
+}
+
+func (rc *coopRunCmd) buildAgentCmd(agent *agentInfo, promptPath string, autoApprove bool) (string, error) {
+	launcherPath := promptPath + ".sh"
+
+	flags := ""
+	for _, flag := range agentFlags(agent, autoApprove) {
+		flags += " " + shellQuote(flag)
+	}
+	// `#!/usr/bin/env bash`, not `#!/bin/bash`: the script runs inside tmux
+	// panes whose shell resolves bash from PATH, and /bin/bash does not exist
+	// on NixOS.
+	script := fmt.Sprintf("#!/usr/bin/env bash\nprompt=$(cat %s)\nrm -f %s %s\nexec %s%s \"$prompt\"\n",
+		shellQuote(promptPath), shellQuote(promptPath), shellQuote(launcherPath), shellQuote(agent.path), flags)
 
 	if err := os.WriteFile(launcherPath, []byte(script), 0700); err != nil {
 		return "", fmt.Errorf("creating agent launcher: %w", err)
@@ -208,44 +225,50 @@ func currentTmuxPaneWidth() int {
 }
 
 func (rc *coopRunCmd) agentPaneCommandBuilder(agent *agentInfo, discoveryPrompt string, autoApprove bool) coopPaneCommandBuilder {
-	return func(session *coop.Session) (string, func(), error) {
+	return func(session *coop.Session) (paneCommand, func(), error) {
 		prompt := discoveryPrompt
 		if session != nil {
 			var err error
 			prompt, err = rc.buildAgentPromptForSession(session)
 			if err != nil {
-				return "", nil, err
+				return paneCommand{}, nil, err
 			}
 		}
 		promptPath, err := writePromptFile(prompt)
 		if err != nil {
-			return "", nil, err
+			return paneCommand{}, nil, err
 		}
 
 		agentCmd, err := rc.buildAgentCmd(agent, promptPath, autoApprove)
 		if err != nil {
 			os.Remove(promptPath)
-			return "", nil, err
+			return paneCommand{}, nil, err
 		}
-		// The returned command is run via `bash -c`, so the launcher path itself
-		// must be shell-quoted — otherwise a temp dir (TMPDIR) containing a space
-		// or shell syntax would be parsed by bash before the launcher runs. The
-		// cleanup closure keeps the raw path for os.Remove.
-		return shellQuote(agentCmd), func() {
-			os.Remove(promptPath)
-			os.Remove(agentCmd)
-		}, nil
+		// The shell command is run via `bash -c`, so the launcher path itself
+		// must be shell-quoted — otherwise a temp dir (TMPDIR) containing a
+		// space or shell syntax would be parsed by bash before the launcher
+		// runs. The cleanup closure keeps the raw path for os.Remove.
+		return paneCommand{
+				shell: shellQuote(agentCmd),
+				argv:  append(append([]string{agent.path}, agentFlags(agent, autoApprove)...), prompt),
+			}, func() {
+				os.Remove(promptPath)
+				os.Remove(agentCmd)
+			}, nil
 	}
 }
 
 func (rc *coopRunCmd) debugAgentPaneCommandBuilder(stripeBin string) coopPaneCommandBuilder {
-	return func(session *coop.Session) (string, func(), error) {
+	return func(session *coop.Session) (paneCommand, func(), error) {
 		sessionID := ""
 		if session != nil {
 			sessionID = session.ID
 		}
 		cmd := fmt.Sprintf("%s coop debug-agent --session %s", shellQuote(stripeBin), shellQuote(sessionID))
-		return shellCommandWithCoopEnv(cmd), nil, nil
+		return paneCommand{
+			shell: shellCommandWithCoopEnv(cmd),
+			argv:  []string{stripeBin, "coop", "debug-agent", "--session", sessionID},
+		}, nil, nil
 	}
 }
 
@@ -291,10 +314,10 @@ func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprint *coo
 		rc.abortStartedSession(session, "agent pane command failed")
 		return err
 	}
-	paneCmd = shellCommandWithCoopEnv(paneCmd)
+	shellCmd := shellCommandWithCoopEnv(paneCmd.shell)
 
 	agentWidth := paneWidth - tuiWidth - coopPaneDividerWidth
-	if _, err := splitCoopAgentPane("-h", "-l", strconv.Itoa(agentWidth), "bash", "-c", paneCmd); err != nil {
+	if _, err := splitCoopAgentPane("-h", "-l", strconv.Itoa(agentWidth), "bash", "-c", shellCmd); err != nil {
 		if cleanup != nil {
 			cleanup()
 		}
@@ -368,7 +391,7 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 		rc.abortStartedSession(session, "agent pane command failed")
 		return err
 	}
-	paneCmd = shellCommandWithCoopEnv(paneCmd)
+	shellCmd := shellCommandWithCoopEnv(paneCmd.shell)
 
 	if err := runTmux("new-session", "-d", "-s", sessionName, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height),
 		"bash", "-c", tuiCmd); err != nil {
@@ -380,7 +403,7 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 	}
 
 	agentWidth := width - tuiWidth - coopPaneDividerWidth
-	agentPane, err := splitCoopAgentPane("-h", "-t", sessionName, "-l", strconv.Itoa(agentWidth), "bash", "-c", paneCmd)
+	agentPane, err := splitCoopAgentPane("-h", "-t", sessionName, "-l", strconv.Itoa(agentWidth), "bash", "-c", shellCmd)
 	if err != nil {
 		if cleanup != nil {
 			cleanup()
@@ -426,6 +449,13 @@ func (rc *coopRunCmd) runFallbackWithCommand(stripeBin string, blueprint *coop.B
 func (rc *coopRunCmd) runFallbackWithReason(stripeBin string, blueprint *coop.Blueprint, buildPaneCmd coopPaneCommandBuilder, reason string) error {
 	fmt.Println(reason)
 
+	// Print the absolute binary path: the second terminal may be a login shell
+	// whose PATH doesn't carry a version-manager shim or ~/.local/bin yet.
+	joinBin := "stripe"
+	if stripeBin != "" {
+		joinBin = shellQuote(stripeBin)
+	}
+
 	var session *coop.Session
 	if blueprint != nil {
 		var err error
@@ -434,9 +464,9 @@ func (rc *coopRunCmd) runFallbackWithReason(stripeBin string, blueprint *coop.Bl
 			return err
 		}
 		fmt.Printf("Session started: %s\n", session.ID)
-		fmt.Printf("Open another terminal and run: %s\n", shellCommandWithCoopEnv("stripe coop join "+session.ID))
+		fmt.Printf("Open another terminal and run: %s\n", shellCommandWithCoopEnv(joinBin+" coop join "+session.ID))
 	} else {
-		fmt.Printf("Open another terminal and run: %s\n", shellCommandWithCoopEnv("stripe coop join --wait"))
+		fmt.Printf("Open another terminal and run: %s\n", shellCommandWithCoopEnv(joinBin+" coop join --wait"))
 	}
 	fmt.Println()
 
@@ -448,7 +478,13 @@ func (rc *coopRunCmd) runFallbackWithReason(stripeBin string, blueprint *coop.Bl
 	if cleanup != nil {
 		defer cleanup()
 	}
-	agentExec := exec.Command("bash", "-c", paneCmd)
+	if len(paneCmd.argv) == 0 {
+		rc.abortStartedSession(session, "agent command empty")
+		return fmt.Errorf("agent command is empty")
+	}
+	// Direct exec, no shell: this is the only launch path that must work
+	// everywhere, including Windows and containers without bash.
+	agentExec := exec.Command(paneCmd.argv[0], paneCmd.argv[1:]...)
 	agentExec.Stdin = os.Stdin
 	agentExec.Stdout = os.Stdout
 	agentExec.Stderr = os.Stderr

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -42,7 +42,25 @@ var (
 const (
 	defaultCoopTmuxSessionWidth  = 200
 	defaultCoopTmuxSessionHeight = 50
-	claudeCoopAgents             = `{"coop-cost-effective-worker":{"description":"Use proactively for well-bounded, self-contained exploration, documentation research, test execution, log analysis, and verification tasks when delegation saves main-session context and cost.","prompt":"Work as a focused cost-effective Co-op subagent. Complete only the bounded task you receive, verify your result, and return concise evidence to the main agent. Find and honor applicable repository guidance, including AGENTS.md and CLAUDE.md, before acting. Do not choose or change the Stripe integration or run Co-op lifecycle commands.","model":"haiku"}}`
+
+	// The TUI pane gets a fixed column width and the agent pane gets everything
+	// else. Fixed (rather than a percentage) because the TUI's usefulness stops
+	// growing past its card width while the agent benefits from every extra
+	// column — and it makes the review card render identically on every
+	// terminal. Both widths sit below tui.SplitWorkspaceMinWidth so the
+	// companion pane always renders the single-column layout.
+	coopTUIPaneWidth       = 48
+	coopTUIPaneWidthNarrow = 40
+
+	// Minimum agent-pane widths paired with each TUI tier. Below the narrow
+	// tier a side-by-side split squeezes both panes past usefulness, so the
+	// launcher runs the agent full-width with manual join instructions instead.
+	coopAgentPaneMinWidth       = 80
+	coopAgentPaneMinWidthNarrow = 72
+
+	// tmux draws a one-column divider between horizontally split panes.
+	coopPaneDividerWidth = 1
+	claudeCoopAgents     = `{"coop-cost-effective-worker":{"description":"Use proactively for well-bounded, self-contained exploration, documentation research, test execution, log analysis, and verification tasks when delegation saves main-session context and cost.","prompt":"Work as a focused cost-effective Co-op subagent. Complete only the bounded task you receive, verify your result, and return concise evidence to the main agent. Find and honor applicable repository guidance, including AGENTS.md and CLAUDE.md, before acting. Do not choose or change the Stripe integration or run Co-op lifecycle commands.","model":"haiku"}}`
 )
 
 func (rc *coopRunCmd) detectAgent() (*agentInfo, error) {
@@ -159,6 +177,36 @@ func (rc *coopRunCmd) hasTmux() bool {
 	return err == nil
 }
 
+// coopTUIPaneWidthFor returns the fixed TUI pane width for a terminal (or
+// tmux pane) of totalWidth columns, or 0 when totalWidth is too narrow for a
+// side-by-side split to leave both panes usable.
+func coopTUIPaneWidthFor(totalWidth int) int {
+	switch {
+	case totalWidth >= coopTUIPaneWidth+coopPaneDividerWidth+coopAgentPaneMinWidth:
+		return coopTUIPaneWidth
+	case totalWidth >= coopTUIPaneWidthNarrow+coopPaneDividerWidth+coopAgentPaneMinWidthNarrow:
+		return coopTUIPaneWidthNarrow
+	default:
+		return 0
+	}
+}
+
+// currentTmuxPaneWidth reports the width of the tmux pane this process is
+// running in. On any failure it assumes the default session width, which
+// yields the standard TUI width; tmux clamps an oversized -l request rather
+// than failing the split.
+func currentTmuxPaneWidth() int {
+	out, err := runTmuxOutput("display-message", "-p", "#{pane_width}")
+	if err != nil {
+		return defaultCoopTmuxSessionWidth
+	}
+	width, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil || width <= 0 {
+		return defaultCoopTmuxSessionWidth
+	}
+	return width
+}
+
 func (rc *coopRunCmd) agentPaneCommandBuilder(agent *agentInfo, discoveryPrompt string, autoApprove bool) coopPaneCommandBuilder {
 	return func(session *coop.Session) (string, func(), error) {
 		prompt := discoveryPrompt
@@ -213,6 +261,13 @@ func (rc *coopRunCmd) runInTmuxSplit(stripeBin string, agent *agentInfo, agentPr
 }
 
 func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprint *coop.Blueprint, buildPaneCmd coopPaneCommandBuilder) error {
+	paneWidth := currentTmuxPaneWidth()
+	tuiWidth := coopTUIPaneWidthFor(paneWidth)
+	if tuiWidth == 0 {
+		return rc.runFallbackWithReason(stripeBin, blueprint, buildPaneCmd,
+			fmt.Sprintf("This tmux pane is %d columns — too narrow to split. Running the agent here.", paneWidth))
+	}
+
 	var session *coop.Session
 	if blueprint != nil {
 		var err error
@@ -238,7 +293,8 @@ func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprint *coo
 	}
 	paneCmd = shellCommandWithCoopEnv(paneCmd)
 
-	if _, err := splitCoopAgentPane("-h", "-p", "60", "bash", "-c", paneCmd); err != nil {
+	agentWidth := paneWidth - tuiWidth - coopPaneDividerWidth
+	if _, err := splitCoopAgentPane("-h", "-l", strconv.Itoa(agentWidth), "bash", "-c", paneCmd); err != nil {
 		if cleanup != nil {
 			cleanup()
 		}
@@ -283,6 +339,13 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 		killTmuxSession(sessionName)
 	}
 
+	width, height := coopTmuxSessionDimensions()
+	tuiWidth := coopTUIPaneWidthFor(width)
+	if tuiWidth == 0 {
+		return rc.runFallbackWithReason(stripeBin, blueprint, buildPaneCmd,
+			fmt.Sprintf("This terminal is %d columns — too narrow for a split view. Running the agent here.", width))
+	}
+
 	var session *coop.Session
 	if blueprint != nil {
 		var err error
@@ -307,7 +370,6 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 	}
 	paneCmd = shellCommandWithCoopEnv(paneCmd)
 
-	width, height := coopTmuxSessionDimensions()
 	if err := runTmux("new-session", "-d", "-s", sessionName, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height),
 		"bash", "-c", tuiCmd); err != nil {
 		if cleanup != nil {
@@ -317,7 +379,8 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 		return fmt.Errorf("tmux new-session failed: %w", err)
 	}
 
-	agentPane, err := splitCoopAgentPane("-h", "-t", sessionName, "-p", "60", "bash", "-c", paneCmd)
+	agentWidth := width - tuiWidth - coopPaneDividerWidth
+	agentPane, err := splitCoopAgentPane("-h", "-t", sessionName, "-l", strconv.Itoa(agentWidth), "bash", "-c", paneCmd)
 	if err != nil {
 		if cleanup != nil {
 			cleanup()
@@ -357,7 +420,11 @@ func (rc *coopRunCmd) runFallback(stripeBin string, agent *agentInfo, agentPromp
 }
 
 func (rc *coopRunCmd) runFallbackWithCommand(stripeBin string, blueprint *coop.Blueprint, buildPaneCmd coopPaneCommandBuilder) error {
-	fmt.Println("tmux not found — running agent in this terminal.")
+	return rc.runFallbackWithReason(stripeBin, blueprint, buildPaneCmd, "tmux not found — running agent in this terminal.")
+}
+
+func (rc *coopRunCmd) runFallbackWithReason(stripeBin string, blueprint *coop.Blueprint, buildPaneCmd coopPaneCommandBuilder, reason string) error {
+	fmt.Println(reason)
 
 	var session *coop.Session
 	if blueprint != nil {

--- a/pkg/cmd/coop/coop_launcher.go
+++ b/pkg/cmd/coop/coop_launcher.go
@@ -69,7 +69,13 @@ const (
 
 	// tmux draws a one-column divider between horizontally split panes.
 	coopPaneDividerWidth = 1
-	claudeCoopAgents     = `{"coop-cost-effective-worker":{"description":"Use proactively for well-bounded, self-contained exploration, documentation research, test execution, log analysis, and verification tasks when delegation saves main-session context and cost.","prompt":"Work as a focused cost-effective Co-op subagent. Complete only the bounded task you receive, verify your result, and return concise evidence to the main agent. Find and honor applicable repository guidance, including AGENTS.md and CLAUDE.md, before acting. Do not choose or change the Stripe integration or run Co-op lifecycle commands.","model":"haiku"}}`
+
+	// coopTUIWidthEnv carries the intended TUI pane width into the TUI
+	// process. tmux redistributes panes proportionally when the terminal is
+	// resized, so without re-pinning, the fixed width drifts back below the
+	// review card's readable floor the first time the user resizes.
+	coopTUIWidthEnv  = "STRIPE_COOP_TUI_WIDTH"
+	claudeCoopAgents = `{"coop-cost-effective-worker":{"description":"Use proactively for well-bounded, self-contained exploration, documentation research, test execution, log analysis, and verification tasks when delegation saves main-session context and cost.","prompt":"Work as a focused cost-effective Co-op subagent. Complete only the bounded task you receive, verify your result, and return concise evidence to the main agent. Find and honor applicable repository guidance, including AGENTS.md and CLAUDE.md, before acting. Do not choose or change the Stripe integration or run Co-op lifecycle commands.","model":"haiku"}}`
 )
 
 func (rc *coopRunCmd) detectAgent() (*agentInfo, error) {
@@ -328,6 +334,10 @@ func (rc *coopRunCmd) runInTmuxSplitWithCommand(stripeBin string, blueprint *coo
 		return fmt.Errorf("tmux split failed: %w", err)
 	}
 
+	// The TUI runs in this process here, so publish the intended width the
+	// same way the new-session path does for its pane.
+	os.Setenv(coopTUIWidthEnv, strconv.Itoa(tuiWidth))
+
 	if blueprint != nil {
 		return tui.Run(store, session.ID, coopTUIOptions()...)
 	}
@@ -366,7 +376,11 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 		killTmuxSession(serverFlags, sessionName)
 	}
 
-	width, height := coopTmuxSessionDimensions()
+	width, height, ok := coopTmuxSessionDimensions()
+	if !ok {
+		return rc.runFallbackWithReason(stripeBin, blueprint, buildPaneCmd,
+			"Could not measure this terminal — skipping the split view. Running the agent here.")
+	}
 	tuiWidth := coopTUIPaneWidthFor(width)
 	if tuiWidth == 0 {
 		return rc.runFallbackWithReason(stripeBin, blueprint, buildPaneCmd,
@@ -388,7 +402,7 @@ func (rc *coopRunCmd) runInNewTmuxWithCommand(stripeBin string, blueprint *coop.
 	} else {
 		tuiCmd += " " + session.ID
 	}
-	tuiCmd = shellCommandWithCoopEnv(tuiCmd)
+	tuiCmd = fmt.Sprintf("%s=%d %s", coopTUIWidthEnv, tuiWidth, shellCommandWithCoopEnv(tuiCmd))
 
 	paneCmd, cleanup, err := buildPaneCmd(session)
 	if err != nil {
@@ -438,16 +452,25 @@ func killTmuxSession(serverFlags []string, sessionName string) {
 	_ = runTmux(withTmuxServerFlags(serverFlags, "kill-session", "-t", sessionName)...)
 }
 
-func coopTmuxSessionDimensions() (int, int) {
-	width, height, err := term.GetSize(int(os.Stdout.Fd()))
-	return normalizeCoopTmuxSessionDimensions(width, height, err)
-}
-
-func normalizeCoopTmuxSessionDimensions(width, height int, err error) (int, int) {
-	if err != nil || width <= 0 || height <= 0 {
-		return defaultCoopTmuxSessionWidth, defaultCoopTmuxSessionHeight
+// coopTmuxSessionDimensions measures the terminal co-op was launched from.
+// ok is false when no terminal could be measured at all — stdout redirected
+// AND stdin not a tty, e.g. `stripe coop start | tee log`. Guessing there
+// would size the split for a terminal that doesn't exist: tmux squeezes the
+// panes proportionally the moment a narrower client attaches, and the TUI
+// lands far below the width its review card needs.
+var coopTmuxSessionDimensions = func() (width, height int, ok bool) {
+	for _, f := range []*os.File{os.Stdout, os.Stdin, os.Stderr} {
+		if w, h, err := term.GetSize(int(f.Fd())); err == nil && w > 0 && h > 0 {
+			return w, h, true
+		}
 	}
-	return width, height
+	if tty, err := os.Open("/dev/tty"); err == nil {
+		defer tty.Close()
+		if w, h, err := term.GetSize(int(tty.Fd())); err == nil && w > 0 && h > 0 {
+			return w, h, true
+		}
+	}
+	return 0, 0, false
 }
 
 func (rc *coopRunCmd) runFallback(stripeBin string, agent *agentInfo, agentPrompt string, autoApprove bool, blueprint *coop.Blueprint) error {

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -168,7 +168,7 @@ func TestClaudeLauncherConfiguresCostEffectiveWorkerAndInteractivePrompt(t *test
 	require.NoError(t, err)
 	script := string(launcher)
 
-	assert.Contains(t, script, "--agents '")
+	assert.Contains(t, script, `'--agents' '`)
 	assert.Contains(t, script, `"model":"haiku"`)
 	assert.Contains(t, script, "Use proactively for well-bounded, self-contained")
 	assert.Contains(t, script, "--dangerously-skip-permissions")
@@ -187,7 +187,7 @@ func TestClaudeLauncherNormalModeDoesNotBypassPermissions(t *testing.T) {
 	require.NoError(t, err)
 	script := string(launcher)
 
-	assert.Contains(t, script, "--agents '")
+	assert.Contains(t, script, `'--agents' '`)
 	assert.NotContains(t, script, "--dangerously-skip-permissions")
 }
 
@@ -212,9 +212,9 @@ func TestFallbackPaneBuildFailureAbortsStartedSession(t *testing.T) {
 	rc := &coopRunCmd{language: "node"}
 	buildErr := errors.New("pane build failed")
 
-	err := rc.runFallbackWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (string, func(), error) {
+	err := rc.runFallbackWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (paneCommand, func(), error) {
 		require.NotNil(t, session)
-		return "", nil, buildErr
+		return paneCommand{}, nil, buildErr
 	})
 	require.ErrorIs(t, err, buildErr)
 
@@ -236,15 +236,15 @@ func TestFallbackJoinInstructionsIncludeCoopEnv(t *testing.T) {
 
 	rc := &coopRunCmd{language: "node"}
 	output := captureStdout(t, func() {
-		err := rc.runFallbackWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (string, func(), error) {
+		err := rc.runFallbackWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (paneCommand, func(), error) {
 			require.NotNil(t, session)
-			return "true", nil, nil
+			return paneCommand{argv: []string{"true"}}, nil, nil
 		})
 		require.NoError(t, err)
 	})
 
 	assert.Contains(t, output, "Open another terminal and run: XDG_CONFIG_HOME=")
-	assert.Contains(t, output, " stripe coop join coop_")
+	assert.Contains(t, output, `'/stripe' coop join coop_`)
 }
 
 func TestFallbackWaitInstructionsIncludeCoopEnv(t *testing.T) {
@@ -252,15 +252,15 @@ func TestFallbackWaitInstructionsIncludeCoopEnv(t *testing.T) {
 
 	rc := &coopRunCmd{language: "node"}
 	output := captureStdout(t, func() {
-		err := rc.runFallbackWithCommand("/stripe", nil, func(session *coop.Session) (string, func(), error) {
+		err := rc.runFallbackWithCommand("/stripe", nil, func(session *coop.Session) (paneCommand, func(), error) {
 			require.Nil(t, session)
-			return "true", nil, nil
+			return paneCommand{argv: []string{"true"}}, nil, nil
 		})
 		require.NoError(t, err)
 	})
 
 	assert.Contains(t, output, "Open another terminal and run: XDG_CONFIG_HOME=")
-	assert.Contains(t, output, " stripe coop join --wait")
+	assert.Contains(t, output, `'/stripe' coop join --wait`)
 }
 
 func TestCoopTUIPaneWidthFor(t *testing.T) {
@@ -321,9 +321,9 @@ func TestTmuxSplitUsesFixedTUIWidth(t *testing.T) {
 	})
 
 	rc := &coopRunCmd{language: "node"}
-	err := rc.runInTmuxSplitWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (string, func(), error) {
+	err := rc.runInTmuxSplitWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (paneCommand, func(), error) {
 		require.NotNil(t, session)
-		return "agent", nil, nil
+		return paneCommand{shell: "agent"}, nil, nil
 	})
 	require.ErrorIs(t, err, splitErr)
 
@@ -352,15 +352,15 @@ func TestTmuxSplitTooNarrowFallsBackToSingleTerminal(t *testing.T) {
 
 	rc := &coopRunCmd{language: "node"}
 	output := captureStdout(t, func() {
-		err := rc.runInTmuxSplitWithCommand("/stripe", nil, func(session *coop.Session) (string, func(), error) {
+		err := rc.runInTmuxSplitWithCommand("/stripe", nil, func(session *coop.Session) (paneCommand, func(), error) {
 			require.Nil(t, session)
-			return "true", nil, nil
+			return paneCommand{argv: []string{"true"}}, nil, nil
 		})
 		require.NoError(t, err)
 	})
 
 	assert.Contains(t, output, "too narrow")
-	assert.Contains(t, output, " stripe coop join --wait")
+	assert.Contains(t, output, `'/stripe' coop join --wait`)
 	assert.Nil(t, findTmuxCall(tmuxCalls, "split-window"))
 }
 
@@ -394,9 +394,9 @@ func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T
 
 	cleanupCalled := false
 	rc := &coopRunCmd{language: "node"}
-	err := rc.runInNewTmuxWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (string, func(), error) {
+	err := rc.runInNewTmuxWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (paneCommand, func(), error) {
 		require.NotNil(t, session)
-		return "agent", func() { cleanupCalled = true }, nil
+		return paneCommand{shell: "agent"}, func() { cleanupCalled = true }, nil
 	})
 	require.ErrorIs(t, err, splitErr)
 	assert.True(t, cleanupCalled)
@@ -498,5 +498,5 @@ func TestAgentPaneCommandShellQuotesLauncherPath(t *testing.T) {
 
 	// The pane command must be exactly the single-quoted launcher path, so
 	// `bash -c` executes the launcher instead of parsing the path.
-	assert.Equal(t, shellQuote(matches[0]), paneCmd)
+	assert.Equal(t, shellQuote(matches[0]), paneCmd.shell)
 }

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -16,35 +16,20 @@ import (
 	"github.com/stripe/stripe-cli/pkg/coop/tui"
 )
 
-func TestNormalizeCoopTmuxSessionDimensionsUsesTerminalSize(t *testing.T) {
-	width, height := normalizeCoopTmuxSessionDimensions(260, 60, nil)
-
-	assert.Equal(t, 260, width)
-	assert.Equal(t, 60, height)
-}
-
-func TestNormalizeCoopTmuxSessionDimensionsFallsBack(t *testing.T) {
-	tests := []struct {
-		name   string
-		width  int
-		height int
-		err    error
-	}{
-		{name: "size error", width: 260, height: 60, err: errors.New("not a terminal")},
-		{name: "zero width", width: 0, height: 60},
-		{name: "zero height", width: 260, height: 0},
-		{name: "negative width", width: -1, height: 60},
-		{name: "negative height", width: 260, height: -1},
+func TestCoopTmuxSessionDimensionsReportsUnmeasurableTerminal(t *testing.T) {
+	// Tests run with stdio redirected and, in CI, with no controlling
+	// terminal. Where /dev/tty is unavailable this must report "unknown"
+	// rather than inventing a size — guessing sizes the split for a terminal
+	// that doesn't exist, and tmux squeezes both panes once a real client
+	// attaches.
+	width, height, ok := coopTmuxSessionDimensions()
+	if !ok {
+		assert.Zero(t, width)
+		assert.Zero(t, height)
+		return
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			width, height := normalizeCoopTmuxSessionDimensions(tt.width, tt.height, tt.err)
-
-			assert.Equal(t, defaultCoopTmuxSessionWidth, width)
-			assert.Equal(t, defaultCoopTmuxSessionHeight, height)
-		})
-	}
+	assert.Positive(t, width, "a measurable terminal must report a usable width")
+	assert.Positive(t, height)
 }
 
 func TestExplicitBlueprintPromptIsCompactBootstrap(t *testing.T) {
@@ -297,6 +282,9 @@ func TestTmuxSplitUsesFixedTUIWidth(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	splitErr := errors.New("split failed")
+	originalDimensions := coopTmuxSessionDimensions
+	coopTmuxSessionDimensions = func() (int, int, bool) { return 200, 50, true }
+	t.Cleanup(func() { coopTmuxSessionDimensions = originalDimensions })
 	var tmuxCalls [][]string
 	originalRunTmux := runTmux
 	originalRunTmuxOutput := runTmuxOutput
@@ -368,6 +356,9 @@ func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	splitErr := errors.New("split failed")
+	originalDimensions := coopTmuxSessionDimensions
+	coopTmuxSessionDimensions = func() (int, int, bool) { return 200, 50, true }
+	t.Cleanup(func() { coopTmuxSessionDimensions = originalDimensions })
 	var tmuxCalls [][]string
 	originalRunTmux := runTmux
 	originalRunTmuxOutput := runTmuxOutput

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/coop"
+	"github.com/stripe/stripe-cli/pkg/coop/tui"
 )
 
 func TestNormalizeCoopTmuxSessionDimensionsUsesTerminalSize(t *testing.T) {
@@ -262,6 +263,107 @@ func TestFallbackWaitInstructionsIncludeCoopEnv(t *testing.T) {
 	assert.Contains(t, output, " stripe coop join --wait")
 }
 
+func TestCoopTUIPaneWidthFor(t *testing.T) {
+	tests := []struct {
+		name  string
+		width int
+		want  int
+	}{
+		{name: "ultrawide", width: 250, want: coopTUIPaneWidth},
+		{name: "default session width", width: defaultCoopTmuxSessionWidth, want: coopTUIPaneWidth},
+		{name: "standard tier floor", width: coopTUIPaneWidth + coopPaneDividerWidth + coopAgentPaneMinWidth, want: coopTUIPaneWidth},
+		{name: "just below standard tier", width: coopTUIPaneWidth + coopPaneDividerWidth + coopAgentPaneMinWidth - 1, want: coopTUIPaneWidthNarrow},
+		{name: "narrow tier floor", width: coopTUIPaneWidthNarrow + coopPaneDividerWidth + coopAgentPaneMinWidthNarrow, want: coopTUIPaneWidthNarrow},
+		{name: "just below narrow tier", width: coopTUIPaneWidthNarrow + coopPaneDividerWidth + coopAgentPaneMinWidthNarrow - 1, want: 0},
+		{name: "laptop 100 cols", width: 100, want: 0},
+		{name: "stock 80x24 terminal", width: 80, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, coopTUIPaneWidthFor(tt.width))
+		})
+	}
+}
+
+func TestCoopTUIPaneWidthsStayBelowSplitWorkspaceThreshold(t *testing.T) {
+	// The companion pane must always render the TUI's single-column layout;
+	// the two-column workspace is reserved for `coop join` in a full terminal.
+	assert.Less(t, coopTUIPaneWidth, tui.SplitWorkspaceMinWidth)
+	assert.Less(t, coopTUIPaneWidthNarrow, tui.SplitWorkspaceMinWidth)
+}
+
+func TestTmuxSplitUsesFixedTUIWidth(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	splitErr := errors.New("split failed")
+	var tmuxCalls [][]string
+	originalRunTmux := runTmux
+	originalRunTmuxOutput := runTmuxOutput
+	runTmux = func(args ...string) error {
+		tmuxCalls = append(tmuxCalls, append([]string(nil), args...))
+		return nil
+	}
+	runTmuxOutput = func(args ...string) (string, error) {
+		tmuxCalls = append(tmuxCalls, append([]string(nil), args...))
+		switch args[0] {
+		case "display-message":
+			return "200\n", nil
+		case "split-window":
+			return "", splitErr
+		default:
+			return "", nil
+		}
+	}
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalRunTmuxOutput
+	})
+
+	rc := &coopRunCmd{language: "node"}
+	err := rc.runInTmuxSplitWithCommand("/stripe", commandTestBlueprint(t), func(session *coop.Session) (string, func(), error) {
+		require.NotNil(t, session)
+		return "agent", nil, nil
+	})
+	require.ErrorIs(t, err, splitErr)
+
+	splitCall := findTmuxCall(tmuxCalls, "split-window")
+	require.NotNil(t, splitCall)
+	// 200-col pane → TUI keeps 48, divider takes 1, agent gets 151.
+	assert.Contains(t, strings.Join(splitCall, " "), "-l 151")
+	assert.NotContains(t, strings.Join(splitCall, " "), "-p")
+}
+
+func TestTmuxSplitTooNarrowFallsBackToSingleTerminal(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	var tmuxCalls [][]string
+	originalRunTmuxOutput := runTmuxOutput
+	runTmuxOutput = func(args ...string) (string, error) {
+		tmuxCalls = append(tmuxCalls, append([]string(nil), args...))
+		if args[0] == "display-message" {
+			return "100\n", nil
+		}
+		return "", nil
+	}
+	t.Cleanup(func() {
+		runTmuxOutput = originalRunTmuxOutput
+	})
+
+	rc := &coopRunCmd{language: "node"}
+	output := captureStdout(t, func() {
+		err := rc.runInTmuxSplitWithCommand("/stripe", nil, func(session *coop.Session) (string, func(), error) {
+			require.Nil(t, session)
+			return "true", nil, nil
+		})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "too narrow")
+	assert.Contains(t, output, " stripe coop join --wait")
+	assert.Nil(t, findTmuxCall(tmuxCalls, "split-window"))
+}
+
 func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
@@ -306,6 +408,9 @@ func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T
 	splitCall := findTmuxCall(tmuxCalls, "split-window")
 	require.NotNil(t, splitCall)
 	assert.Contains(t, splitCall[len(splitCall)-1], "XDG_CONFIG_HOME=")
+	// Non-TTY test environment falls back to the 200-col default session
+	// width: TUI keeps 48, divider takes 1, agent gets 151.
+	assert.Contains(t, strings.Join(splitCall, " "), "-l 151")
 
 	store, err := coop.NewStore(coopConfigFolder())
 	require.NoError(t, err)

--- a/pkg/cmd/coop/coop_launcher_test.go
+++ b/pkg/cmd/coop/coop_launcher_test.go
@@ -373,7 +373,7 @@ func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T
 	originalRunTmuxOutput := runTmuxOutput
 	runTmux = func(args ...string) error {
 		tmuxCalls = append(tmuxCalls, append([]string(nil), args...))
-		switch args[0] {
+		switch tmuxSubcommand(args) {
 		case "has-session":
 			return errors.New("session not found")
 		default:
@@ -382,7 +382,7 @@ func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T
 	}
 	runTmuxOutput = func(args ...string) (string, error) {
 		tmuxCalls = append(tmuxCalls, append([]string(nil), args...))
-		if args[0] == "split-window" {
+		if tmuxSubcommand(args) == "split-window" {
 			return "", splitErr
 		}
 		return "", nil
@@ -400,9 +400,12 @@ func TestNewTmuxSplitFailureKillsTmuxSessionAndAbortsStartedSession(t *testing.T
 	})
 	require.ErrorIs(t, err, splitErr)
 	assert.True(t, cleanupCalled)
-	assert.True(t, hasTmuxCall(tmuxCalls, "kill-session", "-t", "stripe-coop"))
+	assert.True(t, hasTmuxCall(tmuxCalls, "-L", coopTmuxSocket, "kill-session", "-t", "stripe-coop"))
 	newSessionCall := findTmuxCall(tmuxCalls, "new-session")
 	require.NotNil(t, newSessionCall)
+	// The new server must start on the dedicated socket with the shipped conf.
+	assert.Equal(t, []string{"-L", coopTmuxSocket, "-f"}, newSessionCall[:3])
+	assert.Contains(t, newSessionCall[3], "coop.tmux.conf")
 	assert.Contains(t, newSessionCall[len(newSessionCall)-1], "XDG_CONFIG_HOME=")
 	assert.Contains(t, newSessionCall[len(newSessionCall)-1], " coop join ")
 	splitCall := findTmuxCall(tmuxCalls, "split-window")
@@ -443,11 +446,25 @@ func hasTmuxCall(calls [][]string, want ...string) bool {
 
 func findTmuxCall(calls [][]string, command string) []string {
 	for _, call := range calls {
-		if len(call) > 0 && call[0] == command {
+		if tmuxSubcommand(call) == command {
 			return call
 		}
 	}
 	return nil
+}
+
+// tmuxSubcommand returns the subcommand of a tmux invocation, skipping
+// server-selection and config flags (-L <socket>, -f <path>) that precede it.
+func tmuxSubcommand(call []string) string {
+	for i := 0; i < len(call); i++ {
+		switch call[i] {
+		case "-L", "-f":
+			i++
+		default:
+			return call[i]
+		}
+	}
+	return ""
 }
 
 func TestShellQuoteNeutralizesShellMetacharacters(t *testing.T) {

--- a/pkg/cmd/coop/coop_run.go
+++ b/pkg/cmd/coop/coop_run.go
@@ -147,6 +147,9 @@ func newCoopSession(bp *coop.Blueprint, sessionID, language string, rawSettings,
 		return nil, err
 	}
 	session.CreatedAt = time.Now().UTC()
+	if cwd, err := os.Getwd(); err == nil {
+		session.Cwd = cwd
+	}
 	session.ParentSessionID = parentSession
 	session.ParentStepID = parentStep
 	session.UsedSandbox = coopSandboxClaimURL() != ""

--- a/pkg/cmd/coop/coop_start.go
+++ b/pkg/cmd/coop/coop_start.go
@@ -57,6 +57,9 @@ splits the current window. Otherwise creates a new tmux session.`,
 func (rc *coopRunCmd) runCmd(cmd *cobra.Command, args []string) error {
 	hasTmux := rc.hasTmux()
 	inTmux := os.Getenv("TMUX") != ""
+	if !hasTmux && !inTmux && !rc.debugAgent {
+		hasTmux = rc.offerTmuxSetup()
+	}
 
 	var blueprintID string
 	var blueprint *coop.Blueprint

--- a/pkg/cmd/coop/coop_tmux_conf.go
+++ b/pkg/cmd/coop/coop_tmux_conf.go
@@ -1,0 +1,99 @@
+package coopcmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// coopTmuxSocket names the dedicated tmux server the launcher creates when the
+// user isn't already inside tmux. A separate socket keeps co-op's server,
+// session names, and shipped config away from the user's own tmux. It is never
+// used from inside an existing tmux session: tmux only refuses to nest into
+// the *same* server, so attaching a second socket from within a pane nests
+// silently with stacked prefix keys.
+const coopTmuxSocket = "stripe-coop"
+
+// coopTmuxBaseConf works on every tmux version co-op supports. ASCII only: the
+// status line is read back through the attaching client's locale, and without
+// a UTF-8 LANG/LC_ALL non-ASCII characters silently degrade to underscores.
+const coopTmuxBaseConf = `# Written by 'stripe coop start' on every launch; edits are overwritten.
+set -g mouse on
+set -g set-clipboard on
+# Forward the active pane's title to the terminal tab; off by default in tmux.
+set -g set-titles on
+set -g set-titles-string "#T"
+# Pass the review bell through to the terminal instead of drawing it in tmux.
+set -g bell-action any
+set -g visual-bell off
+set -g default-terminal "tmux-256color"
+set -g status-left " Stripe Co-op "
+set -g status-left-length 20
+set -g status-right " mouse: scroll+click | detach: C-b d | quit: q "
+set -g status-right-length 60
+`
+
+// coopTmuxModernConf is appended for tmux >= 3.2, where these options exist.
+const coopTmuxModernConf = `set -g allow-passthrough on
+set -g focus-events on
+set -g extended-keys on
+set -as terminal-features ",*:RGB"
+`
+
+var tmuxVersionOutput = func() (string, error) {
+	out, err := exec.Command("tmux", "-V").Output()
+	return string(out), err
+}
+
+// tmuxVersionAtLeast parses `tmux -V` output like "tmux 3.7b" or "tmux 3.2a"
+// and reports whether it is at least major.minor. Unparseable output (e.g.
+// "tmux next-3.8", or the openbsd builds that print no number) returns false:
+// the baseline config works everywhere, missing modern options only degrades.
+func tmuxVersionAtLeast(versionOutput string, major, minor int) bool {
+	fields := strings.Fields(strings.TrimSpace(versionOutput))
+	if len(fields) < 2 {
+		return false
+	}
+	numeric := strings.TrimRightFunc(fields[1], func(r rune) bool {
+		return r < '0' || r > '9'
+	})
+	majorStr, minorStr, ok := strings.Cut(numeric, ".")
+	if !ok {
+		return false
+	}
+	gotMajor, err := strconv.Atoi(majorStr)
+	if err != nil {
+		return false
+	}
+	gotMinor, err := strconv.Atoi(minorStr)
+	if err != nil {
+		return false
+	}
+	return gotMajor > major || (gotMajor == major && gotMinor >= minor)
+}
+
+func coopTmuxConf() string {
+	conf := coopTmuxBaseConf
+	if out, err := tmuxVersionOutput(); err == nil && tmuxVersionAtLeast(out, 3, 2) {
+		conf += coopTmuxModernConf
+	}
+	return conf
+}
+
+// writeCoopTmuxConf writes the shipped tmux config for the dedicated co-op
+// server and returns its path. Rewritten on every launch so CLI upgrades take
+// effect without a migration.
+func writeCoopTmuxConf() (string, error) {
+	folder := coopConfigFolder()
+	if err := os.MkdirAll(folder, 0o755); err != nil {
+		return "", fmt.Errorf("creating co-op config folder: %w", err)
+	}
+	path := filepath.Join(folder, "coop.tmux.conf")
+	if err := os.WriteFile(path, []byte(coopTmuxConf()), 0o644); err != nil {
+		return "", fmt.Errorf("writing co-op tmux config: %w", err)
+	}
+	return path, nil
+}

--- a/pkg/cmd/coop/coop_tmux_conf_test.go
+++ b/pkg/cmd/coop/coop_tmux_conf_test.go
@@ -1,0 +1,94 @@
+package coopcmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTmuxVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		output string
+		want   bool
+	}{
+		{output: "tmux 3.7b", want: true},
+		{output: "tmux 3.2a", want: true},
+		{output: "tmux 3.2", want: true},
+		{output: "tmux 3.1c", want: false},
+		{output: "tmux 3.0a", want: false},
+		{output: "tmux 10.0", want: true},
+		{output: "tmux next-3.8", want: false}, // unparseable prefix: assume old
+		{output: "tmux", want: false},
+		{output: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.output, func(t *testing.T) {
+			assert.Equal(t, tt.want, tmuxVersionAtLeast(tt.output, 3, 2))
+		})
+	}
+}
+
+// The status line is read back through the attaching client's locale; without
+// a UTF-8 LANG/LC_ALL, non-ASCII characters silently degrade to underscores.
+// Keep the shipped config pure ASCII.
+func TestCoopTmuxConfIsASCIIOnly(t *testing.T) {
+	for i, b := range []byte(coopTmuxBaseConf + coopTmuxModernConf) {
+		require.Less(t, b, byte(128), "non-ASCII byte at offset %d", i)
+	}
+}
+
+func TestCoopTmuxConfGatesModernOptionsOnVersion(t *testing.T) {
+	original := tmuxVersionOutput
+	t.Cleanup(func() { tmuxVersionOutput = original })
+
+	tmuxVersionOutput = func() (string, error) { return "tmux 3.0a", nil }
+	conf := coopTmuxConf()
+	assert.NotContains(t, conf, "allow-passthrough", "tmux 3.0 rejects unknown options")
+	assert.Contains(t, conf, "set -g mouse on")
+	assert.Contains(t, conf, "set -g set-titles on")
+
+	tmuxVersionOutput = func() (string, error) { return "tmux 3.7b", nil }
+	conf = coopTmuxConf()
+	assert.Contains(t, conf, "set -g allow-passthrough on")
+	assert.Contains(t, conf, "set -g focus-events on")
+	assert.Contains(t, conf, ",*:RGB")
+
+	tmuxVersionOutput = func() (string, error) { return "", errors.New("no tmux") }
+	assert.NotContains(t, coopTmuxConf(), "allow-passthrough")
+}
+
+func TestWriteCoopTmuxConf(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	path, err := writeCoopTmuxConf()
+	require.NoError(t, err)
+	assert.Equal(t, "coop.tmux.conf", filepath.Base(path))
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "set -g mouse on")
+	assert.Contains(t, string(content), "set -g bell-action any")
+}
+
+func TestTmuxReviewAlerterRenamesAndRestores(t *testing.T) {
+	originalRunTmux := runTmux
+	var calls [][]string
+	runTmux = func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+	t.Cleanup(func() { runTmux = originalRunTmux })
+
+	a := &tmuxReviewAlerter{tuiPane: "%1"}
+	a.Alert(true, true)
+	a.Alert(false, true)
+
+	require.Len(t, calls, 2)
+	assert.Equal(t, []string{"rename-window", "-t", "%1", "coop: REVIEW"}, calls[0])
+	assert.Equal(t, []string{"set-window-option", "-t", "%1", "automatic-rename", "on"}, calls[1])
+}

--- a/pkg/cmd/coop/coop_tmux_conf_test.go
+++ b/pkg/cmd/coop/coop_tmux_conf_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,11 +85,145 @@ func TestTmuxReviewAlerterRenamesAndRestores(t *testing.T) {
 	}
 	t.Cleanup(func() { runTmux = originalRunTmux })
 
+	originalOutput := runTmuxOutput
+	runTmuxOutput = func(args ...string) (string, error) {
+		if len(args) > 0 && args[len(args)-1] == "#{window_name}" {
+			return "my-project\n", nil
+		}
+		return "off\n", nil // user keeps automatic-rename off
+	}
+	t.Cleanup(func() { runTmuxOutput = originalOutput })
+
 	a := &tmuxReviewAlerter{tuiPane: "%1"}
 	a.Alert(true, true)
 	a.Alert(false, true)
 
 	require.Len(t, calls, 2)
 	assert.Equal(t, []string{"rename-window", "-t", "%1", "coop: REVIEW"}, calls[0])
-	assert.Equal(t, []string{"set-window-option", "-t", "%1", "automatic-rename", "on"}, calls[1])
+	assert.Equal(t, []string{"rename-window", "-t", "%1", "my-project"}, calls[1],
+		"the user's own window name must come back")
+	assert.NotContains(t, calls[1], "automatic-rename",
+		"automatic-rename was off before; co-op must not switch it on")
+}
+
+func TestTmuxReviewAlerterRestoresAutomaticRenameWhenItWasOn(t *testing.T) {
+	originalRunTmux := runTmux
+	originalOutput := runTmuxOutput
+	var calls [][]string
+	runTmux = func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+	runTmuxOutput = func(args ...string) (string, error) {
+		if len(args) > 0 && args[len(args)-1] == "#{window_name}" {
+			return "zsh\n", nil
+		}
+		return "on\n", nil
+	}
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalOutput
+	})
+
+	a := &tmuxReviewAlerter{tuiPane: "%1"}
+	a.Alert(true, true)
+	a.Restore()
+
+	require.Len(t, calls, 3)
+	assert.Equal(t, []string{"set-window-option", "-t", "%1", "automatic-rename", "on"}, calls[2])
+}
+
+func TestTmuxReviewAlerterRestoreIsSafeWithoutRename(t *testing.T) {
+	originalRunTmux := runTmux
+	var calls [][]string
+	runTmux = func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+	t.Cleanup(func() { runTmux = originalRunTmux })
+
+	// Quitting a session that never showed a review must touch nothing.
+	(&tmuxReviewAlerter{tuiPane: "%1"}).Restore()
+	assert.Empty(t, calls)
+}
+
+func TestCoopPaneWidthPinReassertsWidthAfterResize(t *testing.T) {
+	t.Setenv(coopTUIWidthEnv, "48")
+	originalRunTmux := runTmux
+	originalOutput := runTmuxOutput
+	var calls [][]string
+	runTmux = func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+	runTmuxOutput = func(args ...string) (string, error) { return "200\n", nil }
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalOutput
+	})
+
+	pin := coopPaneWidthPin("%1")
+	require.NotNil(t, pin)
+
+	// tmux redistributed the pane down to 29 columns after a resize.
+	pin(29, 40)
+	require.Len(t, calls, 1)
+	assert.Equal(t, []string{"resize-pane", "-t", "%1", "-x", "48"}, calls[0])
+
+	// Already correct: nothing to do.
+	calls = nil
+	pin(48, 40)
+	assert.Empty(t, calls)
+}
+
+func TestCoopPaneWidthPinLeavesNarrowWindowsAlone(t *testing.T) {
+	t.Setenv(coopTUIWidthEnv, "48")
+	originalRunTmux := runTmux
+	originalOutput := runTmuxOutput
+	var calls [][]string
+	runTmux = func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+	// Window shrank below the split threshold entirely.
+	runTmuxOutput = func(args ...string) (string, error) { return "90\n", nil }
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalOutput
+	})
+
+	coopPaneWidthPin("%1")(20, 40)
+	assert.Empty(t, calls, "pinning 48 columns in a 90-column window would starve the agent")
+}
+
+func TestCoopPaneWidthPinInactiveOutsideLauncher(t *testing.T) {
+	t.Setenv(coopTUIWidthEnv, "")
+	assert.Nil(t, coopPaneWidthPin("%1"), "a hand-run coop join must never resize the user's pane")
+}
+
+func TestTmuxAgentResumerRefusesToTypeAtABusyAgent(t *testing.T) {
+	originalRunTmux := runTmux
+	originalOutput := runTmuxOutput
+	var sends [][]string
+	runTmux = func(args ...string) error {
+		sends = append(sends, append([]string(nil), args...))
+		return nil
+	}
+	runTmuxOutput = func(args ...string) (string, error) { return "%2\t1\t0\n", nil }
+	t.Cleanup(func() {
+		runTmux = originalRunTmux
+		runTmuxOutput = originalOutput
+	})
+
+	resumer := newTmuxAgentResumer("%1")
+	resumer.keyDelay = 0
+	// No heartbeat: not parked in await-review. But the session still has an
+	// active node, so the agent is mid-work and may have a dialog open.
+	resumer.heartbeatAge = func(string) (time.Duration, error) { return 0, errors.New("no heartbeat") }
+	resumer.agentIsWorking = func(string) bool { return true }
+
+	err := resumer.Notify("session_busy")
+
+	require.ErrorIs(t, err, errAgentBusy)
+	assert.Empty(t, sends, "typing into a working agent can answer an open permission dialog")
 }

--- a/pkg/cmd/coop/coop_tmux_install.go
+++ b/pkg/cmd/coop/coop_tmux_install.go
@@ -1,0 +1,160 @@
+package coopcmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"charm.land/huh/v2"
+	"golang.org/x/term"
+)
+
+var (
+	statFile = os.Stat
+
+	// canOfferBrewInstall gates the interactive install offer to the one case
+	// where installing needs no elevation and the user is present: Homebrew,
+	// a real TTY, not CI, not a remote box someone else administers.
+	canOfferBrewInstall = func() bool {
+		if _, err := exec.LookPath("brew"); err != nil {
+			return false
+		}
+		if !term.IsTerminal(int(os.Stdin.Fd())) {
+			return false
+		}
+		return os.Getenv("CI") == "" && os.Getenv("SSH_CONNECTION") == ""
+	}
+
+	runTmuxInstall = func() error {
+		cmd := exec.Command("brew", "install", "tmux")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+)
+
+// offerTmuxSetup handles a missing tmux. On macOS with Homebrew it offers to
+// install interactively; everywhere else it prints the right command and moves
+// on — never running a package manager itself, and never with elevation.
+// Returns true when tmux is usable afterwards.
+func (rc *coopRunCmd) offerTmuxSetup() bool {
+	if runtime.GOOS == "windows" {
+		// No native tmux exists; the manual-split flow is the product here.
+		return false
+	}
+	if declinedTmuxInstall() {
+		return false
+	}
+
+	if runtime.GOOS == "darwin" && canOfferBrewInstall() {
+		var choice string
+		if err := selectString("tmux gives co-op a side-by-side view (agent + review TUI). Install it?",
+			[]huh.Option[string]{
+				huh.NewOption("Yes — brew install tmux", "install"),
+				huh.NewOption("Not now", "skip"),
+				huh.NewOption("No, and don't ask again", "never"),
+			},
+			&choice,
+		); err != nil {
+			return false
+		}
+		switch choice {
+		case "install":
+			if err := runTmuxInstall(); err != nil {
+				fmt.Printf("tmux install failed (%v) — continuing without it.\n", err)
+				return false
+			}
+			return rc.hasTmux()
+		case "never":
+			persistTmuxInstallDecline()
+		}
+		return false
+	}
+
+	if hint := tmuxInstallHint(); hint != "" {
+		fmt.Printf("Tip: install tmux for a side-by-side view: %s\n", hint)
+	}
+	return false
+}
+
+// tmuxInstallHint returns the install command for this environment, or "" when
+// suggesting one would be wrong (nothing detected, or nothing to detect).
+func tmuxInstallHint() string {
+	if _, err := statFile("/.dockerenv"); err == nil || os.Getenv("container") != "" {
+		// An in-container install evaporates on rebuild; fix the image instead.
+		return "add tmux to your image, e.g. RUN apt-get update && apt-get install -y tmux"
+	}
+	if _, err := statFile("/etc/NIXOS"); err == nil {
+		return "add tmux to your NixOS configuration (or nix profile install nixpkgs#tmux)"
+	}
+	sudo := "sudo "
+	if os.Geteuid() == 0 {
+		sudo = ""
+	}
+	managers := []struct{ bin, cmd string }{
+		{"apt-get", sudo + "apt-get install -y tmux"},
+		{"dnf", sudo + "dnf install -y tmux"},
+		{"pacman", sudo + "pacman -S tmux"},
+		{"apk", sudo + "apk add tmux"},
+		{"zypper", sudo + "zypper install -y tmux"},
+		{"brew", "brew install tmux"},
+	}
+	for _, m := range managers {
+		if _, err := exec.LookPath(m.bin); err == nil {
+			return m.cmd
+		}
+	}
+	return ""
+}
+
+// nativeSplitHint names this terminal's own split keystroke so "open another
+// terminal" costs one keypress instead of a context switch. Empty when the
+// terminal is unknown.
+func nativeSplitHint() string {
+	if os.Getenv("WT_SESSION") != "" {
+		return "Tip: Alt+Shift+D splits this Windows Terminal pane."
+	}
+	switch os.Getenv("TERM_PROGRAM") {
+	case "vscode":
+		if runtime.GOOS == "darwin" {
+			return `Tip: Cmd+\ splits the VS Code terminal.`
+		}
+		return "Tip: Ctrl+Shift+5 splits the VS Code terminal."
+	case "iTerm.app":
+		return "Tip: Cmd+D splits this iTerm2 window."
+	case "ghostty":
+		if runtime.GOOS == "darwin" {
+			return "Tip: Cmd+D splits this Ghostty window."
+		}
+		return "Tip: Ctrl+Shift+O splits this Ghostty window."
+	case "WarpTerminal":
+		return "Tip: Cmd+D splits this Warp window."
+	case "WezTerm":
+		return `Tip: Ctrl+Alt+Shift+% splits this WezTerm window.`
+	case "Apple_Terminal":
+		return "Tip: Cmd+T opens a new Terminal tab."
+	}
+	if os.Getenv("KITTY_WINDOW_ID") != "" {
+		return "Tip: Ctrl+Shift+Enter opens a new kitty window."
+	}
+	return ""
+}
+
+func tmuxDeclineMarkerPath() string {
+	return filepath.Join(coopConfigFolder(), "tmux-install-declined")
+}
+
+func declinedTmuxInstall() bool {
+	_, err := statFile(tmuxDeclineMarkerPath())
+	return err == nil
+}
+
+func persistTmuxInstallDecline() {
+	if err := os.MkdirAll(coopConfigFolder(), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(tmuxDeclineMarkerPath(), []byte("declined\n"), 0o644)
+}

--- a/pkg/cmd/coop/coop_tmux_install_test.go
+++ b/pkg/cmd/coop/coop_tmux_install_test.go
@@ -1,0 +1,147 @@
+package coopcmd
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"runtime"
+	"testing"
+
+	"charm.land/huh/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stubTmuxInstallEnv(t *testing.T) {
+	t.Helper()
+	originalCanOffer := canOfferBrewInstall
+	originalInstall := runTmuxInstall
+	originalStat := statFile
+	originalSelect := selectString
+	t.Cleanup(func() {
+		canOfferBrewInstall = originalCanOffer
+		runTmuxInstall = originalInstall
+		statFile = originalStat
+		selectString = originalSelect
+	})
+}
+
+func TestOfferTmuxSetupRespectsPersistedDecline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows never offers")
+	}
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	stubTmuxInstallEnv(t)
+	persistTmuxInstallDecline()
+	canOfferBrewInstall = func() bool { return true }
+	selectString = func(title string, options []huh.Option[string], value *string) error {
+		t.Fatal("declined install must never prompt again")
+		return nil
+	}
+
+	assert.False(t, (&coopRunCmd{}).offerTmuxSetup())
+}
+
+func TestOfferTmuxSetupPersistsNever(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("interactive offer is brew/macOS only")
+	}
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	stubTmuxInstallEnv(t)
+	canOfferBrewInstall = func() bool { return true }
+	installCalled := false
+	runTmuxInstall = func() error { installCalled = true; return nil }
+	selectString = func(title string, options []huh.Option[string], value *string) error {
+		require.Len(t, options, 3)
+		*value = "never"
+		return nil
+	}
+
+	assert.False(t, (&coopRunCmd{}).offerTmuxSetup())
+	assert.False(t, installCalled)
+	assert.True(t, declinedTmuxInstall(), "never must persist across launches")
+}
+
+func TestOfferTmuxSetupRunsBrewInstall(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("interactive offer is brew/macOS only")
+	}
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	stubTmuxInstallEnv(t)
+	canOfferBrewInstall = func() bool { return true }
+	installCalled := false
+	runTmuxInstall = func() error { installCalled = true; return nil }
+	selectString = func(title string, options []huh.Option[string], value *string) error {
+		*value = "install"
+		return nil
+	}
+
+	(&coopRunCmd{}).offerTmuxSetup()
+
+	assert.True(t, installCalled)
+	assert.False(t, declinedTmuxInstall())
+}
+
+func TestTmuxInstallHintPrefersImageFixInContainers(t *testing.T) {
+	stubTmuxInstallEnv(t)
+	statFile = func(name string) (os.FileInfo, error) {
+		if name == "/.dockerenv" {
+			return nil, nil
+		}
+		return nil, fs.ErrNotExist
+	}
+
+	hint := tmuxInstallHint()
+	assert.Contains(t, hint, "your image", "container installs evaporate on rebuild; the image is the fix")
+}
+
+func TestTmuxInstallHintErrsQuietWhenNothingDetected(t *testing.T) {
+	stubTmuxInstallEnv(t)
+	statFile = func(name string) (os.FileInfo, error) { return nil, fs.ErrNotExist }
+	t.Setenv("PATH", t.TempDir()) // no package managers resolvable
+
+	assert.Empty(t, tmuxInstallHint())
+}
+
+func TestTmuxInstallHintFailsClosedOnStatError(t *testing.T) {
+	stubTmuxInstallEnv(t)
+	statFile = func(name string) (os.FileInfo, error) { return nil, errors.New("permission denied") }
+	t.Setenv("PATH", t.TempDir())
+
+	assert.Empty(t, tmuxInstallHint())
+}
+
+func TestNativeSplitHintPerTerminal(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      map[string]string
+		contains string
+	}{
+		{name: "windows terminal", env: map[string]string{"WT_SESSION": "x"}, contains: "Windows Terminal"},
+		{name: "vscode", env: map[string]string{"TERM_PROGRAM": "vscode"}, contains: "VS Code"},
+		{name: "iterm2", env: map[string]string{"TERM_PROGRAM": "iTerm.app"}, contains: "iTerm2"},
+		{name: "ghostty", env: map[string]string{"TERM_PROGRAM": "ghostty"}, contains: "Ghostty"},
+		{name: "warp", env: map[string]string{"TERM_PROGRAM": "WarpTerminal"}, contains: "Warp"},
+		{name: "wezterm", env: map[string]string{"TERM_PROGRAM": "WezTerm"}, contains: "WezTerm"},
+		{name: "apple terminal", env: map[string]string{"TERM_PROGRAM": "Apple_Terminal"}, contains: "Terminal tab"},
+		{name: "kitty", env: map[string]string{"KITTY_WINDOW_ID": "1"}, contains: "kitty"},
+		{name: "unknown", env: nil, contains: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("WT_SESSION", "")
+			t.Setenv("TERM_PROGRAM", "")
+			t.Setenv("KITTY_WINDOW_ID", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			hint := nativeSplitHint()
+			if tt.contains == "" {
+				assert.Empty(t, hint)
+				return
+			}
+			assert.Contains(t, hint, tt.contains)
+		})
+	}
+}

--- a/pkg/coop/tui/app.go
+++ b/pkg/coop/tui/app.go
@@ -30,6 +30,18 @@ func WithReviewDecisionNotifier(notify ReviewDecisionNotifier) Option {
 	}
 }
 
+// ReviewAlertNotifier is told when the set of steps awaiting human review
+// becomes non-empty or empty again. focused reports whether the terminal had
+// focus at that moment, so callers can ring a bell only when the user is
+// looking elsewhere.
+type ReviewAlertNotifier func(hasReview, focused bool)
+
+func WithReviewAlertNotifier(notify ReviewAlertNotifier) Option {
+	return func(m *Model) {
+		m.reviewAlertNotifier = notify
+	}
+}
+
 // programOptions honors the CLI's own color setting.
 //
 // Every other command routes color through ansi.ColorsEnabled, which folds in

--- a/pkg/coop/tui/app.go
+++ b/pkg/coop/tui/app.go
@@ -42,6 +42,23 @@ func WithReviewAlertNotifier(notify ReviewAlertNotifier) Option {
 	}
 }
 
+// WithResizeHook is called whenever the terminal reports a new size. Used to
+// re-assert a pane width that the terminal multiplexer redistributed.
+func WithResizeHook(hook func(width, height int)) Option {
+	return func(m *Model) {
+		m.resizeHook = hook
+	}
+}
+
+// WithExitCleanup registers work to run once the TUI has stopped — used to put
+// back terminal state the TUI changed (a renamed tmux window). It runs after
+// Run returns, so it also covers quitting mid-review.
+func WithExitCleanup(cleanup func()) Option {
+	return func(m *Model) {
+		m.exitCleanup = append(m.exitCleanup, cleanup)
+	}
+}
+
 // programOptions honors the CLI's own color setting.
 //
 // Every other command routes color through ansi.ColorsEnabled, which folds in
@@ -61,6 +78,7 @@ func programOptions() []tea.ProgramOption {
 // Run launches the fullscreen co-op TUI for a known session.
 func Run(store *coop.Store, sessionID string, opts ...Option) error {
 	model := NewModel(store, sessionID, opts...)
+	defer model.runExitCleanup()
 	p := tea.NewProgram(model, programOptions()...)
 	_, err := p.Run()
 	return err
@@ -70,6 +88,7 @@ func Run(store *coop.Store, sessionID string, opts ...Option) error {
 // to appear (ignoring the provided existing session IDs) and transitions once found.
 func RunWaiting(store *coop.Store, existingSessionIDs map[string]bool, opts ...Option) error {
 	model := NewWaitingModel(store, existingSessionIDs, opts...)
+	defer model.runExitCleanup()
 	p := tea.NewProgram(model, programOptions()...)
 	_, err := p.Run()
 	return err

--- a/pkg/coop/tui/commands.go
+++ b/pkg/coop/tui/commands.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"os"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -9,10 +10,48 @@ import (
 )
 
 // existingSessionAdoptDelay is how long waiting mode holds out for a brand-new
-// session before adopting an already-active one. Long enough for `coop start`'s
-// agent to create its session first; short enough that a re-run `coop join
-// --wait` doesn't feel hung.
+// session before considering an already-active one. Long enough for `coop
+// start`'s agent to create its session first; short enough that a re-run
+// `coop join --wait` doesn't feel hung.
 const existingSessionAdoptDelay = 10 * time.Second
+
+// existingSessionLivenessWindow bounds how stale a pre-existing session may be
+// and still be adopted. An agent writes to its session file constantly, so a
+// session no one has touched recently belongs to a crashed run — and crashed
+// runs stay `active` forever because nothing reaps them. Adopting one would
+// silently show the wrong work.
+const existingSessionLivenessWindow = 2 * time.Minute
+
+// adoptableExistingSession returns a pre-existing active session that plainly
+// belongs to this launch: same working directory, and updated recently enough
+// that its agent is still alive. Returns nil when nothing qualifies, which
+// keeps waiting mode waiting.
+func adoptableExistingSession(store *coop.Store, cwd string, now time.Time) *coop.Session {
+	if cwd == "" {
+		return nil
+	}
+	ids, err := store.List()
+	if err != nil {
+		return nil
+	}
+	var best *coop.Session
+	for _, id := range ids {
+		session, err := store.Read(id)
+		if err != nil || session.Status != coop.SessionActive {
+			continue
+		}
+		if session.Cwd != cwd {
+			continue
+		}
+		if now.Sub(session.UpdatedAt) > existingSessionLivenessWindow {
+			continue
+		}
+		if best == nil || session.UpdatedAt.After(best.UpdatedAt) {
+			best = session
+		}
+	}
+	return best
+}
 
 func (m Model) loadSession() tea.Cmd {
 	return func() tea.Msg {
@@ -48,6 +87,10 @@ func (m Model) discoverNewSession() tea.Cmd {
 	store := m.store
 	existingSessionIDs := m.existingSessionIDs
 	adoptExisting := !m.waitingSince.IsZero() && time.Since(m.waitingSince) >= existingSessionAdoptDelay
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = ""
+	}
 	return func() tea.Msg {
 		if existingSessionIDs == nil {
 			return noUpdateMsg{}
@@ -57,19 +100,30 @@ func (m Model) discoverNewSession() tea.Cmd {
 			return noUpdateMsg{}
 		}
 		for _, id := range ids {
-			if !existingSessionIDs[id] {
-				session, err := store.Read(id)
-				if err == nil && session.Status == coop.SessionActive {
-					return sessionDiscoveredMsg{sessionID: id}
-				}
+			if existingSessionIDs[id] {
+				continue
 			}
+			session, err := store.Read(id)
+			if err != nil || session.Status != coop.SessionActive {
+				continue
+			}
+			// Skip sessions that announce a different project. Store.List is
+			// ReadDir order over random IDs, so with two concurrent launches
+			// this loop would otherwise latch an arbitrary one. Sessions
+			// written before Cwd existed carry none; accept those.
+			if cwd != "" && session.Cwd != "" && session.Cwd != cwd {
+				continue
+			}
+			return sessionDiscoveredMsg{sessionID: id}
 		}
-		// No new session appeared. If an active one predates the baseline,
-		// adopt it rather than spinning forever: `coop join --wait` is the
-		// exact command the fallback prints, and on a re-run after a quit or
-		// crash the session it described is already in the baseline.
+		// No new session appeared. `coop join --wait` is the exact command the
+		// fallback prints, so on a re-run after a quit the session it
+		// described is already in the baseline and would never be latched.
+		// Adopt it — but only when it plainly belongs to this launch, so a
+		// stale session from another project (or a crashed earlier run) can
+		// never be picked up instead of the one the agent is creating.
 		if adoptExisting {
-			if session, err := store.LatestActiveSession(); err == nil {
+			if session := adoptableExistingSession(store, cwd, time.Now()); session != nil {
 				return sessionDiscoveredMsg{sessionID: session.ID}
 			}
 		}

--- a/pkg/coop/tui/commands.go
+++ b/pkg/coop/tui/commands.go
@@ -1,10 +1,18 @@
 package tui
 
 import (
+	"time"
+
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/stripe/stripe-cli/pkg/coop"
 )
+
+// existingSessionAdoptDelay is how long waiting mode holds out for a brand-new
+// session before adopting an already-active one. Long enough for `coop start`'s
+// agent to create its session first; short enough that a re-run `coop join
+// --wait` doesn't feel hung.
+const existingSessionAdoptDelay = 10 * time.Second
 
 func (m Model) loadSession() tea.Cmd {
 	return func() tea.Msg {
@@ -39,6 +47,7 @@ func (m Model) checkForUpdates() tea.Cmd {
 func (m Model) discoverNewSession() tea.Cmd {
 	store := m.store
 	existingSessionIDs := m.existingSessionIDs
+	adoptExisting := !m.waitingSince.IsZero() && time.Since(m.waitingSince) >= existingSessionAdoptDelay
 	return func() tea.Msg {
 		if existingSessionIDs == nil {
 			return noUpdateMsg{}
@@ -53,6 +62,15 @@ func (m Model) discoverNewSession() tea.Cmd {
 				if err == nil && session.Status == coop.SessionActive {
 					return sessionDiscoveredMsg{sessionID: id}
 				}
+			}
+		}
+		// No new session appeared. If an active one predates the baseline,
+		// adopt it rather than spinning forever: `coop join --wait` is the
+		// exact command the fallback prints, and on a re-run after a quit or
+		// crash the session it described is already in the baseline.
+		if adoptExisting {
+			if session, err := store.LatestActiveSession(); err == nil {
+				return sessionDiscoveredMsg{sessionID: session.ID}
 			}
 		}
 		return noUpdateMsg{}

--- a/pkg/coop/tui/model.go
+++ b/pkg/coop/tui/model.go
@@ -80,6 +80,8 @@ type Model struct {
 	reviewDecisionNotifier ReviewDecisionNotifier
 	reviewAlertNotifier    ReviewAlertNotifier
 	reviewAlerted          bool
+	exitCleanup            []func()
+	resizeHook             func(width, height int)
 
 	agentHeartbeatMissing bool
 	// consecutiveReadErrors tracks failed session polls, so a single transient
@@ -202,6 +204,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.WindowSizeMsg:
 		m.handleWindowSize(msg)
+		if m.resizeHook != nil {
+			hook, w, h := m.resizeHook, msg.Width, msg.Height
+			return m, func() tea.Msg {
+				hook(w, h)
+				return nil
+			}
+		}
 		return m, nil
 
 	case tickMsg:
@@ -261,7 +270,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.resizeViewport()
 		m.syncViewport()
-		return m, tea.Batch(tickCmd(), m.reviewAlertCmd())
+		// Sequenced deliberately: reviewAlertCmd mutates m.reviewAlerted, and
+		// Go leaves the evaluation order of a plain operand relative to a call
+		// in the same return statement unspecified. Assigning first guarantees
+		// the returned copy carries the dedup flag; without it the alert could
+		// re-fire on every poll.
+		alert := m.reviewAlertCmd()
+		return m, tea.Batch(tickCmd(), alert)
 
 	case errMsg:
 		m.recordReadError(msg.err)
@@ -417,6 +432,17 @@ func (m *Model) reviewAlertCmd() tea.Cmd {
 		notify(hasReview, focused)
 		return nil
 	}
+}
+
+// runExitCleanup runs registered teardown once the program has stopped. It is
+// idempotent so callers can defer it unconditionally.
+func (m *Model) runExitCleanup() {
+	for _, cleanup := range m.exitCleanup {
+		if cleanup != nil {
+			cleanup()
+		}
+	}
+	m.exitCleanup = nil
 }
 
 // resumeFollowingIfReviewAppeared clears the manual-navigation latch when a

--- a/pkg/coop/tui/model.go
+++ b/pkg/coop/tui/model.go
@@ -73,6 +73,7 @@ type Model struct {
 
 	waiting                bool
 	waitingMessage         string
+	waitingSince           time.Time
 	existingSessionIDs     map[string]bool
 	lastUpdateTime         time.Time
 	agentIsIdle            bool
@@ -165,6 +166,7 @@ func NewWaitingModel(store *coop.Store, existingSessionIDs map[string]bool, opts
 		sdkSnippetNode:     -1,
 		sdkLoadingNode:     -1,
 		waiting:            true,
+		waitingSince:       time.Now(),
 		existingSessionIDs: existingSessionIDs,
 	}
 	for _, opt := range opts {
@@ -202,9 +204,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tickMsg:
 		m.clearExpiredStatus(time.Now())
-		if !m.focused {
-			return m, tickCmd()
-		}
+		// Poll regardless of focus. An unfocused TUI is the norm, not the
+		// exception — the user works in the agent pane — and skipping the poll
+		// while blurred froze the display at exactly the moment a review
+		// appeared. Focus only gates how loudly we announce changes, never
+		// whether we see them.
 		return m, tea.Batch(m.checkForUpdates(), tickCmd())
 
 	case noUpdateMsg:
@@ -383,9 +387,9 @@ func (m Model) progressBar() *tea.ProgressBar {
 		return tea.NewProgressBar(tea.ProgressBarNone, 0)
 	}
 	value := done * 100 / total
-	// This surfaces in tmux's status line and the OS taskbar without the pane
-	// being focused, which is the only signal that reaches a user watching the
-	// agent's pane instead of this one.
+	// OSC 9;4 progress. Rendered by Windows Terminal and Ghostty (taskbar /
+	// tab); most other terminals and tmux < 3.6 ignore it silently, so this is
+	// a bonus channel, not the primary review notification.
 	state := tea.ProgressBarDefault
 	if m.agentIdle() || m.agentHeartbeatMissing || m.actionableReviewCount() > 0 {
 		state = tea.ProgressBarWarning
@@ -1042,10 +1046,22 @@ func (m *Model) handleReject(note string) tea.Cmd {
 }
 
 func (m Model) notifyReviewDecision() tea.Cmd {
-	if m.reviewDecisionNotifier == nil || m.session == nil {
+	if m.session == nil {
 		return nil
 	}
 	sessionID := m.session.ID
+	if m.reviewDecisionNotifier == nil {
+		// No wake-up channel exists outside tmux (manual-split and fallback
+		// launches). The agent polls the session file only while parked in
+		// await-review; if it has timed out, this decision sits unread until a
+		// human relays it. Say so — persistently, no ttl — instead of silently
+		// implying delivery.
+		return func() tea.Msg {
+			return statusMsg{
+				message: fmt.Sprintf("Decision saved. If the agent doesn't react shortly, run in the agent terminal: %s", coop.ResumeCommand(sessionID)),
+			}
+		}
+	}
 	notify := m.reviewDecisionNotifier
 	return func() tea.Msg {
 		if err := notify(sessionID); err != nil {

--- a/pkg/coop/tui/model.go
+++ b/pkg/coop/tui/model.go
@@ -78,6 +78,8 @@ type Model struct {
 	lastUpdateTime         time.Time
 	agentIsIdle            bool
 	reviewDecisionNotifier ReviewDecisionNotifier
+	reviewAlertNotifier    ReviewAlertNotifier
+	reviewAlerted          bool
 
 	agentHeartbeatMissing bool
 	// consecutiveReadErrors tracks failed session polls, so a single transient
@@ -259,7 +261,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.resizeViewport()
 		m.syncViewport()
-		return m, tickCmd()
+		return m, tea.Batch(tickCmd(), m.reviewAlertCmd())
 
 	case errMsg:
 		m.recordReadError(msg.err)
@@ -395,6 +397,26 @@ func (m Model) progressBar() *tea.ProgressBar {
 		state = tea.ProgressBarWarning
 	}
 	return tea.NewProgressBar(state, value)
+}
+
+// reviewAlertCmd fires the review-alert notifier when the reviews-waiting
+// state flips in either direction. It runs off the update loop so a slow
+// notifier (a tmux shell-out) never blocks rendering.
+func (m *Model) reviewAlertCmd() tea.Cmd {
+	if m.reviewAlertNotifier == nil || m.session == nil {
+		return nil
+	}
+	hasReview := m.actionableReviewCount() > 0
+	if hasReview == m.reviewAlerted {
+		return nil
+	}
+	m.reviewAlerted = hasReview
+	notify := m.reviewAlertNotifier
+	focused := m.focused
+	return func() tea.Msg {
+		notify(hasReview, focused)
+		return nil
+	}
 }
 
 // resumeFollowingIfReviewAppeared clears the manual-navigation latch when a

--- a/pkg/coop/tui/model_test.go
+++ b/pkg/coop/tui/model_test.go
@@ -741,6 +741,48 @@ func TestCheckForUpdatesNoChangeReturnsNoUpdate(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestBlurredTickStillPolls(t *testing.T) {
+	m := readyModel()
+	m.focused = false
+
+	_, cmd := m.Update(tickMsg(time.Now()))
+
+	require.NotNil(t, cmd)
+	batch, ok := cmd().(tea.BatchMsg)
+	require.True(t, ok, "blurred tick must still batch a store poll with the next tick")
+	assert.Len(t, batch, 2)
+}
+
+func TestWaitingModeAdoptsExistingActiveSessionAfterDelay(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+	require.NoError(t, store.Write(&coop.Session{ID: "old_session", Status: coop.SessionActive}))
+
+	m := NewWaitingModel(store, map[string]bool{"old_session": true})
+	m.waitingSince = time.Now().Add(-existingSessionAdoptDelay)
+
+	cmd := m.discoverNewSession()
+	require.NotNil(t, cmd)
+	msg := cmd()
+
+	discovered, ok := msg.(sessionDiscoveredMsg)
+	require.True(t, ok, "waiting mode should adopt the pre-existing active session instead of spinning forever")
+	assert.Equal(t, "old_session", discovered.sessionID)
+}
+
+func TestNotifyReviewDecisionWithoutNotifierExplainsManualResume(t *testing.T) {
+	m := readyModel()
+	m.reviewDecisionNotifier = nil
+
+	cmd := m.notifyReviewDecision()
+
+	require.NotNil(t, cmd)
+	status, ok := cmd().(statusMsg)
+	require.True(t, ok)
+	assert.Contains(t, status.message, coop.ResumeCommand(m.session.ID))
+	assert.Zero(t, status.ttl, "manual-resume guidance must not expire")
+}
+
 func TestDiscoverNewSessionNoChangeReturnsNoUpdate(t *testing.T) {
 	dir := t.TempDir()
 	store, _ := coop.NewStoreAt(dir)

--- a/pkg/coop/tui/model_test.go
+++ b/pkg/coop/tui/model_test.go
@@ -770,6 +770,30 @@ func TestWaitingModeAdoptsExistingActiveSessionAfterDelay(t *testing.T) {
 	assert.Equal(t, "old_session", discovered.sessionID)
 }
 
+func TestReviewAlertFiresOnlyOnTransitions(t *testing.T) {
+	var alerts [][2]bool
+	m := readyModel()
+	m.focused = false
+	m.reviewAlertNotifier = func(hasReview, focused bool) {
+		alerts = append(alerts, [2]bool{hasReview, focused})
+	}
+
+	// Step 0 is ready for review once every node is done or in review.
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+	cmd := m.reviewAlertCmd()
+	require.NotNil(t, cmd, "review appearing must fire an alert")
+	cmd()
+	assert.Equal(t, [][2]bool{{true, false}}, alerts)
+
+	assert.Nil(t, m.reviewAlertCmd(), "unchanged review state must not re-alert")
+
+	m.session.Steps[0].Nodes[1].State = coop.NodeDone
+	cmd = m.reviewAlertCmd()
+	require.NotNil(t, cmd, "review clearing must fire so callers can restore state")
+	cmd()
+	assert.Equal(t, [][2]bool{{true, false}, {false, false}}, alerts)
+}
+
 func TestNotifyReviewDecisionWithoutNotifierExplainsManualResume(t *testing.T) {
 	m := readyModel()
 	m.reviewDecisionNotifier = nil

--- a/pkg/coop/tui/model_test.go
+++ b/pkg/coop/tui/model_test.go
@@ -1,8 +1,11 @@
 package tui
 
 import (
+	"encoding/json"
 	"errors"
 	"image/color"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -753,21 +756,92 @@ func TestBlurredTickStillPolls(t *testing.T) {
 	assert.Len(t, batch, 2)
 }
 
-func TestWaitingModeAdoptsExistingActiveSessionAfterDelay(t *testing.T) {
+func TestWaitingModeAdoptsLiveSessionForThisProject(t *testing.T) {
 	dir := t.TempDir()
 	store, _ := coop.NewStoreAt(dir)
-	require.NoError(t, store.Write(&coop.Session{ID: "old_session", Status: coop.SessionActive}))
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	writeSessionFile(t, dir, &coop.Session{
+		ID: "mine", Status: coop.SessionActive, Cwd: cwd, UpdatedAt: time.Now(),
+	})
 
-	m := NewWaitingModel(store, map[string]bool{"old_session": true})
+	m := NewWaitingModel(store, map[string]bool{"mine": true})
 	m.waitingSince = time.Now().Add(-existingSessionAdoptDelay)
 
-	cmd := m.discoverNewSession()
-	require.NotNil(t, cmd)
-	msg := cmd()
+	msg := m.discoverNewSession()()
 
 	discovered, ok := msg.(sessionDiscoveredMsg)
-	require.True(t, ok, "waiting mode should adopt the pre-existing active session instead of spinning forever")
-	assert.Equal(t, "old_session", discovered.sessionID)
+	require.True(t, ok, "re-running coop join --wait must reattach, not spin forever")
+	assert.Equal(t, "mine", discovered.sessionID)
+}
+
+// The bug this guards: `stripe coop start` runs the TUI as `coop join --wait`
+// while the agent spends minutes on discovery, so the adopt timer always
+// expires first. Crashed runs stay `active` forever (nothing reaps them), so
+// without these filters the TUI attaches to a zombie or another project's
+// session and never switches to the one the agent is creating.
+func TestWaitingModeRefusesUnrelatedSessions(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		session *coop.Session
+	}{
+		{
+			name:    "another project",
+			session: &coop.Session{ID: "other", Status: coop.SessionActive, Cwd: "/somewhere/else", UpdatedAt: time.Now()},
+		},
+		{
+			name:    "crashed run in this project",
+			session: &coop.Session{ID: "zombie", Status: coop.SessionActive, Cwd: cwd, UpdatedAt: time.Now().Add(-time.Hour)},
+		},
+		{
+			name:    "session predating the cwd field",
+			session: &coop.Session{ID: "legacy", Status: coop.SessionActive, UpdatedAt: time.Now()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store, _ := coop.NewStoreAt(dir)
+			// Written directly: Store.Write stamps UpdatedAt with the current
+			// time, which is exactly why a crashed session's timestamp stays
+			// old in the real world — and why it can't be faked through Write.
+			writeSessionFile(t, dir, tt.session)
+
+			m := NewWaitingModel(store, map[string]bool{tt.session.ID: true})
+			m.waitingSince = time.Now().Add(-existingSessionAdoptDelay)
+
+			_, adopted := m.discoverNewSession()().(sessionDiscoveredMsg)
+			assert.False(t, adopted, "must keep waiting for the session this launch is creating")
+		})
+	}
+}
+
+// writeSessionFile writes a session JSON verbatim, preserving timestamps that
+// Store.Write would otherwise overwrite.
+func writeSessionFile(t *testing.T, dir string, session *coop.Session) {
+	t.Helper()
+	session.SchemaVersion = coop.CurrentSessionSchemaVersion
+	data, err := json.Marshal(session)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, session.ID+".json"), data, 0o600))
+}
+
+func TestWaitingModeIgnoresNewSessionsFromOtherProjects(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := coop.NewStoreAt(dir)
+	writeSessionFile(t, dir, &coop.Session{
+		ID: "elsewhere", Status: coop.SessionActive, Cwd: "/somewhere/else", UpdatedAt: time.Now(),
+	})
+
+	// Empty baseline: "elsewhere" looks brand new, but it is not ours.
+	m := NewWaitingModel(store, map[string]bool{})
+
+	_, adopted := m.discoverNewSession()().(sessionDiscoveredMsg)
+	assert.False(t, adopted, "a concurrent launch in another repo must not be latched")
 }
 
 func TestReviewAlertFiresOnlyOnTransitions(t *testing.T) {
@@ -1473,4 +1547,48 @@ func TestReviewAppearingResumesFollowing(t *testing.T) {
 	result, _ := m.Update(sessionUpdatedMsg{session: &next})
 
 	assert.False(t, result.(Model).userMoved)
+}
+
+func TestExitCleanupRunsOnce(t *testing.T) {
+	calls := 0
+	m := readyModel()
+	WithExitCleanup(func() { calls++ })(&m)
+
+	m.runExitCleanup()
+	m.runExitCleanup()
+
+	assert.Equal(t, 1, calls, "cleanup must be idempotent so callers can defer it unconditionally")
+}
+
+func TestReviewAlertDedupSurvivesUpdate(t *testing.T) {
+	var alerts int
+	m := readyModel()
+	m.reviewAlertNotifier = func(hasReview, focused bool) { alerts++ }
+	m.session.Steps[0].Nodes[1].State = coop.NodeReview
+
+	// Drive it through Update twice with the same session state: the dedup
+	// flag lives on the returned model copy, so a second identical update
+	// must not re-alert.
+	next, cmd := m.Update(sessionUpdatedMsg{session: m.session})
+	require.NotNil(t, cmd)
+	runBatch(cmd)
+	updated, ok := next.(Model)
+	require.True(t, ok)
+
+	_, cmd = updated.Update(sessionUpdatedMsg{session: updated.session})
+	runBatch(cmd)
+
+	assert.Equal(t, 1, alerts, "alert must fire once per transition, not once per poll")
+}
+
+// runBatch executes a tea.Cmd and any commands it batches.
+func runBatch(cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if batch, ok := cmd().(tea.BatchMsg); ok {
+		for _, c := range batch {
+			runBatch(c)
+		}
+	}
 }

--- a/pkg/coop/tui/outline.go
+++ b/pkg/coop/tui/outline.go
@@ -18,8 +18,15 @@ func (m Model) renderStepList() string {
 	return m.renderStepOutline().content
 }
 
+// SplitWorkspaceMinWidth is the minimum render width for the two-column
+// workspace (nav rail + detail panel). Narrower models render the
+// single-column outline. The `coop start` launcher sizes its TUI pane below
+// this threshold on purpose, so the companion pane is always single-column;
+// the two-column workspace is for `coop join` running in a full terminal.
+const SplitWorkspaceMinWidth = 100
+
 func (m Model) useSplitWorkspace() bool {
-	return m.width >= 100 && m.session != nil && !m.session.IsComplete()
+	return m.width >= SplitWorkspaceMinWidth && m.session != nil && !m.session.IsComplete()
 }
 
 // outlineWidth returns the column width the step outline should render into.

--- a/pkg/coop/types.go
+++ b/pkg/coop/types.go
@@ -248,11 +248,15 @@ type Session struct {
 	Steps               []SessionStep        `json:"steps"`
 	UsedSandbox         bool                 `json:"used_sandbox,omitempty"`
 	NextSteps           *NextStepsState      `json:"next_steps,omitempty"`
-	ParentSessionID     string               `json:"parent_session_id,omitempty"`
-	ParentStepID        string               `json:"parent_step_id,omitempty"` // which next-step this session fulfills
-	CreatedAt           time.Time            `json:"created_at"`
-	UpdatedAt           time.Time            `json:"updated_at"`
-	Version             int                  `json:"version"`
+	// Cwd is the directory `coop start`/`coop run` was invoked from. Sessions
+	// live in one flat global folder, so this is what distinguishes "the
+	// session for the project I am looking at" from every other one.
+	Cwd             string    `json:"cwd,omitempty"`
+	ParentSessionID string    `json:"parent_session_id,omitempty"`
+	ParentStepID    string    `json:"parent_step_id,omitempty"` // which next-step this session fulfills
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+	Version         int       `json:"version"`
 }
 
 // NextStepsState tracks post-completion suggestions and selection.


### PR DESCRIPTION
Hardens how `stripe coop start` launches, and makes the no-tmux path a real experience instead of an apology. Rebased onto `coop`.

## Why

Auditing the launcher turned up defects across every path — including two that made co-op structurally impossible on some platforms, and one where the review TUI stopped watching the session at exactly the moment a review appeared.

## What changed

**Split sizing.** The 60% proportional split is now a fixed TUI width (48 columns, 40 down to 113 total, no split below that — full-width agent plus join instructions). The TUI's usefulness stops growing past its card width while the agent benefits from every extra column, so the agent gets ~80% on a wide terminal instead of 60%. Both widths sit below the two-column workspace threshold, so the companion pane always renders the single-column layout.

**The TUI stopped watching when unfocused.** `tickMsg` skipped the store poll while blurred — but unfocused is the *normal* state, since the user works in the agent pane. A review could appear and the pane would sit frozen. This was latent only because tmux ships `focus-events off`; the tmux config added here turns it on, so the fix had to land with it.

**Windows was a hard failure, not a fallback.** The launcher wrote a `#!/bin/bash` script and ran it via `bash -c`, so `coop start` died with `exec: "bash": executable file not found` — on the one path that exists for people without tmux. The fallback now execs the agent directly with no shell (also fixes NixOS, where `/bin/bash` doesn't exist), and both launch modes build their flags from one helper so they can't drift.

**Keystroke injection into a live agent.** The tmux wake-up fired `send-keys` on every confirm, appending its prompt to whatever was in the agent's input box — including a half-typed human message — and the trailing Enter could blindly answer an open permission dialog. It now injects only when the agent is neither parked in `await-review` (fresh heartbeat) nor mid-work (no active node), refuses dead panes, and clears the input line first.

**Sessions had no project identity.** `coop join --wait` adopted the globally latest active session. In the default `coop start` flow the TUI waits while the agent spends minutes on discovery, so the adopt timer always expired first — and crashed runs stay `active` forever because nothing reaps them, so the TUI would attach to a zombie and never switch. Sessions now record their working directory, and both the new-session latch and adoption require a matching project plus a recent timestamp.

**tmux config and dedicated socket.** New sessions start on `-L stripe-coop` with a config co-op ships, instead of the user's server and `~/.tmux.conf`. This fixes real defects of stock tmux for this use: `set-titles` is off by default so the window-title channel never reached the terminal at all; no RGB/extended-keys degraded the agent's own TUI inside the split; mouse and clipboard were off. Options newer tmux rejects are gated on `tmux -V`, and the status line is ASCII-only because non-UTF-8 client locales silently turn Unicode into underscores. The in-tmux split path deliberately stays on the user's own server — tmux only refuses to nest into the *same* socket, so attaching a second server from inside a pane nests silently with stacked prefix keys.

**Review alerts.** Renames the window to `coop: REVIEW` in tmux's status line and rings the bell when the terminal is unfocused, restoring the window's prior name and `automatic-rename` setting on clear and on exit.

**No tmux, and can't-install-tmux.** On macOS with Homebrew, a TTY, and no CI/SSH, co-op offers to install tmux — the one case needing no elevation; everywhere else it prints the right package-manager command and moves on, never elevating, never as root, with "don't ask again" persisted. Containers are told to fix the image, since an install there evaporates on rebuild. For people who can't install it, the fallback names the native split keystroke for their terminal (VS Code, Windows Terminal, iTerm2, Ghostty, Warp, WezTerm, kitty, Apple Terminal).

**Pane width drifted after resize.** Verified on tmux 3.7b: narrowing a window from 200 to 120 columns collapses the TUI pane from 48 columns to **8**. The TUI now re-pins its width on resize, only when launched by `coop start` and only while the window is still wide enough to deserve a split.

## Verification

Beyond unit tests, the tmux behavior was checked against a real tmux 3.7b server on a throwaway socket: split geometry (200 cols → 48/151), every shipped config option taking effect, the resize collapse and its repair (8 → 48), window rename/restore leaving `automatic-rename` untouched, and `-f` fully isolating from `~/.tmux.conf`. The shell-free fallback was run end-to-end with a stub agent to confirm the prompt survives as a single argument.

Install-path behavior was checked in Docker across ubuntu/debian-slim/alpine/fedora — tmux installs in 3–10s and starts headlessly in slim images, and 2 of 8 common distros still ship tmux below 3.2, which is why the config is version-gated.
