### PR TITLE
Restrict --access-base to the real access-srv origins

### DIFF
--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -143,6 +143,9 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 	if err := stripe.ValidateDashboardBaseURL(lc.dashboardBaseURL); err != nil {
 		return err
 	}
+	if err := login.ValidateAccessBaseURL(lc.accessBaseURL); err != nil {
+		return err
+	}
 
 	if lc.completeDevice {
 		return login.PollPendingDeviceAuth(cmd.Context(), &Config)
@@ -190,6 +193,9 @@ func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
 func (lc *loginListCmd) listLoggedInAccountsCmd(cmd *cobra.Command, args []string) error {
 	uat, _ := Config.Profile.GetUAT()
 	if strings.HasPrefix(uat, "oak_") {
+		if err := login.ValidateAccessBaseURL(lc.accessBaseURL); err != nil {
+			return err
+		}
 		return login.PrintAuthorizedContexts(cmd.Context(), lc.accessBaseURL, uat)
 	}
 	return Config.ListProfiles()
@@ -198,6 +204,9 @@ func (lc *loginListCmd) listLoggedInAccountsCmd(cmd *cobra.Command, args []strin
 func (lc *loginSwitchCmd) switchLoggedInAccountCmd(cmd *cobra.Command, args []string) error {
 	uat, _ := Config.Profile.GetUAT()
 	if strings.HasPrefix(uat, "oak_") {
+		if err := login.ValidateAccessBaseURL(lc.accessBaseURL); err != nil {
+			return err
+		}
 		accountID := ""
 		if len(args) > 0 {
 			accountID = args[0]

--- a/pkg/cmd/logout.go
+++ b/pkg/cmd/logout.go
@@ -33,6 +33,9 @@ func newLogoutCmd() *logoutCmd {
 }
 
 func (lc *logoutCmd) runLogoutCmd(cmd *cobra.Command, args []string) error {
+	if err := login.ValidateAccessBaseURL(lc.accessBaseURL); err != nil {
+		return err
+	}
 	if lc.all {
 		return logout.All(cmd.Context(), lc.accessBaseURL, &Config)
 	}

--- a/pkg/cmd/logout_test.go
+++ b/pkg/cmd/logout_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/keyring"
+)
+
+func TestLogoutRejectsArbitraryAccessBaseWithoutSendingRefreshToken(t *testing.T) {
+	var requestReceived bool
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	config.KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		config.UATKeychainItemKey:           []byte("oak_live_secret_token"),
+		config.OAuthRefreshTokenKeychainKey: []byte("oart_secret_refresh"),
+	})
+	t.Cleanup(func() { config.KeyRing = nil })
+
+	lc := newLogoutCmd()
+	lc.accessBaseURL = attacker.URL
+
+	err := lc.runLogoutCmd(lc.cmd, []string{})
+	require.Error(t, err)
+	assert.False(t, requestReceived, "an arbitrary --access-base must be rejected before any revocation request is sent")
+
+	_, err = config.KeyRing.Get(config.OAuthRefreshTokenKeychainKey)
+	assert.NoError(t, err, "credentials must remain intact when the access-base is rejected")
+}

--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -92,6 +92,9 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	if err := stripe.ValidateDashboardBaseURL(dashboardBaseURL); err != nil {
 		return err
 	}
+	if err := login.ValidateAccessBaseURL(ic.accessBaseURL); err != nil {
+		return err
+	}
 
 	color := ansi.Color(os.Stdout)
 	pluginName, version := parseInstallArg(args[0])

--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -142,6 +142,10 @@ func newPluginHintCmd(cfg *config.Config, name, description string, opts ...opti
 }
 
 func (p *pluginHintCmd) run(cmd *cobra.Command, args []string) error {
+	if err := login.ValidateAccessBaseURL(p.accessBaseURL); err != nil {
+		return err
+	}
+
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()

--- a/pkg/cmd/pluginhints/pluginhints_test.go
+++ b/pkg/cmd/pluginhints/pluginhints_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/login"
 )
 
 // newTestCmd builds a pluginHintCmd with all side effects mocked out.
@@ -21,12 +22,13 @@ import (
 // need to simulate an unauthenticated user.
 func newTestCmd(name string, opts ...option) *pluginHintCmd {
 	p := &pluginHintCmd{
-		name:        name,
-		description: "Test description.",
-		stdout:      &bytes.Buffer{},
-		stdin:       strings.NewReader(""),
-		accountIDFn: func() (string, error) { return "acct_test", nil },
-		loginFn:     func(ctx context.Context) error { return nil },
+		name:          name,
+		description:   "Test description.",
+		stdout:        &bytes.Buffer{},
+		stdin:         strings.NewReader(""),
+		accountIDFn:   func() (string, error) { return "acct_test", nil },
+		loginFn:       func(ctx context.Context) error { return nil },
+		accessBaseURL: login.DefaultAccessBaseURL,
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -176,6 +178,7 @@ func TestRun_PluginNotFound_PrivatePreviewTrue_ExitsWithOne(t *testing.T) {
 			privatePreview: true,
 			stdout:         os.Stdout,
 			stdin:          strings.NewReader(""),
+			accessBaseURL:  login.DefaultAccessBaseURL,
 		}
 		p.Command = &cobra.Command{Use: "generate", RunE: p.run}
 		p.lookupFn = func(ctx context.Context) error { return errors.New("not found") }

--- a/pkg/cmd/reauth.go
+++ b/pkg/cmd/reauth.go
@@ -34,6 +34,9 @@ Opens the Stripe Dashboard so you can re-consent for the current OAuth session.`
 }
 
 func (rc *reauthCmd) runReauthCmd(cmd *cobra.Command, args []string) error {
+	if err := login.ValidateAccessBaseURL(rc.accessBaseURL); err != nil {
+		return err
+	}
 	uat, _ := Config.Profile.GetUAT()
 	if !strings.HasPrefix(uat, "oak_") {
 		return errorcategory.Errorf(errorcategory.Auth, "reauth requires an OAuth session; run 'stripe login' to authenticate")

--- a/pkg/cmd/reauth_test.go
+++ b/pkg/cmd/reauth_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/keyring"
+)
+
+func TestReauthRejectsArbitraryAccessBaseWithoutSendingUAT(t *testing.T) {
+	var requestReceived bool
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived = true
+		assert.Empty(t, r.Header.Get("Authorization"), "attacker-controlled server must never see the UAT")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	config.KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		config.UATKeychainItemKey: []byte("oak_live_secret_token"),
+	})
+	t.Cleanup(func() { config.KeyRing = nil })
+
+	rc := newReauthCmd()
+	rc.accessBaseURL = attacker.URL
+
+	err := rc.runReauthCmd(rc.cmd, []string{})
+	require.Error(t, err)
+	assert.False(t, requestReceived, "an arbitrary --access-base must be rejected before any reauth request is sent")
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -68,9 +68,18 @@ var rootCmd = &cobra.Command{
 %s`,
 		getLogin(&fs, &Config),
 	),
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if cmd.Name() == "help" {
 			fullHelpMode = true
+		}
+
+		// --access-base is a hidden persistent flag accepted by every command, and
+		// feeds the OAuth token refresher below, which runs silently on any command
+		// using a stored OAuth session. Reject anything other than the real
+		// access-srv origins before it's used for that (or any other) purpose, so
+		// it can't be used to exfiltrate the UAT or refresh token.
+		if err := login.ValidateAccessBaseURL(rootAccessBaseURL); err != nil {
+			return err
 		}
 
 		// Make the --access-base value available to the OAuth token refresher,
@@ -104,6 +113,7 @@ var rootCmd = &cobra.Command{
 			// record command invocation
 			sendCommandInvocationEvent(cmd.Context())
 		}
+		return nil
 	},
 }
 

--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -111,6 +111,10 @@ work immediately.`,
 }
 
 func (scc *sandboxCreateCmd) runSandboxCreateCmd(cmd *cobra.Command, args []string) error {
+	if err := login.ValidateAccessBaseURL(scc.accessBaseURL); err != nil {
+		return err
+	}
+
 	color := ansi.Color(cmd.ErrOrStderr())
 
 	existingKey, _ := Config.Profile.GetAPIKey(false)

--- a/pkg/cmd/switch.go
+++ b/pkg/cmd/switch.go
@@ -50,6 +50,9 @@ Use --live to switch to livemode instead.`,
 }
 
 func (sc *switchContextCmd) run(cmd *cobra.Command, args []string) error {
+	if err := login.ValidateAccessBaseURL(sc.accessBaseURL); err != nil {
+		return err
+	}
 	accountID := ""
 	if len(args) > 0 {
 		accountID = args[0]

--- a/pkg/cmd/switch_test.go
+++ b/pkg/cmd/switch_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/keyring"
+)
+
+func TestSwitchContextRejectsArbitraryAccessBaseWithoutSendingUAT(t *testing.T) {
+	var requestReceived bool
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived = true
+		assert.Empty(t, r.Header.Get("Authorization"), "attacker-controlled server must never see the UAT")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	config.KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		config.UATKeychainItemKey: []byte("oak_live_secret_token"),
+	})
+	t.Cleanup(func() { config.KeyRing = nil })
+
+	sc := &switchContextCmd{accessBaseURL: attacker.URL}
+	sc.cmd = newSwitchCmd().cmd.Commands()[0]
+
+	err := sc.run(sc.cmd, []string{})
+	require.Error(t, err)
+	assert.False(t, requestReceived, "an arbitrary --access-base must be rejected before any request is sent")
+}

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -83,6 +83,9 @@ func (wc *whoamiCmd) runWhoamiCmd(cmd *cobra.Command, args []string) error {
 
 	uat, _ := profile.GetUAT()
 	if strings.HasPrefix(uat, "oak_") {
+		if err := login.ValidateAccessBaseURL(wc.accessBaseURL); err != nil {
+			return err
+		}
 		return wc.runWhoamiOAuth(cmd, uat)
 	}
 

--- a/pkg/cmd/whoami_test.go
+++ b/pkg/cmd/whoami_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -178,6 +180,32 @@ func TestWhoamiLiveModeKeyDetected(t *testing.T) {
 
 	assert.True(t, result.Authenticated)
 	assert.True(t, result.LiveModeKey.Available)
+}
+
+func TestWhoamiOAuth_RejectsArbitraryAccessBaseWithoutSendingUAT(t *testing.T) {
+	config.KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		config.UATKeychainItemKey: []byte("oak_live_secret_token"),
+	})
+	t.Cleanup(func() { config.KeyRing = nil })
+
+	var requestReceived bool
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived = true
+		assert.Empty(t, r.Header.Get("Authorization"), "attacker-controlled server must never see the UAT")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	wc := newWhoamiCmd()
+	wc.profile = &config.Profile{
+		ProfileName: "default",
+		DeviceName:  "test-device",
+	}
+	wc.accessBaseURL = attacker.URL
+
+	_, err := runWhoami(t, wc)
+	require.Error(t, err)
+	assert.False(t, requestReceived, "an arbitrary --access-base must be rejected before any request is sent")
 }
 
 func TestKeyAvailabilityText(t *testing.T) {

--- a/pkg/login/access_base.go
+++ b/pkg/login/access_base.go
@@ -1,0 +1,62 @@
+package login
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+)
+
+var errInvalidAccessBaseURL = errorcategory.New(errorcategory.UserInput,
+	"invalid access base URL: must be exactly https://access.stripe.com or https://qa-access.stripe.com")
+
+// ValidateAccessBaseURL returns an error unless accessBaseURL is exactly the
+// production or QA access-srv origin.
+//
+// Requests built from this value carry the OAuth user access token
+// (Authorization: Bearer) or the stored refresh token (form body), so unlike
+// --api-base/--dashboard-base there is no dev-host, localhost, or path
+// allowance: any scheme, host, port, userinfo, path, query, or fragment
+// other than these two exact strings risks sending live credentials to an
+// attacker-controlled destination.
+func ValidateAccessBaseURL(accessBaseURL string) error {
+	if accessBaseURL == DefaultAccessBaseURL || accessBaseURL == QAAccessBaseURL {
+		return nil
+	}
+	return errInvalidAccessBaseURL
+}
+
+// accessSrvHTTPClient is used for every request to access-srv. Redirects are
+// disabled: an access-srv redirect response could otherwise cause the
+// Authorization header or POST body (which may carry the OAuth access or
+// refresh token) to be forwarded to a different, redirect-controlled origin.
+var accessSrvHTTPClient = &http.Client{
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+// dashboardHostForAccessBaseURL returns the dashboard host that legitimately
+// issues browser URLs (verification, reauth) for the given access-srv origin.
+func dashboardHostForAccessBaseURL(accessBaseURL string) string {
+	if accessBaseURL == QAAccessBaseURL {
+		return "qa-dashboard.stripe.com"
+	}
+	return "dashboard.stripe.com"
+}
+
+// validateBrowserURL returns an error unless rawURL is an https URL on the
+// dashboard host matching accessBaseURL. access-srv responses that embed a
+// browser URL (device-code verification, reauth) are checked here before the
+// CLI displays or opens them, so a compromised or misconfigured access-srv
+// can't redirect the user's browser to an arbitrary destination.
+func validateBrowserURL(rawURL, accessBaseURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return errorcategory.Errorf(errorcategory.Auth, "access-srv returned an unparseable URL: %s", rawURL)
+	}
+	if u.Scheme != "https" || u.Host != dashboardHostForAccessBaseURL(accessBaseURL) {
+		return errorcategory.Errorf(errorcategory.Auth, "refusing to display or open untrusted URL returned by access-srv: %s", rawURL)
+	}
+	return nil
+}

--- a/pkg/login/access_base.go
+++ b/pkg/login/access_base.go
@@ -36,27 +36,34 @@ var accessSrvHTTPClient = &http.Client{
 	},
 }
 
