### PR TITLE
[sandboxes cli] List OAuth-authorized sandboxes through Access

### DIFF
--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -560,7 +560,6 @@ func (snc *sandboxNewCmd) runSandboxNewCmd(cmd *cobra.Command, args []string) er
 	// header; the UAT is injected per-request as a STRIPE-V2-SIG token instead.
 	client := &stripe.Client{
 		BaseURL: baseURL,
-		APIKey:  "",
 	}
 
 	// authConfigure sets the UAT auth + version headers shared by every call.
@@ -924,9 +923,16 @@ func (slc *sandboxListCmd) runSandboxListCmd(cmd *cobra.Command, args []string) 
 		return fmt.Errorf("invalid --api-base %q: %w", slc.apiBase, err)
 	}
 
+	oauthAccounts, isOAuth, err := slc.oauthAuthorizedAccounts(cmd.Context())
+	if err != nil {
+		return err
+	}
+	if isOAuth {
+		return slc.printOAuthSandboxes(cmd, oauthAccounts, stripeAccount)
+	}
+
 	client := &stripe.Client{
 		BaseURL: baseURL,
-		APIKey:  "",
 	}
 
 	authConfigure := func(req *http.Request) error {
@@ -1036,6 +1042,90 @@ func (slc *sandboxListCmd) runSandboxListCmd(cmd *cobra.Command, args []string) 
 	return nil
 }
 
