### PR TITLE
Wait for reauth to complete, then print authorized contexts

### DIFF
--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -196,7 +196,7 @@ func PollPendingDeviceAuth(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("failed to save account info: %w", err)
 	}
 
-	printLoginSuccess(accounts, activeID, activeLivemode)
+	printAuthorizedSummary(accounts, activeID, activeLivemode)
 	warnIfInsecureStorage()
 	return nil
 }

--- a/pkg/login/oauth_device.go
+++ b/pkg/login/oauth_device.go
@@ -220,7 +220,7 @@ func LoginWithDeviceCode(ctx context.Context, accessBaseURL string, cfg *config.
 		return fmt.Errorf("failed to save account info: %w", err)
 	}
 
-	printLoginSuccess(accounts, activeID, activeLivemode)
+	printAuthorizedSummary(accounts, activeID, activeLivemode)
 	warnIfInsecureStorage()
 	return nil
 }
@@ -255,7 +255,9 @@ func buildContextRows(accounts []config.AuthorizedAccount, activeID string, acti
 	return rows
 }
 
-func printLoginSuccess(accounts []config.AuthorizedAccount, activeID string, activeLivemode bool) {
+// printAuthorizedSummary prints the "Done! The Stripe CLI is authorized for
+// ..." banner and context table shared by login and reauth.
+func printAuthorizedSummary(accounts []config.AuthorizedAccount, activeID string, activeLivemode bool) {
 	color := ansi.Color(os.Stdout)
 	rows := buildContextRows(accounts, activeID, activeLivemode)
 
@@ -266,7 +268,7 @@ func printLoginSuccess(accounts []config.AuthorizedAccount, activeID string, act
 
 	if len(rows) == 1 {
 		r := rows[0]
-		ctx := fmt.Sprintf("%s · %s", r.name, r.mode)
+		ctx := fmt.Sprintf("%s · %s", r.name, displayMode(r.mode))
 		fmt.Printf("%s Done! The Stripe CLI is authorized for %s (%s)\n", color.Green("✓"), ctx, r.id)
 		fmt.Printf("  Active context: %s\n\n", ctx)
 		fmt.Println("Run 'stripe reauth' to change permissions or authorize access to additional accounts or sandboxes.")
@@ -280,8 +282,8 @@ func printLoginSuccess(accounts []config.AuthorizedAccount, activeID string, act
 		if len(r.name) > nameW {
 			nameW = len(r.name)
 		}
-		if len(r.mode) > modeW {
-			modeW = len(r.mode)
+		if dl := len(displayMode(r.mode)); dl > modeW {
+			modeW = dl
 		}
 		if len(r.id) > idW {
 			idW = len(r.id)
@@ -289,10 +291,11 @@ func printLoginSuccess(accounts []config.AuthorizedAccount, activeID string, act
 	}
 
 	for _, r := range rows {
+		mode := displayMode(r.mode)
 		if r.active {
-			fmt.Printf("  %-*s  %-*s  %-*s  %s active\n", nameW, r.name, modeW, r.mode, idW, r.id, color.Green("●"))
+			fmt.Printf("  %-*s  %-*s  %-*s  %s active\n", nameW, r.name, modeW, mode, idW, r.id, color.Green("●"))
 		} else {
-			fmt.Printf("  %-*s  %-*s  %s\n", nameW, r.name, modeW, r.mode, r.id)
+			fmt.Printf("  %-*s  %-*s  %s\n", nameW, r.name, modeW, mode, r.id)
 		}
 	}
 

--- a/pkg/login/oauth_reauth.go
+++ b/pkg/login/oauth_reauth.go
@@ -3,16 +3,30 @@ package login
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"os/signal"
+	"sort"
 	"strings"
+	"time"
 
+	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/errorcategory"
 )
 
 const reauthPath = accessAPNPath + "/token/reauth"
+
+const (
+	reauthPollInterval = 3 * time.Second
+	reauthPollTimeout  = 10 * time.Minute
+)
+
+// errReauthTimeout is returned by waitForAccountsChange when reauthPollTimeout
+// elapses with no detected change.
+var errReauthTimeout = errorcategory.New(errorcategory.Auth, "timed out waiting for the reauthorization to finish")
 
 type reauthResponse struct {
 	ReauthURL string `json:"reauth_url"`
@@ -20,8 +34,17 @@ type reauthResponse struct {
 
 // Reauth fetches a reauthentication URL for the active OAuth session and
 // directs the user to it. If a browser is available it is opened automatically;
-// otherwise the URL is printed for the user to visit manually.
+// otherwise the URL is printed for the user to visit manually. It then waits
+// for the authorized-accounts list to change before printing the updated list
+// of authorized contexts; access-srv has no dedicated signal for "the user
+// finished reauthorizing," so a change to the accounts/scopes returned for the
+// token is used as a proxy for completion.
 func Reauth(ctx context.Context, accessBaseURL, accessToken string) error {
+	before, err := ListAuthorizedAccounts(ctx, accessBaseURL, accessToken)
+	if err != nil {
+		return err
+	}
+
 	reauthURL, err := fetchReauthURL(ctx, accessBaseURL, accessToken)
 	if err != nil {
 		return err
@@ -39,7 +62,77 @@ func Reauth(ctx context.Context, accessBaseURL, accessToken string) error {
 	} else {
 		fmt.Printf("Visit the following URL to re-authorize the CLI:\n  %s\n", reauthURL)
 	}
+	fmt.Println("Waiting for you to finish in the browser. Press ^C to cancel.")
+
+	waitCtx, stop := signal.NotifyContext(ctx, os.Interrupt)
+	defer stop()
+
+	after, err := waitForAccountsChange(waitCtx, accessBaseURL, accessToken, before, reauthPollInterval, reauthPollTimeout)
+	if err != nil {
+		switch {
+		case errors.Is(err, context.Canceled):
+			fmt.Println("Canceled. Run 'stripe whoami' to check your authorized contexts.")
+			return nil
+		case errors.Is(err, errReauthTimeout):
+			fmt.Println("Still waiting on the re-authorization. Run 'stripe whoami' once you've finished.")
+			return nil
+		default:
+			return err
+		}
+	}
+
+	ac, _ := config.GetActiveContext()
+	activeID, activeLivemode := "", false
+	if ac != nil {
+		activeID = ac.AccountID
+		activeLivemode = ac.Livemode
+	}
+	printAuthorizedSummary(after, activeID, activeLivemode)
 	return nil
+}
+
+// waitForAccountsChange polls the authorized-accounts list on interval until
+// it differs from before, ctx is canceled, or timeout elapses.
+func waitForAccountsChange(ctx context.Context, accessBaseURL, accessToken string, before []config.AuthorizedAccount, interval, timeout time.Duration) ([]config.AuthorizedAccount, error) {
+	beforeSig := accountsSignature(before)
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline.C:
+			return nil, errReauthTimeout
+		case <-ticker.C:
+			accounts, err := ListAuthorizedAccounts(ctx, accessBaseURL, accessToken)
+			if err != nil {
+				return nil, err
+			}
+			if accountsSignature(accounts) != beforeSig {
+				return accounts, nil
+			}
+		}
+	}
+}
+
+// accountsSignature returns a stable string representation of accounts,
+// used to detect whether the authorized-accounts list has changed.
+func accountsSignature(accounts []config.AuthorizedAccount) string {
+	sorted := make([]config.AuthorizedAccount, len(accounts))
+	copy(sorted, accounts)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+
+	var sb strings.Builder
+	for _, a := range sorted {
+		modes := append([]string{}, a.Modes...)
+		sort.Strings(modes)
+		fmt.Fprintf(&sb, "%s|%s|%s;", a.ID, a.Name, strings.Join(modes, ","))
+	}
+	return sb.String()
 }
 
 func fetchReauthURL(ctx context.Context, accessBaseURL, accessToken string) (string, error) {

--- a/pkg/login/oauth_reauth_test.go
+++ b/pkg/login/oauth_reauth_test.go
@@ -1,0 +1,93 @@
+package login
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+func TestAccountsSignature_orderIndependent(t *testing.T) {
+	a := []config.AuthorizedAccount{
+		{ID: "acct_1", Name: "One", Modes: []string{"live", "test"}},
+		{ID: "acct_2", Name: "Two", Modes: []string{"test"}},
+	}
+	b := []config.AuthorizedAccount{
+		{ID: "acct_2", Name: "Two", Modes: []string{"test"}},
+		{ID: "acct_1", Name: "One", Modes: []string{"test", "live"}},
+	}
+	assert.Equal(t, accountsSignature(a), accountsSignature(b))
+}
+
+func TestAccountsSignature_detectsDifference(t *testing.T) {
+	a := []config.AuthorizedAccount{{ID: "acct_1", Name: "One", Modes: []string{"test"}}}
+	b := []config.AuthorizedAccount{{ID: "acct_1", Name: "One", Modes: []string{"test", "live"}}}
+	assert.NotEqual(t, accountsSignature(a), accountsSignature(b))
+}
+
+func TestWaitForAccountsChange_detectsChange(t *testing.T) {
+	before := []config.AuthorizedAccount{{ID: "acct_1", Name: "One", Modes: []string{"test"}}}
+	after := []config.AuthorizedAccount{{ID: "acct_1", Name: "One", Modes: []string{"test", "live"}}}
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := before
+		if calls.Add(1) >= 3 {
+			resp = after
+		}
+		json.NewEncoder(w).Encode(listAccountsResponse{Accounts: resp}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	got, err := waitForAccountsChange(context.Background(), srv.URL, "oak_test", before, time.Millisecond, time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, after, got)
+	assert.GreaterOrEqual(t, calls.Load(), int32(3))
+}
+
+func TestWaitForAccountsChange_timesOut(t *testing.T) {
+	before := []config.AuthorizedAccount{{ID: "acct_1", Name: "One", Modes: []string{"test"}}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listAccountsResponse{Accounts: before}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	_, err := waitForAccountsChange(context.Background(), srv.URL, "oak_test", before, time.Millisecond, 20*time.Millisecond)
+	assert.ErrorIs(t, err, errReauthTimeout)
+}
+
+func TestWaitForAccountsChange_contextCanceled(t *testing.T) {
+	before := []config.AuthorizedAccount{{ID: "acct_1", Name: "One", Modes: []string{"test"}}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(listAccountsResponse{Accounts: before}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := waitForAccountsChange(ctx, srv.URL, "oak_test", before, time.Millisecond, time.Second)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestWaitForAccountsChange_propagatesRequestError(t *testing.T) {
+	before := []config.AuthorizedAccount{{ID: "acct_1", Name: "One", Modes: []string{"test"}}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := waitForAccountsChange(context.Background(), srv.URL, "oak_test", before, time.Millisecond, time.Second)
+	assert.ErrorContains(t, err, "401")
+}


### PR DESCRIPTION
Updates `stripe reauth` to wait for the user to make changes to their authorized contexts, then prints them.

Before: `stripe reauth` opens the browser and exits immediately

<img width="618" height="63" alt="Screenshot 2026-08-19 at 9 55 00 AM" src="https://github.com/user-attachments/assets/6ec032de-22d5-4df4-bec7-da7c82b6b594" />

After: `stripe reauth` opens the browser and waits for changes

<img width="826" height="381" alt="Screenshot 2026-08-19 at 9 53 32 AM" src="https://github.com/user-attachments/assets/4483b417-9e33-4710-9f8d-32f906ab4845" />

We implement this by polling for changes to the authorized contexts. If the user doesn't actually change anything, this will wait indefinitely until ctrl+c or timeout because we don't have a better mechanism to detect that nothing happened.