### PR TITLE
Report the host underneath agent_host_kind, and categorize claude-desktop-3p

### DIFF
--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -50,7 +50,8 @@ type CLIAnalyticsEventMetadata struct {
 	MachineUUID       string `url:"machine_uuid,omitempty"`     // the persistent machine UUID
 	GeneratedResource bool   `url:"generated_resource"`         // whether or not this was a generated resource
 	AIAgent           string `url:"ai_agent,omitempty"`         // the AI coding agent that invoked the CLI, if any
-	AgentHostKind     string `url:"agent_host_kind,omitempty"`  // where the agent ran: desktop, terminal, ide, remote, sdk, mcp, chat, ci, or other
+	AgentHostKind     string `url:"agent_host_kind,omitempty"`  // where the agent ran: desktop, terminal, ide, remote, sdk, mcp, or other
+	AgentHostRaw      string `url:"agent_host_raw,omitempty"`   // the normalized host underneath agent_host_kind, so a coarsely mapped or unmapped host stays recoverable
 	AgentVersion      string `url:"agent_version,omitempty"`    // the agent's own version, when it reports one
 	InstallMethod     string `url:"install_method,omitempty"`   // how the CLI was installed
 	InTmux            bool   `url:"in_tmux"`                    // whether the CLI was invoked from within tmux
@@ -81,13 +82,16 @@ type NoOpTelemetryClient struct {
 
 // NewEventMetadata initializes an instance of CLIAnalyticsEventContext
 func NewEventMetadata() *CLIAnalyticsEventMetadata {
+	agentHostKind, agentHostRaw := useragent.DetectAgentHost(os.Getenv)
+
 	return &CLIAnalyticsEventMetadata{
 		InvocationID:  uuid.NewString(),
 		CLIVersion:    version.Version,
 		OS:            runtime.GOOS,
 		Arch:          runtime.GOARCH,
 		AIAgent:       useragent.DetectAIAgent(os.Getenv),
-		AgentHostKind: useragent.DetectAgentHostKind(os.Getenv),
+		AgentHostKind: agentHostKind,
+		AgentHostRaw:  agentHostRaw,
 		AgentVersion:  useragent.DetectAgentVersion(os.Getenv),
 		InstallMethod: useragent.DetectInstallMethod(
 			os.Getenv,

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -260,6 +260,7 @@ func TestSendEvent_OmitsUnsetAgentFields(t *testing.T) {
 		bodyString := string(body)
 		require.NotContains(t, bodyString, "agent_version")
 		require.NotContains(t, bodyString, "agent_host_kind")
+		require.NotContains(t, bodyString, "agent_host_raw")
 	}))
 	defer ts.Close()
 	baseURL, _ := url.Parse(ts.URL)
@@ -394,4 +395,17 @@ func TestNewEventMetadata_FromObservedDesktopSession(t *testing.T) {
 	require.Equal(t, "claude_code", tel.AIAgent)
 	require.Equal(t, "desktop", tel.AgentHostKind)
 	require.Equal(t, "2.1.227", tel.AgentVersion)
+	require.Equal(t, "claude-desktop", tel.AgentHostRaw)
+}
+
+func TestNewEventMetadata_ReportsRawHostWhenUncategorized(t *testing.T) {
+	// The debugging case: a host neither vendor had shipped when this CLI was released.
+	// The category cannot identify it; the raw value can.
+	clearAgentEnv(t)
+	t.Setenv("CLAUDECODE", "1")
+	t.Setenv("CLAUDE_CODE_ENTRYPOINT", "some-future-surface")
+
+	tel := stripe.NewEventMetadata()
+	require.Equal(t, "other", tel.AgentHostKind)
+	require.Equal(t, "some-future-surface", tel.AgentHostRaw)
 }

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -147,8 +147,10 @@ func DetectAgentHostKind(getEnv func(string) string) string {
 	host = strings.ToLower(strings.TrimSpace(host))
 	host = strings.NewReplacer(" ", "-", "_", "-").Replace(host)
 
-	// Checked first and by prefix: "remote-desktop" is a remote session, not the
-	// desktop app, so matching "desktop" anywhere would silently inflate desktop counts.
+	// Checked first and by prefix. "remote-desktop" is Claude Desktop driving a session
+	// that executes remotely -- Claude Code labels it "Claude Desktop" as a surface --
+	// but this field describes where the CLI itself ran, and that is the remote host,
+	// not the user's machine. Matching "desktop" anywhere would put it in the wrong one.
 	if host == "remote" || strings.HasPrefix(host, "remote-") {
 		return "remote"
 	}
@@ -222,14 +224,15 @@ const maxVersionLength = 32
 // agentHostKinds categorizes the hosts we know about. "remote*" hosts are handled by
 // prefix in DetectAgentHostKind rather than enumerated here.
 var agentHostKinds = map[string]string{
-	"claude-desktop": "desktop",
-	"claude-vscode":  "ide",
-	"cli":            "terminal",
-	"codex-desktop":  "desktop",
-	"mcp":            "mcp",
-	"sdk-cli":        "sdk",
-	"sdk-py":         "sdk",
-	"sdk-ts":         "sdk",
+	"claude-desktop":    "desktop",
+	"claude-desktop-3p": "desktop",
+	"claude-vscode":     "ide",
+	"cli":               "terminal",
+	"codex-desktop":     "desktop",
+	"mcp":               "mcp",
+	"sdk-cli":           "sdk",
+	"sdk-py":            "sdk",
+	"sdk-ts":            "sdk",
 }
 
 //

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -125,41 +125,43 @@ func DetectAIAgent(getEnv func(string) string) string {
 	return ""
 }
 
-// DetectAgentHostKind reports where the agent ran: "desktop", "terminal", "ide",
-// "remote", "sdk", "mcp", or "other", and "" when no agent reported a host.
+// DetectAgentHost reports where the agent ran, as a bounded category and as the host
+// value itself. Both are empty when no agent reported a host.
 //
-// Only the category is exposed. The underlying values are per-vendor spellings that
-// every consumer would otherwise have to enumerate, and the vendor is already carried
-// by DetectAIAgent.
-func DetectAgentHostKind(getEnv func(string) string) string {
+// kind is what to group by: "desktop", "terminal", "ide", "remote", "sdk", "mcp", or
+// "other" for a host we have not categorized. raw is the normalized host underneath it,
+// reported for every host rather than only uncategorized ones, so that a value we map
+// too coarsely stays recoverable. "claude-desktop" and "claude-desktop-3p" are both
+// desktop, for instance, and without raw nothing downstream can tell them apart.
+//
+// Reporting raw also means an unmapped host can be identified from the data rather than
+// from a vendor's source, which matters because mapping one otherwise costs a code
+// change, a release, and users upgrading before it is even visible.
+func DetectAgentHost(getEnv func(string) string) (kind string, raw string) {
 	host := getEnv("CLAUDE_CODE_ENTRYPOINT")
 	if host == "" {
 		// Codex Desktop sets this alongside the generic Codex signals, and it is
 		// currently the only inherited value separating Desktop from the Codex CLI.
 		host = getEnv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE")
 	}
-	if host == "" {
-		return ""
-	}
 
-	// Vendors disagree on formatting, and Claude Code disagrees with itself: it ships
-	// both "claude_in_slack" and "claude-in-slack", while Codex reports "Codex Desktop".
-	host = strings.ToLower(strings.TrimSpace(host))
-	host = strings.NewReplacer(" ", "-", "_", "-").Replace(host)
+	host = normalizeAgentHost(host)
+	if host == "" {
+		return "", ""
+	}
 
 	// Checked first and by prefix. "remote-desktop" is Claude Desktop driving a session
 	// that executes remotely -- Claude Code labels it "Claude Desktop" as a surface --
 	// but this field describes where the CLI itself ran, and that is the remote host,
 	// not the user's machine. Matching "desktop" anywhere would put it in the wrong one.
 	if host == "remote" || strings.HasPrefix(host, "remote-") {
-		return "remote"
+		return "remote", host
 	}
 	if kind, ok := agentHostKinds[host]; ok {
-		return kind
+		return kind, host
 	}
-	// Reported rather than dropped, so a host we have not categorized stays
-	// distinguishable from no host at all while the field stays bounded.
-	return "other"
+
+	return "other", host
 }
 
 // DetectAgentVersion returns the agent's own version, parsed out of the identifier it
@@ -213,16 +215,19 @@ var encodedUserAgent string
 // Private constants
 //
 
-// maxVersionLength bounds a parsed version before it is reported, so an unexpected or
-// hostile value cannot bloat a request.
-const maxVersionLength = 32
+// maxVersionLength and maxHostLength bound values before they are reported, so an
+// unexpected or hostile value cannot bloat a request.
+const (
+	maxVersionLength = 32
+	maxHostLength    = 32
+)
 
 //
 // Private variables
 //
 
 // agentHostKinds categorizes the hosts we know about. "remote*" hosts are handled by
-// prefix in DetectAgentHostKind rather than enumerated here.
+// prefix in DetectAgentHost rather than enumerated here.
 var agentHostKinds = map[string]string{
 	"claude-desktop":    "desktop",
 	"claude-desktop-3p": "desktop",
@@ -238,6 +243,33 @@ var agentHostKinds = map[string]string{
 //
 // Private functions
 //
+
+// normalizeAgentHost lowercases a reported host, collapses spaces and underscores to
+// dashes, drops anything outside printable ASCII, and bounds the length. Vendors
+// disagree on formatting, and Claude Code disagrees with itself: it ships both
+// "claude_in_slack" and "claude-in-slack", while Codex reports "Codex Desktop".
+//
+// Normalizing before reporting matters because the host is reported as well as
+// categorized: it keeps one host from arriving under several spellings, including
+// across platforms.
+func normalizeAgentHost(host string) string {
+	host = strings.Map(func(r rune) rune {
+		switch {
+		case r == ' ' || r == '_':
+			return '-'
+		case r < ' ' || r > '~':
+			return -1
+		default:
+			return r
+		}
+	}, strings.ToLower(strings.TrimSpace(host)))
+
+	if len(host) > maxHostLength {
+		host = host[:maxHostLength]
+	}
+
+	return host
+}
 
 // validVersion returns the candidate if it is a dot-separated numeric version, and ""
 // otherwise. Deliberately strict: the identifier formats this parses are undocumented,

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -129,29 +129,41 @@ func TestDetectTerminalProgram(t *testing.T) {
 	}
 }
 
-func TestDetectAgentHostKind(t *testing.T) {
+func TestDetectAgentHost(t *testing.T) {
 	tests := []struct {
-		name     string
-		envs     map[string]string
-		expected string
+		name string
+		envs map[string]string
+		kind string
+		raw  string
 	}{
-		{"claude desktop", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop"}, "desktop"},
-		{"claude desktop 3p", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop-3p"}, "desktop"},
-		{"codex desktop, normalized from \"Codex Desktop\"", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "desktop"},
-		{"terminal", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"}, "terminal"},
-		{"ide", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-vscode"}, "ide"},
-		{"sdk", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "sdk-ts"}, "sdk"},
+		{"claude desktop", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop"}, "desktop", "claude-desktop"},
+		// Both are desktop, and raw is the only thing that tells them apart.
+		{"claude desktop 3p", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop-3p"}, "desktop", "claude-desktop-3p"},
+		{"codex desktop, normalized from \"Codex Desktop\"", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "desktop", "codex-desktop"},
+		{"terminal", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"}, "terminal", "cli"},
+		{"ide", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-vscode"}, "ide", "claude-vscode"},
+		{"sdk ts", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "sdk-ts"}, "sdk", "sdk-ts"},
+		{"sdk py", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "sdk-py"}, "sdk", "sdk-py"},
 		// remote_desktop is Claude Desktop driving a remotely executing session. The CLI
 		// runs on the remote host, so it belongs to remote rather than desktop.
-		{"remote desktop is remote", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "remote_desktop"}, "remote"},
-		{"agent env wins over codex", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "terminal"},
-		{"uncategorized host", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "something-new"}, "other"},
-		{"no host", map[string]string{}, ""},
+		{"remote desktop is remote", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "remote_desktop"}, "remote", "remote-desktop"},
+		{"agent env wins over codex", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "terminal", "cli"},
+		{"uncategorized claude host", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-security"}, "other", "claude-security"},
+		{"uncategorized codex host", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Web"}, "other", "codex-web"},
+		{"no host", map[string]string{}, "", ""},
+
+		// Normalization runs before reporting, so one host cannot arrive under several
+		// spellings -- including from different platforms.
+		{"raw is normalized, not verbatim", map[string]string{"CLAUDE_CODE_ENTRYPOINT": " Some_New HOST "}, "other", "some-new-host"},
+		{"raw is bounded", map[string]string{"CLAUDE_CODE_ENTRYPOINT": strings.Repeat("x", 100)}, "other", strings.Repeat("x", 32)},
+		{"unprintable stripped", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "we\x00ird\x7f"}, "other", "weird"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, DetectAgentHostKind(mapEnv(tt.envs)))
+			kind, raw := DetectAgentHost(mapEnv(tt.envs))
+			require.Equal(t, tt.kind, kind)
+			require.Equal(t, tt.raw, raw)
 		})
 	}
 }
@@ -262,7 +274,8 @@ func TestObservedAgentSessions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			getEnv := mapEnv(tt.envs)
 			require.Equal(t, tt.agent, DetectAIAgent(getEnv), tt.description)
-			require.Equal(t, tt.hostKind, DetectAgentHostKind(getEnv), tt.description)
+			kind, _ := DetectAgentHost(getEnv)
+			require.Equal(t, tt.hostKind, kind, tt.description)
 			require.Equal(t, tt.version, DetectAgentVersion(getEnv), tt.description)
 		})
 	}
@@ -295,9 +308,11 @@ func TestObservedAgentSessions_NoSensitiveValuesReported(t *testing.T) {
 	}
 	getEnv := mapEnv(envs)
 
+	hostKind, hostRaw := DetectAgentHost(getEnv)
 	reported := []string{
+		hostRaw,
 		DetectAIAgent(getEnv),
-		DetectAgentHostKind(getEnv),
+		hostKind,
 		DetectAgentVersion(getEnv),
 		DetectInstallMethod(getEnv, errExe, noStat),
 		DetectTerminalProgram(getEnv),

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -136,12 +136,13 @@ func TestDetectAgentHostKind(t *testing.T) {
 		expected string
 	}{
 		{"claude desktop", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop"}, "desktop"},
+		{"claude desktop 3p", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-desktop-3p"}, "desktop"},
 		{"codex desktop, normalized from \"Codex Desktop\"", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "desktop"},
 		{"terminal", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"}, "terminal"},
 		{"ide", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "claude-vscode"}, "ide"},
 		{"sdk", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "sdk-ts"}, "sdk"},
-		// remote-desktop is a remote session, not the desktop app. Matching "desktop"
-		// anywhere would report this as desktop and quietly inflate desktop counts.
+		// remote_desktop is Claude Desktop driving a remotely executing session. The CLI
+		// runs on the remote host, so it belongs to remote rather than desktop.
 		{"remote desktop is remote", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "remote_desktop"}, "remote"},
 		{"agent env wins over codex", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"}, "terminal"},
 		{"uncategorized host", map[string]string{"CLAUDE_CODE_ENTRYPOINT": "something-new"}, "other"},


### PR DESCRIPTION
Follow-up to #1888, which added `agent_host_kind` and `agent_version`. Two gaps surfaced after it merged.

## `claude-desktop-3p` was uncategorized

Claude Code's entrypoint allowlist has 25 values, and `claude-desktop-3p` is one its own code groups with `claude-desktop` as a desktop surface:

```js
// surface label
case "claude-desktop": case "claude-desktop-3p": case "remote_desktop":
  return "Claude Desktop"

// host-managed environments
WBl = new Set(["claude-desktop", "claude-desktop-3p", "local-agent"])
```

It was missing from our map, so those invocations reported `other` and desktop usage was undercounted. Now mapped to `desktop`.

This also corrects a comment #1888 shipped with. It claimed `remote_desktop` "is not the desktop app", which is wrong — the mapping above labels it "Claude Desktop" like the others. The reason it belongs in `remote` is different: the session executes remotely, so the CLI runs on the remote host rather than the user's machine, and the field describes where the CLI ran. Behavior unchanged; only the justification was wrong.

## `agent_host_kind` alone loses distinctions that can't be recovered

The categories are deliberately coarse, so they collapse real differences even when correct:

| host | `agent_host_kind` | `agent_host_raw` |
|---|---|---|
| `claude-desktop` | `desktop` | `claude-desktop` |
| `claude-desktop-3p` | `desktop` | `claude-desktop-3p` |
| `cli` | `terminal` | `cli` |
| `sdk-ts` | `sdk` | `sdk-ts` |
| `sdk-py` | `sdk` | `sdk-py` |
| `remote_desktop` | `remote` | `remote-desktop` |
| `claude-security` | `other` | `claude-security` |

Without the second column nothing downstream can tell those pairs apart, and data collected without it doesn't contain the distinction — it isn't backfillable.

`DetectAgentHost` now returns the normalized host alongside the category, reported as `agent_host_raw`. The two fields split by purpose: **group by `agent_host_kind`, drill into `agent_host_raw`.**

It also answers a question the category cannot. `agent_host_kind=other` says a host is unmapped but not which one — identifying `claude-desktop-3p` meant reading a vendor's minified bundle, and mapping it then costs a code change, a release, and users upgrading. An unmapped host is invisible in the data for months. With the raw value it's answerable from the data.

### Bounds

- **Cardinality is small.** Claude Code ships 25 entrypoint values, Codex a handful.
- **Normalization runs before reporting**, not only before map lookup, so one host can't arrive under several spellings across platforms — a Windows `Codex Web` and a macOS `codex_web` both land as `codex-web`.
- **Stripped to printable ASCII and bounded to 32 characters.**

### Worth explicit review

`agent_host_raw` is the one reported field not drawn from a fixed set. It comes from two allowlisted variables whose stated purpose is self-identification — `CLAUDE_CODE_ENTRYPOINT` and `CODEX_INTERNAL_ORIGINATOR_OVERRIDE` — not session, thread, or auth data. Session IDs, host session IDs, OAuth scopes and permission profiles remain unread, and `CODEX_THREAD_ID` remains a presence check whose value is never captured. `TestObservedAgentSessions_NoSensitiveValuesReported` continues to assert that on output.

## Testing

- `agent_host_raw` reported for every host and empty only when no host was reported, including the `claude-desktop` vs `claude-desktop-3p` split.
- Normalization, the 32-character bound, and non-printable stripping.
- `claude-desktop-3p` categorizing as `desktop`, and `remote_desktop` still as `remote`.
- `TestObservedAgentSessions` continues to pin the detectors against environments captured from real Claude Desktop (macOS and Windows), Codex Desktop, and Codex CLI sessions.
- `go build ./...`, full `go test ./...`, `make lint` 0 issues including the new `errorcategory` linter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
