### PR TITLE
Reject dots in new profile names

### DIFF
--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -121,6 +121,12 @@ For agents and scripts, use the two-step non-interactive flow:
 }
 
 func (lc *loginCmd) runLoginCmd(cmd *cobra.Command, args []string) error {
+	// Reject an invalid profile name before authenticating, so the user is not
+	// sent through a browser flow whose result cannot be saved.
+	if err := Config.Profile.ValidateProfileNameForWrite(); err != nil {
+		return err
+	}
+
 	if err := stripe.ValidateDashboardBaseURL(lc.dashboardBaseURL); err != nil {
 		return err
 	}

--- a/pkg/cmd/login_test.go
+++ b/pkg/cmd/login_test.go
@@ -42,7 +42,13 @@ func TestLoginValidatesProfileNameBeforeAuthentication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Config is package state, and viper.Reset below drops the pflag
+			// binding that ReBindKeys would otherwise use to restore the
+			// default profile name. Put it back by hand so later tests in this
+			// package don't observe this test's profile.
+			origConfig := Config
 			t.Cleanup(func() {
+				Config = origConfig
 				config.KeyRing = nil
 				viper.Reset()
 			})

--- a/pkg/cmd/login_test.go
+++ b/pkg/cmd/login_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/keyring"
+)
+
+// The profile name is checked before authentication starts, so the user is not
+// sent through a browser flow whose credentials could not be saved afterwards.
+func TestLoginValidatesProfileNameBeforeAuthentication(t *testing.T) {
+	tests := []struct {
+		name        string
+		profileName string
+		config      string
+		wantError   string
+	}{
+		{
+			name:        "new dotted profile is rejected",
+			profileName: "example.project",
+			config:      "[default]\ndisplay_name = 'Default'\n",
+			wantError:   `profile name "example.project" cannot contain a period; use a hyphen or underscore instead`,
+		},
+		{
+			name:        "existing dotted profile is allowed through",
+			profileName: "example.project",
+			config:      "[\"example.project\"]\ndisplay_name = 'Existing profile'\n",
+		},
+		{
+			name:        "normal profile is allowed through",
+			profileName: "example-project",
+			config:      "[default]\ndisplay_name = 'Default'\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				config.KeyRing = nil
+				viper.Reset()
+			})
+
+			profilesFile := filepath.Join(t.TempDir(), "config.toml")
+			require.NoError(t, os.WriteFile(profilesFile, []byte(tt.config), 0600))
+			Config = config.Config{
+				LogLevel: "info",
+				Profile: config.Profile{
+					ProfileName: tt.profileName,
+					DeviceName:  "test-device",
+				},
+				ProfilesFile: profilesFile,
+			}
+			config.KeyRing = keyring.NewMemoryStore(nil)
+			Config.InitConfig()
+
+			lc := newLoginCmd()
+			lc.cmd.SetContext(context.Background())
+			// An invalid name must fail before the dashboard URL is even looked at,
+			// so an unreachable one is used to prove nothing downstream ran.
+			lc.dashboardBaseURL = "not-a-valid-url"
+			err := lc.runLoginCmd(lc.cmd, nil)
+
+			if tt.wantError == "" {
+				// The name passed; execution reached the next check rather than
+				// being rejected for the profile name.
+				require.Error(t, err)
+				require.NotContains(t, err.Error(), "profile name")
+				return
+			}
+
+			require.EqualError(t, err, tt.wantError)
+		})
+	}
+}

