### PR TITLE
Retry auto-upgrade test dispatch and notify Slack on failure

### DIFF
--- a/.github/workflows/autoupgrade-test-trigger.yml
+++ b/.github/workflows/autoupgrade-test-trigger.yml
@@ -1,6 +1,7 @@
 on:
   schedule:
     - cron: '*/10 * * * *' # Every 10 minutes
+  workflow_dispatch:
 name: Auto-upgrade test (trigger)
 permissions:
   actions: write
@@ -8,7 +9,38 @@ permissions:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - run: gh workflow run autoupgrade-test.yml --ref v2 --repo stripe/stripe-cli
+      # The dispatch API intermittently returns HTTP 503, which fails the run
+      # even though a retry succeeds. Retry with backoff before giving up.
+      - name: Dispatch auto-upgrade test on v2
+        run: |
+          for delay in 15 30 60 120 0; do
+            if gh workflow run autoupgrade-test.yml --ref v2 --repo stripe/stripe-cli; then
+              echo "Dispatched auto-upgrade test on v2"
+              exit 0
+            fi
+            if [ "$delay" -eq 0 ]; then
+              break
+            fi
+            echo "Dispatch failed, retrying in ${delay}s..."
+            sleep "$delay"
+          done
+          echo "Error: could not dispatch auto-upgrade test after 5 attempts"
+          exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify Slack on failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL is not set; skipping Slack notification"
+            exit 0
+          fi
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "{\"text\": \":red_circle: Could not dispatch the auto-upgrade test on v2 after 5 attempts (likely a transient GitHub API error). Logs: $RUN_URL\"}"


### PR DESCRIPTION
### Summary

#### The problem: 
The scheduled `Auto-upgrade test (trigger)` workflow intermittently fails with a transient error from the workflow dispatch API:

```
could not create workflow dispatch event: HTTP 503: No server is currently available to
service your request. Sorry about that. Please try resubmitting your request...
```

Rerunning the same job succeeds. 6 of the last 40 scheduled runs failed this way today -- the dispatch itself is fine, the API just blips.

#### Changes

- **Retry the dispatch** up to five times with backoff (15s → 30s → 60s → 120s, ~3.75 min worst case, well inside the 10-minute cron interval). Added `timeout-minutes: 10` as a backstop.
- **Notify Slack on real failure** — an `if: failure()` step posts to slack cli bots channel via the existing `SLACK_WEBHOOK_URL` secret with a link to the run logs. It only fires once all five attempts fail, so today's transient blips would have produced zero pings. No-ops if the secret is ever unset.
- **Added `workflow_dispatch`** so the trigger can be exercised manually without waiting for the cron.
