### PR TITLE
Harden GitHub Actions workflows against supply-chain attacks

### DIFF
--- a/.github/actions/install-stripe-cli/action.yml
+++ b/.github/actions/install-stripe-cli/action.yml
@@ -22,7 +22,10 @@ runs:
     - name: Install Stripe CLI on Windows
       if: runner.os == 'Windows'
       shell: powershell
-      run: |
+      # The GITHUB_PATH write below is unavoidable for exposing the installed
+      # binary to later steps. The value is not attacker-controlled: it is the
+      # directory of the stripe binary that winget just installed.
+      run: | # zizmor: ignore[github-env] path comes from the winget install, not from input
         winget install Stripe.StripeCli -e --source winget --accept-package-agreements --accept-source-agreements
         $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH", "User")
         $stripeDir = Split-Path (Get-Command stripe).Source

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+# Workflow actions are pinned to full commit SHAs (see .github/workflows/*.yml),
+# which means they never pick up upstream fixes on their own. Dependabot opens
+# the PRs that move those pins forward; it understands the `# vX.Y.Z` comment
+# next to each SHA and keeps it in sync.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      # One PR for routine action bumps rather than a dozen.
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/autoupgrade-test-trigger.yml
+++ b/.github/workflows/autoupgrade-test-trigger.yml
@@ -3,13 +3,14 @@ on:
     - cron: '*/10 * * * *' # Every 10 minutes
   workflow_dispatch:
 name: Auto-upgrade test (trigger)
-permissions:
-  actions: write
-  contents: read
+permissions: {}
 jobs:
   dispatch:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      actions: write # `gh workflow run` dispatches autoupgrade-test.yml on the v2 branch
+      contents: read # `gh` resolves repo metadata
     steps:
       # The dispatch API intermittently returns HTTP 503, which fails the run
       # even though a retry succeeds. Retry with backoff before giving up.

--- a/.github/workflows/canary-test.yml
+++ b/.github/workflows/canary-test.yml
@@ -50,17 +50,21 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26.5'
 
       - name: Build binary (production-like)
+        env:
+          BINARY: ${{ matrix.binary }}
         run: |
           go generate ./...
-          CGO_ENABLED=0 go build -ldflags="-s -w" -o ${{ matrix.binary }} ./cmd/stripe
+          CGO_ENABLED=0 go build -ldflags="-s -w" -o "$BINARY" ./cmd/stripe
         shell: bash
 
       - name: Run offline canary tests

--- a/.github/workflows/curl-install-test.yml
+++ b/.github/workflows/curl-install-test.yml
@@ -36,11 +36,12 @@ jobs:
     needs: [curl-install-macos, curl-install-linux]
     if: always()
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: |
             scripts/notify.sh
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - run: bash scripts/notify.sh
         env:
           OVERALL_RESULT: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}

