### PR TITLE
Categorize Codex TypeScript SDK invocations

### DIFF
--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -234,6 +234,7 @@ var agentHostKinds = map[string]string{
 	"claude-vscode":     "ide",
 	"cli":               "terminal",
 	"codex-desktop":     "desktop",
+	"codex-sdk-ts":      "sdk",
 	"mcp":               "mcp",
 	"sdk-cli":           "sdk",
 	"sdk-py":            "sdk",

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -140,6 +140,7 @@ func TestDetectAgentHost(t *testing.T) {
 		// Both are desktop, and raw is the only thing that tells them apart.
 		{"claude desktop 3p", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop-3p"}, "desktop", "claude-desktop-3p"},
 		{"codex desktop, normalized from \"Codex Desktop\"", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "desktop", "codex-desktop"},
+		{"codex typescript sdk", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "codex_sdk_ts"}, "sdk", "codex-sdk-ts"},
 		{"terminal", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"}, "terminal", "cli"},
 		{"ide", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-vscode"}, "ide", "claude-vscode"},
 		{"sdk ts", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "sdk-ts"}, "sdk", "sdk-ts"},
@@ -212,6 +213,7 @@ func TestObservedAgentSessions(t *testing.T) {
 		envs        map[string]string
 		agent       string
 		hostKind    string
+		hostRaw     string
 		version     string
 		description string
 	}{
@@ -227,6 +229,7 @@ func TestObservedAgentSessions(t *testing.T) {
 			},
 			agent:    "claude_code",
 			hostKind: "desktop",
+			hostRaw:  "claude-desktop",
 			version:  "2.1.222",
 		},
 		{
@@ -241,6 +244,7 @@ func TestObservedAgentSessions(t *testing.T) {
 			},
 			agent:       "claude_code",
 			hostKind:    "desktop",
+			hostRaw:     "claude-desktop",
 			version:     "2.1.227",
 			description: "no __CFBundleIdentifier on Windows; the env vars carry it",
 		},
@@ -255,8 +259,22 @@ func TestObservedAgentSessions(t *testing.T) {
 			},
 			agent:       "codex_cli",
 			hostKind:    "desktop",
+			hostRaw:     "codex-desktop",
 			version:     "",
 			description: "Desktop also sets the generic Codex signals; the host is what distinguishes it",
+		},
+		{
+			name: "codex typescript sdk",
+			envs: map[string]string{
+				"CODEX_CI":                           "1",
+				"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "codex_sdk_ts",
+				"CODEX_THREAD_ID":                    sensitiveThreadID,
+			},
+			agent:       "codex_cli",
+			hostKind:    "sdk",
+			hostRaw:     "codex-sdk-ts",
+			version:     "",
+			description: "The TypeScript SDK identifies itself through the Codex originator override",
 		},
 		{
 			name: "codex cli",
@@ -274,8 +292,9 @@ func TestObservedAgentSessions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			getEnv := mapEnv(tt.envs)
 			require.Equal(t, tt.agent, DetectAIAgent(getEnv), tt.description)
-			kind, _ := DetectAgentHost(getEnv)
+			kind, raw := DetectAgentHost(getEnv)
 			require.Equal(t, tt.hostKind, kind, tt.description)
+			require.Equal(t, tt.hostRaw, raw, tt.description)
 			require.Equal(t, tt.version, DetectAgentVersion(getEnv), tt.description)
 		})
 	}

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -215,6 +215,7 @@ func TestObservedAgentSessions(t *testing.T) {
 		hostKind    string
 		hostRaw     string
 		version     string
+		terminal    string
 		description string
 	}{
 		{
@@ -269,12 +270,15 @@ func TestObservedAgentSessions(t *testing.T) {
 				"CODEX_CI":                           "1",
 				"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "codex_sdk_ts",
 				"CODEX_THREAD_ID":                    sensitiveThreadID,
+				"TERM_PROGRAM":                       "vscode",
 			},
-			agent:       "codex_cli",
-			hostKind:    "sdk",
-			hostRaw:     "codex-sdk-ts",
-			version:     "",
-			description: "The TypeScript SDK identifies itself through the Codex originator override",
+			agent:    "codex_cli",
+			hostKind: "sdk",
+			hostRaw:  "codex-sdk-ts",
+			version:  "",
+			terminal: "vscode",
+			description: "The TypeScript SDK identifies itself through the Codex originator override " +
+				"and forwards inherited terminal metadata, but does not export its version",
 		},
 		{
 			name: "codex cli",
@@ -296,6 +300,7 @@ func TestObservedAgentSessions(t *testing.T) {
 			require.Equal(t, tt.hostKind, kind, tt.description)
 			require.Equal(t, tt.hostRaw, raw, tt.description)
 			require.Equal(t, tt.version, DetectAgentVersion(getEnv), tt.description)
+			require.Equal(t, tt.terminal, DetectTerminalProgram(getEnv), tt.description)
 		})
 	}
 }


### PR DESCRIPTION
### Summary

- map the Codex TypeScript SDK originator `codex_sdk_ts` to `agent_host_kind=sdk` instead of `other`
- report its normalized originator as `agent_host_raw=codex-sdk-ts`, preserving visibility if vendor values drift
- preserve the existing `ai_agent=codex_cli` value for compatibility
- verify that `terminal_program` is captured when the SDK inherits a terminal environment
- add focused host detection coverage and a complete SDK-session fixture

### Why

`@openai/codex-sdk` [sets](https://github.com/openai/codex/blob/42b5f05cef69491bc578901fb324b3c9a278b253/sdk/typescript/src/exec.ts#L43-L45) `CODEX_INTERNAL_ORIGINATOR_OVERRIDE=codex_sdk_ts` when it launches Codex. #1888 introduced the host category, but the Codex SDK originator fell through to `other`.

Rebased on #1909, the raw host is reported for mapped and unmapped values alike. The resulting fields are:

- `ai_agent=codex_cli`
- `agent_host_kind=sdk`
- `agent_host_raw=codex-sdk-ts`

The SDK [forwards its caller environment](https://github.com/openai/codex/blob/42b5f05cef69491bc578901fb324b3c9a278b253/sdk/typescript/src/exec.ts#L161-L183), so existing terminal detection continues to populate `terminal_program` when values such as `TERM_PROGRAM` are present. Headless SDK runs leave it empty.

### Version availability

`agent_version` remains empty for current Codex SDK runs because there is no version signal in the child-command environment. The TypeScript SDK exports only the originator above. The Python SDK has a version, but [sends it in app-server initialization metadata](https://github.com/openai/codex/blob/42b5f05cef69491bc578901fb324b3c9a278b253/sdk/python/src/openai_codex/client.py#L293-L301) rather than exporting it to commands.

This deliberately avoids mistaking the caller application version (for example, `npm_package_version`) for the Codex SDK version or invoking a potentially different `codex` binary from `PATH`.

### Testing

- `make test`
- `make lint`