+func (slc *sandboxListCmd) oauthAuthorizedAccounts(ctx context.Context) ([]config.AuthorizedAccount, bool, error) {
+	uat, err := Config.Profile.GetUAT()
+	if err != nil {
+		return nil, false, err
+	}
+	if !strings.HasPrefix(uat, "oak_") {
+		return nil, false, nil
+	}
+
+	livemode := true
+	activeContext, err := config.GetActiveContext()
+	if err != nil {
+		return nil, true, err
+	}
+	if activeContext != nil {
+		livemode = activeContext.Livemode
+	}
+
+	credentials, err := Config.Profile.ResolveCredentials(livemode)
+	if err != nil {
+		return nil, true, err
+	}
+	accessBaseURL := Config.Profile.OAuthAccessBaseURL
+	if accessBaseURL == "" {
+		accessBaseURL = login.DefaultAccessBaseURL
+	}
+	accounts, err := login.ListAuthorizedAccounts(ctx, accessBaseURL, credentials.Token)
+	if err == nil || !login.IsAuthorizedAccountsUnauthorized(err) || config.OAuthTokenRefresher == nil {
+		return accounts, true, err
+	}
+
+	if err := config.OAuthTokenRefresher(&Config.Profile); err != nil {
+		return nil, true, err
+	}
+	credentials, err = Config.Profile.ResolveCredentials(livemode)
+	if err != nil {
+		return nil, true, err
+	}
+	accounts, err = login.ListAuthorizedAccounts(ctx, accessBaseURL, credentials.Token)
+	return accounts, true, err
+}
+
+func (slc *sandboxListCmd) printOAuthSandboxes(cmd *cobra.Command, accounts []config.AuthorizedAccount, stripeAccount string) error {
+	if stripeAccount != "" {
+		isAuthorizedLiveAccount := false
+		for _, account := range accounts {
+			if account.ID == stripeAccount && authorizedAccountHasMode(account, "live") {
+				isAuthorizedLiveAccount = true
+				break
+			}
+		}
+		if !isAuthorizedLiveAccount {
+			return fmt.Errorf("no accessible live account matches %s; check the id or run `stripe login` again", stripeAccount)
+		}
+	}
+
+	var sandboxes []config.AuthorizedAccount
+	for _, account := range accounts {
+		if authorizedAccountHasMode(account, "test") && !authorizedAccountHasMode(account, "live") {
+			sandboxes = append(sandboxes, account)
+		}
+	}
+	if len(sandboxes) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No sandboxes found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ACCOUNT\tNAME\tREPLICA OF")
+	for _, account := range sandboxes {
+		fmt.Fprintf(w, "%s\t%s\t\n", account.ID, account.Name)
+	}
+	return w.Flush()
+}
+
+func authorizedAccountHasMode(account config.AuthorizedAccount, mode string) bool {
+	for _, accountMode := range account.Modes {
+		if accountMode == mode {
+			return true
+		}
+	}
+	return false
+}
+
 func newSandboxDeleteCmd() *sandboxDeleteCmd {
 	sdc := &sandboxDeleteCmd{}
 	sdc.cmd = &cobra.Command{
@@ -1093,7 +1183,6 @@ func (sdc *sandboxDeleteCmd) runSandboxDeleteCmd(cmd *cobra.Command, args []stri
 	// Empty APIKey so no Bearer header is set; the UAT is injected as STRIPE-V2-SIG.
 	client := &stripe.Client{
 		BaseURL: baseURL,
-		APIKey:  "",
 	}
 	authConfigure := func(req *http.Request) error {
 		req.Header.Set("Authorization", "STRIPE-V2-SIG "+uat)

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -14,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -1375,6 +1377,141 @@ func TestSandboxListCmd_Empty(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, output, "No sandboxes found")
+}
+
+func TestSandboxListCmd_OAuthListsOnlyTestOnlyAccounts(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte("oak_list_test"), "test uat"))
+	require.NoError(t, config.SaveActiveContext("acct_live", true))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer oak_list_test", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"accounts": []map[string]interface{}{
+				{"id": "acct_live", "name": "Live account", "modes": []string{"live", "test"}},
+				{"id": "acct_sandbox", "name": "Authorized sandbox", "modes": []string{"test"}},
+				{"id": "acct_live_only", "name": "Live only", "modes": []string{"live"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	originalAccessBaseURL := Config.Profile.OAuthAccessBaseURL
+	Config.Profile.OAuthAccessBaseURL = server.URL
+	t.Cleanup(func() { Config.Profile.OAuthAccessBaseURL = originalAccessBaseURL })
+
+	cmd := newSandboxListCmd()
+	var output bytes.Buffer
+	cmd.cmd.SetOut(&output)
+	require.NoError(t, cmd.cmd.Execute())
+	assert.Contains(t, output.String(), "acct_sandbox")
+	assert.Contains(t, output.String(), "Authorized sandbox")
+	assert.NotContains(t, output.String(), "acct_live")
+	assert.NotContains(t, output.String(), "Live only")
+}
+
+func TestSandboxListCmd_OAuthValidatesExplicitLiveAccount(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte("oak_list_test"), "test uat"))
+	require.NoError(t, config.SaveActiveContext("acct_live", true))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"accounts": []map[string]interface{}{
+				{"id": "acct_live", "name": "Live account", "modes": []string{"live", "test"}},
+				{"id": "acct_sandbox", "name": "Authorized sandbox", "modes": []string{"test"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	originalAccessBaseURL := Config.Profile.OAuthAccessBaseURL
+	Config.Profile.OAuthAccessBaseURL = server.URL
+	t.Cleanup(func() { Config.Profile.OAuthAccessBaseURL = originalAccessBaseURL })
+
+	cmd := newSandboxListCmd()
+	cmd.stripeAccount = "acct_sandbox"
+	cmd.cmd.SetContext(context.Background())
+	err := cmd.runSandboxListCmd(cmd.cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no accessible live account matches acct_sandbox")
+}
+
+func TestSandboxListCmd_OAuthProactivelyRefreshesToken(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte("oak_expiring"), "test uat"))
+	require.NoError(t, config.SaveActiveContext("acct_live", true))
+	require.NoError(t, config.SaveUATExpiresAt(time.Now().Add(30*time.Second)))
+
+	originalRefresher := config.OAuthTokenRefresher
+	refreshes := 0
+	config.OAuthTokenRefresher = func(profile *config.Profile) error {
+		refreshes++
+		profile.UAT = "oak_refreshed"
+		require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte(profile.UAT), "refreshed uat"))
+		return config.SaveUATExpiresAt(time.Now().Add(time.Hour))
+	}
+	t.Cleanup(func() { config.OAuthTokenRefresher = originalRefresher })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer oak_refreshed", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"accounts": []map[string]interface{}{}})
+	}))
+	defer server.Close()
+
+	originalAccessBaseURL := Config.Profile.OAuthAccessBaseURL
+	Config.Profile.OAuthAccessBaseURL = server.URL
+	t.Cleanup(func() { Config.Profile.OAuthAccessBaseURL = originalAccessBaseURL })
+
+	cmd := newSandboxListCmd()
+	cmd.cmd.SetContext(context.Background())
+	require.NoError(t, cmd.runSandboxListCmd(cmd.cmd, nil))
+	assert.Equal(t, 1, refreshes)
+}
+
+func TestSandboxListCmd_OAuthRetriesUnauthorizedOnce(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte("oak_expired"), "test uat"))
+	require.NoError(t, config.SaveActiveContext("acct_live", true))
+
+	originalRefresher := config.OAuthTokenRefresher
+	refreshes := 0
+	config.OAuthTokenRefresher = func(profile *config.Profile) error {
+		refreshes++
+		profile.UAT = "oak_refreshed"
+		return config.KeyRing.Set(config.UATKeychainItemKey, []byte(profile.UAT), "refreshed uat")
+	}
+	t.Cleanup(func() { config.OAuthTokenRefresher = originalRefresher })
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]interface{}{"error": "unauthorized"})
+	}))
+	defer server.Close()
+
+	originalAccessBaseURL := Config.Profile.OAuthAccessBaseURL
+	Config.Profile.OAuthAccessBaseURL = server.URL
+	t.Cleanup(func() { Config.Profile.OAuthAccessBaseURL = originalAccessBaseURL })
+
+	cmd := newSandboxListCmd()
+	cmd.cmd.SetContext(context.Background())
+	err := cmd.runSandboxListCmd(cmd.cmd, nil)
+	require.Error(t, err)
+	assert.Equal(t, 1, refreshes)
+	assert.Equal(t, 2, requests)
 }
 
 func TestSandboxListCmd_RejectsOrg(t *testing.T) {

--- a/pkg/login/oauth_accounts.go
+++ b/pkg/login/oauth_accounts.go
@@ -3,9 +3,11 @@ package login
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
@@ -15,6 +17,21 @@ import (
 
 type listAccountsResponse struct {
 	Accounts []config.AuthorizedAccount `json:"accounts"`
+	HasMore  bool                       `json:"has_more"`
+}
+
+type accountsRequestError struct {
+	statusCode int
+	body       string
+}
+
+func (e *accountsRequestError) Error() string {
+	return fmt.Sprintf("accounts request failed (status %d): %s", e.statusCode, e.body)
+}
+
+func IsAuthorizedAccountsUnauthorized(err error) bool {
+	var requestErr *accountsRequestError
+	return errors.As(err, &requestErr) && requestErr.statusCode == http.StatusUnauthorized
 }
 
 // ListAuthorizedAccounts returns the Stripe accounts accessible to accessToken.
@@ -23,33 +40,54 @@ func ListAuthorizedAccounts(ctx context.Context, accessBaseURL, accessToken stri
 }
 
 func fetchAuthorizedAccounts(ctx context.Context, accessBaseURL, accessToken string) ([]config.AuthorizedAccount, error) {
-	endpoint := accessBaseURL + accessAPNPath + "/token/accounts"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
+	endpoint, err := url.Parse(accessBaseURL + accessAPNPath + "/token/accounts")
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, errorcategory.Errorf(errorcategory.Auth, "accounts request failed (status %d): %s", resp.StatusCode, string(body))
-	}
+	var accounts []config.AuthorizedAccount
+	startingAfter := ""
+	for {
+		query := endpoint.Query()
+		query.Set("limit", "100")
+		if startingAfter != "" {
+			query.Set("starting_after", startingAfter)
+		}
+		endpoint.RawQuery = query.Encode()
 
-	var result listAccountsResponse
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse accounts response: %w", err)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, errorcategory.With(&accountsRequestError{statusCode: resp.StatusCode, body: string(body)}, errorcategory.Auth)
+		}
+
+		var result listAccountsResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, fmt.Errorf("failed to parse accounts response: %w", err)
+		}
+		accounts = append(accounts, result.Accounts...)
+		if !result.HasMore {
+			return accounts, nil
+		}
+		if len(result.Accounts) == 0 {
+			return nil, fmt.Errorf("accounts response indicated more results but returned an empty page")
+		}
+		startingAfter = result.Accounts[len(result.Accounts)-1].ID
 	}