--- a/.github/workflows/data-analytics-canary.yml
+++ b/.github/workflows/data-analytics-canary.yml
@@ -27,10 +27,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26.5'
 

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -16,11 +16,12 @@ jobs:
     outputs:
       install_test_result: ${{ steps.install_test.outcome }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - id: install_test
         run: bash scripts/install-test.sh homebrew
   homebrew-core:
@@ -28,11 +29,12 @@ jobs:
     outputs:
       install_test_result: ${{ steps.install_test.outcome }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - id: install_test
         run: bash scripts/install-test.sh homebrew-core
   apt:
@@ -40,16 +42,19 @@ jobs:
     outputs:
       install_test_result: ${{ steps.install_test.outcome }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - id: install_test
         run: bash scripts/install-test.sh apt
   yum:
     runs-on: ubuntu-latest
-    container: fedora:latest
+    # Pinned to the Fedora 44 multi-arch index. Bump this digest when moving to
+    # a newer Fedora; the RPM itself is what this job exercises, not the distro.
+    container: fedora@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898 # fedora:latest (F44)
     outputs:
       install_test_result: ${{ steps.install_test.outcome }}
     steps:
@@ -63,11 +68,12 @@ jobs:
           enabled=1
           gpgcheck=0" | sudo tee /etc/yum.repos.d/stripe.repo
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - id: install_test
         run: bash scripts/install-test.sh yum
   scoop:
@@ -75,12 +81,13 @@ jobs:
     outputs:
       install_test_result: ${{ steps.install_test.outcome }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         sparse-checkout: |
           scripts/install-test.sh
         sparse-checkout-cone-mode: false
-    - uses: MinoruSekine/setup-scoop@v4
+        persist-credentials: false
+    - uses: MinoruSekine/setup-scoop@f1cc59be496ed3a1801a5f64efe5c60ba3d6bb75 # v5.0.1
     - id: install_test
       shell: powershell
       run: bash scripts/install-test.sh scoop
@@ -89,25 +96,30 @@ jobs:
     outputs:
       install_test_result: ${{ steps.install_test.outcome }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         sparse-checkout: |
           scripts/install-test.sh
         sparse-checkout-cone-mode: false
+        persist-credentials: false
     - id: install_test
       shell: powershell
       run: bash scripts/install-test.sh winget
   docker:
     runs-on: ubuntu-latest
-    container: stripe/stripe-cli:latest
+    # Deliberately unpinned: this canary exists to verify that the *currently
+    # published* image works. Pinning a digest here would mean we stop noticing
+    # when a freshly released stripe/stripe-cli:latest is broken.
+    container: stripe/stripe-cli:latest # zizmor: ignore[unpinned-images] floating tag is intentional here
     outputs:
       install_test_result: ${{ steps.install_test.outcome }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - id: install_test
         run: sh scripts/install-test.sh docker
 
@@ -119,12 +131,13 @@ jobs:
     outputs:
       install_test_result: ${{ steps.install_test.outcome }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v6
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
       - id: install_test
@@ -135,12 +148,13 @@ jobs:
     outputs:
       install_test_result: ${{ steps.install_test.outcome }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v6
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
       - id: install_test
@@ -151,17 +165,20 @@ jobs:
     outputs:
       install_test_result: ${{ steps.install_test.outcome }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: |
             scripts/install-test.sh
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v6
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
       # npm 10 has a bug where conflicting bin entries across a package and its
       # optional dependency silently drop the bin link, causing "stripe: not found".
-      - run: npm install -g npm@11
+      # Installing a pinned npm outside a lockfile is the whole point here, and
+      # this job installs no project dependencies.
+      - run: npm install -g npm@11 # zizmor: ignore[adhoc-packages] pinned, and no project deps here
       - id: install_test
         run: bash scripts/install-test.sh npx
 
@@ -170,11 +187,12 @@ jobs:
     needs: [homebrew, homebrew-core, apt, yum, scoop, winget, docker, npm, npm-no-optional, npx]
     if: always()
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: |
             scripts/notify.sh
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - run: bash scripts/notify.sh
         env:
           OVERALL_RESULT: ${{ contains(needs.*.outputs.install_test_result, 'failure') && 'failure' || contains(needs.*.result, 'failure') && 'skip' || 'success' }}

--- a/.github/workflows/plugin-canary.yml
+++ b/.github/workflows/plugin-canary.yml
@@ -30,7 +30,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Install Stripe CLI
         uses: ./.github/actions/install-stripe-cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,16 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-  id-token: write # Required for OIDC to npm
+# No workflow-wide permissions: each job below opts in to only what it needs.
+# `contents: write` is limited to the three GoReleaser jobs that publish the
+# release, and `id-token: write` to the single job that publishes to npm.
+permissions: {}
 
 jobs:
   canary-tests:
     uses: ./.github/workflows/canary-test.yml
+    permissions:
+      contents: read
     with:
       run_api_tests: true
     secrets:
@@ -21,20 +24,24 @@ jobs:
     needs: [canary-tests]
     runs-on: ubuntu-latest
     environment: release
+    permissions: {}
     steps:
       - run: echo "Release approved, proceeding."
 
   build-mac:
     needs: [approve-release]
     runs-on: macos-latest
+    permissions:
+      contents: write # GoReleaser publishes the GitHub release
     steps:
       - name: Code checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_PRIVATE_KEY }}
@@ -43,12 +50,16 @@ jobs:
             stripe-cli
             homebrew-stripe-cli
             scoop-stripe-cli
+          # Request only what GoReleaser needs to commit the Homebrew formula.
+          permission-contents: write
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.26.5
+          # Never restore a cache into a job that publishes release artifacts.
+          cache: false
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -60,15 +71,18 @@ jobs:
   build-linux:
     needs: [approve-release]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # GoReleaser publishes the GitHub release
     env:
       # https://goreleaser.com/customization/docker_manifest/
       DOCKER_CLI_EXPERIMENTAL: "enabled"
 
     steps:
       - name: Code checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       -
         name: Docker Login
         env:
@@ -77,13 +91,15 @@ jobs:
         run: |
           echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.26.5
+          # Never restore a cache into a job that publishes release artifacts.
+          cache: false
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -95,14 +111,17 @@ jobs:
   build-windows:
     needs: [approve-release]
     runs-on: windows-latest
+    permissions:
+      contents: write # GoReleaser publishes the GitHub release
     steps:
       - name: Code checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_STRIPE_CLI_RELEASER_PRIVATE_KEY }}
@@ -111,12 +130,16 @@ jobs:
             stripe-cli
             homebrew-stripe-cli
             scoop-stripe-cli
+          # Request only what GoReleaser needs to commit the Scoop manifest.
+          permission-contents: write
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.26.5
+          # Never restore a cache into a job that publishes release artifacts.
+          cache: false
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -131,9 +154,13 @@ jobs:
   upload-to-virustotal:
     needs: [build-windows]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # only reads release assets
     steps:
       - name: Code checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Upload to VirusTotal
         run: scripts/upload-zip-to-virustotal.sh
         shell: bash
@@ -144,12 +171,17 @@ jobs:
   publish-npm:
     needs: [build-mac, build-linux, build-windows]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # downloads release assets
+      id-token: write # required for OIDC to npm
     steps:
       - name: Code checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
           package-manager-cache: false
@@ -164,7 +196,9 @@ jobs:
           VERSION: ${{ env.VERSION }}
 
       - name: Stamp version into all package.json files
-        run: node npm/scripts/stamp-version.js ${{ env.VERSION }}
+        # VERSION comes from GITHUB_ENV above; read it as a shell variable so a
+        # crafted tag name cannot expand into the command line.
+        run: node npm/scripts/stamp-version.js "$VERSION"
 
       - name: Copy README into each package
         run: |

--- a/.github/workflows/sync-openapi-artifacts.yml
+++ b/.github/workflows/sync-openapi-artifacts.yml
@@ -8,36 +8,55 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      # Read-only is enough: the branch push and PR creation below are performed
+      # with a scoped GitHub App token, not with GITHUB_TOKEN.
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # create-pull-request below pushes with the app token, not with the
+          # credentials checkout would otherwise leave in .git/config.
+          persist-credentials: false
 
+      # Previously tibdex/github-app-token, whose repository is now archived and
+      # therefore receives no security updates. actions/create-github-app-token
+      # is GitHub's maintained equivalent and exposes the same `token` output.
       - name: Fetch app installation token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: gh-api-token
         with:
-          app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
-          private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+          app-id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
+          private-key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+          owner: stripe
+          repositories: stripe-cli
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Get current version
         id: current-version
         run: echo "value=$(jq -r '.info.version' ./api/openapi-spec/spec3.cli.json)" >> $GITHUB_OUTPUT
 
+      # The version input is interpolated via the environment rather than
+      # directly into the shell, so it cannot break out of the string literal.
       - name: Download GA CLI spec
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/ga/cli.json" \
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${VERSION}/ga/cli.json" \
             -o ./api/openapi-spec/spec3.cli.json
 
       - name: Download Preview CLI spec
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/public_preview/cli.json" \
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${VERSION}/public_preview/cli.json" \
             -o ./api/openapi-spec/spec3.cli.preview.json
 
       - name: Check for changes
@@ -53,7 +72,7 @@ jobs:
 
       - name: Set up Go
         if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.26.5
 
@@ -63,7 +82,7 @@ jobs:
 
       - name: Create pull request
         if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: "OpenAPI Update for ${{ inputs.version }}"
           body: |

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -24,9 +24,10 @@ jobs:
 
     steps:
       - name: Code checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       -
         name: Docker Login
         env:
@@ -35,13 +36,16 @@ jobs:
         run: |
           echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.26.5
+          # This job builds release artifacts, so don't restore a cache that a
+          # lower-privileged workflow run could have poisoned.
+          cache: false
       - name: Run GoReleaser Snapshot
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ matrix.go-version }}
     # Windows throws false positives with linting because of CRLF / goimports incompat
@@ -23,14 +23,18 @@ jobs:
         git config --global core.autocrlf false
         git config --global core.eol lf
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        persist-credentials: false
     - name: Run Setup
       run: make setup
     - name: install diffutils
       if: runner.os == 'macOS'
       run: brew install diffutils
     - name: Install protoc
-      uses: arduino/setup-protoc@v3
+      # NB: `v3` is a *branch* in this repo, not a tag, so it moved with every
+      # push. This pins the commit that the v3.0.0 release points at.
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
         version: '28.3'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -41,7 +45,7 @@ jobs:
         go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
       shell: bash
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:
         version: v2.10.1
         args: --max-issues-per-linter=0 --max-same-issues=0


### PR DESCRIPTION
Addresses the zizmor findings from the outbound supply-chain security report.

Locally, `zizmor` goes from **87 findings (60 High) to zero**, with three documented suppressions.

## Two things were worse than the report suggested

**`arduino/setup-protoc@v3` was a git *branch*, not a tag.** There is no `v3` tag in that repository — only `v3.0.0`. So `test.yml` was executing whatever that branch pointed at, and any push upstream silently changed what ran in our CI. It's now pinned to the commit `v3.0.0` points at, which is the same commit the branch points at today, so there is no functional change.

**`tibdex/github-app-token@v2` is an archived repository** and therefore receives no security updates. The report didn't flag this. `release.yml` already used GitHub's maintained `actions/create-github-app-token`, which exposes the same `token` output, so `sync-openapi-artifacts.yml` now uses it too.

## Changes

| Finding | Fix |
| --- | --- |
| `unpinned-uses` (48) | All 10 external actions pinned to full commit SHAs with `# vX.Y.Z` comments |
| `excessive-permissions` | `release.yml` granted `contents: write` + `id-token: write` to *every* job. Workflow default is now `{}`; `contents: write` is limited to the three GoReleaser jobs and `id-token: write` to `publish-npm` alone |
| `github-app` | Both `create-github-app-token` calls requested every permission the installation had; they now request only `permission-contents: write` |
| `cache-poisoning` (4) | `cache: false` on `setup-go` in the release and snapshot builds, so a lower-privileged run cannot poison what we ship |
| `template-injection` | The OpenAPI version input and the release tag reached `run:` blocks via `${{ }}`; they now arrive as environment variables and are quoted |
| `unpinned-images` | Fedora test container pinned to its F44 multi-arch digest |
| `artipacked` (23) | `persist-credentials: false` on all 14 checkouts, so the token isn't left in `.git/config` |
| `archived-uses` | Replaced the archived `tibdex/github-app-token` |

I also noticed `sync-openapi-artifacts.yml` needed neither `contents: write` nor `pull-requests: write` — its PR is created with the scoped app token, not `GITHUB_TOKEN` — so that workflow is now read-only.

Added `.github/dependabot.yml`: SHA-pinned actions never pick up upstream fixes on their own, so without automation this hardening decays into "frozen on old versions." Weekly bumps are grouped into a single PR.

`MinoruSekine/setup-scoop@v4` was a stale floating tag (it pointed at an older commit than `v4.0.2`), so it's upgraded to `v5.0.1`. v5 removed `add_extras_buckets` / `add_nonportable_buckets`, neither of which we pass.

## Deliberate suppressions

Each has an inline comment explaining why:

- **`stripe/stripe-cli:latest`** in the docker install canary is left floating. That canary exists specifically to catch a broken *published* image; pinning a digest would mean we stop noticing when a fresh release is broken.
- **`npm install -g npm@11`** is a pinned workaround for an npm 10 bin-linking bug, in a job that installs no project dependencies.
- **The `GITHUB_PATH` write** in the `install-stripe-cli` composite action, whose value is the directory of the binary winget just installed, not user input.

## Verification

- `zizmor` 1.29.0 reports no findings (3 justified ignores)
- `actionlint` clean apart from one pre-existing issue (below)
- Every workflow parses as valid YAML
- **Every pinned SHA was checked against the GitHub API** to confirm it matches its version comment — a mistyped SHA fails at runtime rather than at review time

## Note for reviewers

The `permission-contents: write` requests assume both GitHub Apps actually hold that permission. They must, since they already commit to the Homebrew and Scoop tap repositories, but the OpenAPI sync is manually dispatched so it's easy to confirm on its next run.

## Pre-existing bugs found but not fixed here

Both are unrelated to security, so I've left them out rather than bundle them into a security change:

1. **`test-snapshot.yml` has never run on pull requests.** Its `pull_request` path filter is `'goreleaser/**'` — missing the leading dot — while `push` correctly uses `'.goreleaser/**'`.
2. `merge_group` does not support `paths` filters, so that filter is silently ignored (`actionlint` flags this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)