### PR TITLE
Pin test workflow actions to commit SHAs on v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ matrix.go-version }}
     # Windows throws false positives with linting because of CRLF / goimports incompat
@@ -22,14 +22,18 @@ jobs:
         git config --global core.autocrlf false
         git config --global core.eol lf
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        persist-credentials: false
     - name: Run Setup
       run: make setup
     - name: install diffutils
       if: runner.os == 'macOS'
       run: brew install diffutils
     - name: Install protoc
-      uses: arduino/setup-protoc@v3
+      # NB: `v3` is a *branch* in this repo, not a tag, so it moved with every
+      # push. This pins the commit that the v3.0.0 release points at.
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
         version: '28.3'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,7 +44,7 @@ jobs:
         go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
       shell: bash
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:
         version: v2.10.1
         args: --max-issues-per-linter=0 --max-same-issues=0


### PR DESCRIPTION
The repo now requires every GitHub Action to be pinned to a full commit SHA. `v2`'s `test.yml` still uses floating tags, so every test job on a `v2` PR is killed during "Set up job" before anything compiles:

```
The actions actions/setup-go@v6, actions/checkout@v6, arduino/setup-protoc@v3,
and golangci/golangci-lint-action@v9 are not allowed in stripe/stripe-cli
because all actions must be pinned to a full-length commit SHA.
```

Master fixed this in #1916; `v2` never got it. This applies the same pinning to `test.yml`, copied from master so a later master -> v2 merge sees identical changes on both sides and resolves without conflict. Unblocks #1920 and #1915.