### PR TITLE
Render docs search results without styling when AI agent is detected

### DIFF
--- a/pkg/cmd/docs/search.go
+++ b/pkg/cmd/docs/search.go
@@ -55,7 +55,8 @@ func (r *RootCommand) runSearch(cmd *cobra.Command, args []string) error {
 	styles := ui.DefaultStyles()
 
 	checkmark := styles.SuccessText.Render("✓")
-	disabled := useragent.DetectAIAgent(os.Getenv) != "" || !isStdoutTTY(cmd)
+	agentDetected := useragent.DetectAIAgent(os.Getenv) != ""
+	disabled := agentDetected || !isStdoutTTY(cmd)
 
 	var response *pkgdocs.SearchResponse
 	err := spinner.New().
@@ -77,10 +78,20 @@ func (r *RootCommand) runSearch(cmd *cobra.Command, args []string) error {
 
 	w := pager.New(cmd.OutOrStdout(), !r.noPager)
 	defer func() { _ = w.Close() }()
-	return r.renderSearch(w, response)
+	return r.renderSearch(w, response, agentDetected)
 }
 
-func (r *RootCommand) renderSearch(w io.Writer, response *pkgdocs.SearchResponse) error {
+func (r *RootCommand) renderSearch(w io.Writer, response *pkgdocs.SearchResponse, agentDetected bool) error {
+	if agentDetected {
+		for _, hit := range response.Hits {
+			route := strings.TrimPrefix(hit.URL, "https://docs.stripe.com")
+			if _, err := fmt.Fprintf(w, "%s\nstripe docs %s\n", hit.Title, route); err != nil {
+				return fmt.Errorf("search: writing output: %w", err)
+			}
+		}
+		return nil
+	}
+
 	styles := ui.DefaultStyles()
 	colorOff := r.color() == colorValueOff
 

--- a/pkg/cmd/docs/search_test.go
+++ b/pkg/cmd/docs/search_test.go
@@ -61,6 +61,34 @@ func TestSearchCommand(t *testing.T) {
 	assert.Less(t, paymentIdx, routeIdx)
 }
 
+func TestSearchCommand_AgentOutputIsPlain(t *testing.T) {
+	t.Setenv("CLAUDECODE", "1")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"hits":[{"title":"Accept a payment","url":"https://docs.stripe.com/payments/accept-a-payment"},{"title":"Payment Element","url":"https://docs.stripe.com/payments/elements"}]}`)
+	}))
+	defer server.Close()
+
+	client := docs.NewClient("test").WithOptions(docs.WithBaseURL(server.URL))
+
+	var out bytes.Buffer
+	root := cmd.New().WithOptions(
+		cmd.WithClient(client),
+		cmd.WithConfig(&cliconfig.Config{Color: "on"}),
+	).Root()
+	root.SetOut(&out)
+	root.SetArgs([]string{"search", "payment methods"})
+
+	err := root.ExecuteContext(context.Background())
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Equal(t, "Accept a payment\nstripe docs /payments/accept-a-payment\nPayment Element\nstripe docs /payments/elements\n", output)
+	assert.NotContains(t, output, "\x1b[")
+	assert.NotContains(t, output, "•")
+}
+
 func TestSearchCommand_ColorOff(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
 ## Summary

Renders `stripe docs search` results as plaintext without any styling when an AI agent is detected. Saves on unnecessary tokens and is consistent with our commands which output content for agents.

**Before**
<img width="515" height="360" alt="CleanShot 2026-08-19 at 17 00 20" src="https://github.com/user-attachments/assets/6858fb4b-7cf4-480a-94d2-14ea0852ca26" />

**After**
<img width="501" height="377" alt="CleanShot 2026-08-19 at 16 58 37" src="https://github.com/user-attachments/assets/887d857e-1806-40d0-9783-088fc37a163e" />
