### PR TITLE
Read and write profile fields in both config.toml layouts

### DIFF
--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -13,7 +13,6 @@ import (
 	"github.com/logrusorgru/aurora"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
@@ -159,7 +158,7 @@ func (scc *sandboxCreateCmd) runSandboxCreateCmd(cmd *cobra.Command, args []stri
 		if accountID != "" {
 			fmt.Printf("Account ID:      %s\n", accountID)
 		}
-		expiresAt := viper.GetString(Config.Profile.GetConfigField(config.SandboxExpiresAtName))
+		expiresAt := Config.Profile.ReadProfileString(config.SandboxExpiresAtName)
 		if expiresAt != "" {
 			fmt.Printf("\nThis sandbox expires %s (in 7 days). Claim it before then by running `stripe sandbox claim`.\n", expiresAt)
 		} else {
@@ -366,15 +365,15 @@ func isClaimableSandbox() bool {
 		return true
 	}
 	// No key — check metadata for partially-cleared sandbox state
-	if viper.GetString(Config.Profile.GetConfigField(config.SandboxClaimURLName)) != "" {
+	if Config.Profile.ReadProfileString(config.SandboxClaimURLName) != "" {
 		return true
 	}
-	return viper.GetString(Config.Profile.GetConfigField(config.SandboxExpiresAtName)) != ""
+	return Config.Profile.ReadProfileString(config.SandboxExpiresAtName) != ""
 }
 
 // isExpiredSandbox returns true if the sandbox_expires_at date has passed.
 func isExpiredSandbox() bool {
-	expiresAt := viper.GetString(Config.Profile.GetConfigField(config.SandboxExpiresAtName))
+	expiresAt := Config.Profile.ReadProfileString(config.SandboxExpiresAtName)
 	if expiresAt == "" {
 		return false
 	}
@@ -420,7 +419,7 @@ func newSandboxClaimCmd() *sandboxClaimCmd {
 }
 
 func (scc *sandboxClaimCmd) runSandboxClaimCmd(cmd *cobra.Command, args []string) error {
-	claimURL := viper.GetString(Config.Profile.GetConfigField(config.SandboxClaimURLName))
+	claimURL := Config.Profile.ReadProfileString(config.SandboxClaimURLName)
 	if claimURL == "" {
 		fmt.Printf("No active sandbox. Run `stripe sandbox create` to get started.\n")
 		return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,12 @@ type Config struct {
 	Profile          Profile
 	ProfilesFile     string
 	InstalledPlugins []string
+
+	// warnedConfigVersion keeps the unsupported-version warning to one line per
+	// invocation. InitConfig runs more than once: root.go initializes it eagerly to
+	// register plugins before cobra parses flags, cobra.OnInitialize runs it again,
+	// and SwitchProfile reloads through it.
+	warnedConfigVersion bool
 }
 
 // GetProfile returns the Profile of the config
@@ -154,6 +160,15 @@ func (c *Config) InitConfig() {
 			"prefix": "config.Config.InitConfig",
 			"path":   viper.ConfigFileUsed(),
 		}).Debug("Using profiles file")
+
+		// Reads tolerate an unknown version: both layouts are tried, so a newer
+		// file's profiles are usually still found. Warn rather than exit, so an
+		// older pinned CLI keeps working for read-only commands. writeConfig is
+		// where an unknown version is actually refused.
+		if _, err := configVersion(viper.GetViper()); err != nil && !c.warnedConfigVersion {
+			c.warnedConfigVersion = true
+			log.Warnf("%s: %s", viper.ConfigFileUsed(), err)
+		}
 	}
 
 	if os.Getenv("STRIPE_CLI_CANARY") == "true" {
@@ -499,16 +514,48 @@ func isProfile(value interface{}) bool {
 	return false
 }
 
-// configVersion reports the schema version recorded in the config file. A v1
-// file has no config_version key, so it reports 0.
-func configVersion(v *viper.Viper) int {
-	return v.GetInt(ConfigVersionName)
+// configVersion reports the schema version recorded in the config file. A v1 file
+// records no config_version key, so an absent key reports ConfigVersionV1.
+//
+// It errors when the recorded version is one this binary cannot act on: either
+// unreadable as a version number, or newer than MaxSupportedConfigVersion. Both
+// are errors rather than a fallback to v1, because v1 means "flat layout" to every
+// caller, and a flat write into a file whose profiles are nested lands a second
+// copy that the read path then shadows — a write that reports success and is
+// invisible to the next read.
+//
+// On success the version is always >= ConfigVersionV1; 0 is returned only with an
+// error.
+func configVersion(v *viper.Viper) (int, error) {
+	raw := v.Get(ConfigVersionName)
+	if raw == nil {
+		return ConfigVersionV1, nil
+	}
+
+	// GetInt discards the cast error, so an unreadable value arrives here as 0 and
+	// is caught by the range check rather than by inspecting the error.
+	version := v.GetInt(ConfigVersionName)
+	if version < ConfigVersionV1 {
+		return 0, fmt.Errorf("%s is set to %v, which is not a version number", ConfigVersionName, raw)
+	}
+
+	if version > MaxSupportedConfigVersion {
+		return version, fmt.Errorf(
+			"%s is %d, but this Stripe CLI understands up to %d. Upgrade the CLI: https://docs.stripe.com/stripe-cli/upgrade",
+			ConfigVersionName, version, MaxSupportedConfigVersion,
+		)
+	}
+
+	return version, nil
 }
 
 // isMigrated reports whether the config file stores profiles in the v2 layout,
-// under the reserved profiles table.
+// under the reserved profiles table. A version this binary cannot act on is not
+// migrated: writeConfig refuses such a file outright, so no write ever reaches
+// the layout decision this gates.
 func isMigrated(v *viper.Viper) bool {
-	return configVersion(v) >= ConfigVersionV2
+	version, err := configVersion(v)
+	return err == nil && version == ConfigVersionV2
 }
 
 // WriteConfigField updates a configuration field and writes the updated
@@ -522,6 +569,16 @@ func (c *Config) WriteConfigField(field string, value interface{}) error {
 
 // writeConfig writes a viper instance to the config file and syncs the global viper.
 func writeConfig(runtimeViper *viper.Viper) error {
+	// Refuse to write a file whose layout version this binary does not know. Both
+	// candidate layouts are a guess at that point, and the flat guess is silently
+	// shadowed by the nested copy, so a login would report success while leaving
+	// the credential unreadable. Checked on the global viper, not runtimeViper:
+	// writeProfile passes a scratch viper that has not merged the file yet, which
+	// is the same reason configFieldForWrite reads the global.
+	if _, err := configVersion(viper.GetViper()); err != nil {
+		return err
+	}
+
 	profilesFile := viper.ConfigFileUsed()
 	runtimeViper.SetConfigFile(profilesFile)
 	configType := strings.TrimPrefix(filepath.Ext(profilesFile), ".")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -499,6 +499,18 @@ func isProfile(value interface{}) bool {
 	return false
 }
 
+// configVersion reports the schema version recorded in the config file. A v1
+// file has no config_version key, so it reports 0.
+func configVersion(v *viper.Viper) int {
+	return v.GetInt(ConfigVersionName)
+}
+
+// isMigrated reports whether the config file stores profiles in the v2 layout,
+// under the reserved profiles table.
+func isMigrated(v *viper.Viper) bool {
+	return configVersion(v) >= ConfigVersionV2
+}
+
 // WriteConfigField updates a configuration field and writes the updated
 // configuration to disk.
 func (c *Config) WriteConfigField(field string, value interface{}) error {

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -72,10 +72,20 @@ const (
 	ProfilesTableName = "profiles"
 )
 
+// ConfigVersionV1 is the original layout, with each profile as a top-level table.
+// A v1 file records no config_version key at all; the constant exists so that
+// version comparisons don't have to spell out that absence.
+const ConfigVersionV1 = 1
+
 // ConfigVersionV2 is the schema version in which every profile moved under the
 // reserved ProfilesTableName table, so that profile names can no longer collide
 // with top-level CLI settings.
 const ConfigVersionV2 = 2
+
+// MaxSupportedConfigVersion is the newest config.toml layout this binary can act
+// on. A file recording a higher version was written by a newer CLI, whose layout
+// this build has no way to know.
+const MaxSupportedConfigVersion = ConfigVersionV2
 
 const UATKeychainItemKey = "uat"
 

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -61,7 +61,21 @@ const (
 	SandboxClaimURLName        = "sandbox_claim_url"
 	SandboxExpiresAtName       = "sandbox_expires_at"
 	UserInfoName               = "user_info"
+
+	// ConfigVersionName is the top-level key recording the config file's schema
+	// version. It is absent from v1 files, which is how an unmigrated file is
+	// recognized.
+	ConfigVersionName = "config_version"
+
+	// ProfilesTableName is the reserved top-level table that holds every profile
+	// in a v2 config file.
+	ProfilesTableName = "profiles"
 )
+
+// ConfigVersionV2 is the schema version in which every profile moved under the
+// reserved ProfilesTableName table, so that profile names can no longer collide
+// with top-level CLI settings.
+const ConfigVersionV2 = 2
 
 const UATKeychainItemKey = "uat"
 
@@ -137,7 +151,7 @@ func ValidateProfileName(name string) error {
 // field, so that a partially written profile (one with no display_name, which a
 // profile abandoned part-way through login can be) is still recognized.
 func (p *Profile) profileExists() bool {
-	return viper.IsSet(p.ProfileName)
+	return viper.IsSet(p.nestedProfileTable()) || viper.IsSet(p.ProfileName)
 }
 
 // ValidateProfileNameForWrite validates the profile name before writing to it.
@@ -192,14 +206,7 @@ func (p *Profile) CreateProfile() error {
 
 func (p *Profile) deleteAuthFields(v *viper.Viper) *viper.Viper {
 	for _, field := range authFieldNames {
-		key := p.GetConfigField(field)
-		if v.IsSet(key) {
-			newViper, err := removeKey(v, key)
-			if err == nil {
-				// failure to remove a key should not break the login flow
-				v = newViper
-			}
-		}
+		v = p.safeRemove(v, field)
 	}
 	return v
 }
@@ -212,7 +219,7 @@ func (p *Profile) GetColor() (string, error) {
 		return color, nil
 	}
 
-	color = viper.GetString(p.GetConfigField("color"))
+	color = p.ReadProfileString("color")
 	switch color {
 	case "", ColorAuto:
 		return ColorAuto, nil
@@ -236,7 +243,7 @@ func (p *Profile) GetDeviceName() (string, error) {
 	}
 
 	if err := viper.ReadInConfig(); err == nil {
-		return viper.GetString(p.GetConfigField(DeviceNameName)), nil
+		return p.ReadProfileString(DeviceNameName), nil
 	}
 
 	return "", validators.ErrDeviceNameNotConfigured
@@ -249,7 +256,7 @@ func (p *Profile) GetAccountID() (string, error) {
 	}
 
 	if err := viper.ReadInConfig(); err == nil {
-		return viper.GetString(p.GetConfigField(AccountIDName)), nil
+		return p.ReadProfileString(AccountIDName), nil
 	}
 
 	return "", validators.ErrAccountIDNotConfigured
@@ -262,7 +269,7 @@ func (p *Profile) GetUserID() (string, error) {
 	}
 
 	if err := viper.ReadInConfig(); err == nil {
-		return viper.GetString(p.GetConfigField(UserIDName)), nil
+		return p.ReadProfileString(UserIDName), nil
 	}
 
 	return "", nil
@@ -296,12 +303,12 @@ func (p *Profile) HasAPIKey(livemode bool) bool {
 		if err := viper.ReadInConfig(); err != nil {
 			return false
 		}
-		if viper.IsSet(p.GetConfigField("secret_key")) {
+		if p.profileFieldIsSet("secret_key") {
 			p.RegisterAlias(TestModeAPIKeyName, "secret_key")
-		} else if viper.IsSet(p.GetConfigField("api_key")) {
+		} else if p.profileFieldIsSet("api_key") {
 			p.RegisterAlias(TestModeAPIKeyName, "api_key")
 		}
-		return viper.GetString(p.GetConfigField(TestModeAPIKeyName)) != ""
+		return p.ReadProfileString(TestModeAPIKeyName) != ""
 	}
 
 	if KeyRing == nil {
@@ -339,14 +346,14 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 	if !livemode {
 		// If the user doesn't have an api_key field set, they might be using an
 		// old configuration so try to read from secret_key
-		if viper.IsSet(p.GetConfigField("secret_key")) {
+		if p.profileFieldIsSet("secret_key") {
 			p.RegisterAlias(TestModeAPIKeyName, "secret_key")
-		} else if viper.IsSet(p.GetConfigField("api_key")) {
+		} else if p.profileFieldIsSet("api_key") {
 			p.RegisterAlias(TestModeAPIKeyName, "api_key")
 		}
 
 		if err := viper.ReadInConfig(); err == nil {
-			key = viper.GetString(p.GetConfigField(TestModeAPIKeyName))
+			key = p.ReadProfileString(TestModeAPIKeyName)
 		}
 	} else {
 		p.redactAllLivemodeValues()
@@ -372,9 +379,9 @@ func (p *Profile) GetExpiresAt(livemode bool) (time.Time, error) {
 	var timeString string
 
 	if livemode {
-		timeString = viper.GetString(p.GetConfigField(LiveModeKeyExpiresAtName))
+		timeString = p.ReadProfileString(LiveModeKeyExpiresAtName)
 	} else {
-		timeString = viper.GetString(p.GetConfigField(TestModeKeyExpiresAtName))
+		timeString = p.ReadProfileString(TestModeKeyExpiresAtName)
 	}
 
 	if timeString != "" {
@@ -398,12 +405,12 @@ func (p *Profile) GetPublishableKey(livemode bool) (string, error) {
 	} else {
 		fieldID = TestModePubKeyName
 
-		if viper.IsSet(p.GetConfigField("publishable_key")) {
+		if p.profileFieldIsSet("publishable_key") {
 			p.RegisterAlias(TestModePubKeyName, "publishable_key")
 		}
 		// there is a bug with viper.GetStringMapString when the key name is too long, which makes
 		// `config --list --project-name <project_name>` unable to read the project specific config
-		if viper.IsSet(p.GetConfigField("test_mode_publishable_key")) {
+		if p.profileFieldIsSet("test_mode_publishable_key") {
 			p.RegisterAlias(TestModePubKeyName, "test_mode_publishable_key")
 		}
 	}
@@ -413,7 +420,7 @@ func (p *Profile) GetPublishableKey(livemode bool) (string, error) {
 		return "", err
 	}
 
-	key = viper.GetString(p.GetConfigField(fieldID))
+	key = p.ReadProfileString(fieldID)
 	if key != "" {
 		return key, nil
 	}
@@ -424,20 +431,76 @@ func (p *Profile) GetPublishableKey(livemode bool) (string, error) {
 // GetDisplayName returns the account display name of the user
 func (p *Profile) GetDisplayName() string {
 	if err := viper.ReadInConfig(); err == nil {
-		return viper.GetString(p.GetConfigField(DisplayNameName))
+		return p.ReadProfileString(DisplayNameName)
 	}
 
 	return ""
 }
 
-// GetConfigField returns the configuration field for the specific profile
+// GetConfigField returns "<profile>.<field>", e.g. "default.account_id". This is
+// both the v1 flat config path and, for livemode secrets, the keyring item ID.
+//
+// The keyring IDs are already on users' machines, so this string is frozen: it
+// cannot gain the v2 "profiles." prefix without orphaning every stored
+// credential. For config access use ReadProfileString, profileFieldIsSet, or
+// configFieldForWrite, which understand both layouts.
 func (p *Profile) GetConfigField(field string) string {
 	return p.ProfileName + "." + field
 }
 
-// RegisterAlias registers an alias for a given key.
+// nestedProfileTable returns the v2 key of this profile's table, e.g.
+// "profiles.default".
+func (p *Profile) nestedProfileTable() string {
+	return ProfilesTableName + "." + p.ProfileName
+}
+
+// nestedConfigField returns the v2 configuration path for a profile field,
+// e.g. "profiles.default.account_id".
+func (p *Profile) nestedConfigField(field string) string {
+	return p.nestedProfileTable() + "." + field
+}
+
+// ReadProfileString reads a profile field from the config file, preferring the
+// v2 nested layout and falling back to the v1 flat layout.
+//
+// Both layouts are supported indefinitely. A config file that has never been
+// migrated stays fully readable.
+func (p *Profile) ReadProfileString(field string) string {
+	if value := viper.GetString(p.nestedConfigField(field)); value != "" {
+		return value
+	}
+
+	return viper.GetString(p.GetConfigField(field))
+}
+
+// profileFieldIsSet reports whether a profile field is present in either layout.
+func (p *Profile) profileFieldIsSet(field string) bool {
+	return viper.IsSet(p.nestedConfigField(field)) || viper.IsSet(p.GetConfigField(field))
+}
+
+// configFieldForWrite returns the path a profile field should be written to,
+// matching the layout the config file already uses.
+//
+// Reads tolerate either layout, but a write has to pick one, so writes follow
+// config_version. An unmigrated file has no config_version key, so GetInt
+// returns 0 and writes stay flat.
+func (p *Profile) configFieldForWrite(field string) string {
+	// The layout is read from the global viper, which is the instance that has
+	// the config file loaded. writeProfile is handed a scratch viper that has not
+	// merged the file in yet at the point the fields are set.
+	if isMigrated(viper.GetViper()) {
+		return p.nestedConfigField(field)
+	}
+
+	return p.GetConfigField(field)
+}
+
+// RegisterAlias registers an alias for a given key in both layouts, so that
+// legacy field names (secret_key, api_key, publishable_key) keep resolving in a
+// migrated config file as well as an unmigrated one.
 func (p *Profile) RegisterAlias(alias, key string) {
 	viper.RegisterAlias(p.GetConfigField(alias), p.GetConfigField(key))
+	viper.RegisterAlias(p.nestedConfigField(alias), p.nestedConfigField(key))
 }
 
 // WriteConfigField updates a configuration field and writes the updated
@@ -449,13 +512,13 @@ func (p *Profile) WriteConfigField(field, value string) error {
 		return err
 	}
 
-	viper.Set(p.GetConfigField(field), value)
+	viper.Set(p.configFieldForWrite(field), value)
 	return writeConfig(viper.GetViper())
 }
 
 // DeleteConfigField deletes a configuration field.
 func (p *Profile) DeleteConfigField(field string) error {
-	v, err := removeKey(viper.GetViper(), p.GetConfigField(field))
+	v, err := p.deleteProfileField(viper.GetViper(), field)
 	if err != nil {
 		return err
 	}
@@ -485,15 +548,15 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 	}
 
 	if p.DeviceName != "" {
-		runtimeViper.Set(p.GetConfigField(DeviceNameName), strings.TrimSpace(p.DeviceName))
+		runtimeViper.Set(p.configFieldForWrite(DeviceNameName), strings.TrimSpace(p.DeviceName))
 	}
 
 	if p.LiveModeAPIKey != "" {
 		expiresAt := getKeyExpiresAt()
-		runtimeViper.Set(p.GetConfigField(LiveModeKeyExpiresAtName), expiresAt)
+		runtimeViper.Set(p.configFieldForWrite(LiveModeKeyExpiresAtName), expiresAt)
 
 		// // store redacted key in config
-		runtimeViper.Set(p.GetConfigField(LiveModeAPIKeyName), RedactAPIKey(strings.TrimSpace(p.LiveModeAPIKey)))
+		runtimeViper.Set(p.configFieldForWrite(LiveModeAPIKeyName), RedactAPIKey(strings.TrimSpace(p.LiveModeAPIKey)))
 
 		// // store actual key in secure keyring
 		if err := p.saveLivemodeValue(LiveModeAPIKeyName, strings.TrimSpace(p.LiveModeAPIKey), "Live mode API key"); err != nil {
@@ -502,36 +565,36 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 	}
 
 	if p.LiveModePublishableKey != "" {
-		runtimeViper.Set(p.GetConfigField(LiveModePubKeyName), strings.TrimSpace(p.LiveModePublishableKey))
+		runtimeViper.Set(p.configFieldForWrite(LiveModePubKeyName), strings.TrimSpace(p.LiveModePublishableKey))
 	}
 
 	if p.TestModeAPIKey != "" {
-		runtimeViper.Set(p.GetConfigField(TestModeAPIKeyName), strings.TrimSpace(p.TestModeAPIKey))
-		runtimeViper.Set(p.GetConfigField(TestModeKeyExpiresAtName), getKeyExpiresAt())
+		runtimeViper.Set(p.configFieldForWrite(TestModeAPIKeyName), strings.TrimSpace(p.TestModeAPIKey))
+		runtimeViper.Set(p.configFieldForWrite(TestModeKeyExpiresAtName), getKeyExpiresAt())
 	}
 
 	if p.TestModePublishableKey != "" {
-		runtimeViper.Set(p.GetConfigField(TestModePubKeyName), strings.TrimSpace(p.TestModePublishableKey))
+		runtimeViper.Set(p.configFieldForWrite(TestModePubKeyName), strings.TrimSpace(p.TestModePublishableKey))
 	}
 
 	if p.DisplayName != "" {
-		runtimeViper.Set(p.GetConfigField(DisplayNameName), strings.TrimSpace(p.DisplayName))
+		runtimeViper.Set(p.configFieldForWrite(DisplayNameName), strings.TrimSpace(p.DisplayName))
 	}
 
 	if p.AccountID != "" {
-		runtimeViper.Set(p.GetConfigField(AccountIDName), strings.TrimSpace(p.AccountID))
+		runtimeViper.Set(p.configFieldForWrite(AccountIDName), strings.TrimSpace(p.AccountID))
 	}
 
 	if p.UserID != "" {
-		runtimeViper.Set(p.GetConfigField(UserIDName), strings.TrimSpace(p.UserID))
+		runtimeViper.Set(p.configFieldForWrite(UserIDName), strings.TrimSpace(p.UserID))
 	}
 
 	if p.SandboxClaimURL != "" {
-		runtimeViper.Set(p.GetConfigField(SandboxClaimURLName), strings.TrimSpace(p.SandboxClaimURL))
+		runtimeViper.Set(p.configFieldForWrite(SandboxClaimURLName), strings.TrimSpace(p.SandboxClaimURL))
 	}
 
 	if p.SandboxExpiresAt != "" {
-		runtimeViper.Set(p.GetConfigField(SandboxExpiresAtName), strings.TrimSpace(p.SandboxExpiresAt))
+		runtimeViper.Set(p.configFieldForWrite(SandboxExpiresAtName), strings.TrimSpace(p.SandboxExpiresAt))
 	}
 
 	if KeyRing != nil {
@@ -565,17 +628,36 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 	return writeConfig(runtimeViper)
 }
 
-func (p *Profile) safeRemove(v *viper.Viper, key string) *viper.Viper {
-	if v.IsSet(p.GetConfigField(key)) {
-		newViper, err := removeKey(v, p.GetConfigField(key))
-		if err == nil {
-			// I don't want to fail the entire login process on not being able to remove
-			// the old secret_key field so if there's no error
-			return newViper
+// deleteProfileField removes a profile field from both the v2 nested layout and
+// the v1 flat layout. An older CLI or plugin can write a flat copy into a
+// migrated file, and clearing only one layout is not a partial delete but a
+// no-op: whichever copy is left is the one the read path returns.
+func (p *Profile) deleteProfileField(v *viper.Viper, field string) (*viper.Viper, error) {
+	for _, path := range []string{p.nestedConfigField(field), p.GetConfigField(field)} {
+		if !v.IsSet(path) {
+			continue
 		}
+
+		newViper, err := removeKey(v, path)
+		if err != nil {
+			return nil, err
+		}
+
+		v = newViper
 	}
 
-	return v
+	return v, nil
+}
+
+func (p *Profile) safeRemove(v *viper.Viper, key string) *viper.Viper {
+	newViper, err := p.deleteProfileField(v, key)
+	if err != nil {
+		// I don't want to fail the entire login process on not being able to remove
+		// the old secret_key field, so keep the viper we already have.
+		return v
+	}
+
+	return newViper
 }
 
 // redactAllLivemodeValues redacts all livemode values in the local config file
@@ -584,8 +666,8 @@ func (p *Profile) redactAllLivemodeValues() {
 
 	if err := viper.ReadInConfig(); err == nil {
 		// if the config file has expires at date, then it is using the new livemode key storage
-		if viper.IsSet(p.GetConfigField(LiveModeAPIKeyName)) {
-			key := viper.GetString(p.GetConfigField(LiveModeAPIKeyName))
+		if p.profileFieldIsSet(LiveModeAPIKeyName) {
+			key := p.ReadProfileString(LiveModeAPIKeyName)
 			if key == "" || len(key) < 12 {
 				p.DeleteConfigField(LiveModeAPIKeyName)
 				return

--- a/pkg/config/profile_layout_test.go
+++ b/pkg/config/profile_layout_test.go
@@ -1,0 +1,189 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// The v2 layout keeps every profile under the reserved profiles table, which is
+// what makes a profile name unable to collide with a setting. Note that
+// installed_plugins is both a real setting here and a profile name.
+const v2ConfigFile = `config_version = 2
+installed_plugins = ['apps']
+
+[profiles.default]
+  account_id = 'acct_v2'
+  device_name = 'device-v2'
+  display_name = 'V2 Account'
+  test_mode_api_key = 'sk_test_v2_key'
+  test_mode_key_expires_at = '2026-01-02'
+
+[profiles.installed_plugins]
+  display_name = 'Collides With A Setting'
+  test_mode_api_key = 'sk_test_collide_key'
+`
+
+const v1ConfigFile = `installed_plugins = ['apps']
+
+[default]
+  account_id = 'acct_v1'
+  device_name = 'device-v1'
+  display_name = 'V1 Account'
+  test_mode_api_key = 'sk_test_v1_key'
+  test_mode_key_expires_at = '2026-01-02'
+`
+
+func TestReadProfileFromV2Layout(t *testing.T) {
+	setupProfileConfig(t, v2ConfigFile)
+
+	p := Profile{ProfileName: "default"}
+
+	deviceName, err := p.GetDeviceName()
+	require.NoError(t, err)
+	require.Equal(t, "device-v2", deviceName)
+
+	accountID, err := p.GetAccountID()
+	require.NoError(t, err)
+	require.Equal(t, "acct_v2", accountID)
+
+	apiKey, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_v2_key", apiKey)
+
+	require.Equal(t, "V2 Account", p.GetDisplayName())
+	require.True(t, p.HasAPIKey(false))
+}
+
+func TestReadProfileFallsBackToV1Layout(t *testing.T) {
+	setupProfileConfig(t, v1ConfigFile)
+
+	p := Profile{ProfileName: "default"}
+
+	deviceName, err := p.GetDeviceName()
+	require.NoError(t, err)
+	require.Equal(t, "device-v1", deviceName)
+
+	apiKey, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_v1_key", apiKey)
+
+	require.Equal(t, "V1 Account", p.GetDisplayName())
+}
+
+// A migrated file can still pick up a top-level profile table, because an older
+// CLI or plugin writing the same file does not know about the profiles table.
+// The migrated copy is the one that wins.
+func TestReadProfilePrefersV2LayoutOverV1Shadow(t *testing.T) {
+	setupProfileConfig(t, v2ConfigFile+`
+[default]
+  device_name = 'shadow-device'
+  display_name = 'Shadow Account'
+  test_mode_api_key = 'sk_test_shadow_key'
+`)
+
+	p := Profile{ProfileName: "default"}
+
+	deviceName, err := p.GetDeviceName()
+	require.NoError(t, err)
+	require.Equal(t, "device-v2", deviceName)
+
+	apiKey, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_v2_key", apiKey)
+}
+
+// The point of the restructure: a profile named after a setting no longer
+// overwrites that setting.
+func TestProfileNamedAfterSettingDoesNotCollide(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+
+	require.Equal(t, []string{"apps"}, c.GetInstalledPlugins())
+
+	p := Profile{ProfileName: "installed_plugins"}
+	require.Equal(t, "Collides With A Setting", p.GetDisplayName())
+}
+
+// Legacy field names have to keep resolving in a migrated file, since the
+// migration moves fields without renaming them.
+func TestLegacyFieldAliasResolvesInV2Layout(t *testing.T) {
+	setupProfileConfig(t, `config_version = 2
+
+[profiles.default]
+  display_name = 'Legacy Account'
+  secret_key = 'sk_test_legacy_key'
+`)
+
+	p := Profile{ProfileName: "default"}
+
+	require.True(t, p.HasAPIKey(false))
+
+	apiKey, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_legacy_key", apiKey)
+}
+
+func TestWriteConfigFieldUsesV2LayoutWhenMigrated(t *testing.T) {
+	_, profilesFile := setupProfileConfig(t, v2ConfigFile)
+
+	p := Profile{ProfileName: "default"}
+	require.NoError(t, p.WriteConfigField("color", "on"))
+
+	require.Equal(t, "on", viper.GetString("profiles.default.color"))
+
+	contents := string(helperLoadBytes(t, profilesFile))
+	require.Contains(t, contents, "[profiles.default]")
+	// A flat write into a migrated file would create a second, shadow copy of
+	// the profile at the top level.
+	require.NotContains(t, contents, "\n[default]")
+}
+
+func TestWriteConfigFieldStaysFlatWhenNotMigrated(t *testing.T) {
+	_, profilesFile := setupProfileConfig(t, v1ConfigFile)
+
+	p := Profile{ProfileName: "default"}
+	require.NoError(t, p.WriteConfigField("color", "on"))
+
+	require.Equal(t, "on", viper.GetString("default.color"))
+
+	contents := string(helperLoadBytes(t, profilesFile))
+	require.NotContains(t, contents, "profiles")
+}
+
+func TestWriteProfileUsesV2LayoutWhenMigrated(t *testing.T) {
+	setupProfileConfig(t, v2ConfigFile)
+
+	p := Profile{
+		ProfileName:    "default",
+		DeviceName:     "rewritten-device",
+		TestModeAPIKey: "sk_test_rewritten_key",
+		DisplayName:    "Rewritten Account",
+	}
+	require.NoError(t, p.CreateProfile())
+
+	require.Equal(t, "rewritten-device", viper.GetString("profiles.default.device_name"))
+	require.Equal(t, "sk_test_rewritten_key", viper.GetString("profiles.default.test_mode_api_key"))
+	require.False(t, viper.IsSet("default.device_name"))
+
+	// Settings that share the top level with profiles must survive the write.
+	require.Equal(t, []string{"apps"}, viper.GetStringSlice("installed_plugins"))
+	require.Equal(t, ConfigVersionV2, viper.GetInt(ConfigVersionName))
+}
+
+// A delete has to clear the field from both layouts, or a stale copy is left
+// behind in a file that contains both.
+func TestDeleteConfigFieldClearsBothLayouts(t *testing.T) {
+	setupProfileConfig(t, v2ConfigFile+`
+[default]
+  device_name = 'shadow-device'
+  display_name = 'Shadow Account'
+`)
+
+	p := Profile{ProfileName: "default"}
+	require.NoError(t, p.DeleteConfigField(DeviceNameName))
+
+	require.False(t, viper.IsSet("profiles.default.device_name"))
+	require.False(t, viper.IsSet("default.device_name"))
+	require.Equal(t, "V2 Account", viper.GetString("profiles.default.display_name"))
+}

--- a/pkg/config/profile_layout_test.go
+++ b/pkg/config/profile_layout_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -186,4 +187,92 @@ func TestDeleteConfigFieldClearsBothLayouts(t *testing.T) {
 	require.False(t, viper.IsSet("profiles.default.device_name"))
 	require.False(t, viper.IsSet("default.device_name"))
 	require.Equal(t, "V2 Account", viper.GetString("profiles.default.display_name"))
+}
+
+// A config_version this binary does not know could only have been written by a
+// newer CLI, which is a routine situation the moment a v3 ships: a pinned CLI in
+// CI, or a synced home directory, reads the file a newer binary migrated.
+const unsupportedVersionConfigFile = `config_version = 3
+
+[profiles.default]
+  device_name = 'device-v3'
+  display_name = 'V3 Account'
+  test_mode_api_key = 'sk_test_v3_key'
+`
+
+func readVersionFrom(t *testing.T, contents string) (int, error) {
+	t.Helper()
+
+	v := viper.New()
+	v.SetConfigType("toml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(contents)))
+
+	return configVersion(v)
+}
+
+func TestConfigVersionTreatsAbsentKeyAsV1(t *testing.T) {
+	version, err := readVersionFrom(t, v1ConfigFile)
+	require.NoError(t, err)
+	require.Equal(t, ConfigVersionV1, version)
+}
+
+// Viper truncates a float before we ever see it, so these are rejected by the
+// range check rather than by a cast failure. A value that truncates into the
+// supported range is deliberately left alone.
+func TestConfigVersionRejectsValuesThatAreNotVersionNumbers(t *testing.T) {
+	for _, raw := range []string{"'abc'", "0", "0.3", "-1", "-1.12", "''"} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := readVersionFrom(t, "config_version = "+raw+"\n")
+			require.ErrorContains(t, err, "is not a version number")
+		})
+	}
+}
+
+func TestConfigVersionRejectsVersionsNewerThanSupported(t *testing.T) {
+	_, err := readVersionFrom(t, unsupportedVersionConfigFile)
+	require.ErrorContains(t, err, "understands up to 2")
+}
+
+// Reads stay best-effort on an unknown version: both layouts are tried, so the
+// profile a newer CLI wrote is still found and read-only commands keep working.
+func TestReadProfileStillWorksWhenVersionIsNewerThanSupported(t *testing.T) {
+	setupProfileConfig(t, unsupportedVersionConfigFile)
+
+	p := Profile{ProfileName: "default"}
+
+	deviceName, err := p.GetDeviceName()
+	require.NoError(t, err)
+	require.Equal(t, "device-v3", deviceName)
+
+	require.Equal(t, "V3 Account", p.GetDisplayName())
+}
+
+// Writes are refused instead, because both candidate layouts are a guess at that
+// point and the flat guess is silently shadowed by the nested copy.
+func TestWriteRefusedWhenVersionIsNewerThanSupported(t *testing.T) {
+	_, profilesFile := setupProfileConfig(t, unsupportedVersionConfigFile)
+
+	p := Profile{ProfileName: "default"}
+	require.ErrorContains(t, p.WriteConfigField("color", "on"), "understands up to 2")
+
+	// The refusal has to leave the file untouched, not half-written.
+	require.Equal(t, unsupportedVersionConfigFile, string(helperLoadBytes(t, profilesFile)))
+}
+
+func TestWriteRefusedWhenVersionIsNotAVersionNumber(t *testing.T) {
+	setupProfileConfig(t, `config_version = 'abc'
+
+[profiles.default]
+  display_name = 'Malformed Version'
+`)
+
+	p := Profile{ProfileName: "default"}
+	require.ErrorContains(t, p.WriteConfigField("color", "on"), "is not a version number")
+}
+
+// An unknown version is not "migrated", so nothing downstream mistakes it for the
+// v2 layout it happens to resemble.
+func TestIsMigratedOnlyAtTheSupportedVersion(t *testing.T) {
+	setupProfileConfig(t, unsupportedVersionConfigFile)
+	require.False(t, isMigrated(viper.GetViper()))
 }


### PR DESCRIPTION
### Reviewers
r? @
cc @stripe/developer-products

### Summary

To avoid profile names colliding with CLI settings, we're introducing a v2 `config.toml` that moves every profile under a reserved `[profiles.<name>]` table, marked by `config_version = 2`.

This PR makes profile field access handle both versions of the file. 
- reads: `profiles.<name>.<field>`, falling back to the flat `<name>.<field>`
- writes: follow the layout the file already uses
- deletes: clear both layouts
- keyring item IDs: unchanged at `<profile>.<field>`, since prefixing them would orphan every livemode
  credential already in the keychain. That's why `GetConfigField` still returns the flat path.

The reason we handle both layouts is, despite the migration, we can't guarantee every user's config ends up on v2, for example some will be held back by an old plugin. Handling both keeps those users able to read their own profiles and keys instead of being locked out.


### Test Plan

`pkg/config/profile_layout_test.go`
