### PR TITLE
Revoke previous OAuth token on `login --new-session`

### DIFF
--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -16,6 +16,13 @@ import (
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
 
+// revokeToken and initiateLogin are package variables so tests can stub out
+// the network calls made by runLoginCmd.
+var (
+	revokeToken   = login.RevokeToken
+	initiateLogin = login.InitiateLogin
+)
+
 type loginCmd struct {
 	cmd              *cobra.Command
 	interactive      bool
@@ -172,7 +179,7 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 		}
 	} else if strings.HasPrefix(uat, "oak_") {
 		// Revoke the previous OAuth session before starting a new one, same as `stripe logout`.
-		if err := login.RevokeToken(cmd.Context(), lc.accessBaseURL); err != nil {
+		if err := revokeToken(cmd.Context(), lc.accessBaseURL); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: token revocation failed: %s\n", err)
 		}
 	}
@@ -181,7 +188,7 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 		if useragent.DetectAIAgent(os.Getenv) != "" {
 			fmt.Fprintln(os.Stderr, "If you do not have an account, run `stripe sandbox create` instead (provisions a claimable sandbox without a browser).")
 		}
-		return login.InitiateLogin(cmd.Context(), lc.dashboardBaseURL, lc.accessBaseURL, &Config)
+		return initiateLogin(cmd.Context(), lc.dashboardBaseURL, lc.accessBaseURL, &Config)
 	}
 
 	if lc.interactive {

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -152,8 +152,8 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 		return login.PollForLogin(cmd.Context(), lc.completeURL, &Config)
 	}
 
+	uat, _ := Config.Profile.GetUAT()
 	if !lc.newSession {
-		uat, _ := Config.Profile.GetUAT()
 		if strings.HasPrefix(uat, "oak_") {
 			identity := Config.Profile.GetDisplayName()
 			if identity == "" {
@@ -169,6 +169,11 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 			fmt.Fprintln(cmd.OutOrStdout(), "Run 'stripe reauth' to change permissions or authorize access to additional accounts or sandboxes.")
 			fmt.Fprintln(cmd.OutOrStdout(), "To log in as a different user, run: stripe login --new-session")
 			return nil
+		}
+	} else if strings.HasPrefix(uat, "oak_") {
+		// Revoke the previous OAuth session before starting a new one, same as `stripe logout`.
+		if err := login.RevokeToken(cmd.Context(), lc.accessBaseURL); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: token revocation failed: %s\n", err)
 		}
 	}
 