-// dashboardHostForAccessBaseURL returns the dashboard host that legitimately
-// issues browser URLs (verification, reauth) for the given access-srv origin.
-func dashboardHostForAccessBaseURL(accessBaseURL string) string {
+// trustedBrowserHosts returns the hosts that may legitimately appear in a
+// browser URL for the given access-srv origin: the access-srv host itself
+// (device-code verification URIs are hosted there) and the corresponding
+// dashboard host (reauthentication URIs are hosted there).
+func trustedBrowserHosts(accessBaseURL string) []string {
 	if accessBaseURL == QAAccessBaseURL {
-		return "qa-dashboard.stripe.com"
+		return []string{"qa-access.stripe.com", "qa-dashboard.stripe.com"}
 	}
-	return "dashboard.stripe.com"
+	return []string{"access.stripe.com", "dashboard.stripe.com"}
 }
 
-// validateBrowserURL returns an error unless rawURL is an https URL on the
-// dashboard host matching accessBaseURL. access-srv responses that embed a
-// browser URL (device-code verification, reauth) are checked here before the
-// CLI displays or opens them, so a compromised or misconfigured access-srv
-// can't redirect the user's browser to an arbitrary destination.
+// validateBrowserURL returns an error unless rawURL is an https URL on a host
+// trusted for accessBaseURL. access-srv responses that embed a browser URL
+// (device-code verification, reauth) are checked here before the CLI
+// displays or opens them, so a compromised or misconfigured access-srv can't
+// redirect the user's browser to an arbitrary destination.
 func validateBrowserURL(rawURL, accessBaseURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return errorcategory.Errorf(errorcategory.Auth, "access-srv returned an unparseable URL: %s", rawURL)
 	}
-	if u.Scheme != "https" || u.Host != dashboardHostForAccessBaseURL(accessBaseURL) {
+	if u.Scheme != "https" {
 		return errorcategory.Errorf(errorcategory.Auth, "refusing to display or open untrusted URL returned by access-srv: %s", rawURL)
 	}
-	return nil
+	for _, host := range trustedBrowserHosts(accessBaseURL) {
+		if u.Host == host {
+			return nil
+		}
+	}
+	return errorcategory.Errorf(errorcategory.Auth, "refusing to display or open untrusted URL returned by access-srv: %s", rawURL)
 }

--- a/pkg/login/access_base_test.go
+++ b/pkg/login/access_base_test.go
@@ -35,7 +35,11 @@ func TestValidateAccessBaseURL_RejectsArbitraryBases(t *testing.T) {
 	}
 }
 
