### PR TITLE
Fix grammar and terminology in login flows

### DIFF
--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -32,7 +32,7 @@ func newDeleteCmd(isPreview bool) *requests.Base {
 		Use:   "delete <path>",
 		Args:  validators.ExactArgs(1),
 		Short: "Make a " + verb + " request to the Stripe API",
-		Long: `Make ` + verb + ` requests to the Stripe API using your sandbox key.
+		Long: `Make ` + verb + ` requests to the Stripe API using your test key.
 ` + previewNote + `
 For a full list of supported paths, see the API reference:
 https://stripe.com/docs/api

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -32,7 +32,7 @@ func newDeleteCmd(isPreview bool) *requests.Base {
 		Use:   "delete <path>",
 		Args:  validators.ExactArgs(1),
 		Short: "Make a " + verb + " request to the Stripe API",
-		Long: `Make ` + verb + ` requests to the Stripe API using your test mode key.
+		Long: `Make ` + verb + ` requests to the Stripe API using your sandbox key.
 ` + previewNote + `
 For a full list of supported paths, see the API reference:
 https://stripe.com/docs/api

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -32,7 +32,7 @@ func newDeleteCmd(isPreview bool) *requests.Base {
 		Use:   "delete <path>",
 		Args:  validators.ExactArgs(1),
 		Short: "Make a " + verb + " request to the Stripe API",
-		Long: `Make ` + verb + ` requests to the Stripe API using your test key.
+		Long: `Make ` + verb + ` requests to the Stripe API using your sandbox key.
 ` + previewNote + `
 For a full list of supported paths, see the API reference:
 https://stripe.com/docs/api

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -144,9 +144,9 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	var mismatch *config.ActiveContextLivemodeMismatchError
 	if errors.As(err, &mismatch) {
 		if mismatch.ActiveLivemode {
-			return errorcategory.UserInputErrorf("your active context is livemode; add --live to match it, or run 'stripe switch context' to select a test mode context")
+			return errorcategory.UserInputErrorf("You're in live mode. Add --live to run the command, or run 'stripe switch context' to select a sandbox.")
 		}
-		return errorcategory.UserInputErrorf("your active context is test mode; remove --live to match it, or run 'stripe switch context' to select a livemode context")
+		return errorcategory.UserInputErrorf("You're in a sandbox. Remove --live to run the command, or run 'stripe switch context' to select a live account.")
 	}
 	if err != nil {
 		return err

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -51,8 +51,8 @@ func newLoginCmd() *loginCmd {
 	lc.cmd = &cobra.Command{
 		Use:   "login",
 		Args:  validators.NoArgs,
-		Short: "Login to your Stripe account",
-		Long: `Login to your Stripe account to set up the CLI.
+		Short: "Log in to your Stripe account",
+		Long: `Log in to your Stripe account to set up the CLI.
 
 By default (when stdin is a terminal), this opens a browser-based OAuth flow: it
 prints a pairing code, launches your browser to the Stripe Dashboard, and waits for
@@ -138,7 +138,7 @@ For agents and scripts, use the two-step non-interactive flow:
 		Example: `stripe login switch\n  stripe login switch acct_1234\n  stripe login switch acct_1234 --live`,
 		RunE:    switchCmd.switchLoggedInAccountCmd,
 	}
-	switchCmd.cmd.Flags().BoolVar(&switchCmd.livemode, "live", false, "Select livemode for the given account")
+	switchCmd.cmd.Flags().BoolVar(&switchCmd.livemode, "live", false, "Select live mode for the given account")
 	switchCmd.cmd.Flags().StringVar(&switchCmd.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
 	switchCmd.cmd.Flags().MarkHidden("access-base") // #nosec G104
 

--- a/pkg/cmd/logout.go
+++ b/pkg/cmd/logout.go
@@ -20,8 +20,8 @@ func newLogoutCmd() *logoutCmd {
 	lc.cmd = &cobra.Command{
 		Use:   "logout",
 		Args:  validators.NoArgs,
-		Short: "Logout of your Stripe account",
-		Long:  `Logout of your Stripe account from the CLI`,
+		Short: "Log out of your Stripe account",
+		Long:  `Log out of your Stripe account from the CLI`,
 		RunE:  lc.runLogoutCmd,
 	}
 

--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -174,7 +174,7 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if ac, acErr := config.GetActiveContext(); acErr == nil && ac != nil && ac.Livemode {
-		return errorcategory.UserInputErrorf("'stripe logs tail' only works in test mode, but your active context is livemode; run 'stripe switch context' to select a test mode context")
+		return errorcategory.UserInputErrorf("'stripe logs tail' only works in sandboxes, but you're in live mode. Run 'stripe switch context' to select a sandbox.")
 	}
 
 	creds, err := tailCmd.cfg.Profile.ResolveCredentials(false)

--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -218,7 +218,7 @@ func (p *pluginHintCmd) suggestNotAvailable() error {
 		return nil
 	}
 
-	fmt.Fprintf(p.stdout, "The logged-in account %s does not have access to the private preview 'generate' plugin. Log into a different account with 'stripe login', or contact Stripe support.\n", accountID)
+	fmt.Fprintf(p.stdout, "The logged-in account %s does not have access to the private preview 'generate' plugin. Log in to a different account with 'stripe login', or contact Stripe support.\n", accountID)
 	fmt.Fprintf(p.stdout, "\n")
 	fmt.Fprintf(p.stdout, "%s\n", p.description)
 	os.Exit(1)

--- a/pkg/cmd/post.go
+++ b/pkg/cmd/post.go
@@ -32,7 +32,7 @@ func newPostCmd(isPreview bool) *requests.Base {
 		Use:   "post <path>",
 		Args:  validators.ExactArgs(1),
 		Short: "Make a " + verb + " request to the Stripe API",
-		Long: `Make ` + verb + ` requests to the Stripe API using your test key.
+		Long: `Make ` + verb + ` requests to the Stripe API using your sandbox key.
 
 The post command supports API features like idempotency keys and expand flags.
 ` + previewNote + `

--- a/pkg/cmd/post.go
+++ b/pkg/cmd/post.go
@@ -32,7 +32,7 @@ func newPostCmd(isPreview bool) *requests.Base {
 		Use:   "post <path>",
 		Args:  validators.ExactArgs(1),
 		Short: "Make a " + verb + " request to the Stripe API",
-		Long: `Make ` + verb + ` requests to the Stripe API using your test mode key.
+		Long: `Make ` + verb + ` requests to the Stripe API using your sandbox key.
 
 The post command supports API features like idempotency keys and expand flags.
 ` + previewNote + `

--- a/pkg/cmd/post.go
+++ b/pkg/cmd/post.go
@@ -32,7 +32,7 @@ func newPostCmd(isPreview bool) *requests.Base {
 		Use:   "post <path>",
 		Args:  validators.ExactArgs(1),
 		Short: "Make a " + verb + " request to the Stripe API",
-		Long: `Make ` + verb + ` requests to the Stripe API using your sandbox key.
+		Long: `Make ` + verb + ` requests to the Stripe API using your test key.
 
 The post command supports API features like idempotency keys and expand flags.
 ` + previewNote + `

--- a/pkg/cmd/switch.go
+++ b/pkg/cmd/switch.go
@@ -34,14 +34,14 @@ func newSwitchCmd() *switchCmd {
 Without an argument, shows an interactive list of your authorized accounts and
 modes. Navigate with ↑↓, confirm with enter, or cancel with esc.
 
-With an account ID, switches directly to that account in test mode by default.
-Use --live to switch to livemode instead.`,
+With an account ID, switches directly to that account's sandbox by default.
+Use --live to switch to live mode instead.`,
 		Example: `  stripe switch context
   stripe switch context acct_1234
   stripe switch context acct_1234 --live`,
 		RunE: ctxCmd.run,
 	}
-	ctxCmd.cmd.Flags().BoolVar(&ctxCmd.livemode, "live", false, "Select livemode for the given account")
+	ctxCmd.cmd.Flags().BoolVar(&ctxCmd.livemode, "live", false, "Select live mode for the given account")
 	ctxCmd.cmd.Flags().StringVar(&ctxCmd.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
 	ctxCmd.cmd.Flags().MarkHidden("access-base") //nolint:errcheck
 

--- a/pkg/cmd/switch.go
+++ b/pkg/cmd/switch.go
@@ -34,8 +34,7 @@ func newSwitchCmd() *switchCmd {
 Without an argument, shows an interactive list of your authorized accounts and
 modes. Navigate with ↑↓, confirm with enter, or cancel with esc.
 
-With an account ID, switches directly to that account's sandbox by default.
-Use --live to switch to live mode instead.`,
+With an account ID, switches directly to that account. Add --live to switch to live mode.`,
 		Example: `  stripe switch context
   stripe switch context acct_1234
   stripe switch context acct_1234 --live`,

--- a/pkg/cmd/templates.go
+++ b/pkg/cmd/templates.go
@@ -333,7 +333,7 @@ func getLogin(fs *afero.Fs, cfg *config.Config) string {
 
 	if !exists {
 		return `
-Before using the CLI, you'll need to login:
+Before using the CLI, you'll need to log in:
 
   $ stripe login
 

--- a/pkg/cmd/templates_test.go
+++ b/pkg/cmd/templates_test.go
@@ -18,7 +18,7 @@ func TestGetLogin(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	cfg := config.Config{}
 	expected := `
-Before using the CLI, you'll need to login:
+Before using the CLI, you'll need to log in:
 
   $ stripe login
 

--- a/pkg/cmd/trigger.go
+++ b/pkg/cmd/trigger.go
@@ -50,7 +50,7 @@ needed to create the triggered event as well as the corresponding API objects.
 		Annotations: map[string]string{
 			AIAgentHelpAnnotationKey: "  Use `--override` to customize event data, e.g. `--override customer:email=test@example.com`.\n" +
 				"  Use `--skip` to skip specific steps in the trigger sequence.\n" +
-				"  Triggers create real API objects in test mode that you can inspect afterward.",
+				"  Triggers create real API objects in your sandbox that you can inspect afterward.",
 		},
 		RunE: tc.runTriggerCmd,
 	}

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -53,14 +53,14 @@ func newWhoamiCmd() *whoamiCmd {
 	wc.cmd = &cobra.Command{
 		Use:   "whoami",
 		Args:  validators.NoArgs,
-		Short: "Show the current Stripe auth state",
-		Long: `Display the current authentication state for the Stripe CLI.
+		Short: "Show the current Stripe auth context",
+		Long: `Display the current authentication context for the Stripe CLI.
 
 Reads credentials from the config file and keychain — no API calls are made.
 
 Use --format json for output suitable for scripting or agent consumption. The
 schema is stable: test_mode_key and live_mode_key are always present regardless
-of auth state, and authenticated: false indicates no usable credentials exist.
+of auth context, and authenticated: false indicates no usable credentials exist.
 
 Exit codes:
   0  Authenticated (at least one key is available)
@@ -133,7 +133,7 @@ func (wc *whoamiCmd) runWhoamiOAuth(cmd *cobra.Command, uat string) error {
 	ac, _ := config.GetActiveContext()
 	if ac != nil {
 		displayName := wc.profile.GetDisplayName()
-		mode := "test"
+		mode := "sandbox"
 		if ac.Livemode {
 			mode = "live"
 		}
@@ -175,7 +175,7 @@ func printWhoamiText(out io.Writer, data whoamiOutput) {
 		fmt.Fprintf(w, "Device name:\t%s\n", data.DeviceName)
 	}
 
-	fmt.Fprintf(w, "Test mode key:\t%s\n", keyAvailabilityText(data.TestModeKey))
+	fmt.Fprintf(w, "Sandbox key:\t%s\n", keyAvailabilityText(data.TestModeKey))
 	fmt.Fprintf(w, "Live mode key:\t%s\n", keyAvailabilityText(data.LiveModeKey))
 	fmt.Fprintf(w, "API version:\t%s\n", data.APIVersion)
 	fmt.Fprintf(w, "Preview API version:\t%s\n", data.PreviewAPIVersion)

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -175,8 +175,8 @@ func printWhoamiText(out io.Writer, data whoamiOutput) {
 		fmt.Fprintf(w, "Device name:\t%s\n", data.DeviceName)
 	}
 
-	fmt.Fprintf(w, "Sandbox key:\t%s\n", keyAvailabilityText(data.TestModeKey))
-	fmt.Fprintf(w, "Live mode key:\t%s\n", keyAvailabilityText(data.LiveModeKey))
+	fmt.Fprintf(w, "Test key:\t%s\n", keyAvailabilityText(data.TestModeKey))
+	fmt.Fprintf(w, "Live key:\t%s\n", keyAvailabilityText(data.LiveModeKey))
 	fmt.Fprintf(w, "API version:\t%s\n", data.APIVersion)
 	fmt.Fprintf(w, "Preview API version:\t%s\n", data.PreviewAPIVersion)
 }

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -175,7 +175,7 @@ func printWhoamiText(out io.Writer, data whoamiOutput) {
 		fmt.Fprintf(w, "Device name:\t%s\n", data.DeviceName)
 	}
 
-	fmt.Fprintf(w, "Test key:\t%s\n", keyAvailabilityText(data.TestModeKey))
+	fmt.Fprintf(w, "Sandbox key:\t%s\n", keyAvailabilityText(data.TestModeKey))
 	fmt.Fprintf(w, "Live mode key:\t%s\n", keyAvailabilityText(data.LiveModeKey))
 	fmt.Fprintf(w, "API version:\t%s\n", data.APIVersion)
 	fmt.Fprintf(w, "Preview API version:\t%s\n", data.PreviewAPIVersion)

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -175,8 +175,8 @@ func printWhoamiText(out io.Writer, data whoamiOutput) {
 		fmt.Fprintf(w, "Device name:\t%s\n", data.DeviceName)
 	}
 
-	fmt.Fprintf(w, "Test key:\t%s\n", keyAvailabilityText(data.TestModeKey))
-	fmt.Fprintf(w, "Live key:\t%s\n", keyAvailabilityText(data.LiveModeKey))
+	fmt.Fprintf(w, "Sandbox key:\t%s\n", keyAvailabilityText(data.TestModeKey))
+	fmt.Fprintf(w, "Live mode key:\t%s\n", keyAvailabilityText(data.LiveModeKey))
 	fmt.Fprintf(w, "API version:\t%s\n", data.APIVersion)
 	fmt.Fprintf(w, "Preview API version:\t%s\n", data.PreviewAPIVersion)
 }

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -175,7 +175,7 @@ func printWhoamiText(out io.Writer, data whoamiOutput) {
 		fmt.Fprintf(w, "Device name:\t%s\n", data.DeviceName)
 	}
 
-	fmt.Fprintf(w, "Sandbox key:\t%s\n", keyAvailabilityText(data.TestModeKey))
+	fmt.Fprintf(w, "Test key:\t%s\n", keyAvailabilityText(data.TestModeKey))
 	fmt.Fprintf(w, "Live mode key:\t%s\n", keyAvailabilityText(data.LiveModeKey))
 	fmt.Fprintf(w, "API version:\t%s\n", data.APIVersion)
 	fmt.Fprintf(w, "Preview API version:\t%s\n", data.PreviewAPIVersion)

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -834,9 +834,9 @@ type ActiveContextLivemodeMismatchError struct {
 
 func (e *ActiveContextLivemodeMismatchError) Error() string {
 	if e.ActiveLivemode {
-		return "your active context is livemode; run 'stripe switch context' to select a test mode context"
+		return "You're in live mode. Run 'stripe switch context' to select a sandbox."
 	}
-	return "your active context is test mode; run 'stripe switch context' to select a livemode context"
+	return "You're in a sandbox. Run 'stripe switch context' to select a live account."
 }
 
 // ResolveCredentials returns the credentials for the given mode. If an OAK
@@ -887,7 +887,7 @@ func (p *Profile) ResolveCredentials(livemode bool) (stripe.Credentials, error) 
 				return stripe.Credentials{}, err
 			}
 			if livemode && compartmentID == "" {
-				return stripe.Credentials{}, errorcategory.UserInputErrorf("you're logged in to a sandbox; to access livemode, reauthenticate with 'stripe login' and select your live account")
+				return stripe.Credentials{}, errorcategory.UserInputErrorf("You're logged in to a sandbox. To access live mode, reauthenticate with 'stripe login' and select your live account.")
 			}
 			return stripe.NewOAKCredentials(uat, compartmentID, livemode), nil
 		}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -779,7 +779,7 @@ func (p *Profile) PrintActiveContextBanner() {
 		if ac == nil {
 			return
 		}
-		mode := "test"
+		mode := "sandbox"
 		if ac.Livemode {
 			mode = "live"
 		}

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -387,7 +387,7 @@ func TestResolveCredentialsOAKLivemodeNoCompartment(t *testing.T) {
 	p := Profile{ProfileName: "default"}
 	_, err := p.ResolveCredentials(true)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "you're logged in to a sandbox")
+	require.Contains(t, err.Error(), "You're logged in to a sandbox")
 	require.Contains(t, err.Error(), "stripe login")
 }
 

--- a/pkg/login/oauth_accounts.go
+++ b/pkg/login/oauth_accounts.go
@@ -86,7 +86,7 @@ func PrintAuthorizedContexts(ctx context.Context, accessBaseURL, accessToken str
 			rows = append(rows, row{
 				name:   a.Name,
 				id:     a.ID,
-				mode:   m,
+				mode:   displayMode(m),
 				active: a.ID == activeID && m == activeMode,
 			})
 			if len(a.Name) > nameW {
@@ -108,6 +108,14 @@ func PrintAuthorizedContexts(ctx context.Context, accessBaseURL, accessToken str
 		}
 	}
 	return nil
+}
+
+// displayMode maps the API's "test" mode value to the CLI's "sandbox" terminology.
+func displayMode(m string) string {
+	if m == "test" {
+		return "sandbox"
+	}
+	return m
 }
 
 // pickActiveContext selects the active account and livemode from the list of

--- a/pkg/login/switch_context.go
+++ b/pkg/login/switch_context.go
@@ -70,7 +70,7 @@ func applyContext(cfg *config.Config, account config.AuthorizedAccount, mode str
 	if err := cfg.Profile.CreateProfile(); err != nil {
 		return err
 	}
-	fmt.Printf("Active context: %s · %s (%s)\n", account.Name, mode, account.ID)
+	fmt.Printf("Active context: %s · %s (%s)\n", account.Name, displayMode(mode), account.ID)
 	return nil
 }
 
@@ -234,7 +234,7 @@ func (m switchContextModel) View() tea.View {
 			if r.active {
 				activeMarker = "  " + switchActiveStyle.Render("● active")
 			}
-			line := fmt.Sprintf("%s%-*s  %-*s  %-7s%s", pointer, m.nameW, r.name, m.idW, r.id, r.mode, activeMarker)
+			line := fmt.Sprintf("%s%-*s  %-*s  %-7s%s", pointer, m.nameW, r.name, m.idW, r.id, displayMode(r.mode), activeMarker)
 			line = strings.TrimRight(line, " ")
 			if i == m.cursor {
 				line = switchCursorStyle.Render(line)

--- a/pkg/login/switch_context.go
+++ b/pkg/login/switch_context.go
@@ -50,11 +50,11 @@ func switchByID(cfg *config.Config, accounts []config.AuthorizedAccount, account
 			}
 		}
 		if livemode {
-			return errorcategory.Errorf(errorcategory.Auth, "account %s is not authorized for livemode", accountID)
+			return errorcategory.Errorf(errorcategory.Auth, "Account %s does not have live mode access", accountID)
 		}
-		return errorcategory.Errorf(errorcategory.Auth, "account %s is not authorized for test mode; use --live to switch to livemode", accountID)
+		return errorcategory.Errorf(errorcategory.Auth, "Account %s does not have sandbox access; use --live to switch to live mode", accountID)
 	}
-	return errorcategory.Errorf(errorcategory.Auth, "account %s not found in your authorized accounts", accountID)
+	return errorcategory.Errorf(errorcategory.Auth, "Account %s not found in your authorized accounts", accountID)
 }
 
 func applyContext(cfg *config.Config, account config.AuthorizedAccount, mode string) error {

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -235,9 +235,9 @@ func (rb *Base) ResolveCredentials() (stripe.Credentials, error) {
 	var mismatch *config.ActiveContextLivemodeMismatchError
 	if errors.As(err, &mismatch) {
 		if mismatch.ActiveLivemode {
-			return stripe.Credentials{}, errorcategory.UserInputErrorf("your active context is livemode; add --live to match it, or run 'stripe switch context' to select a test mode context")
+			return stripe.Credentials{}, errorcategory.UserInputErrorf("You're in live mode. Add --live to run the command, or run 'stripe switch context' to select a sandbox.")
 		}
-		return stripe.Credentials{}, errorcategory.UserInputErrorf("your active context is test mode; remove --live to match it, or run 'stripe switch context' to select a livemode context")
+		return stripe.Credentials{}, errorcategory.UserInputErrorf("You're in a sandbox. Remove --live to run the command, or run 'stripe switch context' to select a live account.")
 	}
 	return creds, err
 }

--- a/pkg/validators/validate.go
+++ b/pkg/validators/validate.go
@@ -94,7 +94,7 @@ func APIKey(input string) error {
 
 	keyParts := strings.Split(input, "_")
 	if len(keyParts) < 3 {
-		return authError("You are using a legacy-style API key, which is unsupported by the CLI. Please generate a new sandbox API key")
+		return authError("You are using a legacy-style API key, which is unsupported by the CLI. Please generate a new test API key")
 	}
 
 	if keyParts[0] != "sk" && keyParts[0] != "rk" && keyParts[0] != "rkcs" {
@@ -114,7 +114,7 @@ func APIKeyNotRestricted(input string) error {
 
 	keyParts := strings.Split(input, "_")
 	if len(keyParts) < 3 {
-		return authError("You are using a legacy-style API key, which is unsupported by the CLI. Please generate a new sandbox API key")
+		return authError("You are using a legacy-style API key, which is unsupported by the CLI. Please generate a new test API key")
 	}
 
 	if keyParts[0] != "sk" || keyParts[0] == "rk" {

--- a/pkg/validators/validate.go
+++ b/pkg/validators/validate.go
@@ -94,7 +94,7 @@ func APIKey(input string) error {
 
 	keyParts := strings.Split(input, "_")
 	if len(keyParts) < 3 {
-		return authError("you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
+		return authError("You are using a legacy-style API key, which is unsupported by the CLI. Please generate a new sandbox API key")
 	}
 
 	if keyParts[0] != "sk" && keyParts[0] != "rk" && keyParts[0] != "rkcs" {
@@ -114,7 +114,7 @@ func APIKeyNotRestricted(input string) error {
 
 	keyParts := strings.Split(input, "_")
 	if len(keyParts) < 3 {
-		return authError("you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
+		return authError("You are using a legacy-style API key, which is unsupported by the CLI. Please generate a new sandbox API key")
 	}
 
 	if keyParts[0] != "sk" || keyParts[0] == "rk" {

--- a/pkg/validators/validate_test.go
+++ b/pkg/validators/validate_test.go
@@ -41,7 +41,7 @@ func TestKeyTooShort(t *testing.T) {
 
 func TestLegacyAPIKeys(t *testing.T) {
 	err := APIKey("sk_123457890abcdef")
-	require.EqualError(t, err, "you are using a legacy-style API key which is unsupported by the CLI. Please generate a new test mode API key")
+	require.EqualError(t, err, "You are using a legacy-style API key, which is unsupported by the CLI. Please generate a new sandbox API key")
 	requireErrorCategory(t, err, errorcategory.Auth)
 }
 

--- a/pkg/validators/validate_test.go
+++ b/pkg/validators/validate_test.go
@@ -41,7 +41,7 @@ func TestKeyTooShort(t *testing.T) {
 
 func TestLegacyAPIKeys(t *testing.T) {
 	err := APIKey("sk_123457890abcdef")
-	require.EqualError(t, err, "You are using a legacy-style API key, which is unsupported by the CLI. Please generate a new sandbox API key")
+	require.EqualError(t, err, "You are using a legacy-style API key, which is unsupported by the CLI. Please generate a new test API key")
 	requireErrorCategory(t, err, errorcategory.Auth)
 }
 


### PR DESCRIPTION
Updates a bunch of copy in the login flows:
- Messages are sentence-cased
- "Livemode" and "testmode" are correctly referenced as "live mode" and "sandbox"
- The verb forms "log in" and "log out" are used where appropriate
- Couple other minor suggestions.

Examples:
<img width="666" height="138" alt="Screenshot 2026-08-18 at 4 37 21 PM" src="https://github.com/user-attachments/assets/0e6d6baf-caa3-46cf-ae62-9f84e300413d" />
<img width="790" height="144" alt="Screenshot 2026-08-18 at 4 37 44 PM" src="https://github.com/user-attachments/assets/a936227b-01c6-40fb-a405-a0f911e3ed58" />
<img width="675" height="301" alt="Screenshot 2026-08-18 at 4 38 33 PM" src="https://github.com/user-attachments/assets/b811a060-906a-45a3-90e3-6096d24d5b66" />
