### PR TITLE
Make dotted profile names removable, and warn about them

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -1,19 +1,29 @@
 package cmd
 
 import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 )
 
 type configCmd struct {
 	cmd    *cobra.Command
 	config *config.Config
 
-	list  bool
-	edit  bool
-	unset string
-	set   bool
+	list          bool
+	edit          bool
+	unset         string
+	set           bool
+	removeProfile string
+	autoConfirm   bool
 }
 
 func newConfigCmd() *configCmd {
@@ -27,7 +37,8 @@ func newConfigCmd() *configCmd {
 you need more granular control over the configuration.`,
 		Example: `stripe config --list
   stripe config --set color off
-  stripe config --unset color`,
+  stripe config --unset color
+  stripe config --remove-profile my-project`,
 		RunE: cc.runConfigCmd,
 	}
 
@@ -35,6 +46,8 @@ you need more granular control over the configuration.`,
 	cc.cmd.Flags().BoolVarP(&cc.edit, "edit", "e", false, "Open an editor to the config file")
 	cc.cmd.Flags().StringVar(&cc.unset, "unset", "", "Unset a specific config field")
 	cc.cmd.Flags().BoolVar(&cc.set, "set", false, "Set a config field to some value")
+	cc.cmd.Flags().StringVar(&cc.removeProfile, "remove-profile", "", "Remove a profile and its stored credentials from the config file")
+	cc.cmd.Flags().BoolVarP(&cc.autoConfirm, "confirm", "c", false, "Skip the confirmation prompt for --remove-profile")
 
 	cc.cmd.Flags().SetInterspersed(false) // allow args to happen after flags to enable 2 arguments to --set
 
@@ -47,6 +60,8 @@ func (cc *configCmd) runConfigCmd(cmd *cobra.Command, args []string) error {
 		return cc.config.Profile.WriteConfigField(args[0], args[1])
 	case cc.unset != "":
 		return cc.config.Profile.DeleteConfigField(cc.unset)
+	case cc.removeProfile != "":
+		return cc.runRemoveProfile(cmd)
 	case cc.list:
 		return cc.config.PrintConfig()
 	case cc.edit:
@@ -55,4 +70,62 @@ func (cc *configCmd) runConfigCmd(cmd *cobra.Command, args []string) error {
 		// no flags set or unrecognized flags/args
 		return cc.cmd.Help()
 	}
+}
+
+func (cc *configCmd) runRemoveProfile(cmd *cobra.Command) error {
+	profileName := cc.removeProfile
+
+	confirmed, err := cc.confirmRemoveProfile(cmd, profileName)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		fmt.Fprintln(cmd.OutOrStdout(), "Aborted. No changes were made.")
+		return nil
+	}
+
+	if err := cc.config.RemoveProfile(profileName); err != nil {
+		if errors.Is(err, config.ErrProfileNotFound) {
+			return errorcategory.UserInputErrorf("no profile named %q was found in %s", profileName, cc.config.ProfilesFile)
+		}
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Removed profile %q and cleared its stored credentials.\n", profileName)
+
+	return nil
+}
+
+// confirmRemoveProfile asks before removing, because a profile can hold an API
+// key the user pasted in by hand rather than one `stripe login` can reissue.
+// Non-interactive runs must pass --confirm rather than silently proceeding.
+func (cc *configCmd) confirmRemoveProfile(cmd *cobra.Command, profileName string) (bool, error) {
+	if cc.autoConfirm {
+		return true, nil
+	}
+
+	if !cc.isInteractive(cmd) {
+		return false, errorcategory.UserInputErrorf("refusing to remove profile %q without confirmation; re-run with --confirm", profileName)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "This removes the profile %q and its stored credentials from %s.\nEnter 'yes' to confirm: ", profileName, cc.config.ProfilesFile)
+
+	input, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	return strings.ToLower(strings.Trim(input, " \r\n")) == "yes", nil
+}
+
+// isInteractive reports whether there is a user on the other end to answer the
+// prompt. The terminal check applies to os.Stdin only: when a caller has
+// substituted the command's input, that input is the thing being read, so it is
+// what decides, not the process's real stdin.
+func (cc *configCmd) isInteractive(cmd *cobra.Command) bool {
+	if cmd.InOrStdin() != os.Stdin {
+		return true
+	}
+
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }

--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -1,0 +1,310 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/keyring"
+)
+
+// A config file holding the shapes a profile can take on disk: a normal one, a
+// dotted one written before periods were rejected, the space-substituted
+// duplicate CopyProfile leaves behind, a table with no display_name, and the
+// machine-wide keys that sit alongside profiles at the top level.
+const removeProfileTestConfig = `color = 'auto'
+machine_uuid = 'bfe13def-d33f-4b4a-9939-dfc900eb635c'
+project-name = 'default'
+
+["bbq.sandbox"]
+account_id = 'acct_123'
+device_name = 'st-test'
+display_name = 'BBQ sandbox'
+test_mode_api_key = 'sk_test_dotted'
+
+['bbq sandbox']
+account_id = 'acct_123'
+device_name = 'st-test'
+display_name = 'BBQ sandbox'
+profile_name = 'BBQ sandbox'
+
+[default]
+device_name = 'st-test'
+display_name = 'Default'
+test_mode_api_key = 'sk_test_default'
+
+[no-display-name]
+device_name = 'st-test'
+
+[plugin_configs]
+[plugin_configs.apps]
+updates = 'off'
+`
+
+func setupRemoveProfileTest(t *testing.T, contents string) (*configCmd, string) {
+	t.Helper()
+
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(profilesFile, []byte(contents), 0600))
+
+	origProfilesFile := Config.ProfilesFile
+	origProfileName := Config.Profile.ProfileName
+	origKeyRing := config.KeyRing
+
+	viper.Reset()
+	Config.ProfilesFile = profilesFile
+	Config.Profile.ProfileName = "default"
+	config.KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		"bbq.sandbox.live_mode_api_key": []byte("rk_live_dotted"),
+		"default.live_mode_api_key":     []byte("rk_live_default"),
+	})
+	Config.InitConfig()
+
+	t.Cleanup(func() {
+		Config.ProfilesFile = origProfilesFile
+		Config.Profile.ProfileName = origProfileName
+		config.KeyRing = origKeyRing
+		viper.Reset()
+	})
+
+	cc := newConfigCmd()
+	cc.autoConfirm = true
+
+	return cc, profilesFile
+}
+
+// run executes the command and returns everything it wrote to stdout.
+func runRemoveProfile(t *testing.T, cc *configCmd, name string) (string, error) {
+	t.Helper()
+
+	var out bytes.Buffer
+	cc.cmd.SetOut(&out)
+	cc.cmd.SetArgs([]string{"--remove-profile", name})
+	if cc.autoConfirm {
+		cc.cmd.SetArgs([]string{"--remove-profile", name, "--confirm"})
+	}
+
+	err := cc.cmd.Execute()
+
+	return out.String(), err
+}
+
+// readBack reloads the config file from disk so assertions see what was actually
+// persisted rather than in-memory viper state.
+func readBack(t *testing.T, profilesFile string) *viper.Viper {
+	t.Helper()
+
+	v := viper.New()
+	v.SetConfigFile(profilesFile)
+	v.SetConfigType("toml")
+	require.NoError(t, v.ReadInConfig())
+
+	return v
+}
+
+// The case that matters most here: a dotted profile is read back as a nested
+// table, so the enumeration over top-level tables never sees it. Removal has to
+// address it by key path, and must not take the sibling profile that shares its
+// first segment.
+func TestConfigRemoveProfileWithDottedName(t *testing.T) {
+	cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+
+	out, err := runRemoveProfile(t, cc, "bbq.sandbox")
+	require.NoError(t, err)
+	assert.Contains(t, out, `Removed profile "bbq.sandbox"`)
+
+	v := readBack(t, profilesFile)
+	assert.False(t, v.IsSet("bbq.sandbox.display_name"), "dotted profile should be gone from the file")
+
+	// The space-substituted duplicate is a separate profile and must survive.
+	assert.Equal(t, "BBQ sandbox", v.GetString("bbq sandbox.display_name"))
+	assert.Equal(t, "Default", v.GetString("default.display_name"))
+	assert.Equal(t, "st-test", v.GetString("no-display-name.device_name"))
+
+	// Machine-wide settings are untouched.
+	assert.Equal(t, "bfe13def-d33f-4b4a-9939-dfc900eb635c", v.GetString("machine_uuid"))
+	assert.Equal(t, "off", v.GetString("plugin_configs.apps.updates"))
+
+	// The keyring entry is namespaced by profile name, so it has to go too, and
+	// only for the profile that was removed.
+	_, err = config.KeyRing.Get("bbq.sandbox.live_mode_api_key")
+	assert.ErrorIs(t, err, keyring.ErrKeyNotFound)
+	remaining, err := config.KeyRing.Get("default.live_mode_api_key")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("rk_live_default"), remaining)
+}
+
+// Removing the space-substituted duplicate must not disturb the dotted original,
+// which is the same assertion in the other direction.
+func TestConfigRemoveProfileLeavesDottedSibling(t *testing.T) {
+	cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+
+	_, err := runRemoveProfile(t, cc, "bbq sandbox")
+	require.NoError(t, err)
+
+	v := readBack(t, profilesFile)
+	assert.False(t, v.IsSet("bbq sandbox.display_name"))
+	assert.Equal(t, "BBQ sandbox", v.GetString("bbq.sandbox.display_name"))
+	assert.Equal(t, "sk_test_dotted", v.GetString("bbq.sandbox.test_mode_api_key"))
+}
+
+func TestConfigRemoveProfileNormalName(t *testing.T) {
+	cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+
+	_, err := runRemoveProfile(t, cc, "default")
+	require.NoError(t, err)
+
+	v := readBack(t, profilesFile)
+	assert.False(t, v.IsSet("default.display_name"))
+	assert.Equal(t, "BBQ sandbox", v.GetString("bbq.sandbox.display_name"))
+}
+
+// A profile written before display_name was always set is invisible to
+// isProfile, so it needs the same key-path fallback the dotted case uses.
+func TestConfigRemoveProfileWithoutDisplayName(t *testing.T) {
+	cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+
+	_, err := runRemoveProfile(t, cc, "no-display-name")
+	require.NoError(t, err)
+
+	v := readBack(t, profilesFile)
+	assert.False(t, v.IsSet("no-display-name.device_name"))
+}
+
+// A profile can also be addressed by its profile_name attribute, which is what
+// CopyProfile records and what `stripe login list` displays.
+func TestConfigRemoveProfileByProfileNameAttribute(t *testing.T) {
+	cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+
+	_, err := runRemoveProfile(t, cc, "BBQ sandbox")
+	require.NoError(t, err)
+
+	v := readBack(t, profilesFile)
+	assert.False(t, v.IsSet("bbq sandbox.display_name"))
+}
+
+func TestConfigRemoveProfileNotFound(t *testing.T) {
+	cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+	before := readFile(t, profilesFile)
+
+	_, err := runRemoveProfile(t, cc, "nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `no profile named "nope" was found`)
+
+	category, ok := errorcategory.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, errorcategory.UserInput, category)
+
+	assert.Equal(t, before, readFile(t, profilesFile), "a failed removal must not rewrite the file")
+}
+
+// A near-miss on a dotted name must not be treated as a hit on its first
+// segment, which is the failure mode viper's key flattening invites.
+func TestConfigRemoveProfileDoesNotMatchPartialDottedName(t *testing.T) {
+	cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+
+	_, err := runRemoveProfile(t, cc, "bbq")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `no profile named "bbq" was found`)
+
+	v := readBack(t, profilesFile)
+	assert.Equal(t, "BBQ sandbox", v.GetString("bbq.sandbox.display_name"))
+}
+
+// Machine-wide keys share the top level with profiles, so a name collision must
+// not let this command delete them.
+func TestConfigRemoveProfileRejectsReservedKeys(t *testing.T) {
+	for _, name := range []string{"machine_uuid", "plugin_configs", "color", "project-name", "installed_plugins", "user_info"} {
+		t.Run(name, func(t *testing.T) {
+			cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+			before := readFile(t, profilesFile)
+
+			_, err := runRemoveProfile(t, cc, name)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "reserved config key")
+			assert.Equal(t, before, readFile(t, profilesFile))
+		})
+	}
+}
+
+// plugin_configs is a nested table, so a key path under it would otherwise
+// resolve like a dotted profile name.
+func TestConfigRemoveProfileRejectsPluginConfigSubtable(t *testing.T) {
+	cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+
+	_, err := runRemoveProfile(t, cc, "plugin_configs.apps")
+	require.Error(t, err)
+
+	v := readBack(t, profilesFile)
+	assert.Equal(t, "off", v.GetString("plugin_configs.apps.updates"))
+}
+
+func TestConfigRemoveProfileRequiresConfirmation(t *testing.T) {
+	cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+	cc.autoConfirm = false
+	before := readFile(t, profilesFile)
+
+	var out bytes.Buffer
+	cc.cmd.SetOut(&out)
+	cc.cmd.SetIn(strings.NewReader("no\n"))
+	cc.cmd.SetArgs([]string{"--remove-profile", "bbq.sandbox"})
+	require.NoError(t, cc.cmd.Execute())
+
+	assert.Contains(t, out.String(), "Aborted. No changes were made.")
+	assert.Equal(t, before, readFile(t, profilesFile))
+}
+
+func TestConfigRemoveProfileProceedsOnYes(t *testing.T) {
+	cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+	cc.autoConfirm = false
+
+	var out bytes.Buffer
+	cc.cmd.SetOut(&out)
+	cc.cmd.SetIn(strings.NewReader("yes\n"))
+	cc.cmd.SetArgs([]string{"--remove-profile", "bbq.sandbox"})
+	require.NoError(t, cc.cmd.Execute())
+
+	v := readBack(t, profilesFile)
+	assert.False(t, v.IsSet("bbq.sandbox.display_name"))
+}
+
+// With no terminal to prompt at, removal must refuse rather than assume yes.
+// os.Stdin under `go test` is not a terminal, which is the same condition as a
+// piped or CI invocation.
+func TestConfigRemoveProfileRefusesWhenNonInteractive(t *testing.T) {
+	cc, profilesFile := setupRemoveProfileTest(t, removeProfileTestConfig)
+	cc.autoConfirm = false
+	before := readFile(t, profilesFile)
+
+	var out bytes.Buffer
+	cc.cmd.SetOut(&out)
+	cc.cmd.SetIn(os.Stdin)
+	cc.cmd.SetArgs([]string{"--remove-profile", "bbq.sandbox"})
+
+	err := cc.cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "re-run with --confirm")
+
+	category, ok := errorcategory.Get(err)
+	require.True(t, ok)
+	assert.Equal(t, errorcategory.UserInput, category)
+
+	assert.Equal(t, before, readFile(t, profilesFile))
+}
+
+func readFile(t *testing.T, name string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(name)
+	require.NoError(t, err)
+
+	return data
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -88,6 +88,11 @@ var rootCmd = &cobra.Command{
 
 		reporting.SetCommandPath(cmd.CommandPath())
 
+		// Warn here rather than in InitConfig: the profile name can come from the
+		// persisted project-name key or STRIPE_PROJECT_NAME, and ReBindKeys applies
+		// both of those after InitConfig has already run.
+		Config.Profile.WarnIfLegacyProfileName()
+
 		// if getting the config errors, don't fail running the command
 		merchant, _ := Config.Profile.GetAccountID()
 		telemetryMetadata := stripe.GetEventMetadata(cmd.Context())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -363,11 +363,50 @@ func (c *Config) SwitchProfile(profileName string) error {
 	return nil
 }
 
+// reservedTopLevelKeys are config keys that sit alongside profiles at the top
+// level of the file but are not profiles. They are excluded from profile removal
+// so that a name collision cannot destroy machine-wide settings.
+var reservedTopLevelKeys = map[string]bool{
+	"color":             true,
+	"installed_plugins": true,
+	"machine_uuid":      true,
+	"plugin_configs":    true,
+	"project-name":      true,
+	UserInfoName:        true,
+}
+
+// ErrProfileNotFound is returned when no profile matches the requested name.
+var ErrProfileNotFound = errorcategory.New(errorcategory.UserInput, "profile not found")
+
+// isReservedConfigKey reports whether name addresses machine-wide config rather
+// than a profile.
+//
+// The first path segment is what matters: a name like "plugin_configs.apps"
+// resolves to a real table, so without this it would look like a legacy profile
+// whose name contains a period and be removable as one.
+func isReservedConfigKey(name string) bool {
+	first, _, _ := strings.Cut(strings.ToLower(name), ".")
+	return reservedTopLevelKeys[first]
+}
+
 // RemoveProfile removes the profile whose name matches the provided
 // profileName from the config file.
+//
+// It returns ErrProfileNotFound when there is nothing to remove, so a caller
+// acting on a name a user typed can tell the difference between a removal and a
+// no-op. Callers that treat removal as best effort can ignore it.
 func (c *Config) RemoveProfile(profileName string) error {
+	if profileName == "" {
+		return errorcategory.Errorf(errorcategory.UserInput, "profile name cannot be empty")
+	}
+
+	if isReservedConfigKey(profileName) {
+		return errorcategory.Errorf(errorcategory.UserInput, "%q is a reserved config key, not a profile", profileName)
+	}
+
 	runtimeViper := viper.GetViper()
 	var err error
+	var matched bool
 
 	for field, value := range runtimeViper.AllSettings() {
 		if isProfile(value) {
@@ -381,6 +420,8 @@ func (c *Config) RemoveProfile(profileName string) error {
 				profileNameAttr = v["profile_name"]
 			}
 			if field == profileName || profileNameAttr == profileName {
+				matched = true
+
 				runtimeViper, err = removeKey(runtimeViper, field)
 				if err != nil {
 					return err
@@ -391,7 +432,48 @@ func (c *Config) RemoveProfile(profileName string) error {
 		}
 	}
 
+	// The enumeration above only finds tables that isProfile recognizes, which
+	// requires a display_name, and it cannot see a profile whose name contains a
+	// period at all because viper reads that back as nesting. Fall back to
+	// addressing the table by its full key path, which hits exactly that profile
+	// and leaves siblings intact.
+	if !matched && isProfileTable(runtimeViper, profileName) {
+		matched = true
+
+		runtimeViper, err = removeKey(runtimeViper, profileName)
+		if err != nil {
+			return err
+		}
+
+		deleteLivemodeKey(LiveModeAPIKeyName, profileName)
+	}
+
+	if !matched {
+		return ErrProfileNotFound
+	}
+
 	return writeConfig(runtimeViper)
+}
+
+// isProfileTable reports whether profileName addresses a table in the config
+// file. It deliberately does not require a display_name: a profile written
+// before display_name was always set, or one whose write was interrupted, still
+// needs to be removable.
+//
+// Get is used rather than AllSettings because Get returns the raw, unflattened
+// sub-map, so a name containing a period resolves to the table the user wrote
+// rather than being split into a path.
+func isProfileTable(v *viper.Viper, profileName string) bool {
+	if !v.IsSet(profileName) {
+		return false
+	}
+
+	switch v.Get(profileName).(type) {
+	case map[string]interface{}, map[string]string:
+		return true
+	}
+
+	return false
 }
 
 // RemoveAllProfiles removes all the profiles from the config file.
@@ -417,6 +499,7 @@ func (c *Config) RemoveAllProfiles() error {
 // preserving non-auth settings like color.
 func (c *Config) RemoveAuthFields(profileName string) error {
 	runtimeViper := viper.GetViper()
+	var matched bool
 
 	for field, value := range runtimeViper.AllSettings() {
 		if isProfile(value) {
@@ -430,11 +513,22 @@ func (c *Config) RemoveAuthFields(profileName string) error {
 				profileNameAttr = v["profile_name"]
 			}
 			if field == profileName || profileNameAttr == profileName {
+				matched = true
+
 				p := &Profile{ProfileName: field}
 				runtimeViper = p.deleteAuthFields(runtimeViper)
 				deleteLivemodeKey(LiveModeAPIKeyName, field)
 			}
 		}
+	}
+
+	// Profiles with a period in the name are nested tables that the enumeration
+	// above cannot see. Clearing them by name is the only way for a user to log
+	// out of one, so handle that case explicitly.
+	if !matched && isNestedProfileName(profileName) && runtimeViper.IsSet(profileName) {
+		p := &Profile{ProfileName: profileName}
+		runtimeViper = p.deleteAuthFields(runtimeViper)
+		deleteLivemodeKey(LiveModeAPIKeyName, profileName)
 	}
 
 	deleteTopLevelLivemodeKey(UATKeychainItemKey)
@@ -491,6 +585,14 @@ func deleteTopLevelLivemodeKey(key string) error {
 		return nil
 	}
 	return err
+}
+
+// isNestedProfileName reports whether a profile name would be read back from
+// the config file as a nested table rather than a single top-level one. Such
+// profiles are skipped by every loop over AllSettings(), because viper joins and
+// splits keys on "." and so cannot distinguish ["a.b"] from [a] -> [b].
+func isNestedProfileName(profileName string) bool {
+	return profileName != "" && strings.Contains(profileName, ".")
 }
 
 // isProfile identifies whether a config entry pertains to a user profile.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -257,6 +257,65 @@ func TestRemoveProfile(t *testing.T) {
 	require.False(t, v.IsSet("to-remove"))
 }
 
+// setupLegacyDottedProfile writes a config file containing a dotted profile
+// alongside a normal one. Dotted names are no longer accepted for new profiles,
+// but ones written before the ban must stay manageable.
+func setupLegacyDottedProfile(t *testing.T) (*Config, string, func()) {
+	t.Helper()
+
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	contents := "[\"example.project\"]\n" +
+		"display_name = 'Legacy'\n" +
+		"test_mode_api_key = 'sk_test_legacy'\n\n" +
+		"[example]\n" +
+		"display_name = 'Sibling'\n" +
+		"test_mode_api_key = 'sk_test_sibling'\n"
+	require.NoError(t, os.WriteFile(profilesFile, []byte(contents), 0600))
+
+	c := &Config{
+		LogLevel:     "info",
+		ProfilesFile: profilesFile,
+		Profile:      Profile{ProfileName: "example.project"},
+	}
+	KeyRing = keyring.NewMemoryStore(nil)
+	c.InitConfig()
+
+	return c, profilesFile, func() {
+		KeyRing = nil
+		viper.Reset()
+	}
+}
+
+// A dotted profile is read back as a nested table, so the enumeration in
+// RemoveProfile never sees it. It must still be removable by name, and removing
+// it must not take the profile that shares its first segment with it.
+func TestRemoveProfileWithDottedName(t *testing.T) {
+	c, _, cleanup := setupLegacyDottedProfile(t)
+	defer cleanup()
+
+	require.NoError(t, c.RemoveProfile("example.project"))
+
+	c.InitConfig()
+	v := viper.GetViper()
+	require.False(t, v.IsSet("example.project.display_name"))
+	require.Equal(t, "sk_test_sibling", v.GetString("example.test_mode_api_key"))
+}
+
+// `stripe logout --project-name example.project` is the documented way out of a
+// legacy dotted profile, so it has to actually clear the credentials rather than
+// report success and leave them on disk.
+func TestRemoveAuthFieldsWithDottedName(t *testing.T) {
+	c, _, cleanup := setupLegacyDottedProfile(t)
+	defer cleanup()
+
+	require.NoError(t, c.RemoveAuthFields("example.project"))
+
+	c.InitConfig()
+	v := viper.GetViper()
+	require.Empty(t, v.GetString("example.project.test_mode_api_key"))
+	require.Equal(t, "sk_test_sibling", v.GetString("example.test_mode_api_key"))
+}
+
 func TestSwitchProfile(t *testing.T) {
 	c, _, cleanup := setupTestConfig(t)
 	defer cleanup()

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -149,6 +149,48 @@ var authFieldNames = []string{
 	"experimental",
 }
 
+// profileExists reports whether the config file already contains a table for
+// this profile. This checks for the table itself rather than any particular
+// field, so that a partially written profile (one with no display_name, which a
+// profile abandoned part-way through login can be) is still recognized.
+func (p *Profile) profileExists() bool {
+	return viper.IsSet(p.ProfileName)
+}
+
+// warnLegacyProfileNameOnce guards the deprecation warning so it prints at most
+// once per process.
+var warnLegacyProfileNameOnce sync.Once
+
+// WarnIfLegacyProfileName tells the user when the active profile has a period in
+// its name.
+//
+// Profile fields are addressed as <profile>.<field> keys in viper, which uses
+// "." as its path separator. A profile name containing a period is therefore
+// indistinguishable from a nested table: viper reads ["a.b"] back as a -> b, so
+// the profile becomes invisible to every operation that enumerates top-level
+// tables, even though reads against it keep working. That makes this warning the
+// only signal the user gets that the profile cannot be listed by name.
+//
+// It only fires for a profile that is actually in the config file, so that a
+// period in a name nobody is using stays silent.
+func (p *Profile) WarnIfLegacyProfileName() {
+	if !strings.Contains(p.ProfileName, ".") || !p.profileExists() {
+		return
+	}
+
+	warnLegacyProfileNameOnce.Do(func() {
+		color := ansi.Color(os.Stderr)
+		fmt.Fprintln(os.Stderr, color.Yellow(fmt.Sprintf(`
+(!) The profile %[1]q contains a period, which can cause unexpected
+behavior and will stop being accepted in a future release. We strongly
+recommend migrating it: log in under a new name and remove the old one.
+  stripe login --project-name %[2]s
+  stripe config --remove-profile %[1]s`,
+			p.ProfileName,
+			strings.ReplaceAll(p.ProfileName, ".", "-"))))
+	})
+}
+
 // CreateProfile creates a profile when logging in
 func (p *Profile) CreateProfile() error {
 	// Remove only auth-related keys under existing profile first
@@ -438,6 +480,7 @@ func (p *Profile) RegisterAlias(alias, key string) {
 // configuration to disk.
 func (p *Profile) WriteConfigField(field, value string) error {
 	viper.ReadInConfig()
+
 	viper.Set(p.GetConfigField(field), value)
 	return writeConfig(viper.GetViper())
 }

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -12,6 +14,113 @@ import (
 	"github.com/stripe/stripe-cli/pkg/errorcategory"
 	"github.com/stripe/stripe-cli/pkg/keyring"
 )
+
+// setupProfileConfig writes contents to a temp config file and initializes the
+// global viper from it, so tests exercise the same read path as the CLI rather
+// than viper's override layer, which nests keys by splitting on ".".
+func setupProfileConfig(t *testing.T, contents string) (*Config, string) {
+	t.Helper()
+
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(profilesFile, []byte(contents), 0600))
+
+	if KeyRing == nil {
+		KeyRing = keyring.NewMemoryStore(nil)
+	}
+	t.Cleanup(func() {
+		KeyRing = nil
+		viper.Reset()
+	})
+
+	c := &Config{LogLevel: "info", ProfilesFile: profilesFile}
+	c.InitConfig()
+
+	return c, profilesFile
+}
+
+func TestWarnIfLegacyProfileName(t *testing.T) {
+	tests := []struct {
+		name        string
+		profileName string
+		contents    string
+		wantWarning bool
+	}{
+		{
+			name:        "existing dotted profile warns",
+			profileName: "example.project",
+			contents:    "[\"example.project\"]\ndisplay_name = 'Legacy'\n",
+			wantWarning: true,
+		},
+		{
+			// Nothing is broken until such a profile is actually written, so
+			// warning here would only be noise.
+			name:        "dotted profile that is not in the config file is silent",
+			profileName: "example.project",
+			contents:    "[default]\ndisplay_name = 'Default'\n",
+		},
+		{
+			name:        "valid profile is silent",
+			profileName: "default",
+			contents:    "[default]\ndisplay_name = 'Default'\n",
+		},
+		{
+			name:     "empty profile name is silent",
+			contents: "[default]\ndisplay_name = 'Default'\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupProfileConfig(t, tt.contents)
+
+			warnLegacyProfileNameOnce = sync.Once{}
+			t.Cleanup(func() { warnLegacyProfileNameOnce = sync.Once{} })
+
+			p := Profile{ProfileName: tt.profileName}
+			stderr := captureStderr(t, p.WarnIfLegacyProfileName)
+
+			if !tt.wantWarning {
+				require.Empty(t, stderr)
+				return
+			}
+
+			require.Contains(t, stderr, `The profile "example.project" contains a period`)
+			require.Contains(t, stderr, "stripe login --project-name example-project")
+			require.Contains(t, stderr, "stripe config --remove-profile example.project")
+		})
+	}
+}
+
+// The warning is printed once per process so it does not repeat for every
+// command in a session.
+func TestWarnIfLegacyProfileNameOnlyWarnsOnce(t *testing.T) {
+	setupProfileConfig(t, "[\"example.project\"]\ndisplay_name = 'Legacy'\n")
+
+	warnLegacyProfileNameOnce = sync.Once{}
+	t.Cleanup(func() { warnLegacyProfileNameOnce = sync.Once{} })
+
+	p := Profile{ProfileName: "example.project"}
+	require.NotEmpty(t, captureStderr(t, p.WarnIfLegacyProfileName))
+	require.Empty(t, captureStderr(t, p.WarnIfLegacyProfileName))
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	original := os.Stderr
+	os.Stderr = w
+	fn()
+	os.Stderr = original
+	require.NoError(t, w.Close())
+
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	return string(out)
+}
 
 func TestWriteProfile(t *testing.T) {
 	profilesFile := filepath.Join(t.TempDir(), "config.toml")


### PR DESCRIPTION
### Motivation
We don't reject periods in profile names, but viper treats a period as a path separator. A profile named `sandbox.profile` is stored and read back as nested tables (bbq -> sandbox), so it misbehaves in profile-related commands

### Summary
This PR adds a warning when we detect a profile name containing dots, and a new `stripe config --remove-profile` command users can run to remove the profile. Nothing is rejected yet, banning dots in new names is a breaking change and ships in the next major release (#1920).


### Testing
- [x] added unit tests
- [x] manually tested
```
% ./bin/stripe login list 

(!) The profile "test.profile" contains a period, which can cause unexpected
behavior and will stop being accepted in a future release. We strongly
recommend migrating it: log in under a new name and remove the old one.
  stripe login --project-name test-profile
  stripe config --remove-profile test.profile
Authorized contexts (1):
  BBQ sandbox  acct_1... test     ● active
% ./bin/stripe config --remove-profile plugin_configs.apps

(!) The profile "test.profile" contains a period, which can cause unexpected
behavior and will stop being accepted in a future release. We strongly
recommend migrating it: log in under a new name and remove the old one.
  stripe login --project-name test-profile
  stripe config --remove-profile test.profile
"plugin_configs.apps" is a reserved config key, not a profile


% ./bin/stripe config --remove-profile nope

(!) The profile "test.profile" contains a period, which can cause unexpected
behavior and will stop being accepted in a future release. We strongly
recommend migrating it: log in under a new name and remove the old one.
  stripe login --project-name test-profile
  stripe config --remove-profile test.profile
no profile named "nope" was found in bin/cfgtest/config.toml

% ./bin/stripe config --remove-profile test.profile

(!) The profile "test.profile" contains a period, which can cause unexpected
behavior and will stop being accepted in a future release. We strongly
recommend migrating it: log in under a new name and remove the old one.
  stripe login --project-name test-profile
  stripe config --remove-profile test.profile
This removes the profile "test.profile" and its stored credentials from bin/cfgtest/config.toml.
Enter 'yes' to confirm: yes
Removed profile "test.profile" and cleared its stored credentials.

% ./bin/stripe login list
Authorized contexts (1):
  BBQ sandbox  acct_1....  test     ● active
 % 
```