### PR TITLE
Add linux/arm64 releases to the plugin test manifest

### DIFF
--- a/pkg/plugins/test_artifacts/plugins.toml
+++ b/pkg/plugins/test_artifacts/plugins.toml
@@ -26,6 +26,12 @@
     Sum = "125653c37803a51a048f6687f7f66d511be614f675f199cd6c71928b74875238"
 
   [[Plugin.Release]]
+    Arch = "arm64"
+    OS = "linux"
+    Version = "0.0.1"
+    Sum = "125653c37803a51a048f6687f7f66d511be614f675f199cd6c71928b74875238"
+
+  [[Plugin.Release]]
     Arch = "amd64"
     OS = "windows"
     Version = "0.0.1"
@@ -50,6 +56,12 @@
     Sum = "3c909ec628b7d32536a65fd15545db527a7509e734995d4ef4806694fbd89c3a"
 
   [[Plugin.Release]]
+    Arch = "arm64"
+    OS = "linux"
+    Version = "1.0.1"
+    Sum = "3c909ec628b7d32536a65fd15545db527a7509e734995d4ef4806694fbd89c3a"
+
+  [[Plugin.Release]]
     Arch = "amd64"
     OS = "windows"
     Version = "1.0.1"
@@ -69,6 +81,12 @@
 
   [[Plugin.Release]]
     Arch = "amd64"
+    OS = "linux"
+    Version = "2.0.1"
+    Sum = "3752e4e3a9f1b17f85b542b355893b8614ad8662a3fb8eba6ebed66d1f9e2a87"
+
+  [[Plugin.Release]]
+    Arch = "arm64"
     OS = "linux"
     Version = "2.0.1"
     Sum = "3752e4e3a9f1b17f85b542b355893b8614ad8662a3fb8eba6ebed66d1f9e2a87"
@@ -98,6 +116,12 @@
 
   [[Plugin.Release]]
     Arch = "amd64"
+    OS = "linux"
+    Version = "1.2.1"
+    Sum = "2f05d4b689d270cafb02285f35f44866f7dc8a2d368a3f9d1124373eeab31fb1"
+
+  [[Plugin.Release]]
+    Arch = "arm64"
     OS = "linux"
     Version = "1.2.1"
     Sum = "2f05d4b689d270cafb02285f35f44866f7dc8a2d368a3f9d1124373eeab31fb1"
@@ -142,6 +166,12 @@
 
   [[Plugin.Release]]
     Arch = "amd64"
+    OS = "linux"
+    Version = "1.0.0"
+    Sum = "0000000000000000000000000000000000000000000000000000000000000000"
+
+  [[Plugin.Release]]
+    Arch = "arm64"
     OS = "linux"
     Version = "1.0.0"
     Sum = "0000000000000000000000000000000000000000000000000000000000000000"

--- a/pkg/plugins/utilities_test.go
+++ b/pkg/plugins/utilities_test.go
@@ -112,7 +112,7 @@ func TestLookUpPluginUsesLocalMetadata(t *testing.T) {
 	require.Equal(t, "appB", plugin.Shortname)
 	require.Equal(t, "stripe-cli-app-b", plugin.Binary)
 	require.Equal(t, "FDBE6FB9-A149-44BD-9639-4D33D8B594E8", plugin.MagicCookieValue)
-	require.Len(t, plugin.Releases, 4)
+	require.Len(t, plugin.Releases, 5)
 }
 
 func TestLookUpPluginFallsBackToCachedManifest(t *testing.T) {


### PR DESCRIPTION
### Reviewers
r? @
cc @stripe/developer-products

 ### Summary
The `pkg/plugins` tests fail on linux/arm64. A nixpkgs maintainer hit it packaging 1.45.2 for aarch64-linux, and the same failure reproduces on current master.

Plugin resolution is scoped to the running platform. `Plugin.getReleaseForVersion` calls `getRelease(version, runtime.GOOS, runtime.GOARCH)` in `pkg/plugins/plugin.go`, and `LookUpLatestVersion` filters the release list on the same two values. The shared fixture `pkg/plugins/test_artifacts/plugins.toml` gives each release one block per platform, and the set was darwin/amd64, darwin/arm64, linux/amd64 and windows/amd64. No block in the file matches linux/arm64, so on that platform every lookup against the fixture returns nil. It surfaces as `no plugin named "appA" exists`, as an older version being read out of local metadata instead of the manifest, and as a network call that a test asserts should never be made.

This adds an arm64 block beside each existing linux/amd64 block, five in all, one per plugin version the fixture describes. Checksums are copied from the sibling entries for the same version, matching what the file already does across platforms, since it uses one checksum per version rather than per artifact. `TestLookUpPluginUsesLocalMetadata` asserts appB's release count, so that assertion moves from 4 to 5.

Scoped to linux/arm64 rather than every OS/arch pair: the CLI is released for linux/arm64 in `.goreleaser/linux.yml`, while windows/arm64 is not built at all. Precedent for the narrow change: darwin/arm64 was added to this same file in #932 once Apple Silicon machines started failing the same way. The remaining gap is windows/386, which goreleaser does build — left out because nobody has reported running the suite there, glad to add it if you would rather the fixture mirror the release matrix exactly.

CI covers ubuntu-latest, macos-latest and windows-latest, which is why this has stayed hidden: macos-latest supplies the darwin/arm64 coverage and nothing in the matrix runs linux/arm64.

I do not have an aarch64-linux machine, so I verified by substitution in a scratch checkout. Replacing `runtime.GOOS` and `runtime.GOARCH` in `pkg/plugins` with `linux` and `arm64` literals reproduces the reported failures on master and passes with this change applied. The same substitution for linux/amd64, darwin/amd64, darwin/arm64 and windows/amd64 passes both before and after, so the added entries do not disturb the platforms that already worked.

Commands run on this branch:

- `go test ./pkg/plugins/... ./pkg/cmd/plugin/...`, and again with `-race`
- `make test`
- `make lint`, which reports 0 issues from golangci-lint and a clean error category lint
- `go vet ./pkg/plugins/... ./pkg/cmd/plugin/...`
- `GOOS=linux GOARCH=arm64 go vet ./pkg/plugins/...` and `GOOS=linux GOARCH=arm64 go test -c ./pkg/plugins` to confirm the target still builds

Fixes #1906