--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -107,6 +107,12 @@ work immediately.`,
 }
 
 func (scc *sandboxCreateCmd) runSandboxCreateCmd(cmd *cobra.Command, args []string) error {
+	// Reject an invalid profile name before provisioning, so we never create a
+	// sandbox whose keys cannot be saved.
+	if err := Config.Profile.ValidateProfileNameForWrite(); err != nil {
+		return err
+	}
+
 	color := ansi.Color(cmd.ErrOrStderr())
 
 	existingKey, _ := Config.Profile.GetAPIKey(false)

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -133,6 +133,35 @@ func dashboardServer(t *testing.T) *httptest.Server {
 	}))
 }
 
+// A sandbox provisioned under an invalid profile name would have nowhere to save
+// its keys, so the name is checked before any request is made.
+func TestSandboxCreateCmd_RejectsNewDottedProfileBeforeProvisioning(t *testing.T) {
+	cleanup := setupSandboxTestConfig(t)
+	defer cleanup()
+
+	Config.Profile.ProfileName = "example.project"
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	browserOpened := false
+	openBrowserFunc = func(string) error {
+		browserOpened = true
+		return nil
+	}
+
+	cmd := newSandboxCreateCmd()
+	cmd.cmd.SetArgs([]string{"--email", "unused", "--base-url", server.URL})
+	err := cmd.cmd.Execute()
+
+	require.EqualError(t, err, `profile name "example.project" cannot contain a period; use a hyphen or underscore instead`)
+	assert.Zero(t, requestCount)
+	assert.False(t, browserOpened)
+}
+
 func TestSandboxCreateCmd_MissingEmail(t *testing.T) {
 	cleanup := setupSandboxTestConfig(t)
 	defer cleanup()

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -106,8 +106,67 @@ var authFieldNames = []string{
 	"experimental",
 }
 
+// ValidateProfileName reports whether name can be used as a profile name.
+//
+// Profile fields are addressed as <profile>.<field> keys in viper, which uses
+// "." as its path separator. A profile name containing a period is therefore
+// indistinguishable from a nested table: viper reads ["a.b"] back as a -> b, so
+// the profile becomes invisible to every operation that enumerates top-level
+// tables (listing, removal, clearing credentials) even though reads still work.
+// An empty name produces a leading-period key that viper silently drops, so
+// writes to it are discarded without error.
+//
+// Every other character round-trips correctly and is allowed.
+//
+// TODO: return errorcategory.UserInputErrorf once master is merged into v2 and
+// the errorcategory package is available on this branch.
+func ValidateProfileName(name string) error {
+	if name == "" {
+		return fmt.Errorf("profile name cannot be empty")
+	}
+
+	if strings.Contains(name, ".") {
+		return fmt.Errorf("profile name %q cannot contain a period; use a hyphen or underscore instead", name)
+	}
+
+	return nil
+}
+
+// profileExists reports whether the config file already contains a table for
+// this profile. This checks for the table itself rather than any particular
+// field, so that a partially written profile (one with no display_name, which a
+// profile abandoned part-way through login can be) is still recognized.
+func (p *Profile) profileExists() bool {
+	return viper.IsSet(p.ProfileName)
+}
+
+// ValidateProfileNameForWrite validates the profile name before writing to it.
+//
+// Profiles that already exist are allowed through unchanged: reads against them
+// work correctly, and refusing to write would leave users unable to update a
+// profile they are actively using. Only the creation of new invalid names is
+// blocked.
+//
+// This grandfather clause can be dropped once the config migration renames
+// existing dotted profiles, at which point the rule becomes unconditional.
+func (p *Profile) ValidateProfileNameForWrite() error {
+	if p.profileExists() {
+		return nil
+	}
+
+	return ValidateProfileName(p.ProfileName)
+}
+
 // CreateProfile creates a profile when logging in
 func (p *Profile) CreateProfile() error {
+	// Validate up front so a rejected name leaves both the config file and the
+	// keyring untouched: the calls below delete existing credentials before
+	// anything is written back. writeProfile revalidates as the backstop for the
+	// write paths that do not go through here.
+	if err := p.ValidateProfileNameForWrite(); err != nil {
+		return err
+	}
+
 	// Remove only auth-related keys under existing profile first
 	v := p.deleteAuthFields(viper.GetViper())
 
@@ -385,6 +444,11 @@ func (p *Profile) RegisterAlias(alias, key string) {
 // configuration to disk.
 func (p *Profile) WriteConfigField(field, value string) error {
 	viper.ReadInConfig()
+
+	if err := p.ValidateProfileNameForWrite(); err != nil {
+		return err
+	}
+
 	viper.Set(p.GetConfigField(field), value)
 	return writeConfig(viper.GetViper())
 }
@@ -406,6 +470,14 @@ func (p *Profile) DeleteConfigField(field string) error {
 
 func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 	profilesFile := viper.ConfigFileUsed()
+
+	// Validate before any mutation so a rejected name leaves the config file and
+	// the keyring untouched. This is the single funnel every profile write goes
+	// through, so commands cannot reintroduce an invalid name by bypassing the
+	// earlier checks in `stripe login` and `stripe sandbox create`.
+	if err := p.ValidateProfileNameForWrite(); err != nil {
+		return err
+	}
 
 	err := makePath(profilesFile)
 	if err != nil {

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -11,6 +11,200 @@ import (
 	"github.com/stripe/stripe-cli/pkg/keyring"
 )
 
+const dottedNameError = `profile name "example.project" cannot contain a period; use a hyphen or underscore instead`
+
+// setupProfileConfig writes contents to a temp config file and initializes the
+// global viper from it, so tests exercise the same read path as the CLI rather
+// than viper's override layer, which nests keys by splitting on ".".
+func setupProfileConfig(t *testing.T, contents string) (*Config, string) {
+	t.Helper()
+
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(profilesFile, []byte(contents), 0600))
+
+	if KeyRing == nil {
+		KeyRing = keyring.NewMemoryStore(nil)
+	}
+	t.Cleanup(func() {
+		KeyRing = nil
+		viper.Reset()
+	})
+
+	c := &Config{LogLevel: "info", ProfilesFile: profilesFile}
+	c.InitConfig()
+
+	return c, profilesFile
+}
+
+func TestValidateProfileName(t *testing.T) {
+	tests := []struct {
+		name        string
+		profileName string
+		wantError   string
+	}{
+		{name: "hyphenated", profileName: "example-project"},
+		{name: "underscored", profileName: "example_project"},
+		// Every character other than "." round-trips correctly through viper and
+		// TOML, so the rule stays as narrow as the actual constraint.
+		{name: "spaces", profileName: "example project"},
+		{name: "whitespace only", profileName: " "},
+		{name: "double quote", profileName: `example"project`},
+		{name: "single quote", profileName: "example'project"},
+		{name: "equals", profileName: "example=project"},
+		{name: "hash", profileName: "example#project"},
+		{name: "brackets", profileName: "example[project]"},
+		{name: "slashes", profileName: `example/\project`},
+		{name: "unicode", profileName: "ünïcode"},
+		{name: "uppercase", profileName: "ExampleProject"},
+
+		{name: "dotted", profileName: "example.project", wantError: dottedNameError},
+		{name: "leading dot", profileName: ".example", wantError: `profile name ".example" cannot contain a period; use a hyphen or underscore instead`},
+		// An empty name produces a ".<field>" key, which viper drops silently, so
+		// every write to it is discarded without an error.
+		{name: "empty", profileName: "", wantError: "profile name cannot be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProfileName(tt.profileName)
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.EqualError(t, err, tt.wantError)
+		})
+	}
+}
+
+func TestValidateProfileNameForWriteAllowsExistingProfiles(t *testing.T) {
+	tests := []struct {
+		name        string
+		profileName string
+		contents    string
+		wantExists  bool
+		wantError   string
+	}{
+		{
+			name:        "new dotted profile is rejected",
+			profileName: "example.project",
+			contents:    "[default]\ndisplay_name = 'Default'\n",
+			wantError:   dottedNameError,
+		},
+		{
+			name:        "existing dotted profile is allowed",
+			profileName: "example.project",
+			contents:    "[\"example.project\"]\ndisplay_name = 'Existing profile'\n",
+			wantExists:  true,
+		},
+		{
+			// A dotted profile written before this rule existed may have no
+			// display_name. It must still be recognized as existing, or it becomes
+			// unreachable: not writable, not listable, and not removable.
+			name:        "existing dotted profile without display_name is allowed",
+			profileName: "example.project",
+			contents:    "[\"example.project\"]\ncolor = 'on'\n",
+			wantExists:  true,
+		},
+		{
+			name:        "already-nested form is allowed",
+			profileName: "example.project",
+			contents:    "[example]\n[example.project]\ncolor = 'on'\n",
+			wantExists:  true,
+		},
+		{
+			name:        "space-separated profile is not equivalent",
+			profileName: "example.project",
+			contents:    "['example project']\ndisplay_name = 'Existing profile'\n",
+			wantError:   dottedNameError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupProfileConfig(t, tt.contents)
+
+			p := Profile{ProfileName: tt.profileName}
+			require.Equal(t, tt.wantExists, p.profileExists())
+
+			err := p.ValidateProfileNameForWrite()
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.EqualError(t, err, tt.wantError)
+		})
+	}
+}
+
+func TestCreateProfileRejectsNewDottedNameBeforeMutation(t *testing.T) {
+	initialConfig := "[default]\ndisplay_name = 'Default'\n"
+
+	KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		"example.project.live_mode_api_key": []byte("existing-value"),
+	})
+	_, profilesFile := setupProfileConfig(t, initialConfig)
+
+	p := Profile{
+		ProfileName:    "example.project",
+		DisplayName:    "New profile",
+		LiveModeAPIKey: "new-value",
+	}
+	require.EqualError(t, p.CreateProfile(), dottedNameError)
+
+	require.Equal(t, []byte(initialConfig), helperLoadBytes(t, profilesFile))
+	storedValue, err := KeyRing.Get("example.project.live_mode_api_key")
+	require.NoError(t, err)
+	require.Equal(t, []byte("existing-value"), storedValue)
+}
+
+// WriteConfigField is a separate write path from CreateProfile, reached by
+// `stripe config --set`, docs preferences, and the Terminal quickstart. It must
+// enforce the same rule, otherwise the ban can be bypassed entirely.
+func TestWriteConfigFieldRejectsNewDottedName(t *testing.T) {
+	initialConfig := "[default]\ndisplay_name = 'Default'\n"
+	_, profilesFile := setupProfileConfig(t, initialConfig)
+
+	p := Profile{ProfileName: "example.project"}
+	require.EqualError(t, p.WriteConfigField("color", "off"), dottedNameError)
+
+	require.Equal(t, []byte(initialConfig), helperLoadBytes(t, profilesFile))
+}
+
+func TestWriteConfigFieldRejectsEmptyProfileName(t *testing.T) {
+	initialConfig := "[default]\ndisplay_name = 'Default'\n"
+	_, profilesFile := setupProfileConfig(t, initialConfig)
+
+	p := Profile{ProfileName: ""}
+	require.EqualError(t, p.WriteConfigField("color", "off"), "profile name cannot be empty")
+
+	require.Equal(t, []byte(initialConfig), helperLoadBytes(t, profilesFile))
+}
+
+// A dotted profile that predates this rule must stay writable, or it becomes
+// permanently stuck: unusable and unfixable.
+func TestCreateProfileAllowsExistingDottedName(t *testing.T) {
+	setupProfileConfig(t, "[\"example.project\"]\ndisplay_name = 'Existing profile'\n")
+
+	p := Profile{
+		ProfileName: "example.project",
+		DisplayName: "Updated profile",
+		DeviceName:  "test-device",
+	}
+	require.NoError(t, p.CreateProfile())
+	require.Equal(t, "Updated profile", viper.GetString("example.project.display_name"))
+	require.Equal(t, "test-device", viper.GetString("example.project.device_name"))
+}
+
+func TestWriteConfigFieldAllowsExistingDottedNameWithoutDisplayName(t *testing.T) {
+	setupProfileConfig(t, "[example]\n[example.project]\ncolor = 'on'\n")
+
+	p := Profile{ProfileName: "example.project"}
+	require.NoError(t, p.WriteConfigField("device_name", "test-device"))
+	require.Equal(t, "test-device", viper.GetString("example.project.device_name"))
+}
+
 func TestWriteProfile(t *testing.T) {
 	profilesFile := filepath.Join(t.TempDir(), "config.toml")
 	p := Profile{


### PR DESCRIPTION
### Summary
Follow up #1922, reject dots in newly created profile names before authentication, sandbox provisioning, or persistence, while allowing existing dotted profiles to continue updating. This prevents new profile names from being interpreted as nested configuration paths.
This will be released in v2 as a breaking change.

### Testing 
- [x] Added unit tests
- [x] manually tested
```
% ./bin/stripe login --project-name new.profile
profile name "new.profile" cannot contain a period; use a hyphen or underscore instead
```