-	return result.Accounts, nil
 }
 
 // PrintAuthorizedContexts fetches the authorized accounts for accessToken and

--- a/pkg/login/oauth_accounts_test.go
+++ b/pkg/login/oauth_accounts_test.go
@@ -42,6 +42,44 @@ func TestFetchAuthorizedAccounts_non200(t *testing.T) {
 	assert.ErrorContains(t, err, "404")
 }
 
+func TestFetchAuthorizedAccounts_paginates(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		assert.Equal(t, "100", r.URL.Query().Get("limit"))
+		w.Header().Set("Content-Type", "application/json")
+		switch requests {
+		case 1:
+			assert.Empty(t, r.URL.Query().Get("starting_after"))
+			json.NewEncoder(w).Encode(listAccountsResponse{
+				Accounts: []config.AuthorizedAccount{{ID: "acct_first", Name: "First", Modes: []string{"live"}}},
+				HasMore:  true,
+			})
+		case 2:
+			assert.Equal(t, "acct_first", r.URL.Query().Get("starting_after"))
+			json.NewEncoder(w).Encode(listAccountsResponse{
+				Accounts: []config.AuthorizedAccount{{ID: "acct_second", Name: "Second", Modes: []string{"test"}}},
+			})
+		default:
+			t.Fatalf("unexpected request %d", requests)
+		}
+	}))
+	defer srv.Close()
+
+	got, err := fetchAuthorizedAccounts(context.Background(), srv.URL, "oak_test")
+	require.NoError(t, err)
+	assert.Equal(t, []config.AuthorizedAccount{
+		{ID: "acct_first", Name: "First", Modes: []string{"live"}},
+		{ID: "acct_second", Name: "Second", Modes: []string{"test"}},
+	}, got)
+	assert.Equal(t, 2, requests)
+}
+
+func TestIsAuthorizedAccountsUnauthorized(t *testing.T) {
+	assert.True(t, IsAuthorizedAccountsUnauthorized(&accountsRequestError{statusCode: http.StatusUnauthorized}))
+	assert.False(t, IsAuthorizedAccountsUnauthorized(&accountsRequestError{statusCode: http.StatusForbidden}))
+}
+
 func TestListAuthorizedAccounts_returnsRealDataWhenAvailable(t *testing.T) {
 	want := []config.AuthorizedAccount{
 		{ID: "acct_real", Name: "Real Business", Modes: []string{"live", "test"}},


### PR DESCRIPTION
### Reviewers
cc @stripe/sandboxes-engineering 

### Summary
Adds OAuth-backed `stripe sandbox list` by reading authorized accounts from Access. The command lists only test-only OAuth contexts that are already authorized through `stripe login` or `stripe reauth`; it does not provide an account-wide sandbox inventory.

The OAuth path preserves legacy UAT listing, validates an explicit `--stripe-account` against an authorized live account, proactively refreshes expiring tokens, and refreshes and retries Access enumeration once after a 401. It also paginates Access authorized-account responses. Access does not expose replica relationships, so `REPLICA OF` remains blank.

### Test plan
- `go test ./pkg/cmd -run '^TestSandboxListCmd_' -count=1`
- `go test ./pkg/login -run '^(TestFetchAuthorizedAccounts|TestListAuthorizedAccounts|TestIsAuthorizedAccountsUnauthorized)' -count=1`
- `make build`

### Rollback
Safe to revert. OAuth sessions would return to the prior listing behavior; the legacy UAT listing path is unchanged.