-func TestValidateBrowserURL_AllowsMatchingDashboardHost(t *testing.T) {
+func TestValidateBrowserURL_AllowsMatchingAccessSrvOrDashboardHost(t *testing.T) {
+	// Device-code verification URIs are hosted on access-srv itself.
+	assert.NoError(t, validateBrowserURL("https://access.stripe.com/stripecli/oauth2/device", DefaultAccessBaseURL))
+	assert.NoError(t, validateBrowserURL("https://qa-access.stripe.com/stripecli/oauth2/device", QAAccessBaseURL))
+	// Reauthentication URIs are hosted on the dashboard.
 	assert.NoError(t, validateBrowserURL("https://dashboard.stripe.com/verify", DefaultAccessBaseURL))
 	assert.NoError(t, validateBrowserURL("https://qa-dashboard.stripe.com/verify", QAAccessBaseURL))
 }
@@ -47,7 +51,9 @@ func TestValidateBrowserURL_RejectsMismatchedOrUntrustedURLs(t *testing.T) {
 	}{
 		"wrong scheme":               {"http://dashboard.stripe.com/verify", DefaultAccessBaseURL},
 		"arbitrary host":             {"https://evil.example.com/verify", DefaultAccessBaseURL},
+		"qa access used for prod":    {"https://qa-access.stripe.com/verify", DefaultAccessBaseURL},
 		"qa dashboard used for prod": {"https://qa-dashboard.stripe.com/verify", DefaultAccessBaseURL},
+		"prod access used for qa":    {"https://access.stripe.com/verify", QAAccessBaseURL},
 		"prod dashboard used for qa": {"https://dashboard.stripe.com/verify", QAAccessBaseURL},
 		"unparseable URL":            {"https://[::1", DefaultAccessBaseURL},
 	}

--- a/pkg/login/access_base_test.go
+++ b/pkg/login/access_base_test.go
@@ -1,0 +1,60 @@
+package login
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateAccessBaseURL_AllowsExactProdAndQAOrigins(t *testing.T) {
+	assert.NoError(t, ValidateAccessBaseURL(DefaultAccessBaseURL))
+	assert.NoError(t, ValidateAccessBaseURL(QAAccessBaseURL))
+}
+
+func TestValidateAccessBaseURL_RejectsArbitraryBases(t *testing.T) {
+	cases := map[string]string{
+		"http scheme":             "http://access.stripe.com",
+		"userinfo":                "https://attacker@access.stripe.com",
+		"unexpected port":         "https://access.stripe.com:8443",
+		"path suffix":             "https://access.stripe.com/../attacker.com",
+		"query string":            "https://access.stripe.com?redirect=evil.com",
+		"fragment":                "https://access.stripe.com#evil.com",
+		"lookalike host suffix":   "https://access.stripe.com.evil.com",
+		"lookalike host prefix":   "https://evil-access.stripe.com",
+		"arbitrary attacker host": "https://evil.example.com",
+		"trailing slash":          "https://access.stripe.com/",
+		"empty string":            "",
+		"local dev override":      "http://localhost:8080",
+		"qa lookalike":            "https://qa-access.stripe.com.evil.com",
+	}
+
+	for name, base := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Error(t, ValidateAccessBaseURL(base))
+		})
+	}
+}
+
+func TestValidateBrowserURL_AllowsMatchingDashboardHost(t *testing.T) {
+	assert.NoError(t, validateBrowserURL("https://dashboard.stripe.com/verify", DefaultAccessBaseURL))
+	assert.NoError(t, validateBrowserURL("https://qa-dashboard.stripe.com/verify", QAAccessBaseURL))
+}
+
+func TestValidateBrowserURL_RejectsMismatchedOrUntrustedURLs(t *testing.T) {
+	cases := map[string]struct {
+		url           string
+		accessBaseURL string
+	}{
+		"wrong scheme":               {"http://dashboard.stripe.com/verify", DefaultAccessBaseURL},
+		"arbitrary host":             {"https://evil.example.com/verify", DefaultAccessBaseURL},
+		"qa dashboard used for prod": {"https://qa-dashboard.stripe.com/verify", DefaultAccessBaseURL},
+		"prod dashboard used for qa": {"https://dashboard.stripe.com/verify", QAAccessBaseURL},
+		"unparseable URL":            {"https://[::1", DefaultAccessBaseURL},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Error(t, validateBrowserURL(tc.url, tc.accessBaseURL))
+		})
+	}
+}

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -96,6 +96,9 @@ func initiateOAuthDeviceLogin(ctx context.Context, accessBaseURL string) error {
 	if err != nil {
 		return fmt.Errorf("failed to request device code: %w", err)
 	}
+	if err := validateBrowserURL(authResp.VerificationURI, accessBaseURL); err != nil {
+		return err
+	}
 
 	cont := &oauthContinuation{
 		DeviceCode:    authResp.DeviceCode,
@@ -157,6 +160,10 @@ func PollPendingDeviceAuth(ctx context.Context, cfg *config.Config) error {
 	}
 	// Remove the pending file whether polling succeeds or fails.
 	defer clearPendingDeviceAuth()
+
+	if err := ValidateAccessBaseURL(cont.AccessBaseURL); err != nil {
+		return err
+	}
 
 	clientID := clientIDForAccessBaseURL(cont.AccessBaseURL)
 	interval := max(time.Duration(cont.Interval)*time.Second, 5*time.Second)

--- a/pkg/login/oauth_accounts.go
+++ b/pkg/login/oauth_accounts.go
@@ -30,7 +30,7 @@ func fetchAuthorizedAccounts(ctx context.Context, accessBaseURL, accessToken str
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := accessSrvHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/login/oauth_credentials.go
+++ b/pkg/login/oauth_credentials.go
@@ -71,7 +71,7 @@ func RevokeToken(ctx context.Context, accessBaseURL string) error {
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := accessSrvHTTPClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/login/oauth_credentials_test.go
+++ b/pkg/login/oauth_credentials_test.go
@@ -1,6 +1,9 @@
 package login
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
 
@@ -118,6 +121,32 @@ func TestClearOAuthCredentials(t *testing.T) {
 
 	_, err = config.KeyRing.Get(OAuthRefreshTokenKeychainKey)
 	assert.Error(t, err, "refresh token should be removed")
+}
+
+func TestRevokeToken_DoesNotFollowRedirectToAttackerHost(t *testing.T) {
+	_, cleanup := setupOAuthTestConfig(t)
+	defer cleanup()
+
+	var attackerReceivedRefreshToken bool
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.FormValue("token") == "oart_secret_refresh" {
+			attackerReceivedRefreshToken = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	accessSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/stripecli/oauth2/revoke", http.StatusTemporaryRedirect)
+	}))
+	defer accessSrv.Close()
+
+	require.NoError(t, config.KeyRing.Set(OAuthRefreshTokenKeychainKey, []byte("oart_secret_refresh"), ""))
+
+	err := RevokeToken(context.Background(), accessSrv.URL)
+	require.Error(t, err, "the disabled redirect must surface as a non-2xx/redirect response, not a followed request")
+	assert.False(t, attackerReceivedRefreshToken, "the refresh token must never reach a redirect-controlled host")
 }
 
 func TestClearOAuthCredentials_NoExistingTokens(t *testing.T) {

--- a/pkg/login/oauth_device.go
+++ b/pkg/login/oauth_device.go
@@ -175,6 +175,9 @@ func LoginWithDeviceCode(ctx context.Context, accessBaseURL string, cfg *config.
 	if err != nil {
 		return fmt.Errorf("failed to request device code: %w", err)
 	}
+	if err := validateBrowserURL(authResp.VerificationURI, accessBaseURL); err != nil {
+		return err
+	}
 
 	color := ansi.Color(os.Stdout)
 	fmt.Printf("Your pairing code is: %s\n", color.Bold(authResp.UserCode))
@@ -345,5 +348,5 @@ func doPostForm(ctx context.Context, endpoint string, data url.Values) (*http.Re
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	return http.DefaultClient.Do(req)
+	return accessSrvHTTPClient.Do(req)
 }

--- a/pkg/login/oauth_device_test.go
+++ b/pkg/login/oauth_device_test.go
@@ -241,7 +241,7 @@ func TestLoginWithDeviceCodeFailsWhenAccountsFetchFails(t *testing.T) {
 			json.NewEncoder(w).Encode(DeviceAuthResponse{ //nolint:errcheck
 				DeviceCode:      "device-code",
 				UserCode:        "ABCD-EFGH",
-				VerificationURI: "https://example.com/verify",
+				VerificationURI: "https://dashboard.stripe.com/verify",
 				ExpiresIn:       30,
 				Interval:        1,
 			})

--- a/pkg/login/oauth_reauth.go
+++ b/pkg/login/oauth_reauth.go
@@ -26,6 +26,9 @@ func Reauth(ctx context.Context, accessBaseURL, accessToken string) error {
 	if err != nil {
 		return err
 	}
+	if err := validateBrowserURL(reauthURL, accessBaseURL); err != nil {
+		return err
+	}
 
 	if !isSSH() && canOpenBrowser() {
 		fmt.Println("Opening the Stripe Dashboard to re-authorize the CLI...")
@@ -47,7 +50,7 @@ func fetchReauthURL(ctx context.Context, accessBaseURL, accessToken string) (str
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := accessSrvHTTPClient.Do(req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### Summary

Adds validation to the `--access-base` to ensure it can only be set to known domains, i.e. the ones for prod and QA

### Testing

No flag set, everything points to prod

<img width="819" height="439" alt="Screenshot 2026-08-14 at 1 01 33 PM" src="https://github.com/user-attachments/assets/6d08fd86-94e6-4a1a-9609-7c342cda701d" />

Flag set to QA, everything points to QA

<img width="980" height="533" alt="Screenshot 2026-08-14 at 1 01 45 PM" src="https://github.com/user-attachments/assets/61503ba6-a46b-4c16-bb4c-d0c8afb1b4b0" />

Error when flag set to unknown value

<img width="844" height="85" alt="Screenshot 2026-08-14 at 1 02 05 PM" src="https://github.com/user-attachments/assets/a2ec709b-7658-449c-a8b3-fc3570ad594f" />

Legacy flow still works

<img width="994" height="198" alt="Screenshot 2026-08-14 at 1 02 36 PM" src="https://github.com/user-attachments/assets/36c6e40c-65e3-40ee-88db-34d9eee4eb44" />