--- a/pkg/cmd/login_test.go
+++ b/pkg/cmd/login_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/keyring"
+)
+
+// TestLoginNewSessionRevokesPreviousToken verifies that `stripe login --new-session`
+// revokes the previously stored OAuth token, same as `stripe logout`, before
+// starting a new login flow.
+func TestLoginNewSessionRevokesPreviousToken(t *testing.T) {
+	var revokeCalled bool
+
+	accessSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/stripecli/oauth2/revoke":
+			revokeCalled = true
+			require.NoError(t, r.ParseForm())
+			assert.Equal(t, "oart_previous_refresh", r.FormValue("token"))
+			w.WriteHeader(http.StatusOK)
+		case "/stripecli/oauth2/device/authorization":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"device_code":"dc","user_code":"uc","verification_uri":"https://dashboard.stripe.com/verify","expires_in":600,"interval":5}`))
+		default:
+			t.Fatalf("unexpected request to %s", r.URL.Path)
+		}
+	}))
+	defer accessSrv.Close()
+
+	dashboardSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A 3xx response from /stripecli/auth signals that the OAuth device-code
+		// flow (rather than the legacy RAK flow) should be used.
+		w.Header().Set("Location", "https://dashboard.stripe.com/")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer dashboardSrv.Close()
+
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	Config = config.Config{
+		LogLevel: "info",
+		Profile: config.Profile{
+			ProfileName: "default",
+			DeviceName:  "test-device",
+		},
+		ProfilesFile: profilesFile,
+	}
+	Config.InitConfig()
+
+	config.KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		config.UATKeychainItemKey:           []byte("oak_previous_uat"),
+		config.OAuthRefreshTokenKeychainKey: []byte("oart_previous_refresh"),
+	})
+	t.Cleanup(func() {
+		config.KeyRing = nil
+		viper.Reset()
+	})
+
+	lc := newLoginCmd()
+	lc.newSession = true
+	lc.nonInteractive = true
+	lc.dashboardBaseURL = dashboardSrv.URL
+	lc.accessBaseURL = accessSrv.URL
+	lc.cmd.SetContext(context.Background())
+
+	require.NoError(t, lc.runLoginCmd(lc.cmd, []string{}))
+	assert.True(t, revokeCalled, "expected --new-session to revoke the previous OAuth token")
+}

--- a/pkg/cmd/login_test.go
+++ b/pkg/cmd/login_test.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"path/filepath"
 	"testing"
 
@@ -18,32 +16,31 @@ import (
 // TestLoginNewSessionRevokesPreviousToken verifies that `stripe login --new-session`
 // revokes the previously stored OAuth token, same as `stripe logout`, before
 // starting a new login flow.
+//
+// revokeToken and initiateLogin are stubbed rather than backed by an
+// httptest server: --access-base is validated against a hardcoded
+// production/QA allowlist before any of this logic runs (it carries OAuth
+// credentials), so a mock server URL can never be assigned to it.
 func TestLoginNewSessionRevokesPreviousToken(t *testing.T) {
-	var revokeCalled bool
+	origRevokeToken, origInitiateLogin := revokeToken, initiateLogin
+	t.Cleanup(func() {
+		revokeToken = origRevokeToken
+		initiateLogin = origInitiateLogin
+	})
 
-	accessSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/stripecli/oauth2/revoke":
-			revokeCalled = true
-			require.NoError(t, r.ParseForm())
-			assert.Equal(t, "oart_previous_refresh", r.FormValue("token"))
-			w.WriteHeader(http.StatusOK)
-		case "/stripecli/oauth2/device/authorization":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"device_code":"dc","user_code":"uc","verification_uri":"https://dashboard.stripe.com/verify","expires_in":600,"interval":5}`))
-		default:
-			t.Fatalf("unexpected request to %s", r.URL.Path)
-		}
-	}))
-	defer accessSrv.Close()
-
-	dashboardSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// A 3xx response from /stripecli/auth signals that the OAuth device-code
-		// flow (rather than the legacy RAK flow) should be used.
-		w.Header().Set("Location", "https://dashboard.stripe.com/")
-		w.WriteHeader(http.StatusFound)
-	}))
-	defer dashboardSrv.Close()
+	var revokeCalled, initiateLoginCalled bool
+	revokeToken = func(ctx context.Context, accessBaseURL string) error {
+		revokeCalled = true
+		rt, err := config.KeyRing.Get(config.OAuthRefreshTokenKeychainKey)
+		require.NoError(t, err)
+		assert.Equal(t, "oart_previous_refresh", string(rt))
+		return nil
+	}
+	initiateLogin = func(ctx context.Context, dashboardBaseURL, accessBaseURL string, cfg *config.Config) error {
+		initiateLoginCalled = true
+		assert.True(t, revokeCalled, "expected the previous session to be revoked before continuing")
+		return nil
+	}
 
 	profilesFile := filepath.Join(t.TempDir(), "config.toml")
 	Config = config.Config{
@@ -68,10 +65,9 @@ func TestLoginNewSessionRevokesPreviousToken(t *testing.T) {
 	lc := newLoginCmd()
 	lc.newSession = true
 	lc.nonInteractive = true
-	lc.dashboardBaseURL = dashboardSrv.URL
-	lc.accessBaseURL = accessSrv.URL
 	lc.cmd.SetContext(context.Background())
 
 	require.NoError(t, lc.runLoginCmd(lc.cmd, []string{}))
 	assert.True(t, revokeCalled, "expected --new-session to revoke the previous OAuth token")
+	assert.True(t, initiateLoginCalled, "expected login to continue after revoking")
 }


### PR DESCRIPTION
### Summary

Mirrors `stripe logout`'s revocation behavior so the old session is invalidated server-side before a new one is established, rather than left valid until it expires naturally.

### Testing

Ran `stripe login --new-session` a couple times with both the released build and this branch. I then went to /settings/user in the Dashboard and saw the right behavior.