### PR TITLE
Call migration script to update config.toml file

### DIFF
--- a/pkg/cmd/config_migration.go
+++ b/pkg/cmd/config_migration.go
@@ -1,18 +1,19 @@
 package cmd
 
 import (
-	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
-	"strings"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/plugins"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 // configMigration is the policy around config.MigrateConfigFile: whether the
@@ -20,19 +21,23 @@ import (
 // about it. Every dependency is a field so the policy can be tested without a
 // terminal or an installed plugin.
 type configMigration struct {
-	profilesFile      string
-	needsMigration    func() bool
-	pluginsReady      func() bool
-	incompatibilities func() ([]plugins.ConfigV2Incompatibility, error)
-	migrate           func(path string) (bool, error)
-	reload            func() error
-	getEnv            func(string) string
-	interactive       bool
-	in                io.Reader
-	out               io.Writer
+	profilesFile         string
+	needsMigration       func() bool
+	pluginsReady         func() bool
+	incompatibilities    func() ([]plugins.ConfigV2Incompatibility, error)
+	installedPluginCount func() int
+	upgradePlugin        func(plugins.ConfigV2Incompatibility) (string, error)
+	migrate              func(path string) (bool, error)
+	reload               func() error
+	getEnv               func(string) string
+	out                  io.Writer
 }
 
-func newConfigMigration(cfg *config.Config) configMigration {
+func newConfigMigration(cfg *config.Config, ctx context.Context) configMigration {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	return configMigration{
 		profilesFile:   cfg.ProfilesFile,
 		needsMigration: config.NeedsMigration,
@@ -40,29 +45,39 @@ func newConfigMigration(cfg *config.Config) configMigration {
 		incompatibilities: func() ([]plugins.ConfigV2Incompatibility, error) {
 			return plugins.ConfigV2Incompatibilities(cfg, fs)
 		},
-		migrate:     config.MigrateConfigFile,
-		reload:      config.ReloadConfigFile,
-		getEnv:      os.Getenv,
-		interactive: interactiveHuman(os.Getenv, term.IsTerminal(int(os.Stdin.Fd()))),
-		in:          os.Stdin,
-		out:         os.Stderr,
+		installedPluginCount: func() int {
+			names, err := plugins.GetInstalledPluginNames(cfg, fs)
+			if err != nil {
+				return 0
+			}
+
+			return len(names)
+		},
+		upgradePlugin: func(incompatibility plugins.ConfigV2Incompatibility) (string, error) {
+			return upgradePluginForConfigV2(ctx, cfg, fs, incompatibility)
+		},
+		migrate: config.MigrateConfigFile,
+		reload:  config.ReloadConfigFile,
+		getEnv:  os.Getenv,
+		out:     os.Stderr,
 	}
 }
 
-// migrateConfigIfNeeded offers the one-time move to the v2 config layout, before
-// the command the user asked for runs.
+// migrateConfigIfNeeded rewrites the config file to the v2 layout before the
+// command the user asked for runs. It does not ask: plugins that are too old
+// are upgraded, then the file is migrated.
 func migrateConfigIfNeeded(cmd *cobra.Command) {
 	if !migrationSafeCommand(cmd) {
 		return
 	}
 
-	newConfigMigration(&Config).run()
+	newConfigMigration(&Config, cmd.Context()).run()
 }
 
-// migrationSafeCommand reports whether it is acceptable to write to the terminal
-// and to the config file while running this command. Help and shell completion
-// output gets read by other programs, and a prompt in the middle of it would be
-// worse than a config file left in the old layout.
+// migrationSafeCommand reports whether it is acceptable to write status lines
+// and to rewrite the config file while running this command. Help and shell
+// completion output gets read by other programs, and a status line in the
+// middle of it would be worse than a config file left in the old layout.
 func migrationSafeCommand(cmd *cobra.Command) bool {
 	for c := cmd; c != nil; c = c.Parent() {
 		switch c.Name() {
@@ -105,28 +120,83 @@ func (m configMigration) run() {
 		return
 	}
 
-	// A prompt nobody answers would hang, and migrating unasked in a script is
-	// worse than not migrating at all.
-	if !m.interactive {
-		logger.Debug("Skipping the config migration: not an interactive session")
+	if !m.ensurePluginsCompatible(logger) {
 		return
 	}
+
+	m.migrateAndReload()
+}
+
+// ensurePluginsCompatible upgrades any installed plugin that cannot read the v2
+// layout. It returns false when an upgrade fails, in which case the config file
+// is left alone.
+func (m configMigration) ensurePluginsCompatible(logger *log.Entry) bool {
+	fmt.Fprint(m.out, "checking installed plugins...")
 
 	incompatibilities, err := m.incompatibilities()
 	if err != nil {
+		fmt.Fprintln(m.out)
 		logger.Debugf("Skipping the config migration: could not check installed plugins: %s", err)
-		return
+		return false
 	}
 
-	if len(incompatibilities) > 0 {
-		m.reportIncompatiblePlugins(incompatibilities)
-		return
+	if len(incompatibilities) == 0 {
+		switch n := m.pluginCount(); {
+		case n == 0:
+			fmt.Fprintln(m.out, " none installed.")
+		case n == 1:
+			fmt.Fprintln(m.out, " 1 is compatible.")
+		default:
+			fmt.Fprintf(m.out, " all %d are compatible.\n", n)
+		}
+
+		return true
 	}
 
-	if !m.confirm() {
-		return
+	fmt.Fprintln(m.out)
+
+	for _, incompatibility := range incompatibilities {
+		newVersion, err := m.upgradeOne(incompatibility)
+		if err != nil {
+			logger.Debugf("could not upgrade %s: %s", incompatibility.Plugin, err)
+			m.reportUpgradeFailure(incompatibility)
+			return false
+		}
+
+		fmt.Fprintf(m.out, "✔ upgraded %s from v%s to v%s.\n", incompatibility.Plugin, incompatibility.InstalledVersion, newVersion)
 	}
 
+	return true
+}
+
+func (m configMigration) pluginCount() int {
+	if m.installedPluginCount == nil {
+		return 0
+	}
+
+	return m.installedPluginCount()
+}
+
+func (m configMigration) upgradeOne(incompatibility plugins.ConfigV2Incompatibility) (string, error) {
+	if m.upgradePlugin == nil {
+		return "", fmt.Errorf("plugin upgrade is not configured")
+	}
+
+	return m.upgradePlugin(incompatibility)
+}
+
+func (m configMigration) reportUpgradeFailure(incompatibility plugins.ConfigV2Incompatibility) {
+	if incompatibility.MinimumVersion != "" {
+		fmt.Fprintf(m.out, "! could not upgrade %s to the minimum required version (%s).\n", incompatibility.Plugin, incompatibility.MinimumVersion)
+	} else {
+		fmt.Fprintf(m.out, "! could not upgrade %s to a version that reads the new config format.\n", incompatibility.Plugin)
+	}
+
+	fmt.Fprintf(m.out, "  run `%s`, then try again.\n", incompatibility.UpgradeCommand())
+	fmt.Fprintln(m.out, "your config file was not changed.")
+}
+
+func (m configMigration) migrateAndReload() {
 	changed, err := m.migrate(m.profilesFile)
 	if err != nil {
 		fmt.Fprintf(m.out, "Could not update %s to the new config format: %s\n", m.profilesFile, err)
@@ -144,36 +214,28 @@ func (m configMigration) run() {
 		return
 	}
 
-	fmt.Fprintf(m.out, "Updated %s to the new config format. The previous version is saved as %s.\n", m.profilesFile, m.profilesFile+config.ConfigBackupSuffix)
+	fmt.Fprintf(m.out, "✔ updated %s (backup saved to %s)\n", m.profilesFile, filepath.Base(m.profilesFile+config.ConfigBackupSuffix))
 }
 
-func (m configMigration) reportIncompatiblePlugins(incompatibilities []plugins.ConfigV2Incompatibility) {
-	fmt.Fprintf(m.out, "%s uses an older config format. Updating it needs newer versions of these plugins:\n", m.profilesFile)
+// upgradePluginForConfigV2 installs the latest release of a plugin that is too
+// old to read the v2 layout. If that latest release is still below the minimum,
+// it does not install anything.
+func upgradePluginForConfigV2(ctx context.Context, cfg *config.Config, fs afero.Fs, incompatibility plugins.ConfigV2Incompatibility) (string, error) {
+	apiBaseURL := stripe.DefaultAPIBaseURL
+	dashboardBaseURL := stripe.DashboardBaseURLForAPIBaseURL(apiBaseURL)
 
-	for _, incompatibility := range incompatibilities {
-		fmt.Fprintf(m.out, "  %s %s — run `%s`\n", incompatibility.Plugin, incompatibility.InstalledVersion, incompatibility.UpgradeCommand())
+	resolved, err := plugins.ResolvePluginForUpgrade(ctx, cfg, fs, incompatibility.Plugin, apiBaseURL, dashboardBaseURL)
+	if err != nil {
+		return "", err
 	}
 
-	fmt.Fprintln(m.out, "Until then the file is left alone, and everything keeps working: this CLI reads both formats.")
-}
-
-// confirm asks whether to rewrite the config file. It defaults to yes, since the
-// migration keeps a backup and the CLI reads either layout afterwards.
-func (m configMigration) confirm() bool {
-	fmt.Fprintf(m.out, "%s uses an older config format, in which a profile name can collide with a CLI setting.\n", m.profilesFile)
-	fmt.Fprintf(m.out, "Update it now? The previous version is saved as %s. [Y/n]: ", m.profilesFile+config.ConfigBackupSuffix)
-
-	answer, err := bufio.NewReader(m.in).ReadString('\n')
-	if err != nil && answer == "" {
-		fmt.Fprintln(m.out)
-		return false
+	if !plugins.ReadsConfigV2(incompatibility.Plugin, resolved.Version) {
+		return "", fmt.Errorf("latest %s version %s cannot read the v2 config format (need %s)", incompatibility.Plugin, resolved.Version, incompatibility.MinimumVersion)
 	}
 
-	switch strings.ToLower(strings.TrimSpace(answer)) {
-	case "", "y", "yes":
-		return true
-	default:
-		fmt.Fprintf(m.out, "Leaving %s as it is. This CLI reads both formats.\n", m.profilesFile)
-		return false
+	if err := resolved.Install(ctx, cfg, fs, apiBaseURL, dashboardBaseURL); err != nil {
+		return "", err
 	}
+
+	return resolved.Version, nil
 }

--- a/pkg/cmd/config_migration.go
+++ b/pkg/cmd/config_migration.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/plugins"
+)
+
+// configMigration is the policy around config.MigrateConfigFile: whether the
+// file should be rewritten in the v2 layout right now, and what the user is told
+// about it. Every dependency is a field so the policy can be tested without a
+// terminal or an installed plugin.
+type configMigration struct {
+	profilesFile      string
+	needsMigration    func() bool
+	pluginsReady      func() bool
+	incompatibilities func() ([]plugins.ConfigV2Incompatibility, error)
+	migrate           func(path string) (bool, error)
+	reload            func() error
+	getEnv            func(string) string
+	interactive       bool
+	in                io.Reader
+	out               io.Writer
+}
+
+func newConfigMigration(cfg *config.Config) configMigration {
+	return configMigration{
+		profilesFile:   cfg.ProfilesFile,
+		needsMigration: config.NeedsMigration,
+		pluginsReady:   plugins.ConfigV2Ready,
+		incompatibilities: func() ([]plugins.ConfigV2Incompatibility, error) {
+			return plugins.ConfigV2Incompatibilities(cfg, fs)
+		},
+		migrate:     config.MigrateConfigFile,
+		reload:      config.ReloadConfigFile,
+		getEnv:      os.Getenv,
+		interactive: interactiveHuman(os.Getenv, term.IsTerminal(int(os.Stdin.Fd()))),
+		in:          os.Stdin,
+		out:         os.Stderr,
+	}
+}
+
+// migrateConfigIfNeeded offers the one-time move to the v2 config layout, before
+// the command the user asked for runs.
+func migrateConfigIfNeeded(cmd *cobra.Command) {
+	if !migrationSafeCommand(cmd) {
+		return
+	}
+
+	newConfigMigration(&Config).run()
+}
+
+// migrationSafeCommand reports whether it is acceptable to write to the terminal
+// and to the config file while running this command. Help and shell completion
+// output gets read by other programs, and a prompt in the middle of it would be
+// worse than a config file left in the old layout.
+func migrationSafeCommand(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		switch c.Name() {
+		case "help", "completion":
+			return false
+		}
+	}
+
+	return true
+}
+
+// run migrates the config file when doing so is both needed and safe.
+//
+// Nothing here fails the command the user actually asked for. Every reason to
+// stop is a reason the old layout stays, and the old layout keeps working: this
+// version of the CLI reads both.
+func (m configMigration) run() {
+	logger := log.WithFields(log.Fields{
+		"prefix": "cmd.configMigration.run",
+	})
+
+	if !m.needsMigration() {
+		return
+	}
+
+	if m.getEnv(config.SkipMigrationEnvVar) != "" {
+		logger.Debugf("Skipping the config migration because %s is set", config.SkipMigrationEnvVar)
+		return
+	}
+
+	if _, err := os.Stat(m.profilesFile); err != nil {
+		// No config file yet, so there is nothing to move. The first write picks
+		// the layout.
+		logger.Debugf("Skipping the config migration: %s", err)
+		return
+	}
+
+	if !m.pluginsReady() {
+		logger.Debug("Skipping the config migration: no plugin release is known to read the new config format yet")
+		return
+	}
+
+	// A prompt nobody answers would hang, and migrating unasked in a script is
+	// worse than not migrating at all.
+	if !m.interactive {
+		logger.Debug("Skipping the config migration: not an interactive session")
+		return
+	}
+
+	incompatibilities, err := m.incompatibilities()
+	if err != nil {
+		logger.Debugf("Skipping the config migration: could not check installed plugins: %s", err)
+		return
+	}
+
+	if len(incompatibilities) > 0 {
+		m.reportIncompatiblePlugins(incompatibilities)
+		return
+	}
+
+	if !m.confirm() {
+		return
+	}
+
+	changed, err := m.migrate(m.profilesFile)
+	if err != nil {
+		fmt.Fprintf(m.out, "Could not update %s to the new config format: %s\n", m.profilesFile, err)
+		fmt.Fprintln(m.out, "The file was left as it was, and the CLI still reads it.")
+
+		return
+	}
+
+	if !changed {
+		return
+	}
+
+	if err := m.reload(); err != nil {
+		fmt.Fprintf(m.out, "Updated %s to the new config format, but could not re-read it: %s\n", m.profilesFile, err)
+		return
+	}
+
+	fmt.Fprintf(m.out, "Updated %s to the new config format. The previous version is saved as %s.\n", m.profilesFile, m.profilesFile+config.ConfigBackupSuffix)
+}
+
+func (m configMigration) reportIncompatiblePlugins(incompatibilities []plugins.ConfigV2Incompatibility) {
+	fmt.Fprintf(m.out, "%s uses an older config format. Updating it needs newer versions of these plugins:\n", m.profilesFile)
+
+	for _, incompatibility := range incompatibilities {
+		fmt.Fprintf(m.out, "  %s %s — run `%s`\n", incompatibility.Plugin, incompatibility.InstalledVersion, incompatibility.UpgradeCommand())
+	}
+
+	fmt.Fprintln(m.out, "Until then the file is left alone, and everything keeps working: this CLI reads both formats.")
+}
+
+// confirm asks whether to rewrite the config file. It defaults to yes, since the
+// migration keeps a backup and the CLI reads either layout afterwards.
+func (m configMigration) confirm() bool {
+	fmt.Fprintf(m.out, "%s uses an older config format, in which a profile name can collide with a CLI setting.\n", m.profilesFile)
+	fmt.Fprintf(m.out, "Update it now? The previous version is saved as %s. [Y/n]: ", m.profilesFile+config.ConfigBackupSuffix)
+
+	answer, err := bufio.NewReader(m.in).ReadString('\n')
+	if err != nil && answer == "" {
+		fmt.Fprintln(m.out)
+		return false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "", "y", "yes":
+		return true
+	default:
+		fmt.Fprintf(m.out, "Leaving %s as it is. This CLI reads both formats.\n", m.profilesFile)
+		return false
+	}
+}

--- a/pkg/cmd/config_migration.go
+++ b/pkg/cmd/config_migration.go
@@ -134,10 +134,10 @@ func (m configMigration) ensurePluginsCompatible(logger *log.Entry) bool {
 	}
 
 	if len(incompatibilities) == 0 {
-		switch n := m.pluginCount(); {
-		case n == 0:
+		switch n := m.pluginCount(); n {
+		case 0:
 			fmt.Fprintln(m.out, " none installed.")
-		case n == 1:
+		case 1:
 			fmt.Fprintln(m.out, " 1 is compatible.")
 		default:
 			fmt.Fprintf(m.out, " all %d are compatible.\n", n)

--- a/pkg/cmd/config_migration.go
+++ b/pkg/cmd/config_migration.go
@@ -29,7 +29,6 @@ type configMigration struct {
 	upgradePlugin        func(plugins.ConfigV2Incompatibility) (string, error)
 	migrate              func(path string) (bool, error)
 	reload               func() error
-	getEnv               func(string) string
 	out                  io.Writer
 }
 
@@ -58,7 +57,6 @@ func newConfigMigration(cfg *config.Config, ctx context.Context) configMigration
 		},
 		migrate: config.MigrateConfigFile,
 		reload:  config.ReloadConfigFile,
-		getEnv:  os.Getenv,
 		out:     os.Stderr,
 	}
 }
@@ -100,11 +98,6 @@ func (m configMigration) run() {
 	})
 
 	if !m.needsMigration() {
-		return
-	}
-
-	if m.getEnv(config.SkipMigrationEnvVar) != "" {
-		logger.Debugf("Skipping the config migration because %s is set", config.SkipMigrationEnvVar)
 		return
 	}
 
@@ -214,7 +207,7 @@ func (m configMigration) migrateAndReload() {
 		return
 	}
 
-	fmt.Fprintf(m.out, "✔ updated %s (backup saved to %s)\n", m.profilesFile, filepath.Base(m.profilesFile+config.ConfigBackupSuffix))
+	fmt.Fprintf(m.out, "✔ updated %s to the new config format (backup saved to %s)\n", m.profilesFile, filepath.Base(m.profilesFile+config.ConfigBackupSuffix))
 }
 
 // upgradePluginForConfigV2 installs the latest release of a plugin that is too

--- a/pkg/cmd/config_migration_test.go
+++ b/pkg/cmd/config_migration_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -22,9 +21,10 @@ type migrationHarness struct {
 	migrated     bool
 	reloaded     bool
 	migratedPath string
+	upgrades     []string
 }
 
-func newMigrationHarness(t *testing.T, answer string) *migrationHarness {
+func newMigrationHarness(t *testing.T) *migrationHarness {
 	t.Helper()
 
 	profilesFile := filepath.Join(t.TempDir(), "config.toml")
@@ -32,10 +32,15 @@ func newMigrationHarness(t *testing.T, answer string) *migrationHarness {
 
 	h := &migrationHarness{out: &bytes.Buffer{}}
 	h.migration = configMigration{
-		profilesFile:      profilesFile,
-		needsMigration:    func() bool { return true },
-		pluginsReady:      func() bool { return true },
-		incompatibilities: func() ([]plugins.ConfigV2Incompatibility, error) { return nil, nil },
+		profilesFile:         profilesFile,
+		needsMigration:       func() bool { return true },
+		pluginsReady:         func() bool { return true },
+		incompatibilities:    func() ([]plugins.ConfigV2Incompatibility, error) { return nil, nil },
+		installedPluginCount: func() int { return 3 },
+		upgradePlugin: func(incompatibility plugins.ConfigV2Incompatibility) (string, error) {
+			h.upgrades = append(h.upgrades, incompatibility.Plugin)
+			return "1.2.0", nil
+		},
 		migrate: func(path string) (bool, error) {
 			h.migrated = true
 			h.migratedPath = path
@@ -47,60 +52,40 @@ func newMigrationHarness(t *testing.T, answer string) *migrationHarness {
 
 			return nil
 		},
-		getEnv:      func(string) string { return "" },
-		interactive: true,
-		in:          strings.NewReader(answer),
-		out:         h.out,
+		getEnv: func(string) string { return "" },
+		out:    h.out,
 	}
 
 	return h
 }
 
 func TestConfigMigrationRunsWhenNeeded(t *testing.T) {
-	h := newMigrationHarness(t, "y\n")
+	h := newMigrationHarness(t)
 
 	h.migration.run()
 
 	require.True(t, h.migrated)
 	require.True(t, h.reloaded)
 	require.Equal(t, h.migration.profilesFile, h.migratedPath)
-	require.Contains(t, h.out.String(), "Updated "+h.migration.profilesFile)
-	require.Contains(t, h.out.String(), config.ConfigBackupSuffix)
+	require.Contains(t, h.out.String(), "checking installed plugins... all 3 are compatible.")
+	require.Contains(t, h.out.String(), "✔ updated "+h.migration.profilesFile)
+	require.Contains(t, h.out.String(), "backup saved to config.toml"+config.ConfigBackupSuffix)
 }
 
-// The migration keeps a backup and the CLI reads both layouts afterwards, so a
-// bare Enter accepts.
-func TestConfigMigrationDefaultsToYes(t *testing.T) {
-	h := newMigrationHarness(t, "\n")
+// There is no confirm prompt, so CI and AI agents migrate the same way a person
+// at a terminal does.
+func TestConfigMigrationDoesNotAsk(t *testing.T) {
+	h := newMigrationHarness(t)
 
 	h.migration.run()
 
 	require.True(t, h.migrated)
-}
-
-func TestConfigMigrationRespectsDeclining(t *testing.T) {
-	h := newMigrationHarness(t, "n\n")
-
-	h.migration.run()
-
-	require.False(t, h.migrated)
-	require.Contains(t, h.out.String(), "Leaving")
-}
-
-// Nothing is read from a terminal that isn't there, and a script should not have
-// its config file rewritten unasked.
-func TestConfigMigrationSkipsNonInteractiveSession(t *testing.T) {
-	h := newMigrationHarness(t, "y\n")
-	h.migration.interactive = false
-
-	h.migration.run()
-
-	require.False(t, h.migrated)
-	require.Empty(t, h.out.String())
+	require.NotContains(t, h.out.String(), "Update it now")
+	require.NotContains(t, h.out.String(), "[Y/n]")
 }
 
 func TestConfigMigrationHonorsKillSwitch(t *testing.T) {
-	h := newMigrationHarness(t, "y\n")
+	h := newMigrationHarness(t)
 	h.migration.getEnv = func(name string) string {
 		if name == config.SkipMigrationEnvVar {
 			return "1"
@@ -116,7 +101,7 @@ func TestConfigMigrationHonorsKillSwitch(t *testing.T) {
 }
 
 func TestConfigMigrationSkipsAlreadyMigratedConfig(t *testing.T) {
-	h := newMigrationHarness(t, "y\n")
+	h := newMigrationHarness(t)
 	h.migration.needsMigration = func() bool { return false }
 
 	h.migration.run()
@@ -126,7 +111,7 @@ func TestConfigMigrationSkipsAlreadyMigratedConfig(t *testing.T) {
 }
 
 func TestConfigMigrationSkipsMissingConfigFile(t *testing.T) {
-	h := newMigrationHarness(t, "y\n")
+	h := newMigrationHarness(t)
 	h.migration.profilesFile = filepath.Join(t.TempDir(), "config.toml")
 
 	h.migration.run()
@@ -135,27 +120,48 @@ func TestConfigMigrationSkipsMissingConfigFile(t *testing.T) {
 	require.Empty(t, h.out.String())
 }
 
-// Plugins parse the config file themselves, so migrating past one that only knows
-// the flat layout would leave it unable to find any profile.
-func TestConfigMigrationSkipsWhenAPluginIsTooOld(t *testing.T) {
-	h := newMigrationHarness(t, "y\n")
+func TestConfigMigrationUpgradesAPluginThatIsTooOld(t *testing.T) {
+	h := newMigrationHarness(t)
 	h.migration.incompatibilities = func() ([]plugins.ConfigV2Incompatibility, error) {
 		return []plugins.ConfigV2Incompatibility{{
-			Plugin:           "apps",
-			InstalledVersion: "1.4.0",
-			MinimumVersion:   "1.5.0",
+			Plugin:           "projects",
+			InstalledVersion: "0.8.2",
+			MinimumVersion:   "1.2.0",
 		}}, nil
 	}
 
 	h.migration.run()
 
+	require.Equal(t, []string{"projects"}, h.upgrades)
+	require.True(t, h.migrated)
+	require.Contains(t, h.out.String(), "checking installed plugins...")
+	require.Contains(t, h.out.String(), "✔ upgraded projects from v0.8.2 to v1.2.0.")
+	require.Contains(t, h.out.String(), "✔ updated "+h.migration.profilesFile)
+}
+
+func TestConfigMigrationDoesNotMigrateWhenPluginUpgradeFails(t *testing.T) {
+	h := newMigrationHarness(t)
+	h.migration.incompatibilities = func() ([]plugins.ConfigV2Incompatibility, error) {
+		return []plugins.ConfigV2Incompatibility{{
+			Plugin:           "projects",
+			InstalledVersion: "0.8.2",
+			MinimumVersion:   "1.2.0",
+		}}, nil
+	}
+	h.migration.upgradePlugin = func(plugins.ConfigV2Incompatibility) (string, error) {
+		return "", os.ErrPermission
+	}
+
+	h.migration.run()
+
 	require.False(t, h.migrated)
-	require.Contains(t, h.out.String(), "apps 1.4.0")
-	require.Contains(t, h.out.String(), "stripe plugin upgrade apps")
+	require.Contains(t, h.out.String(), "! could not upgrade projects to the minimum required version (1.2.0).")
+	require.Contains(t, h.out.String(), "run `stripe plugin upgrade projects`, then try again.")
+	require.Contains(t, h.out.String(), "your config file was not changed.")
 }
 
 func TestConfigMigrationSkipsUntilPluginVersionsAreKnown(t *testing.T) {
-	h := newMigrationHarness(t, "y\n")
+	h := newMigrationHarness(t)
 	h.migration.pluginsReady = func() bool { return false }
 
 	h.migration.run()
@@ -167,7 +173,7 @@ func TestConfigMigrationSkipsUntilPluginVersionsAreKnown(t *testing.T) {
 // A migration that fails has already restored the original file, and the command
 // the user asked for still runs.
 func TestConfigMigrationReportsFailureWithoutFailingTheCommand(t *testing.T) {
-	h := newMigrationHarness(t, "y\n")
+	h := newMigrationHarness(t)
 	h.migration.migrate = func(string) (bool, error) {
 		return false, os.ErrPermission
 	}
@@ -179,8 +185,8 @@ func TestConfigMigrationReportsFailureWithoutFailingTheCommand(t *testing.T) {
 	require.Contains(t, h.out.String(), "still reads it")
 }
 
-// Help and completion output is read by other programs, so a prompt in the middle
-// of it is worse than a config file left in the old layout.
+// Help and completion output is read by other programs, so a status line in the
+// middle of it is worse than a config file left in the old layout.
 func TestMigrationSafeCommand(t *testing.T) {
 	root := &cobra.Command{Use: "stripe"}
 	listen := &cobra.Command{Use: "listen"}

--- a/pkg/cmd/config_migration_test.go
+++ b/pkg/cmd/config_migration_test.go
@@ -52,8 +52,7 @@ func newMigrationHarness(t *testing.T) *migrationHarness {
 
 			return nil
 		},
-		getEnv: func(string) string { return "" },
-		out:    h.out,
+		out: h.out,
 	}
 
 	return h
@@ -68,7 +67,7 @@ func TestConfigMigrationRunsWhenNeeded(t *testing.T) {
 	require.True(t, h.reloaded)
 	require.Equal(t, h.migration.profilesFile, h.migratedPath)
 	require.Contains(t, h.out.String(), "checking installed plugins... all 3 are compatible.")
-	require.Contains(t, h.out.String(), "✔ updated "+h.migration.profilesFile)
+	require.Contains(t, h.out.String(), "✔ updated "+h.migration.profilesFile+" to the new config format")
 	require.Contains(t, h.out.String(), "backup saved to config.toml"+config.ConfigBackupSuffix)
 }
 
@@ -82,22 +81,6 @@ func TestConfigMigrationDoesNotAsk(t *testing.T) {
 	require.True(t, h.migrated)
 	require.NotContains(t, h.out.String(), "Update it now")
 	require.NotContains(t, h.out.String(), "[Y/n]")
-}
-
-func TestConfigMigrationHonorsKillSwitch(t *testing.T) {
-	h := newMigrationHarness(t)
-	h.migration.getEnv = func(name string) string {
-		if name == config.SkipMigrationEnvVar {
-			return "1"
-		}
-
-		return ""
-	}
-
-	h.migration.run()
-
-	require.False(t, h.migrated)
-	require.Empty(t, h.out.String())
 }
 
 func TestConfigMigrationSkipsAlreadyMigratedConfig(t *testing.T) {
@@ -136,7 +119,7 @@ func TestConfigMigrationUpgradesAPluginThatIsTooOld(t *testing.T) {
 	require.True(t, h.migrated)
 	require.Contains(t, h.out.String(), "checking installed plugins...")
 	require.Contains(t, h.out.String(), "✔ upgraded projects from v0.8.2 to v1.2.0.")
-	require.Contains(t, h.out.String(), "✔ updated "+h.migration.profilesFile)
+	require.Contains(t, h.out.String(), "✔ updated "+h.migration.profilesFile+" to the new config format")
 }
 
 func TestConfigMigrationDoesNotMigrateWhenPluginUpgradeFails(t *testing.T) {

--- a/pkg/cmd/config_migration_test.go
+++ b/pkg/cmd/config_migration_test.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/plugins"
+)
+
+// migrationHarness is a configMigration with every gate open and nothing real
+// behind it, so each test can close exactly one gate.
+type migrationHarness struct {
+	migration    configMigration
+	out          *bytes.Buffer
+	migrated     bool
+	reloaded     bool
+	migratedPath string
+}
+
+func newMigrationHarness(t *testing.T, answer string) *migrationHarness {
+	t.Helper()
+
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(profilesFile, []byte("[default]\n  display_name = 'Account'\n"), 0600))
+
+	h := &migrationHarness{out: &bytes.Buffer{}}
+	h.migration = configMigration{
+		profilesFile:      profilesFile,
+		needsMigration:    func() bool { return true },
+		pluginsReady:      func() bool { return true },
+		incompatibilities: func() ([]plugins.ConfigV2Incompatibility, error) { return nil, nil },
+		migrate: func(path string) (bool, error) {
+			h.migrated = true
+			h.migratedPath = path
+
+			return true, nil
+		},
+		reload: func() error {
+			h.reloaded = true
+
+			return nil
+		},
+		getEnv:      func(string) string { return "" },
+		interactive: true,
+		in:          strings.NewReader(answer),
+		out:         h.out,
+	}
+
+	return h
+}
+
+func TestConfigMigrationRunsWhenNeeded(t *testing.T) {
+	h := newMigrationHarness(t, "y\n")
+
+	h.migration.run()
+
+	require.True(t, h.migrated)
+	require.True(t, h.reloaded)
+	require.Equal(t, h.migration.profilesFile, h.migratedPath)
+	require.Contains(t, h.out.String(), "Updated "+h.migration.profilesFile)
+	require.Contains(t, h.out.String(), config.ConfigBackupSuffix)
+}
+
+// The migration keeps a backup and the CLI reads both layouts afterwards, so a
+// bare Enter accepts.
+func TestConfigMigrationDefaultsToYes(t *testing.T) {
+	h := newMigrationHarness(t, "\n")
+
+	h.migration.run()
+
+	require.True(t, h.migrated)
+}
+
+func TestConfigMigrationRespectsDeclining(t *testing.T) {
+	h := newMigrationHarness(t, "n\n")
+
+	h.migration.run()
+
+	require.False(t, h.migrated)
+	require.Contains(t, h.out.String(), "Leaving")
+}
+
+// Nothing is read from a terminal that isn't there, and a script should not have
+// its config file rewritten unasked.
+func TestConfigMigrationSkipsNonInteractiveSession(t *testing.T) {
+	h := newMigrationHarness(t, "y\n")
+	h.migration.interactive = false
+
+	h.migration.run()
+
+	require.False(t, h.migrated)
+	require.Empty(t, h.out.String())
+}
+
+func TestConfigMigrationHonorsKillSwitch(t *testing.T) {
+	h := newMigrationHarness(t, "y\n")
+	h.migration.getEnv = func(name string) string {
+		if name == config.SkipMigrationEnvVar {
+			return "1"
+		}
+
+		return ""
+	}
+
+	h.migration.run()
+
+	require.False(t, h.migrated)
+	require.Empty(t, h.out.String())
+}
+
+func TestConfigMigrationSkipsAlreadyMigratedConfig(t *testing.T) {
+	h := newMigrationHarness(t, "y\n")
+	h.migration.needsMigration = func() bool { return false }
+
+	h.migration.run()
+
+	require.False(t, h.migrated)
+	require.Empty(t, h.out.String())
+}
+
+func TestConfigMigrationSkipsMissingConfigFile(t *testing.T) {
+	h := newMigrationHarness(t, "y\n")
+	h.migration.profilesFile = filepath.Join(t.TempDir(), "config.toml")
+
+	h.migration.run()
+
+	require.False(t, h.migrated)
+	require.Empty(t, h.out.String())
+}
+
+// Plugins parse the config file themselves, so migrating past one that only knows
+// the flat layout would leave it unable to find any profile.
+func TestConfigMigrationSkipsWhenAPluginIsTooOld(t *testing.T) {
+	h := newMigrationHarness(t, "y\n")
+	h.migration.incompatibilities = func() ([]plugins.ConfigV2Incompatibility, error) {
+		return []plugins.ConfigV2Incompatibility{{
+			Plugin:           "apps",
+			InstalledVersion: "1.4.0",
+			MinimumVersion:   "1.5.0",
+		}}, nil
+	}
+
+	h.migration.run()
+
+	require.False(t, h.migrated)
+	require.Contains(t, h.out.String(), "apps 1.4.0")
+	require.Contains(t, h.out.String(), "stripe plugin upgrade apps")
+}
+
+func TestConfigMigrationSkipsUntilPluginVersionsAreKnown(t *testing.T) {
+	h := newMigrationHarness(t, "y\n")
+	h.migration.pluginsReady = func() bool { return false }
+
+	h.migration.run()
+
+	require.False(t, h.migrated)
+	require.Empty(t, h.out.String())
+}
+
+// A migration that fails has already restored the original file, and the command
+// the user asked for still runs.
+func TestConfigMigrationReportsFailureWithoutFailingTheCommand(t *testing.T) {
+	h := newMigrationHarness(t, "y\n")
+	h.migration.migrate = func(string) (bool, error) {
+		return false, os.ErrPermission
+	}
+
+	h.migration.run()
+
+	require.False(t, h.reloaded)
+	require.Contains(t, h.out.String(), "Could not update")
+	require.Contains(t, h.out.String(), "still reads it")
+}
+
+// Help and completion output is read by other programs, so a prompt in the middle
+// of it is worse than a config file left in the old layout.
+func TestMigrationSafeCommand(t *testing.T) {
+	root := &cobra.Command{Use: "stripe"}
+	listen := &cobra.Command{Use: "listen"}
+	completion := &cobra.Command{Use: "completion"}
+	completionZsh := &cobra.Command{Use: "zsh"}
+	help := &cobra.Command{Use: "help"}
+
+	completion.AddCommand(completionZsh)
+	root.AddCommand(listen, completion, help)
+
+	require.True(t, migrationSafeCommand(root))
+	require.True(t, migrationSafeCommand(listen))
+	require.False(t, migrationSafeCommand(completion))
+	require.False(t, migrationSafeCommand(completionZsh))
+	require.False(t, migrationSafeCommand(help))
+}

--- a/pkg/cmd/login_helpers.go
+++ b/pkg/cmd/login_helpers.go
@@ -2,11 +2,17 @@ package cmd
 
 import "github.com/stripe/stripe-cli/pkg/useragent"
 
+// interactiveHuman reports whether the CLI is talking to a person at a terminal.
+// Agents with a real TTY (e.g. Claude Code) and headless environments (CI,
+// /dev/null stdin) both return false, so nothing blocks waiting for an answer
+// nobody is there to give.
+// getEnv and stdinIsTerminal are injected to allow testing.
+func interactiveHuman(getEnv func(string) string, stdinIsTerminal bool) bool {
+	return stdinIsTerminal && useragent.DetectAIAgent(getEnv) == ""
+}
+
 // shouldAutoLogin reports whether the CLI should attempt automatic browser-based login.
 // Returns true only when stdin is an interactive terminal and no AI agent is detected.
-// Agents with a real TTY (e.g. Claude Code) and headless environments (CI, /dev/null stdin)
-// both return false, ensuring neither blocks waiting for a browser flow.
-// getEnv and stdinIsTerminal are injected to allow testing.
 func shouldAutoLogin(getEnv func(string) string, stdinIsTerminal bool) bool {
-	return stdinIsTerminal && useragent.DetectAIAgent(getEnv) == ""
+	return interactiveHuman(getEnv, stdinIsTerminal)
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -69,6 +69,12 @@ var rootCmd = &cobra.Command{
 			fullHelpMode = true
 		}
 
+		// Move the config file to the v2 layout before the command reads anything
+		// out of it. This lives here rather than in InitConfig because Go plugins
+		// call InitConfig directly, and would otherwise rewrite the user's config
+		// file themselves at arbitrary times.
+		migrateConfigIfNeeded(cmd)
+
 		// if getting the config errors, don't fail running the command
 		merchant, _ := Config.Profile.GetAccountID()
 		telemetryMetadata := stripe.GetEventMetadata(cmd.Context())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -687,9 +687,20 @@ func writeConfig(runtimeViper *viper.Viper) error {
 		return err
 	}
 
-	// Reset global viper and re-read from file.
-	// We must reset because ReadInConfig merges with existing values rather than
-	// replacing them - so deleted keys would persist without this reset.
+	return ReloadConfigFile()
+}
+
+// ReloadConfigFile re-reads the config file into the global viper, replacing what
+// is already loaded rather than merging into it. Anything that rewrites the file
+// behind viper's back — the config migration, for one — needs this to see its own
+// changes.
+//
+// The reset matters: ReadInConfig merges with existing values, so keys the
+// rewrite removed would otherwise linger in memory.
+func ReloadConfigFile() error {
+	profilesFile := viper.ConfigFileUsed()
+	configType := strings.TrimPrefix(filepath.Ext(profilesFile), ".")
+
 	viper.Reset()
 	viper.SetConfigFile(profilesFile)
 	viper.SetConfigType(configType)

--- a/pkg/config/migrate.go
+++ b/pkg/config/migrate.go
@@ -18,11 +18,6 @@ import (
 // the migration leaves behind, e.g. "config.toml.v1.bak".
 const ConfigBackupSuffix = ".v1.bak"
 
-// SkipMigrationEnvVar disables the migration when set to any non-empty value. It
-// is the kill switch if the migration misbehaves in the field; setting
-// config_version = 1 in the config file is the per-user equivalent.
-const SkipMigrationEnvVar = "STRIPE_CLI_SKIP_CONFIG_MIGRATION"
-
 // reservedTopLevelKeys are the top-level config.toml keys that belong to the CLI
 // itself. Every other top-level table in a v1 file is a candidate profile.
 //
@@ -83,31 +78,23 @@ func IsMigrated() bool {
 // the v2 layout. It answers from the config already in memory, so it costs
 // nothing on the common path.
 //
-// It says nothing about whether migrating is *safe* — an installed plugin too old
-// to read the v2 layout, or a non-interactive session, must not migrate — and it
-// does not check that the config file exists, since a viper with no file loaded
-// looks exactly like an unmigrated one.
+// It does not check that migrating is safe for plugins, and it does not check
+// that the config file exists: a viper with no file loaded looks exactly like an
+// unmigrated one.
 func NeedsMigration() bool {
 	v := viper.GetViper()
 
-	version, err := configVersion(v)
-	if err != nil {
+	if _, err := configVersion(v); err != nil {
 		// A version this binary cannot act on. writeConfig refuses such a file
 		// outright, so rewriting its layout is not on the table either.
 		return false
 	}
 
-	switch {
-	// configVersion reports an absent key as v1, so the raw key has to be
-	// consulted as well: only a config_version written out explicitly is a pin.
-	case version == ConfigVersionV1 && v.Get(ConfigVersionName) != nil:
-		// The user pinned the flat layout.
-		return false
-	case !isMigrated(v):
+	if !isMigrated(v) {
 		return true
-	default:
-		return hasFlatProfileTable(v)
 	}
+
+	return hasFlatProfileTable(v)
 }
 
 // hasFlatProfileTable reports whether a migrated config file still holds a
@@ -143,9 +130,7 @@ func hasFlatProfileTable(v *viper.Viper) bool {
 // A file whose config_version is newer than this binary understands is left
 // untouched and returns an error.
 //
-// This function does not decide *whether* to migrate. Callers own that: an
-// installed plugin too old to read the v2 layout, or a non-interactive session,
-// must not migrate.
+// This function does not decide *whether* to migrate. Callers own that.
 func MigrateConfigFile(path string) (bool, error) {
 	if err := fsutil.RefuseWriteThroughSymlinkOS(path, filepath.Dir(filepath.Dir(path)), filepath.Base(path)); err != nil {
 		return false, err
@@ -208,9 +193,9 @@ func MigrateConfigFile(path string) (bool, error) {
 }
 
 // planMigration reads a config document and returns the v2 document to write.
-// changed is false when there is nothing to do: a file pinned to v1, or an
-// already-migrated file with no stray top-level profiles. A config_version newer
-// than this binary understands returns an error.
+// changed is false when there is nothing to do: an already-migrated file with no
+// stray top-level profiles. A config_version newer than this binary understands
+// returns an error.
 func planMigration(contents []byte) (*migrationPlan, bool, error) {
 	// Decode raw TOML rather than going through viper, which lowercases every
 	// key. Round-tripping profile names through viper would rename a profile the
@@ -223,13 +208,6 @@ func planMigration(contents []byte) (*migrationPlan, bool, error) {
 	version := configVersionOf(doc)
 	if version > MaxSupportedConfigVersion {
 		return nil, false, unsupportedConfigVersionError(version)
-	}
-
-	// configVersionOf reports an absent key as 0, so this is only true of a file
-	// that spells the version out: the user pinned the flat layout, and there is
-	// nothing to do even when a caller asks for the migration directly.
-	if version == ConfigVersionV1 {
-		return nil, false, nil
 	}
 
 	plan := &migrationPlan{

--- a/pkg/config/migrate.go
+++ b/pkg/config/migrate.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/BurntSushi/toml"
+	"github.com/spf13/viper"
 
 	"github.com/stripe/stripe-cli/pkg/fsutil"
 )
@@ -16,6 +17,11 @@ import (
 // ConfigBackupSuffix is appended to the config file name to name the backup that
 // the migration leaves behind, e.g. "config.toml.v1.bak".
 const ConfigBackupSuffix = ".v1.bak"
+
+// SkipMigrationEnvVar disables the migration when set to any non-empty value. It
+// is the kill switch if the migration misbehaves in the field; setting
+// config_version = 1 in the config file is the per-user equivalent.
+const SkipMigrationEnvVar = "STRIPE_CLI_SKIP_CONFIG_MIGRATION"
 
 // reservedTopLevelKeys are the top-level config.toml keys that belong to the CLI
 // itself. Every other top-level table in a v1 file is a candidate profile.
@@ -66,6 +72,63 @@ var profileFieldNames = map[string]bool{
 type migrationPlan struct {
 	profiles map[string]map[string]interface{}
 	settings map[string]interface{}
+}
+
+// IsMigrated reports whether the loaded config file uses the v2 layout.
+func IsMigrated() bool {
+	return isMigrated(viper.GetViper())
+}
+
+// NeedsMigration reports whether the loaded config file should be rewritten in
+// the v2 layout. It answers from the config already in memory, so it costs
+// nothing on the common path.
+//
+// It says nothing about whether migrating is *safe* — an installed plugin too old
+// to read the v2 layout, or a non-interactive session, must not migrate — and it
+// does not check that the config file exists, since a viper with no file loaded
+// looks exactly like an unmigrated one.
+func NeedsMigration() bool {
+	v := viper.GetViper()
+
+	version, err := configVersion(v)
+	if err != nil {
+		// A version this binary cannot act on. writeConfig refuses such a file
+		// outright, so rewriting its layout is not on the table either.
+		return false
+	}
+
+	switch {
+	// configVersion reports an absent key as v1, so the raw key has to be
+	// consulted as well: only a config_version written out explicitly is a pin.
+	case version == ConfigVersionV1 && v.Get(ConfigVersionName) != nil:
+		// The user pinned the flat layout.
+		return false
+	case !isMigrated(v):
+		return true
+	default:
+		return hasFlatProfileTable(v)
+	}
+}
+
+// hasFlatProfileTable reports whether a migrated config file still holds a
+// profile at the top level. An older CLI or plugin writing the same file does not
+// know about the profiles table, so it leaves one behind; folding it back in is
+// what stops the two copies from diverging.
+//
+// This mirrors the rule planMigration applies, so that NeedsMigration and the
+// migration itself always agree on whether there is work to do.
+func hasFlatProfileTable(v *viper.Viper) bool {
+	for key, value := range v.AllSettings() {
+		if reservedTopLevelKeys[key] {
+			continue
+		}
+
+		if table, ok := toStringMap(value); ok && looksLikeProfile(table) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // MigrateConfigFile rewrites the config file at path in the v2 layout, moving
@@ -145,9 +208,9 @@ func MigrateConfigFile(path string) (bool, error) {
 }
 
 // planMigration reads a config document and returns the v2 document to write.
-// changed is false when there is nothing to do: an already-migrated file with no
-// stray top-level profiles. A config_version newer than this binary understands
-// returns an error.
+// changed is false when there is nothing to do: a file pinned to v1, or an
+// already-migrated file with no stray top-level profiles. A config_version newer
+// than this binary understands returns an error.
 func planMigration(contents []byte) (*migrationPlan, bool, error) {
 	// Decode raw TOML rather than going through viper, which lowercases every
 	// key. Round-tripping profile names through viper would rename a profile the
@@ -160,6 +223,13 @@ func planMigration(contents []byte) (*migrationPlan, bool, error) {
 	version := configVersionOf(doc)
 	if version > MaxSupportedConfigVersion {
 		return nil, false, unsupportedConfigVersionError(version)
+	}
+
+	// configVersionOf reports an absent key as 0, so this is only true of a file
+	// that spells the version out: the user pinned the flat layout, and there is
+	// nothing to do even when a caller asks for the migration directly.
+	if version == ConfigVersionV1 {
+		return nil, false, nil
 	}
 
 	plan := &migrationPlan{

--- a/pkg/config/migrate_test.go
+++ b/pkg/config/migrate_test.go
@@ -341,26 +341,6 @@ func TestNeedsMigrationIgnoresSettingTables(t *testing.T) {
 	require.False(t, NeedsMigration())
 }
 
-// Writing the version out explicitly is how a user opts out for good.
-func TestConfigPinnedToV1IsLeftAlone(t *testing.T) {
-	pinned := `config_version = 1
-
-[default]
-  display_name = 'Pinned Account'
-  test_mode_api_key = 'sk_test_pinned_key'
-`
-	_, profilesFile := setupProfileConfig(t, pinned)
-
-	require.False(t, NeedsMigration())
-
-	changed, err := MigrateConfigFile(profilesFile)
-	require.NoError(t, err)
-	require.False(t, changed)
-	require.Equal(t, pinned, string(helperLoadBytes(t, profilesFile)))
-}
-
-// The migration rewrites the config file, so it has to refuse the same symlinked
-// destinations the normal write path refuses.
 func TestMigrateConfigFileRefusesSymlink(t *testing.T) {
 	profilesFile, victimFile := setupSymlinkedProfilesFile(t)
 

--- a/pkg/config/migrate_test.go
+++ b/pkg/config/migrate_test.go
@@ -299,6 +299,66 @@ func TestMigrateConfigFileRejectsUnparseableFile(t *testing.T) {
 	require.NoFileExists(t, path+ConfigBackupSuffix)
 }
 
+func TestNeedsMigrationForV1Config(t *testing.T) {
+	setupProfileConfig(t, v1ConfigFile)
+
+	require.True(t, NeedsMigration())
+	require.False(t, IsMigrated())
+}
+
+func TestNeedsMigrationForV2Config(t *testing.T) {
+	setupProfileConfig(t, v2ConfigFile)
+
+	require.False(t, NeedsMigration())
+	require.True(t, IsMigrated())
+}
+
+// A migrated file that has picked up a top-level profile still has work to do:
+// folding the stray copy back in is what stops the two from diverging.
+func TestNeedsMigrationForV2ConfigWithShadowTable(t *testing.T) {
+	setupProfileConfig(t, v2ConfigFile+`
+[legacy]
+  display_name = 'Written By An Old Plugin'
+`)
+
+	require.True(t, NeedsMigration())
+}
+
+// A setting that happens to be a table is not a profile, so it is not work.
+func TestNeedsMigrationIgnoresSettingTables(t *testing.T) {
+	setupProfileConfig(t, `config_version = 2
+
+[profiles.default]
+  display_name = 'V2 Account'
+
+[plugin_configs.__global]
+  updates = 'off'
+
+[user_info]
+  compartments = []
+`)
+
+	require.False(t, NeedsMigration())
+}
+
+// Writing the version out explicitly is how a user opts out for good.
+func TestConfigPinnedToV1IsLeftAlone(t *testing.T) {
+	pinned := `config_version = 1
+
+[default]
+  display_name = 'Pinned Account'
+  test_mode_api_key = 'sk_test_pinned_key'
+`
+	_, profilesFile := setupProfileConfig(t, pinned)
+
+	require.False(t, NeedsMigration())
+
+	changed, err := MigrateConfigFile(profilesFile)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Equal(t, pinned, string(helperLoadBytes(t, profilesFile)))
+}
+
 // The migration rewrites the config file, so it has to refuse the same symlinked
 // destinations the normal write path refuses.
 func TestMigrateConfigFileRefusesSymlink(t *testing.T) {

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -74,7 +74,9 @@ const (
 
 // ConfigVersionV1 is the original layout, with each profile as a top-level table.
 // A v1 file records no config_version key at all; the constant exists so that
-// version comparisons don't have to spell out that absence.
+// version comparisons don't have to spell out that absence. Writing the version
+// out explicitly pins the file to the flat layout and opts it out of the
+// migration.
 const ConfigVersionV1 = 1
 
 // ConfigVersionV2 is the schema version in which every profile moved under the

--- a/pkg/plugins/config_compat.go
+++ b/pkg/plugins/config_compat.go
@@ -1,0 +1,148 @@
+package plugins
+
+import (
+	"fmt"
+
+	goversion "github.com/hashicorp/go-version"
+	"github.com/spf13/afero"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+// configV2MinimumVersions maps a plugin shortname to the lowest released version
+// of that plugin which reads the v2 config layout.
+//
+// Plugins parse config.toml themselves rather than asking the CLI for it, and
+// plugin auto-update is off by default, so an installed plugin binary can be
+// arbitrarily old. Migrating the config file out from under one that only knows
+// the flat layout would leave it unable to find any profile — hence the gate.
+//
+// The map is empty until those plugin releases exist. While it is empty the CLI
+// cannot tell a compatible plugin from an incompatible one, so ConfigV2Ready
+// reports false and the migration does not run at all.
+var configV2MinimumVersions = map[string]string{}
+
+// ConfigV2Ready reports whether the CLI knows which plugin releases can read a
+// migrated config file. Until it does, migrating would break every installed
+// plugin with no way to detect it, so callers must not migrate.
+func ConfigV2Ready() bool {
+	return len(configV2MinimumVersions) > 0
+}
+
+// ConfigV2Incompatibility is one installed plugin that cannot read a config file
+// in the v2 layout.
+type ConfigV2Incompatibility struct {
+	// Plugin is the plugin's shortname, e.g. "apps".
+	Plugin string
+
+	// InstalledVersion is the version installed locally.
+	InstalledVersion string
+
+	// MinimumVersion is the lowest version that reads the v2 layout, or the empty
+	// string when the CLI knows of no such version for this plugin.
+	MinimumVersion string
+}
+
+// Error describes the incompatibility and how to resolve it.
+func (i ConfigV2Incompatibility) Error() string {
+	if i.MinimumVersion == "" {
+		return fmt.Sprintf("the installed %s plugin (%s) cannot read the new config file format", i.Plugin, i.InstalledVersion)
+	}
+
+	return fmt.Sprintf("the installed %s plugin (%s) cannot read the new config file format; %s or later can", i.Plugin, i.InstalledVersion, i.MinimumVersion)
+}
+
+// UpgradeCommand returns the command that installs a version of this plugin able
+// to read the v2 layout.
+func (i ConfigV2Incompatibility) UpgradeCommand() string {
+	return fmt.Sprintf("stripe plugin upgrade %s", i.Plugin)
+}
+
+// ConfigV2Incompatibilities lists the installed plugins that cannot read a config
+// file in the v2 layout. An empty result means migrating is safe as far as
+// plugins are concerned.
+func ConfigV2Incompatibilities(cfg config.IConfig, fs afero.Fs) ([]ConfigV2Incompatibility, error) {
+	names, err := GetInstalledPluginNames(cfg, fs)
+	if err != nil {
+		return nil, err
+	}
+
+	incompatibilities := make([]ConfigV2Incompatibility, 0)
+
+	for _, name := range names {
+		plugin := Plugin{Shortname: name}
+
+		installedVersion, err := plugin.lookUpInstalledVersion(cfg, fs)
+		if err != nil {
+			return nil, err
+		}
+
+		if installedVersion == "" {
+			// Recorded in config but no binary on disk, so there is nothing that
+			// could read the config file. The next run installs a current version.
+			continue
+		}
+
+		if readsConfigV2(name, installedVersion) {
+			continue
+		}
+
+		incompatibilities = append(incompatibilities, ConfigV2Incompatibility{
+			Plugin:           name,
+			InstalledVersion: installedVersion,
+			MinimumVersion:   configV2MinimumVersions[name],
+		})
+	}
+
+	return incompatibilities, nil
+}
+
+// readsConfigV2 reports whether a specific installed version of a plugin reads the
+// v2 config layout. It fails closed: a plugin the CLI has no minimum version for,
+// or a version it cannot parse, is treated as unable to.
+func readsConfigV2(pluginName, installedVersion string) bool {
+	if isLocalDevelopmentVersion(installedVersion) {
+		// A locally built plugin belongs to whoever built it, and its version says
+		// nothing about what it supports.
+		return true
+	}
+
+	minimum, known := configV2MinimumVersions[pluginName]
+	if !known || minimum == "" {
+		return false
+	}
+
+	installed, err := goversion.NewVersion(installedVersion)
+	if err != nil {
+		return false
+	}
+
+	required, err := goversion.NewVersion(minimum)
+	if err != nil {
+		return false
+	}
+
+	return !installed.LessThan(required)
+}
+
+// refuseIfConfigTooNew stops a plugin from running against a config file it
+// cannot read. The migration gate keeps that from happening in the first place,
+// but a config file can still arrive already migrated: a downgraded CLI, a
+// dotfiles sync between machines, or a plugin binary restored from a backup.
+func (p *Plugin) refuseIfConfigTooNew(installedVersion string) error {
+	if !ConfigV2Ready() || !config.IsMigrated() {
+		return nil
+	}
+
+	if readsConfigV2(p.Shortname, installedVersion) {
+		return nil
+	}
+
+	incompatibility := ConfigV2Incompatibility{
+		Plugin:           p.Shortname,
+		InstalledVersion: installedVersion,
+		MinimumVersion:   configV2MinimumVersions[p.Shortname],
+	}
+
+	return fmt.Errorf("%s. Run `%s` to update it", incompatibility.Error(), incompatibility.UpgradeCommand())
+}

--- a/pkg/plugins/config_compat.go
+++ b/pkg/plugins/config_compat.go
@@ -97,9 +97,12 @@ func ConfigV2Incompatibilities(cfg config.IConfig, fs afero.Fs) ([]ConfigV2Incom
 	return incompatibilities, nil
 }
 
-// readsConfigV2 reports whether a specific installed version of a plugin reads the
-// v2 config layout. It fails closed: a plugin the CLI has no minimum version for,
-// or a version it cannot parse, is treated as unable to.
+// ReadsConfigV2 reports whether a specific plugin version can read the v2 config
+// layout. Returns false when we could not determine.
+func ReadsConfigV2(pluginName, installedVersion string) bool {
+	return readsConfigV2(pluginName, installedVersion)
+}
+
 func readsConfigV2(pluginName, installedVersion string) bool {
 	if isLocalDevelopmentVersion(installedVersion) {
 		// A locally built plugin belongs to whoever built it, and its version says

--- a/pkg/plugins/config_compat_test.go
+++ b/pkg/plugins/config_compat_test.go
@@ -1,0 +1,138 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+func withConfigV2MinimumVersions(t *testing.T, versions map[string]string) {
+	t.Helper()
+
+	original := configV2MinimumVersions
+	configV2MinimumVersions = versions
+	t.Cleanup(func() {
+		configV2MinimumVersions = original
+	})
+}
+
+// Until plugin releases that read the v2 layout exist, the CLI cannot tell a
+// compatible plugin from an incompatible one, so it must not migrate at all.
+func TestConfigV2NotReadyWithoutKnownVersions(t *testing.T) {
+	require.False(t, ConfigV2Ready())
+
+	withConfigV2MinimumVersions(t, map[string]string{"apps": "1.5.0"})
+	require.True(t, ConfigV2Ready())
+}
+
+func TestReadsConfigV2(t *testing.T) {
+	withConfigV2MinimumVersions(t, map[string]string{
+		"apps":     "1.5.0",
+		"projects": "",
+	})
+
+	tests := []struct {
+		name             string
+		plugin           string
+		installedVersion string
+		want             bool
+	}{
+		{name: "above the minimum", plugin: "apps", installedVersion: "1.6.0", want: true},
+		{name: "at the minimum", plugin: "apps", installedVersion: "1.5.0", want: true},
+		{name: "below the minimum", plugin: "apps", installedVersion: "1.4.9", want: false},
+		{name: "no compatible release yet", plugin: "projects", installedVersion: "9.9.9", want: false},
+		{name: "plugin the CLI does not know", plugin: "somethingelse", installedVersion: "9.9.9", want: false},
+		{name: "unparseable version", plugin: "apps", installedVersion: "not-a-version", want: false},
+		// A locally built plugin belongs to whoever built it.
+		{name: "local dev build", plugin: "apps", installedVersion: localDevelopmentVersion, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, readsConfigV2(tt.plugin, tt.installedVersion))
+		})
+	}
+}
+
+func TestConfigV2IncompatibilitiesReportsOldPlugin(t *testing.T) {
+	withConfigV2MinimumVersions(t, map[string]string{"apps": "1.5.0", "projects": "2.0.0"})
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/plugins/apps/1.4.0", 0755))
+	require.NoError(t, fs.MkdirAll("/plugins/projects/2.1.0", 0755))
+
+	cfg := &TestConfig{}
+	cfg.InstalledPlugins = []string{"apps", "projects"}
+
+	incompatibilities, err := ConfigV2Incompatibilities(cfg, fs)
+	require.NoError(t, err)
+	require.Equal(t, []ConfigV2Incompatibility{{
+		Plugin:           "apps",
+		InstalledVersion: "1.4.0",
+		MinimumVersion:   "1.5.0",
+	}}, incompatibilities)
+
+	require.Contains(t, incompatibilities[0].Error(), "1.5.0 or later can")
+	require.Equal(t, "stripe plugin upgrade apps", incompatibilities[0].UpgradeCommand())
+}
+
+// A plugin recorded in the config with no binary on disk cannot read anything.
+// The next run installs a current version.
+func TestConfigV2IncompatibilitiesIgnoresUninstalledPlugin(t *testing.T) {
+	withConfigV2MinimumVersions(t, map[string]string{"apps": "1.5.0"})
+
+	cfg := &TestConfig{}
+	cfg.InstalledPlugins = []string{"apps"}
+
+	incompatibilities, err := ConfigV2Incompatibilities(cfg, afero.NewMemMapFs())
+	require.NoError(t, err)
+	require.Empty(t, incompatibilities)
+}
+
+func TestConfigV2IncompatibilitiesEmptyWhenEverythingIsCurrent(t *testing.T) {
+	withConfigV2MinimumVersions(t, map[string]string{"apps": "1.5.0"})
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/plugins/apps/1.5.0", 0755))
+
+	cfg := &TestConfig{}
+	cfg.InstalledPlugins = []string{"apps"}
+
+	incompatibilities, err := ConfigV2Incompatibilities(cfg, fs)
+	require.NoError(t, err)
+	require.Empty(t, incompatibilities)
+}
+
+// A migrated config file can reach a machine whose plugin is too old to read it:
+// a downgraded CLI, synced dotfiles, or a restored binary.
+func TestRefuseIfConfigTooNew(t *testing.T) {
+	withConfigV2MinimumVersions(t, map[string]string{"apps": "1.5.0"})
+	t.Cleanup(viper.Reset)
+
+	plugin := Plugin{Shortname: "apps"}
+
+	viper.Set(config.ConfigVersionName, config.ConfigVersionV2)
+	err := plugin.refuseIfConfigTooNew("1.4.0")
+	require.ErrorContains(t, err, "cannot read the new config file format")
+	require.ErrorContains(t, err, "stripe plugin upgrade apps")
+
+	require.NoError(t, plugin.refuseIfConfigTooNew("1.5.0"))
+
+	// An unmigrated config file is readable by every version.
+	viper.Set(config.ConfigVersionName, nil)
+	require.NoError(t, plugin.refuseIfConfigTooNew("1.4.0"))
+}
+
+// With no known plugin versions the CLI never migrates, so it has no grounds to
+// refuse a plugin either.
+func TestRefuseIfConfigTooNewIsInertUntilVersionsAreKnown(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Set(config.ConfigVersionName, config.ConfigVersionV2)
+
+	plugin := Plugin{Shortname: "apps"}
+	require.NoError(t, plugin.refuseIfConfigTooNew("1.4.0"))
+}

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -648,6 +648,13 @@ func (p *Plugin) Run(ctx context.Context, config *config.Config, fs afero.Fs, ar
 		}
 	}
 
+	// Plugins read the config file themselves, so one too old to understand the v2
+	// layout would start up and find no profiles at all. Fail with something the
+	// user can act on instead.
+	if err := p.refuseIfConfigTooNew(version); err != nil {
+		return err
+	}
+
 	pluginDir, err := p.getPluginInstallPath(config, version)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Reviewers
r? @
cc @stripe/developer-products

### Summary
Calls the migration script before each command (`PersistentPreRun`). Does not run from `InitConfig`, so plugins cannot migrate the file themselves.

1. Skip `help` and `completion`.
2. Skip if the file is already v2, or there is no file yet.
3. Skip if we do not yet know which plugin versions read v2 (`plugins.configV2MinimumVersions` is empty, so this PR is a no-op until that map is filled in).
4. If an installed plugin is too old, upgrade it. If the upgrade fails, leave `config.toml` unchanged and tell the user to run `stripe plugin upgrade <plugin>`.
5. Run the migration. Backup: `config.toml.v1.bak`.
6. Reload viper so the current command sees the new layout.
7. Print: `✔ updated <path> to the new config format (backup saved to config.toml.v1.bak)`.

A migration failure prints an error and continues the original command.

If the file is already v2 and someone runs a too-old plugin, `Plugin.Run` refuses to start it.

### Test Plan

`pkg/cmd/config_migration_test.go`, `pkg/plugins/config_compat_test.go`, `pkg/config/migrate_test.go`