### PR TITLE
Restore docs navigation scroll positions

### DIFF
--- a/pkg/docs/markdown/document.go
+++ b/pkg/docs/markdown/document.go
@@ -3,6 +3,9 @@ package markdown
 import (
 	"bytes"
 	"net/url"
+	"strconv"
+	"strings"
+	"unicode"
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
@@ -36,6 +39,69 @@ type Reference struct {
 type Document struct {
 	Node   ast.Node
 	Source []byte
+}
+
+// Heading describes a document heading and its URL fragment.
+type Heading struct {
+	Level    int
+	Text     string
+	Fragment string
+}
+
+// Headings returns the document headings in source order. Repeated fragments
+// receive the same numeric suffixes used by documentation URLs.
+func (d *Document) Headings() []Heading {
+	var headings []Heading
+	used := make(map[string]bool)
+	_ = ast.Walk(d.Node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		h, ok := n.(*ast.Heading)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		text := string(nodeText(h, d.Source))
+		baseFragment := NormalizeFragment(text)
+		fragment := baseFragment
+		for suffix := 1; used[fragment]; suffix++ {
+			fragment = baseFragment + "-" + strconv.Itoa(suffix)
+		}
+		used[fragment] = true
+		headings = append(headings, Heading{Level: h.Level, Text: text, Fragment: fragment})
+		return ast.WalkContinue, nil
+	})
+	return headings
+}
+
+// HeadingForFragment returns the heading matching fragment.
+func (d *Document) HeadingForFragment(fragment string) (Heading, bool) {
+	fragment = strings.TrimPrefix(fragment, "#")
+	for _, heading := range d.Headings() {
+		if heading.Fragment == fragment {
+			return heading, true
+		}
+	}
+	return Heading{}, false
+}
+
+// NormalizeFragment converts heading text to the fragment format used by docs URLs.
+func NormalizeFragment(s string) string {
+	var b strings.Builder
+	separator := false
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		switch {
+		case unicode.IsLetter(r), unicode.IsNumber(r), r == '_':
+			if separator && b.Len() > 0 {
+				b.WriteByte('-')
+			}
+			separator = false
+			b.WriteRune(r)
+		case unicode.IsSpace(r), r == '-':
+			separator = true
+		}
+	}
+	return strings.TrimSuffix(b.String(), "-")
 }
 
 // Title returns the text of the first h1 heading in the document, or an empty

--- a/pkg/docs/markdown/document_test.go
+++ b/pkg/docs/markdown/document_test.go
@@ -87,6 +87,33 @@ func TestTitle(t *testing.T) {
 	}
 }
 
