### PR TITLE
[Draft] Add a non-promoting release path for v1 maintenance tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,34 @@ jobs:
     steps:
       - run: echo "Release approved, proceeding."
 
-  build-mac:
+  release-metadata:
     needs: [approve-release]
+    runs-on: ubuntu-latest
+    outputs:
+      goreleaser-config-suffix: ${{ steps.version.outputs.goreleaser-config-suffix }}
+      npm-dist-tag: ${{ steps.version.outputs.npm-dist-tag }}
+    steps:
+      - name: Determine release channel
+        id: version
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          major="${version%%.*}"
+          if [[ ! "${major}" =~ ^[0-9]+$ ]]; then
+            echo "Invalid release tag: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
+          if [[ "${major}" == "1" ]]; then
+            echo "goreleaser-config-suffix=-maintenance" >> "${GITHUB_OUTPUT}"
+            echo "npm-dist-tag=v1" >> "${GITHUB_OUTPUT}"
+          else
+            echo "goreleaser-config-suffix=" >> "${GITHUB_OUTPUT}"
+            echo "npm-dist-tag=latest" >> "${GITHUB_OUTPUT}"
+          fi
+
+  build-mac:
+    needs: [release-metadata]
     runs-on: macos-latest
     steps:
       - name: Code checkout
@@ -52,13 +78,13 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release -f .goreleaser/mac.yml --clean
+          args: release -f .goreleaser/mac${{ needs.release-metadata.outputs.goreleaser-config-suffix }}.yml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   build-linux:
-    needs: [approve-release]
+    needs: [release-metadata]
     runs-on: ubuntu-22.04
     env:
       # https://goreleaser.com/customization/docker_manifest/
@@ -87,13 +113,13 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release -f .goreleaser/linux.yml --clean
+          args: release -f .goreleaser/linux${{ needs.release-metadata.outputs.goreleaser-config-suffix }}.yml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACTORY_SECRET: ${{ secrets.ARTIFACTORY_SECRET }}
 
   build-windows:
-    needs: [approve-release]
+    needs: [release-metadata]
     runs-on: windows-latest
     steps:
       - name: Code checkout
@@ -120,7 +146,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release -f .goreleaser/windows.yml --clean
+          args: release -f .goreleaser/windows${{ needs.release-metadata.outputs.goreleaser-config-suffix }}.yml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -142,7 +168,7 @@ jobs:
           VIRUSTOTAL_API_KEY: ${{ secrets.VIRUSTOTAL_API_KEY }}
 
   publish-npm:
-    needs: [build-mac, build-linux, build-windows]
+    needs: [release-metadata, build-mac, build-linux, build-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout
@@ -155,7 +181,7 @@ jobs:
           package-manager-cache: false
 
       - name: Derive version from tag
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "${GITHUB_ENV}"
 
       - name: Download and extract platform binaries from GitHub Release
         run: node npm/scripts/fetch-binaries.js
@@ -173,10 +199,14 @@ jobs:
           done
 
       - name: Publish platform packages
+        env:
+          NPM_DIST_TAG: ${{ needs.release-metadata.outputs.npm-dist-tag }}
         run: |
           for dir in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
-            npm publish ./npm/$dir
+            npm publish ./npm/$dir --tag "${NPM_DIST_TAG}"
           done
 
       - name: Publish wrapper package
-        run: npm publish ./npm/wrapper
+        env:
+          NPM_DIST_TAG: ${{ needs.release-metadata.outputs.npm-dist-tag }}
+        run: npm publish ./npm/wrapper --tag "${NPM_DIST_TAG}"

--- a/.goreleaser/linux-maintenance.yml
+++ b/.goreleaser/linux-maintenance.yml
@@ -1,0 +1,109 @@
+version: 2
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod download
+    - go generate ./...
+project_name: stripe
+builds:
+  - id: stripe-linux
+    ldflags:
+      - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
+    binary: stripe
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/stripe/main.go
+    goos:
+      - linux
+    goarch:
+      - amd64
+  - id: stripe-linux-arm
+    ldflags:
+      - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
+    binary: stripe
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/stripe/main.go
+    goos:
+      - linux
+    goarch:
+      - arm64
+archives:
+  - name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_
+      {{- if eq .Arch "386" }}i386
+      {{- else if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - none*
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+checksum:
+  name_template: "{{ .ProjectName }}-linux-checksums.txt"
+release:
+  replace_existing_artifacts: true
+  make_latest: false
+snapshot:
+  version_template: "{{ .Version }}-next"
+nfpms:
+  - id: deb
+    package_name: stripe
+    vendor: Stripe
+    homepage: https://stripe.com
+    maintainer: Stripe <support@stripe.com>
+    description: Stripe CLI utility
+    license: Apache 2.0
+    formats:
+      - deb
+  - id: rpm
+    package_name: stripe
+    vendor: Stripe
+    homepage: https://stripe.com
+    maintainer: Stripe <support@stripe.com>
+    description: Stripe CLI utility
+    license: Apache 2.0
+    formats:
+      - rpm
+dockers:
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    ids:
+      - stripe-linux
+    image_templates:
+      - "stripe/stripe-cli:{{ .Tag }}-amd64"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=repository=https://github.com/stripe/stripe-cli"
+      - "--label=homepage=https://stripe.com"
+      - "--platform=linux/amd64"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+      - stripe-linux-arm
+    image_templates:
+      - "stripe/stripe-cli:{{ .Tag }}-arm64"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=repository=https://github.com/stripe/stripe-cli"
+      - "--label=homepage=https://stripe.com"
+      - "--platform=linux/arm64/v8"
+docker_manifests:
+  - name_template: "stripe/stripe-cli:{{ .Tag }}"
+    image_templates:
+      - "stripe/stripe-cli:{{ .Tag }}-amd64"
+      - "stripe/stripe-cli:{{ .Tag }}-arm64"

--- a/.goreleaser/linux-maintenance.yml
+++ b/.goreleaser/linux-maintenance.yml
@@ -50,6 +50,8 @@ release:
   make_latest: false
 snapshot:
   version_template: "{{ .Version }}-next"
+# Maintenance packages remain available as versioned release assets without
+# updating package repositories.
 nfpms:
   - id: deb
     package_name: stripe

--- a/.goreleaser/mac-maintenance.yml
+++ b/.goreleaser/mac-maintenance.yml
@@ -1,0 +1,68 @@
+version: 2
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod download
+    - go generate ./...
+project_name: stripe
+builds:
+  - id: stripe-darwin
+    ldflags:
+      - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
+    binary: stripe
+    env:
+      - CGO_ENABLED=1
+    main: ./cmd/stripe/main.go
+    goos:
+      - darwin
+    goarch:
+      - amd64
+  - id: stripe-darwin-arm
+    ldflags:
+      - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
+    binary: stripe
+    env:
+      - CGO_ENABLED=1
+    main: ./cmd/stripe/main.go
+    goos:
+      - darwin
+    goarch:
+      - arm64
+archives:
+  - name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- if eq .Os "darwin"}}mac-os
+      {{- else }}{{ .Os }}{{end}}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - none*
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      ids:
+        - stripe-darwin
+        - stripe-darwin-arm
+      sign:
+        certificate: "{{.Env.MACOS_SIGN_P12}}"
+        password: "{{.Env.MACOS_SIGN_PASSWORD}}"
+      notarize:
+        issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
+        key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
+        key: "{{.Env.MACOS_NOTARY_KEY}}"
+        wait: true
+        timeout: 20m
+checksum:
+  name_template: "{{ .ProjectName }}-mac-checksums.txt"
+release:
+  replace_existing_artifacts: true
+  make_latest: false
+snapshot:
+  version_template: "{{ .Version }}-next"

--- a/.goreleaser/windows-maintenance.yml
+++ b/.goreleaser/windows-maintenance.yml
@@ -1,0 +1,47 @@
+version: 2
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod download
+    - go generate ./...
+project_name: stripe
+builds:
+  - id: stripe-windows
+    ldflags:
+      - -s -w -X github.com/stripe/stripe-cli/pkg/version.Version={{.Version}}
+    binary: stripe
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    main: ./cmd/stripe/main.go
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - "386"
+archives:
+  - name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_
+      {{- if eq .Arch "386" }}i386
+      {{- else if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: zip
+    files:
+      - none*
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+checksum:
+  name_template: "{{ .ProjectName }}-windows-checksums.txt"
+release:
+  replace_existing_artifacts: true
+  make_latest: false
+snapshot:
+  version_template: "{{ .Version }}-next"


### PR DESCRIPTION
### Summary 
After v2 becomes the default Stripe CLI release, critical fixes may still need to be released for users remaining on v1. The existing release workflow treats every version tag the same, so publishing a newer v1 patch after v2 could unintentionally replace v2 in channels that point to the latest release.

This change adds a maintenance release path for v1 tags. It continues producing versioned GitHub release assets, Docker images, and npm packages while avoiding updates to default distribution channels. npm packages use the explicit v1 dist-tag, and v1 GitHub releases are not marked as the latest release. Releases for v2 and later continue using the existing publication path.

This allows supported v1 fixes to ship without changing what new installations or default upgrade paths receive.