+func TestHeadings(t *testing.T) {
+	doc, err := markdown.Parse([]byte("# Getting started!\n\n## Use **formatted** headings\n\n## Repeat\n\n## Repeat\n\n## Repeat 1\n\n## Repeat"))
+	require.NoError(t, err)
+
+	assert.Equal(t, []markdown.Heading{
+		{Level: 1, Text: "Getting started!", Fragment: "getting-started"},
+		{Level: 2, Text: "Use formatted headings", Fragment: "use-formatted-headings"},
+		{Level: 2, Text: "Repeat", Fragment: "repeat"},
+		{Level: 2, Text: "Repeat", Fragment: "repeat-1"},
+		{Level: 2, Text: "Repeat 1", Fragment: "repeat-1-1"},
+		{Level: 2, Text: "Repeat", Fragment: "repeat-2"},
+	}, doc.Headings())
+
+	heading, ok := doc.HeadingForFragment("#use-formatted-headings")
+	require.True(t, ok)
+	assert.Equal(t, "Use formatted headings", heading.Text)
+
+	_, ok = doc.HeadingForFragment("missing")
+	assert.False(t, ok)
+}
+
+func TestNormalizeFragment(t *testing.T) {
+	assert.Equal(t, "create-a-payment", markdown.NormalizeFragment(" Create a payment! "))
+	assert.Equal(t, "api_reference", markdown.NormalizeFragment("API_reference"))
+	assert.Equal(t, "café-options", markdown.NormalizeFragment("Café — options"))
+}
+
 func TestReferences(t *testing.T) {
 	mustURL := func(raw string) *url.URL {
 		u, err := url.Parse(raw)

--- a/pkg/docs/markdown/renderer.go
+++ b/pkg/docs/markdown/renderer.go
@@ -3,10 +3,12 @@ package markdown
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"charm.land/glamour/v2"
 	"charm.land/glamour/v2/ansi"
 	"charm.land/lipgloss/v2"
+	"github.com/acarl005/stripansi"
 )
 
 const (
@@ -16,6 +18,48 @@ const (
 // Renderer renders a Document to a terminal-friendly string.
 type Renderer interface {
 	Render(doc *Document) (string, error)
+}
+
+// RenderedDocument contains rendered content and the line offset of each heading.
+type RenderedDocument struct {
+	Content        string
+	HeadingOffsets map[string]int
+}
+
+// RenderWithHeadingOffsets renders doc and locates each heading in the output.
+func RenderWithHeadingOffsets(r Renderer, doc *Document) (RenderedDocument, error) {
+	content, err := r.Render(doc)
+	if err != nil {
+		return RenderedDocument{}, err
+	}
+
+	result := RenderedDocument{
+		Content:        content,
+		HeadingOffsets: make(map[string]int),
+	}
+	lines := strings.Split(content, "\n")
+	searchFrom := 0
+	for _, heading := range doc.Headings() {
+		for i := searchFrom; i < len(lines); i++ {
+			if renderedLineMatchesHeading(lines[i], heading) {
+				result.HeadingOffsets[heading.Fragment] = i
+				searchFrom = i + 1
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func renderedLineMatchesHeading(line string, heading Heading) bool {
+	line = strings.TrimSpace(stripansi.Strip(line))
+	if heading.Level > 1 && !strings.HasPrefix(line, strings.Repeat("#", heading.Level)+" ") {
+		return false
+	}
+	line = strings.TrimSpace(strings.TrimLeft(line, "#"))
+	lineFragment := NormalizeFragment(line)
+	headingFragment := NormalizeFragment(heading.Text)
+	return lineFragment != "" && (lineFragment == headingFragment || strings.HasPrefix(headingFragment, lineFragment+"-"))
 }
 
 // WithStyle sets a built-in glamour style by name (e.g. "dark", "light", "dracula", "notty").

--- a/pkg/docs/markdown/renderer_test.go
+++ b/pkg/docs/markdown/renderer_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,6 +87,28 @@ func TestRendererRenderShowcase(t *testing.T) {
 			assert.Equal(t, string(want), out)
 		})
 	}
+}
+
+func TestRenderWithHeadingOffsets(t *testing.T) {
+	src := "# Title\n\n" + strings.Repeat("A paragraph with enough words to wrap. ", 8) + "\n\n## Formatted **heading**\n\nBody.\n\n## Formatted **heading**\n\nBody.\n\n## Formatted heading 1"
+	doc, err := markdown.Parse([]byte(src))
+	require.NoError(t, err)
+
+	r, err := markdown.NewRenderer(markdown.WithStyle("notty"), markdown.WithWordWrap(30))
+	require.NoError(t, err)
+	result, err := markdown.RenderWithHeadingOffsets(r, doc)
+	require.NoError(t, err)
+
+	first, ok := result.HeadingOffsets["formatted-heading"]
+	require.True(t, ok)
+	second, ok := result.HeadingOffsets["formatted-heading-1"]
+	require.True(t, ok)
+	naturallySuffixed, ok := result.HeadingOffsets["formatted-heading-1-1"]
+	require.True(t, ok)
+	assert.Greater(t, first, result.HeadingOffsets["title"])
+	assert.Greater(t, second, first)
+	assert.Greater(t, naturallySuffixed, second)
+	assert.Contains(t, result.Content, "Formatted **heading**")
 }
 
 func TestRendererRender(t *testing.T) {

--- a/pkg/docs/tui/model.go
+++ b/pkg/docs/tui/model.go
@@ -47,8 +47,9 @@ type pageLoadedMsg struct {
 }
 
 type historyEntry struct {
-	page Page
-	doc  *markdown.Document
+	page    Page
+	doc     *markdown.Document
+	yOffset int
 }
 
 // Model is the top-level Bubble Tea model for the docs TUI.
@@ -67,10 +68,12 @@ type Model struct {
 	adaptiveWordWrap bool
 
 	// Content
-	page    Page
-	doc     *markdown.Document
-	title   string
-	history []historyEntry
+	page           Page
+	doc            *markdown.Document
+	title          string
+	headingOffsets map[string]int
+	activeFragment string
+	history        []historyEntry
 
 	// Initial palette input (set via WithPaletteInput)
 	initialQuery string
@@ -236,8 +239,8 @@ func (m Model) initViewport(msg tea.WindowSizeMsg) Model {
 	m.viewport.KeyMap = viewport.KeyMap{}
 	m.help.SetWidth(msg.Width)
 	if m.doc != nil && m.renderer != nil {
-		if out, err := m.renderer.Render(m.doc); err == nil {
-			m.viewport.SetContent(out)
+		if rendered, err := markdown.RenderWithHeadingOffsets(m.renderer, m.doc); err == nil {
+			m.setRenderedContent(rendered, fragmentFromURL(m.page.URL), 0)
 		}
 	}
 	m.ready = true
@@ -257,9 +260,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case pageLoadedMsg:
-		return m.updateWithPage(Page{Content: msg.page.Content, URL: msg.page.URL}, msg.doc, m.ready, true)
+		return m.updateWithPage(Page{Content: msg.page.Content, URL: msg.page.URL}, msg.doc, m.ready, true, nil)
 	case pageReadyMsg:
-		return m.updateWithPage(msg.page, msg.doc, true, true)
+		return m.updateWithPage(msg.page, msg.doc, true, true, nil)
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -277,8 +280,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case rerenderMsg:
-		if msg.forWidth == m.width {
-			m.viewport.SetContent(msg.content)
+		if msg.forWidth == m.width && msg.doc == m.doc {
+			offset := m.viewport.YOffset()
+			m.setRenderedContent(msg.rendered, m.activeFragment, offset)
 		}
 		return m, nil
 
@@ -346,10 +350,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 // updateWithPage updates the model with a newly fetched page, replacing the
-// current content, title, and link palette.
-func (m Model) updateWithPage(page Page, doc *markdown.Document, render, push bool) (Model, tea.Cmd) {
+// current content, title, and link palette. A restored offset takes precedence
+// over the destination URL fragment.
+func (m Model) updateWithPage(page Page, doc *markdown.Document, render, push bool, restoredOffset *int) (Model, tea.Cmd) {
 	if push && !m.isLanding() {
-		m.history = append(m.history, historyEntry{page: m.page, doc: m.doc})
+		m.history = append(m.history, historyEntry{
+			page:    m.page,
+			doc:     m.doc,
+			yOffset: m.viewport.YOffset(),
+		})
 		m.keys.Back.SetEnabled(true)
 	}
 	m.loading = false
@@ -358,12 +367,40 @@ func (m Model) updateWithPage(page Page, doc *markdown.Document, render, push bo
 	m.title = doc.Title()
 	m.palette = newPalette(m.page, m.doc, m.client)
 	m.setScrollEnabled(true)
+	m.activeFragment = ""
+	m.headingOffsets = nil
 	if render && m.renderer != nil {
-		if out, err := m.renderer.Render(doc); err == nil {
-			m.viewport.SetContent(out)
+		if rendered, err := markdown.RenderWithHeadingOffsets(m.renderer, doc); err == nil {
+			offset := 0
+			fragment := fragmentFromURL(page.URL)
+			if restoredOffset != nil {
+				offset = *restoredOffset
+				fragment = ""
+			}
+			m.setRenderedContent(rendered, fragment, offset)
 		}
 	}
 	return m, nil
+}
+
+func (m *Model) setRenderedContent(rendered markdown.RenderedDocument, fragment string, fallbackOffset int) {
+	m.viewport.SetContent(rendered.Content)
+	m.viewport.SetYOffset(0)
+	m.headingOffsets = rendered.HeadingOffsets
+	m.activeFragment = ""
+	if offset, ok := rendered.HeadingOffsets[fragment]; ok && fragment != "" {
+		m.viewport.SetYOffset(offset)
+		m.activeFragment = fragment
+		return
+	}
+	m.viewport.SetYOffset(fallbackOffset)
+}
+
+func fragmentFromURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	return u.Fragment
 }
 
 // handleSelected processes a palette item selection.
@@ -380,6 +417,9 @@ func (m Model) handleSelected(msg palette.SelectedMsg) (Model, tea.Cmd) {
 			fetched, err := client.FetchPage(context.Background(), u)
 			if err != nil {
 				return statusMsg("Failed to load page")
+			}
+			if fetched.URL != nil {
+				fetched.URL.Fragment = u.Fragment
 			}
 			doc, err := markdown.Parse(fetched.Content, markdown.WithRelativeURLs("https://docs.stripe.com"))
 			if err != nil {
@@ -475,7 +515,7 @@ func (m Model) handleBack() (Model, tea.Cmd) {
 	last := m.history[len(m.history)-1]
 	m.history = m.history[:len(m.history)-1]
 	m.keys.Back.SetEnabled(len(m.history) > 0)
-	return m.updateWithPage(last.page, last.doc, true, false)
+	return m.updateWithPage(last.page, last.doc, true, false, &last.yOffset)
 }
 
 // View renders the current model state to the terminal.
@@ -572,7 +612,8 @@ func (m Model) status() string {
 
 // rerenderMsg carries the result of an out-of-band word-wrap re-render.
 type rerenderMsg struct {
-	content  string
+	doc      *markdown.Document
+	rendered markdown.RenderedDocument
 	forWidth int
 }
 
@@ -588,11 +629,11 @@ func (m Model) rerenderCmd() tea.Cmd {
 		if err != nil {
 			return nil
 		}
-		out, err := r.Render(doc)
+		rendered, err := markdown.RenderWithHeadingOffsets(r, doc)
 		if err != nil {
 			return nil
 		}
-		return rerenderMsg{content: out, forWidth: width}
+		return rerenderMsg{doc: doc, rendered: rendered, forWidth: width}
 	}
 }
 
@@ -610,6 +651,9 @@ func (m Model) fetchPageCmd(dest *url.URL) tea.Cmd {
 		fetched, err := client.FetchPage(context.Background(), u)
 		if err != nil {
 			return statusMsg("Failed to load page")
+		}
+		if fetched.URL != nil {
+			fetched.URL.Fragment = u.Fragment
 		}
 		doc, err := markdown.Parse(fetched.Content, markdown.WithRelativeURLs("https://docs.stripe.com"))
 		if err != nil {

--- a/pkg/docs/tui/model_test.go
+++ b/pkg/docs/tui/model_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -162,6 +163,38 @@ func TestUpdate_WindowSizeMsg_RendersDocument(t *testing.T) {
 	model := result.(Model)
 
 	assert.NotEmpty(t, model.viewport.GetContent())
+}
+
+func TestUpdate_WindowSizeMsg_RerenderPreservesPosition(t *testing.T) {
+	src := []byte("# Title\n\n" + strings.Repeat("A paragraph with enough words to wrap across lines. ", 20) + "\n\n## Target\n\n" + strings.Repeat("Body after the target.\n\n", 10))
+	m := New(
+		WithRendererOptions(markdown.WithStyle("notty")),
+		WithPage(Page{Content: src, URL: &url.URL{Path: "/page", Fragment: "target"}}),
+	)
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 8})
+	model := result.(Model)
+	initialOffset := model.viewport.YOffset()
+	require.Greater(t, initialOffset, 0)
+
+	result, cmd := model.Update(tea.WindowSizeMsg{Width: 35, Height: 8})
+	model = result.(Model)
+	require.NotNil(t, cmd)
+	msg := cmd()
+	require.NotNil(t, msg)
+	result, _ = model.Update(msg)
+	model = result.(Model)
+
+	assert.Equal(t, model.headingOffsets["target"], model.viewport.YOffset())
+	assert.Greater(t, model.viewport.YOffset(), initialOffset)
+
+	model.activeFragment = ""
+	model.viewport.SetYOffset(5)
+	result, cmd = model.Update(tea.WindowSizeMsg{Width: 45, Height: 8})
+	model = result.(Model)
+	require.NotNil(t, cmd)
+	result, _ = model.Update(cmd())
+	model = result.(Model)
+	assert.Equal(t, 5, model.viewport.YOffset())
 }
 
 func TestUpdate_QuitKey(t *testing.T) {
@@ -504,6 +537,49 @@ func TestUpdate_PageReadyMsg(t *testing.T) {
 	assert.NotEmpty(t, model.viewport.GetContent())
 }
 
+func TestUpdate_ForwardNavigationStartsAtTop(t *testing.T) {
+	r, err := markdown.NewRenderer(markdown.WithStyle("notty"))
+	require.NoError(t, err)
+	m := New(WithRenderer(r), WithPage(Page{Content: longDocument("Original"), URL: &url.URL{Path: "/original"}}))
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 8})
+	model := result.(Model)
+	model.viewport.SetYOffset(10)
+	require.Greater(t, model.viewport.YOffset(), 0)
+
+	doc, err := markdown.Parse(longDocument("Next"))
+	require.NoError(t, err)
+	result, _ = model.Update(pageReadyMsg{page: Page{Content: doc.Source, URL: &url.URL{Path: "/next"}}, doc: doc})
+	model = result.(Model)
+
+	assert.Equal(t, 0, model.viewport.YOffset())
+	require.Len(t, model.history, 1)
+	assert.Greater(t, model.history[0].yOffset, 0)
+}
+
+func TestUpdate_FragmentNavigation(t *testing.T) {
+	r, err := markdown.NewRenderer(markdown.WithStyle("notty"), markdown.WithWordWrap(40))
+	require.NoError(t, err)
+	m := New(WithRenderer(r), WithPage(Page{Content: []byte("# Original")}))
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 8})
+	model := result.(Model)
+
+	src := []byte("# Next\n\n" + strings.Repeat("Paragraph content.\n\n", 10) + "## Target heading\n\n" + strings.Repeat("Body after the target.\n\n", 10))
+	doc, err := markdown.Parse(src)
+	require.NoError(t, err)
+	result, _ = model.Update(pageReadyMsg{page: Page{Content: src, URL: &url.URL{Path: "/next", Fragment: "target-heading"}}, doc: doc})
+	model = result.(Model)
+
+	assert.Equal(t, model.headingOffsets["target-heading"], model.viewport.YOffset())
+	assert.Greater(t, model.viewport.YOffset(), 0)
+	assert.Equal(t, "target-heading", model.activeFragment)
+
+	missingPage := Page{Content: src, URL: &url.URL{Path: "/missing", Fragment: "missing"}}
+	result, _ = model.Update(pageReadyMsg{page: missingPage, doc: doc})
+	model = result.(Model)
+	assert.Equal(t, 0, model.viewport.YOffset())
+	assert.Empty(t, model.activeFragment)
+}
+
 func TestUpdate_BackWithEmptyHistoryIsNoOp(t *testing.T) {
 	page := Page{Content: []byte("# Original"), URL: &url.URL{Path: "/original"}}
 	m := New(WithPage(page))
@@ -548,6 +624,39 @@ func TestUpdate_BackRestoresPreviousPage(t *testing.T) {
 	assert.Equal(t, originalContent, model.viewport.GetContent())
 	assert.Empty(t, model.history)
 	assert.False(t, model.keys.Back.Enabled())
+}
+
+func TestUpdate_BackRestoresScrollOffset(t *testing.T) {
+	r, err := markdown.NewRenderer(markdown.WithStyle("notty"))
+	require.NoError(t, err)
+
+	pageA := Page{Content: longDocument("Page A"), URL: &url.URL{Path: "/a"}}
+	m := New(WithRenderer(r), WithPage(pageA))
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 8})
+	model := result.(Model)
+	model.viewport.SetYOffset(8)
+	offsetA := model.viewport.YOffset()
+
+	docB, err := markdown.Parse(longDocument("Page B"))
+	require.NoError(t, err)
+	pageB := Page{Content: docB.Source, URL: &url.URL{Path: "/b"}}
+	result, _ = model.Update(pageReadyMsg{page: pageB, doc: docB})
+	model = result.(Model)
+	model.viewport.SetYOffset(14)
+	offsetB := model.viewport.YOffset()
+
+	docC, err := markdown.Parse(longDocument("Page C"))
+	require.NoError(t, err)
+	result, _ = model.Update(pageReadyMsg{page: Page{Content: docC.Source, URL: &url.URL{Path: "/c"}}, doc: docC})
+	model = result.(Model)
+
+	result, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	model = result.(Model)
+	assert.Equal(t, offsetB, model.viewport.YOffset())
+
+	result, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	model = result.(Model)
+	assert.Equal(t, offsetA, model.viewport.YOffset())
 }
 
 func TestUpdate_BackNavigatesMultipleHistoryEntries(t *testing.T) {
@@ -663,6 +772,10 @@ func TestView_ProgressBar_NilWhenPaletteVisibleButNotLoading(t *testing.T) {
 	assert.True(t, model.palette.Visible())
 	assert.False(t, model.palette.Loading())
 	assert.Nil(t, model.View().ProgressBar)
+}
+
+func longDocument(title string) []byte {
+	return []byte("# " + title + "\n\n" + strings.Repeat("Paragraph content for scrolling.\n\n", 40))
 }
 
 func TestView_WindowTitle_FromPage(t *testing.T) {


### PR DESCRIPTION
 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->

Preserve scroll position when navigating between docs pages. Such that, when I go to a new page it starts at the top, and when I go to the previous page it'll be at the scroll position I was when I left.

**Before**
* Navigating to the new page started me at the bottom
* Going to the previous page didn't retain my position
<img width="800" height="419" alt="CleanShot 2026-08-19 at 12 28 22" src="https://github.com/user-attachments/assets/3d7d2ec6-7665-45a5-b1bb-ffce337b6820" />

**After**
<img width="800" height="308" alt="CleanShot 2026-08-19 at 12 25 34" src="https://github.com/user-attachments/assets/a2dbeef8-5e69-43a7-b421-90fe73944312" />
