### PR TITLE
Read and write both config.toml layouts in v1

### DIFF
--- a/pkg/cmd/docs/prefs.go
+++ b/pkg/cmd/docs/prefs.go
@@ -8,7 +8,6 @@ import (
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/list"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	pkgdocs "github.com/stripe/stripe-cli/pkg/docs"
 	"github.com/stripe/stripe-cli/pkg/docs/pager"
@@ -191,7 +190,7 @@ func (r *RootCommand) loadDocsPrefMap() map[string]string {
 	if r.cfg == nil {
 		return nil
 	}
-	raw := viper.GetStringMapString(r.cfg.Profile.GetConfigField(docsPrefsConfigKey))
+	raw := r.cfg.Profile.ReadProfileStringMap(docsPrefsConfigKey)
 	if len(raw) == 0 {
 		return nil
 	}
@@ -202,7 +201,7 @@ func (r *RootCommand) getDocsPref(id string) string {
 	if r.cfg == nil {
 		return ""
 	}
-	return viper.GetString(r.cfg.Profile.GetConfigField(docsPrefsConfigKey + "." + id))
+	return r.cfg.Profile.ReadProfileString(docsPrefsConfigKey + "." + id)
 }
 
 func (r *RootCommand) writeDocsPref(id, value string) error {

--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -13,7 +13,6 @@ import (
 	"github.com/logrusorgru/aurora"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
@@ -161,7 +160,7 @@ func (scc *sandboxCreateCmd) runSandboxCreateCmd(cmd *cobra.Command, args []stri
 		if accountID != "" {
 			fmt.Printf("Account ID:      %s\n", accountID)
 		}
-		expiresAt := viper.GetString(Config.Profile.GetConfigField(config.SandboxExpiresAtName))
+		expiresAt := Config.Profile.ReadProfileString(config.SandboxExpiresAtName)
 		if expiresAt != "" {
 			fmt.Printf("\nThis sandbox expires %s (in 7 days). Claim it before then by running `stripe sandbox claim`.\n", expiresAt)
 		} else {
@@ -368,15 +367,15 @@ func isClaimableSandbox() bool {
 		return true
 	}
 	// No key — check metadata for partially-cleared sandbox state
-	if viper.GetString(Config.Profile.GetConfigField(config.SandboxClaimURLName)) != "" {
+	if Config.Profile.ReadProfileString(config.SandboxClaimURLName) != "" {
 		return true
 	}
-	return viper.GetString(Config.Profile.GetConfigField(config.SandboxExpiresAtName)) != ""
+	return Config.Profile.ReadProfileString(config.SandboxExpiresAtName) != ""
 }
 
 // isExpiredSandbox returns true if the sandbox_expires_at date has passed.
 func isExpiredSandbox() bool {
-	expiresAt := viper.GetString(Config.Profile.GetConfigField(config.SandboxExpiresAtName))
+	expiresAt := Config.Profile.ReadProfileString(config.SandboxExpiresAtName)
 	if expiresAt == "" {
 		return false
 	}
@@ -422,7 +421,7 @@ func newSandboxClaimCmd() *sandboxClaimCmd {
 }
 
 func (scc *sandboxClaimCmd) runSandboxClaimCmd(cmd *cobra.Command, args []string) error {
-	claimURL := viper.GetString(Config.Profile.GetConfigField(config.SandboxClaimURLName))
+	claimURL := Config.Profile.ReadProfileString(config.SandboxClaimURLName)
 	if claimURL == "" {
 		fmt.Printf("No active sandbox. Run `stripe sandbox create` to get started.\n")
 		return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,12 @@ type Config struct {
 	Profile          Profile
 	ProfilesFile     string
 	InstalledPlugins []string
+
+	// warnedConfigVersion keeps the unsupported-version warning to one line per
+	// invocation. InitConfig runs more than once: root.go initializes it eagerly to
+	// register plugins before cobra parses flags, cobra.OnInitialize runs it again,
+	// and SwitchProfile reloads through it.
+	warnedConfigVersion bool
 }
 
 // GetProfile returns the Profile of the config
@@ -154,6 +160,15 @@ func (c *Config) InitConfig() {
 			"prefix": "config.Config.InitConfig",
 			"path":   viper.ConfigFileUsed(),
 		}).Debug("Using profiles file")
+
+		// Reads tolerate an unknown version: both layouts are tried, so a newer
+		// file's profiles are usually still found. Warn rather than exit, so an
+		// older pinned CLI keeps working for read-only commands. writeConfig is
+		// where an unknown version is actually refused.
+		if _, err := configVersion(viper.GetViper()); err != nil && !c.warnedConfigVersion {
+			c.warnedConfigVersion = true
+			log.Warnf("%s: %s", viper.ConfigFileUsed(), err)
+		}
 	}
 
 	if os.Getenv("STRIPE_CLI_CANARY") == "true" {
@@ -604,17 +619,50 @@ func isProfile(value interface{}) bool {
 	return false
 }
 
-// configVersion reports the schema version recorded in the config file. A v1
-// file has no config_version key, so it reports 0.
-func configVersion(v *viper.Viper) int {
-	return v.GetInt(ConfigVersionName)
+// configVersion reports the schema version recorded in the config file. A v1 file
+// records no config_version key, so an absent key reports ConfigVersionV1.
+//
+// It errors when the recorded version is one this binary cannot act on: either
+// unreadable as a version number, or newer than MaxSupportedConfigVersion. Both
+// are errors rather than a fallback to v1, because v1 means "flat layout" to every
+// caller, and a flat write into a file whose profiles are nested lands a second
+// copy that the read path then shadows — a write that reports success and is
+// invisible to the next read.
+//
+// On success the version is always >= ConfigVersionV1; 0 is returned only with an
+// error.
+func configVersion(v *viper.Viper) (int, error) {
+	raw := v.Get(ConfigVersionName)
+	if raw == nil {
+		return ConfigVersionV1, nil
+	}
+
+	// GetInt discards the cast error, so an unreadable value arrives here as 0 and
+	// is caught by the range check rather than by inspecting the error.
+	version := v.GetInt(ConfigVersionName)
+	if version < ConfigVersionV1 {
+		return 0, errorcategory.Errorf(errorcategory.Filesystem,
+			"%s is set to %v, which is not a version number", ConfigVersionName, raw)
+	}
+
+	if version > MaxSupportedConfigVersion {
+		return version, errorcategory.Errorf(errorcategory.Filesystem,
+			"%s is %d, but this Stripe CLI understands up to %d. Upgrade the CLI: https://docs.stripe.com/stripe-cli/upgrade",
+			ConfigVersionName, version, MaxSupportedConfigVersion)
+	}
+
+	return version, nil
 }
 
 // isMigrated reports whether the config file stores profiles in the v2 layout,
-// under the reserved profiles table. This release line never sets
-// config_version; it only recognizes a file that a v2 CLI already migrated.
+// under the reserved profiles table. This release line never sets config_version;
+// it only recognizes a file that a v2 CLI already migrated.
+//
+// A version this binary cannot act on is not migrated: writeConfig refuses such a
+// file outright, so no write ever reaches the layout decision this gates.
 func isMigrated(v *viper.Viper) bool {
-	return configVersion(v) >= ConfigVersionV2
+	version, err := configVersion(v)
+	return err == nil && version == ConfigVersionV2
 }
 
 // profileTableKeyForWrite returns the key a whole profile table should be
@@ -745,6 +793,16 @@ func (c *Config) WriteConfigField(field string, value interface{}) error {
 
 // writeConfig writes a viper instance to the config file and syncs the global viper.
 func writeConfig(runtimeViper *viper.Viper) error {
+	// Refuse to write a file whose layout version this binary does not know. Both
+	// candidate layouts are a guess at that point, and the flat guess is silently
+	// shadowed by the nested copy, so a login would report success while leaving
+	// the credential unreadable. Checked on the global viper, not runtimeViper:
+	// writeProfile passes a scratch viper that has not merged the file yet, which
+	// is the same reason configFieldForWrite reads the global.
+	if _, err := configVersion(viper.GetViper()); err != nil {
+		return err
+	}
+
 	profilesFile := viper.ConfigFileUsed()
 	runtimeViper.SetConfigFile(profilesFile)
 	configType := strings.TrimPrefix(filepath.Ext(profilesFile), ".")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -225,16 +225,23 @@ func (c *Config) CopyProfile(source string, target string) error {
 
 	runtimeViper := viper.GetViper()
 	safeSource := strings.ReplaceAll(source, ".", " ")
-	if !runtimeViper.IsSet(safeSource) {
-		return errorcategory.Errorf(errorcategory.UserInput, "source profile '%s' does not exist", source)
-	}
-	existing := runtimeViper.Get(safeSource)
-	if !isProfile(existing) {
-		return errorcategory.Errorf(errorcategory.UserInput, "source '%s' is not a profile", source)
+
+	// Prefer the v2 table, where any entry is a profile, and fall back to the
+	// top level, where a profile is only recognizable by its display_name.
+	existing := runtimeViper.Get(ProfilesTableName + "." + safeSource)
+	if _, ok := toStringMap(existing); !ok {
+		if !runtimeViper.IsSet(safeSource) {
+			return errorcategory.Errorf(errorcategory.UserInput, "source profile '%s' does not exist", source)
+		}
+
+		existing = runtimeViper.Get(safeSource)
+		if !isProfile(existing) {
+			return errorcategory.Errorf(errorcategory.UserInput, "source '%s' is not a profile", source)
+		}
 	}
 
 	safeTarget := strings.ReplaceAll(target, ".", " ")
-	existingMap := existing.(map[string]interface{})
+	existingMap, _ := toStringMap(existing)
 	newProfile := make(map[string]interface{})
 	for k, v := range existingMap {
 		if isPluginConfigSection(v) {
@@ -245,7 +252,7 @@ func (c *Config) CopyProfile(source string, target string) error {
 	}
 	newProfile["profile_name"] = safeTarget
 
-	runtimeViper.Set(safeTarget, newProfile)
+	runtimeViper.Set(profileTableKeyForWrite(runtimeViper, safeTarget), newProfile)
 
 	return writeConfig(runtimeViper)
 }
@@ -254,17 +261,8 @@ func (c *Config) ListProfiles() error {
 	runtimeViper := viper.GetViper()
 	var profiles []string
 
-	for _, value := range runtimeViper.AllSettings() {
-		if !isProfile(value) {
-			continue
-		}
-		var displayName string
-		switch v := value.(type) {
-		case map[string]interface{}:
-			displayName, _ = v["display_name"].(string)
-		case map[string]string:
-			displayName = v["display_name"]
-		}
+	for _, entry := range listProfileEntries(runtimeViper) {
+		displayName, _ := entry.settings["display_name"].(string)
 		if displayName != "" && !slices.Contains(profiles, displayName) {
 			profiles = append(profiles, displayName)
 		}
@@ -303,7 +301,10 @@ func (c *Config) PrintConfig() error {
 
 		fmt.Print(string(configFile))
 	} else {
-		configs := viper.GetStringMapString(profileName)
+		configs := viper.GetStringMapString(ProfilesTableName + "." + profileName)
+		if len(configs) == 0 {
+			configs = viper.GetStringMapString(profileName)
+		}
 
 		if len(configs) > 0 {
 			fmt.Printf("[%s]\n", profileName)
@@ -408,44 +409,44 @@ func (c *Config) RemoveProfile(profileName string) error {
 	var err error
 	var matched bool
 
-	for field, value := range runtimeViper.AllSettings() {
-		if isProfile(value) {
-			var profileNameAttr string
-			switch v := value.(type) {
-			case map[string]interface{}:
-				if pn, ok := v["profile_name"].(string); ok {
-					profileNameAttr = pn
-				}
-			case map[string]string:
-				profileNameAttr = v["profile_name"]
-			}
-			if field == profileName || profileNameAttr == profileName {
-				matched = true
-
-				runtimeViper, err = removeKey(runtimeViper, field)
-				if err != nil {
-					return err
-				}
-
-				deleteLivemodeKey(LiveModeAPIKeyName, field)
-			}
+	for _, entry := range listProfileEntries(runtimeViper) {
+		if !entry.matches(profileName) {
+			continue
 		}
-	}
 
-	// The enumeration above only finds tables that isProfile recognizes, which
-	// requires a display_name, and it cannot see a profile whose name contains a
-	// period at all because viper reads that back as nesting. Fall back to
-	// addressing the table by its full key path, which hits exactly that profile
-	// and leaves siblings intact.
-	if !matched && isProfileTable(runtimeViper, profileName) {
 		matched = true
 
-		runtimeViper, err = removeKey(runtimeViper, profileName)
+		runtimeViper, err = removeKey(runtimeViper, entry.key)
 		if err != nil {
 			return err
 		}
 
-		deleteLivemodeKey(LiveModeAPIKeyName, profileName)
+		deleteLivemodeKey(LiveModeAPIKeyName, entry.name)
+	}
+
+	// A top-level profile is only found above when isProfile recognizes it, which
+	// requires a display_name, and a profile whose name contains a period is
+	// invisible to the enumeration entirely because viper reads that back as
+	// nesting. Fall back to addressing the table by its full key path, which hits
+	// exactly that profile and leaves siblings intact. The v2 path is tried first
+	// for the same reason reads prefer it.
+	if !matched {
+		for _, key := range []string{ProfilesTableName + "." + profileName, profileName} {
+			if !isProfileTable(runtimeViper, key) {
+				continue
+			}
+
+			matched = true
+
+			runtimeViper, err = removeKey(runtimeViper, key)
+			if err != nil {
+				return err
+			}
+
+			deleteLivemodeKey(LiveModeAPIKeyName, profileName)
+
+			break
+		}
 	}
 
 	if !matched {
@@ -481,15 +482,13 @@ func (c *Config) RemoveAllProfiles() error {
 	runtimeViper := viper.GetViper()
 	var err error
 
-	for field, value := range runtimeViper.AllSettings() {
-		if isProfile(value) {
-			runtimeViper, err = removeKey(runtimeViper, field)
-			if err != nil {
-				return err
-			}
-
-			deleteLivemodeKey(LiveModeAPIKeyName, field)
+	for _, entry := range listProfileEntries(runtimeViper) {
+		runtimeViper, err = removeKey(runtimeViper, entry.key)
+		if err != nil {
+			return err
 		}
+
+		deleteLivemodeKey(LiveModeAPIKeyName, entry.name)
 	}
 
 	return writeConfig(runtimeViper)
@@ -501,31 +500,24 @@ func (c *Config) RemoveAuthFields(profileName string) error {
 	runtimeViper := viper.GetViper()
 	var matched bool
 
-	for field, value := range runtimeViper.AllSettings() {
-		if isProfile(value) {
-			var profileNameAttr string
-			switch v := value.(type) {
-			case map[string]interface{}:
-				if pn, ok := v["profile_name"].(string); ok {
-					profileNameAttr = pn
-				}
-			case map[string]string:
-				profileNameAttr = v["profile_name"]
-			}
-			if field == profileName || profileNameAttr == profileName {
-				matched = true
-
-				p := &Profile{ProfileName: field}
-				runtimeViper = p.deleteAuthFields(runtimeViper)
-				deleteLivemodeKey(LiveModeAPIKeyName, field)
-			}
+	for _, entry := range listProfileEntries(runtimeViper) {
+		if !entry.matches(profileName) {
+			continue
 		}
+
+		matched = true
+
+		p := &Profile{ProfileName: entry.name}
+		runtimeViper = p.deleteAuthFields(runtimeViper)
+		deleteLivemodeKey(LiveModeAPIKeyName, entry.name)
 	}
 
 	// Profiles with a period in the name are nested tables that the enumeration
 	// above cannot see. Clearing them by name is the only way for a user to log
-	// out of one, so handle that case explicitly.
-	if !matched && isNestedProfileName(profileName) && runtimeViper.IsSet(profileName) {
+	// out of one, so handle that case explicitly. deleteAuthFields clears both
+	// layouts, so this covers a dotted profile wherever it lives.
+	if !matched && isNestedProfileName(profileName) &&
+		(runtimeViper.IsSet(ProfilesTableName+"."+profileName) || runtimeViper.IsSet(profileName)) {
 		p := &Profile{ProfileName: profileName}
 		runtimeViper = p.deleteAuthFields(runtimeViper)
 		deleteLivemodeKey(LiveModeAPIKeyName, profileName)
@@ -549,12 +541,10 @@ func (c *Config) RemoveAuthFields(profileName string) error {
 func (c *Config) RemoveAllAuthFields() error {
 	runtimeViper := viper.GetViper()
 
-	for field, value := range runtimeViper.AllSettings() {
-		if isProfile(value) {
-			p := &Profile{ProfileName: field}
-			runtimeViper = p.deleteAuthFields(runtimeViper)
-			deleteLivemodeKey(LiveModeAPIKeyName, field)
-		}
+	for _, entry := range listProfileEntries(runtimeViper) {
+		p := &Profile{ProfileName: entry.name}
+		runtimeViper = p.deleteAuthFields(runtimeViper)
+		deleteLivemodeKey(LiveModeAPIKeyName, entry.name)
 	}
 
 	deleteTopLevelLivemodeKey(UATKeychainItemKey)
@@ -595,8 +585,13 @@ func isNestedProfileName(profileName string) bool {
 	return profileName != "" && strings.Contains(profileName, ".")
 }
 
-// isProfile identifies whether a config entry pertains to a user profile.
-// A profile is a map that contains a display_name field.
+// isProfile identifies whether a top-level config entry pertains to a user
+// profile. At the top level a profile is indistinguishable from a settings table
+// except by its contents, so it is identified by its display_name field.
+//
+// Entries inside the v2 profiles table need no such guess: every table in there
+// is a profile by definition. Use listProfileEntries to enumerate profiles in a
+// way that covers both layouts.
 func isProfile(value interface{}) bool {
 	switch v := value.(type) {
 	case map[string]interface{}:
@@ -607,6 +602,136 @@ func isProfile(value interface{}) bool {
 		return ok
 	}
 	return false
+}
+
+// configVersion reports the schema version recorded in the config file. A v1
+// file has no config_version key, so it reports 0.
+func configVersion(v *viper.Viper) int {
+	return v.GetInt(ConfigVersionName)
+}
+
+// isMigrated reports whether the config file stores profiles in the v2 layout,
+// under the reserved profiles table. This release line never sets
+// config_version; it only recognizes a file that a v2 CLI already migrated.
+func isMigrated(v *viper.Viper) bool {
+	return configVersion(v) >= ConfigVersionV2
+}
+
+// profileTableKeyForWrite returns the key a whole profile table should be
+// written to, matching the layout the config file already uses.
+func profileTableKeyForWrite(v *viper.Viper, profileName string) string {
+	if isMigrated(v) {
+		return ProfilesTableName + "." + profileName
+	}
+
+	return profileName
+}
+
+// profileEntry is one profile found in the config file, in either layout.
+type profileEntry struct {
+	// name is the profile's name, e.g. "default". Keyring item IDs are prefixed
+	// with this name in both layouts, so it is what credential lookups need.
+	name string
+
+	// key is the viper key of the profile's table: "default" in a v1 file,
+	// "profiles.default" in a v2 file.
+	key string
+
+	// settings is the contents of the profile's table.
+	settings map[string]interface{}
+}
+
+// matches reports whether this entry is the profile the user named, either by
+// its table name or by its recorded profile_name.
+func (e profileEntry) matches(profileName string) bool {
+	if e.name == profileName {
+		return true
+	}
+
+	recorded, _ := e.settings["profile_name"].(string)
+
+	return recorded == profileName
+}
+
+// listProfileEntries returns every profile in the config file, reading both the
+// v2 profiles table and the v1 top level.
+//
+// Both layouts are scanned because a migrated file can still acquire a top-level
+// profile table: this CLI, and any plugin old enough not to know about the
+// profiles table, writes one. A v1 entry is skipped when a v2 profile of the
+// same name exists, so the migrated copy always wins, matching the read
+// precedence in ReadProfileString.
+func listProfileEntries(v *viper.Viper) []profileEntry {
+	settings := v.AllSettings()
+	entries := make([]profileEntry, 0, len(settings))
+	nestedNames := make(map[string]bool)
+
+	if nested, ok := toStringMap(settings[ProfilesTableName]); ok {
+		for name, value := range nested {
+			table, ok := toStringMap(value)
+			if !ok || !holdsProfileFields(table) {
+				continue
+			}
+
+			nestedNames[name] = true
+			entries = append(entries, profileEntry{
+				name:     name,
+				key:      ProfilesTableName + "." + name,
+				settings: table,
+			})
+		}
+	}
+
+	for name, value := range settings {
+		if name == ProfilesTableName || nestedNames[name] || !isProfile(value) {
+			continue
+		}
+
+		table, _ := toStringMap(value)
+		entries = append(entries, profileEntry{name: name, key: name, settings: table})
+	}
+
+	// AllSettings returns a map, so sort for stable output and stable ordering of
+	// the writes that follow.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
+
+	return entries
+}
+
+// holdsProfileFields reports whether a table inside the profiles table is a
+// profile rather than a container of them.
+//
+// Viper splits keys on ".", so a hand-written profile whose name contains a
+// period reads back as nesting: profiles."a.b" becomes profiles -> a -> b. Every
+// profile field is a scalar, so requiring at least one keeps such a container
+// from being listed and removed as if it were a profile named "a". Migration
+// never produces one — it leaves a dotted profile at the top level, where the
+// existing by-name fallbacks handle it.
+func holdsProfileFields(table map[string]interface{}) bool {
+	for _, value := range table {
+		if _, isTable := toStringMap(value); !isTable {
+			return true
+		}
+	}
+
+	return false
+}
+
+// toStringMap normalizes the two map shapes viper hands back for a TOML table.
+func toStringMap(value interface{}) (map[string]interface{}, bool) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		return v, true
+	case map[string]string:
+		normalized := make(map[string]interface{}, len(v))
+		for key, item := range v {
+			normalized[key] = item
+		}
+
+		return normalized, true
+	}
+
+	return nil, false
 }
 
 // WriteConfigField updates a configuration field and writes the updated

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -381,13 +381,15 @@ func (c *Config) SwitchProfile(profileName string) error {
 
 // reservedTopLevelKeys are config keys that sit alongside profiles at the top
 // level of the file but are not profiles. They are excluded from profile removal
-// so that a name collision cannot destroy machine-wide settings.
+// so that a name collision cannot destroy machine-wide settings — or, for
+// "profiles", the entire v2 profile table.
 var reservedTopLevelKeys = map[string]bool{
 	"color":             true,
 	"installed_plugins": true,
 	"machine_uuid":      true,
 	"plugin_configs":    true,
 	"project-name":      true,
+	ProfilesTableName:   true,
 	UserInfoName:        true,
 }
 

--- a/pkg/config/config_layout_test.go
+++ b/pkg/config/config_layout_test.go
@@ -296,6 +296,16 @@ func TestRemoveProfileStillRefusesAReservedName(t *testing.T) {
 	require.Equal(t, []string{"apps"}, viper.GetStringSlice("installed_plugins"))
 }
 
+// Without this, --remove-profile profiles matches the v2 [profiles] table and
+// deletes every profile.
+func TestRemoveProfileRefusesTheProfilesTable(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+
+	require.ErrorContains(t, c.RemoveProfile(ProfilesTableName), "reserved config key")
+	require.True(t, viper.IsSet("profiles.default"))
+	require.True(t, viper.IsSet("profiles.installed_plugins"))
+}
+
 func TestRemoveProfileReportsNotFoundInV2Layout(t *testing.T) {
 	c, _ := setupProfileConfig(t, v2ConfigFile)
 

--- a/pkg/config/config_layout_test.go
+++ b/pkg/config/config_layout_test.go
@@ -3,10 +3,13 @@ package config
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 )
 
 // The v2 layout keeps every profile under the reserved profiles table, which is
@@ -376,4 +379,97 @@ func TestDottedNameInsideProfilesTableIsNotListedAsAProfile(t *testing.T) {
 	// Addressing it by its full name still works, which is how a user removes it.
 	require.NoError(t, c.RemoveProfile("example.project"))
 	require.False(t, viper.IsSet(`profiles.example.project`))
+}
+
+// A config_version this binary does not know could only have been written by a
+// newer CLI, which is a routine situation the moment a v3 ships: a pinned CLI in
+// CI, or a synced home directory, reads the file a newer binary migrated. This
+// release line is the one most likely to meet such a file.
+const unsupportedVersionConfigFile = `config_version = 3
+
+[profiles.default]
+  device_name = 'device-v3'
+  display_name = 'V3 Account'
+  test_mode_api_key = 'sk_test_v3_key'
+`
+
+func readVersionFrom(t *testing.T, contents string) (int, error) {
+	t.Helper()
+
+	v := viper.New()
+	v.SetConfigType("toml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(contents)))
+
+	return configVersion(v)
+}
+
+func TestConfigVersionTreatsAbsentKeyAsV1(t *testing.T) {
+	version, err := readVersionFrom(t, v1ConfigFile)
+	require.NoError(t, err)
+	require.Equal(t, ConfigVersionV1, version)
+}
+
+// Viper truncates a float before we ever see it, so these are rejected by the
+// range check rather than by a cast failure. A value that truncates into the
+// supported range is deliberately left alone.
+func TestConfigVersionRejectsValuesThatAreNotVersionNumbers(t *testing.T) {
+	for _, raw := range []string{"'abc'", "0", "0.3", "-1", "-1.12", "''"} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := readVersionFrom(t, "config_version = "+raw+"\n")
+			require.ErrorContains(t, err, "is not a version number")
+		})
+	}
+}
+
+func TestConfigVersionRejectsVersionsNewerThanSupported(t *testing.T) {
+	_, err := readVersionFrom(t, unsupportedVersionConfigFile)
+	require.ErrorContains(t, err, "understands up to 2")
+
+	category, ok := errorcategory.Get(err)
+	require.True(t, ok)
+	require.Equal(t, errorcategory.Filesystem, category)
+}
+
+// Reads stay best-effort on an unknown version: both layouts are tried, so the
+// profile a newer CLI wrote is still found and read-only commands keep working.
+func TestReadProfileStillWorksWhenVersionIsNewerThanSupported(t *testing.T) {
+	setupProfileConfig(t, unsupportedVersionConfigFile)
+
+	p := Profile{ProfileName: "default"}
+
+	deviceName, err := p.GetDeviceName()
+	require.NoError(t, err)
+	require.Equal(t, "device-v3", deviceName)
+
+	require.Equal(t, "V3 Account", p.GetDisplayName())
+}
+
+// Writes are refused instead, because both candidate layouts are a guess at that
+// point and the flat guess is silently shadowed by the nested copy.
+func TestWriteRefusedWhenVersionIsNewerThanSupported(t *testing.T) {
+	_, profilesFile := setupProfileConfig(t, unsupportedVersionConfigFile)
+
+	p := Profile{ProfileName: "default"}
+	require.ErrorContains(t, p.WriteConfigField("color", "on"), "understands up to 2")
+
+	// The refusal has to leave the file untouched, not half-written.
+	require.Equal(t, unsupportedVersionConfigFile, string(helperLoadBytes(t, profilesFile)))
+}
+
+func TestWriteRefusedWhenVersionIsNotAVersionNumber(t *testing.T) {
+	setupProfileConfig(t, `config_version = 'abc'
+
+[profiles.default]
+  display_name = 'Malformed Version'
+`)
+
+	p := Profile{ProfileName: "default"}
+	require.ErrorContains(t, p.WriteConfigField("color", "on"), "is not a version number")
+}
+
+// An unknown version is not "migrated", so nothing downstream mistakes it for the
+// v2 layout it happens to resemble.
+func TestIsMigratedOnlyAtTheSupportedVersion(t *testing.T) {
+	setupProfileConfig(t, unsupportedVersionConfigFile)
+	require.False(t, isMigrated(viper.GetViper()))
 }

--- a/pkg/config/config_layout_test.go
+++ b/pkg/config/config_layout_test.go
@@ -1,0 +1,379 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// The v2 layout keeps every profile under the reserved profiles table, which is
+// what makes a profile name unable to collide with a setting. Note that
+// installed_plugins is both a real setting here and a profile name — something
+// this release line cannot produce, but can be handed by a v2 CLI.
+const v2ConfigFile = `config_version = 2
+installed_plugins = ['apps']
+
+[profiles.default]
+  account_id = 'acct_v2'
+  device_name = 'device-v2'
+  display_name = 'V2 Account'
+  test_mode_api_key = 'sk_test_v2_key'
+  test_mode_key_expires_at = '2026-01-02'
+
+[profiles.installed_plugins]
+  display_name = 'Collides With A Setting'
+  test_mode_api_key = 'sk_test_collide_key'
+`
+
+const v1ConfigFile = `installed_plugins = ['apps']
+
+[default]
+  account_id = 'acct_v1'
+  device_name = 'device-v1'
+  display_name = 'V1 Account'
+  test_mode_api_key = 'sk_test_v1_key'
+  test_mode_key_expires_at = '2026-01-02'
+`
+
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+
+	original := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	fnErr := fn()
+
+	w.Close()
+	os.Stdout = original
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	require.NoError(t, fnErr)
+
+	return buf.String()
+}
+
+func TestReadProfileFromV2Layout(t *testing.T) {
+	setupProfileConfig(t, v2ConfigFile)
+
+	p := Profile{ProfileName: "default"}
+
+	deviceName, err := p.GetDeviceName()
+	require.NoError(t, err)
+	require.Equal(t, "device-v2", deviceName)
+
+	accountID, err := p.GetAccountID()
+	require.NoError(t, err)
+	require.Equal(t, "acct_v2", accountID)
+
+	apiKey, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_v2_key", apiKey)
+
+	require.Equal(t, "V2 Account", p.GetDisplayName())
+	require.True(t, p.HasAPIKey(false))
+}
+
+func TestReadProfileFallsBackToV1Layout(t *testing.T) {
+	setupProfileConfig(t, v1ConfigFile)
+
+	p := Profile{ProfileName: "default"}
+
+	deviceName, err := p.GetDeviceName()
+	require.NoError(t, err)
+	require.Equal(t, "device-v1", deviceName)
+
+	apiKey, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_v1_key", apiKey)
+
+	require.Equal(t, "V1 Account", p.GetDisplayName())
+}
+
+// A migrated file can still pick up a top-level profile table, because this CLI
+// and any plugin old enough not to know about the profiles table writes one. The
+// migrated copy is the one that wins.
+func TestReadProfilePrefersV2LayoutOverV1Shadow(t *testing.T) {
+	setupProfileConfig(t, v2ConfigFile+`
+[default]
+  device_name = 'shadow-device'
+  display_name = 'Shadow Account'
+  test_mode_api_key = 'sk_test_shadow_key'
+`)
+
+	p := Profile{ProfileName: "default"}
+
+	deviceName, err := p.GetDeviceName()
+	require.NoError(t, err)
+	require.Equal(t, "device-v2", deviceName)
+
+	apiKey, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_v2_key", apiKey)
+}
+
+// The point of the restructure: a profile named after a setting no longer
+// overwrites that setting, and this release line has to read both back.
+func TestProfileNamedAfterSettingDoesNotCollide(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+
+	require.Equal(t, []string{"apps"}, c.GetInstalledPlugins())
+
+	p := Profile{ProfileName: "installed_plugins"}
+	require.Equal(t, "Collides With A Setting", p.GetDisplayName())
+}
+
+// Legacy field names have to keep resolving in a migrated file, since the
+// migration moves fields without renaming them.
+func TestLegacyFieldAliasResolvesInV2Layout(t *testing.T) {
+	setupProfileConfig(t, `config_version = 2
+
+[profiles.default]
+  display_name = 'Legacy Account'
+  secret_key = 'sk_test_legacy_key'
+`)
+
+	p := Profile{ProfileName: "default"}
+
+	require.True(t, p.HasAPIKey(false))
+
+	apiKey, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_legacy_key", apiKey)
+}
+
+func TestWriteConfigFieldUsesV2LayoutWhenMigrated(t *testing.T) {
+	_, profilesFile := setupProfileConfig(t, v2ConfigFile)
+
+	p := Profile{ProfileName: "default"}
+	require.NoError(t, p.WriteConfigField("color", "on"))
+
+	require.Equal(t, "on", viper.GetString("profiles.default.color"))
+
+	contents := string(helperLoadBytes(t, profilesFile))
+	require.Contains(t, contents, "[profiles.default]")
+	// A flat write into a migrated file would create a second, shadow copy of the
+	// profile at the top level, which the read above would then shadow in turn.
+	require.NotContains(t, contents, "\n[default]")
+}
+
+func TestWriteConfigFieldStaysFlatWhenNotMigrated(t *testing.T) {
+	_, profilesFile := setupProfileConfig(t, v1ConfigFile)
+
+	p := Profile{ProfileName: "default"}
+	require.NoError(t, p.WriteConfigField("color", "on"))
+
+	require.Equal(t, "on", viper.GetString("default.color"))
+
+	contents := string(helperLoadBytes(t, profilesFile))
+	require.NotContains(t, contents, "profiles")
+}
+
+// Nothing on this release line migrates a file, so a v1 file stays v1 even after
+// it is rewritten.
+func TestWritingDoesNotMigrateAConfigFile(t *testing.T) {
+	_, profilesFile := setupProfileConfig(t, v1ConfigFile)
+
+	p := Profile{
+		ProfileName:    "default",
+		DeviceName:     "rewritten-device",
+		TestModeAPIKey: "sk_test_rewritten_key",
+		DisplayName:    "Rewritten Account",
+	}
+	require.NoError(t, p.CreateProfile())
+
+	require.False(t, viper.IsSet(ConfigVersionName))
+	require.Equal(t, "rewritten-device", viper.GetString("default.device_name"))
+
+	contents := string(helperLoadBytes(t, profilesFile))
+	require.NotContains(t, contents, "profiles")
+}
+
+// Logging in on a migrated file has to write into the profiles table. A flat
+// write would leave the fresh credentials shadowed by the stale nested copy, so
+// the login would be invisible to the CLI that just performed it.
+func TestLoginWritesIntoV2LayoutWhenMigrated(t *testing.T) {
+	setupProfileConfig(t, v2ConfigFile)
+
+	p := Profile{
+		ProfileName:    "default",
+		DeviceName:     "rewritten-device",
+		TestModeAPIKey: "sk_test_rewritten_key",
+		DisplayName:    "Rewritten Account",
+	}
+	require.NoError(t, p.CreateProfile())
+
+	require.Equal(t, "rewritten-device", viper.GetString("profiles.default.device_name"))
+	require.Equal(t, "sk_test_rewritten_key", viper.GetString("profiles.default.test_mode_api_key"))
+	require.False(t, viper.IsSet("default.device_name"))
+
+	apiKey, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_rewritten_key", apiKey)
+
+	// Settings that share the top level with profiles must survive the write.
+	require.Equal(t, []string{"apps"}, viper.GetStringSlice("installed_plugins"))
+	require.Equal(t, ConfigVersionV2, viper.GetInt(ConfigVersionName))
+}
+
+// A delete has to clear the field from both layouts, or a stale copy is left
+// behind in a file that contains both.
+func TestDeleteConfigFieldClearsBothLayouts(t *testing.T) {
+	setupProfileConfig(t, v2ConfigFile+`
+[default]
+  device_name = 'shadow-device'
+  display_name = 'Shadow Account'
+`)
+
+	p := Profile{ProfileName: "default"}
+	require.NoError(t, p.DeleteConfigField(DeviceNameName))
+
+	require.False(t, viper.IsSet("profiles.default.device_name"))
+	require.False(t, viper.IsSet("default.device_name"))
+	require.Equal(t, "V2 Account", viper.GetString("profiles.default.display_name"))
+}
+
+func TestRedactLivemodeValueInV2Layout(t *testing.T) {
+	setupProfileConfig(t, `config_version = 2
+
+[profiles.default]
+  display_name = 'V2 Account'
+  live_mode_api_key = 'sk_live_1234567890abcdef'
+`)
+
+	p := Profile{ProfileName: "default"}
+	p.redactAllLivemodeValues()
+
+	require.Equal(t, "sk_live_************cdef", viper.GetString("profiles.default.live_mode_api_key"))
+	require.False(t, viper.IsSet("default.live_mode_api_key"))
+}
+
+func TestListProfilesReadsBothLayouts(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile+`
+[legacy]
+  display_name = 'Legacy Account'
+`)
+	c.Profile = Profile{ProfileName: "default"}
+
+	output := captureStdout(t, c.ListProfiles)
+
+	require.Contains(t, output, "V2 Account")
+	require.Contains(t, output, "Collides With A Setting")
+	require.Contains(t, output, "Legacy Account")
+	require.Contains(t, output, "* V2 Account (active)")
+}
+
+func TestRemoveProfileInV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile+`
+[profiles.legacy]
+  display_name = 'Legacy Account'
+`)
+
+	require.NoError(t, c.RemoveProfile("legacy"))
+
+	require.False(t, viper.IsSet("profiles.legacy"))
+	require.Equal(t, "V2 Account", viper.GetString("profiles.default.display_name"))
+}
+
+// The reserved-key guard predates the restructure and still refuses a profile
+// named after a setting, even though the v2 layout makes removing one safe.
+// Loosening a guard on a destructive operation is not worth it here: this
+// release line cannot create such a profile, and a v2 CLI can remove it.
+func TestRemoveProfileStillRefusesAReservedName(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+
+	require.ErrorContains(t, c.RemoveProfile("installed_plugins"), "reserved config key")
+	require.True(t, viper.IsSet("profiles.installed_plugins"))
+	require.Equal(t, []string{"apps"}, viper.GetStringSlice("installed_plugins"))
+}
+
+func TestRemoveProfileReportsNotFoundInV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+
+	require.ErrorIs(t, c.RemoveProfile("nonexistent"), ErrProfileNotFound)
+}
+
+// A profile the migration left partially written has no display_name, so it is
+// only recognizable by living inside the profiles table.
+func TestRemoveProfileWithoutDisplayNameInV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, `config_version = 2
+
+[profiles.partial]
+  test_mode_api_key = 'sk_test_partial_key'
+`)
+
+	require.NoError(t, c.RemoveProfile("partial"))
+	require.False(t, viper.IsSet("profiles.partial"))
+}
+
+func TestRemoveAllProfilesInV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+
+	require.NoError(t, c.RemoveAllProfiles())
+
+	require.False(t, viper.IsSet("profiles.default"))
+	require.False(t, viper.IsSet("profiles.installed_plugins"))
+	require.Equal(t, []string{"apps"}, viper.GetStringSlice("installed_plugins"))
+}
+
+func TestRemoveAuthFieldsInV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, `config_version = 2
+
+[profiles.default]
+  color = 'on'
+  display_name = 'V2 Account'
+  test_mode_api_key = 'sk_test_v2_key'
+`)
+
+	require.NoError(t, c.RemoveAuthFields("default"))
+
+	require.False(t, viper.IsSet("profiles.default.test_mode_api_key"))
+	require.Equal(t, "on", viper.GetString("profiles.default.color"))
+}
+
+func TestCopyProfileInV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+
+	require.NoError(t, c.CopyProfile("default", "backup"))
+
+	require.Equal(t, "sk_test_v2_key", viper.GetString("profiles.backup.test_mode_api_key"))
+	require.Equal(t, "backup", viper.GetString("profiles.backup.profile_name"))
+	require.False(t, viper.IsSet("backup"))
+}
+
+func TestPrintConfigReadsV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+	c.Profile = Profile{ProfileName: "installed_plugins"}
+
+	output := captureStdout(t, c.PrintConfig)
+
+	require.Contains(t, output, "[installed_plugins]")
+	require.Contains(t, output, "display_name=Collides With A Setting")
+}
+
+// Viper splits keys on ".", so a hand-written dotted profile name inside the
+// profiles table reads back as a container of tables rather than a profile.
+// Listing it as a profile named "example" would be wrong.
+func TestDottedNameInsideProfilesTableIsNotListedAsAProfile(t *testing.T) {
+	c, _ := setupProfileConfig(t, `config_version = 2
+
+[profiles."example.project"]
+  display_name = 'Dotted Account'
+`)
+	c.Profile = Profile{ProfileName: "default"}
+
+	output := captureStdout(t, c.ListProfiles)
+
+	require.Contains(t, output, "No profiles found.")
+	require.ErrorIs(t, c.RemoveProfile("example"), ErrProfileNotFound)
+
+	// Addressing it by its full name still works, which is how a user removes it.
+	require.NoError(t, c.RemoveProfile("example.project"))
+	require.False(t, viper.IsSet(`profiles.example.project`))
+}

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -100,6 +100,11 @@ const (
 	ProfilesTableName = "profiles"
 )
 
+// ConfigVersionV1 is the original layout, with each profile as a top-level table.
+// A v1 file records no config_version key at all; the constant exists so that
+// version comparisons don't have to spell out that absence.
+const ConfigVersionV1 = 1
+
 // ConfigVersionV2 is the schema version in which every profile moved under the
 // reserved ProfilesTableName table, so that profile names can no longer collide
 // with top-level CLI settings.
@@ -108,6 +113,12 @@ const (
 // and updates a file that a v2 CLI already migrated, so that downgrading needs no
 // action from the user.
 const ConfigVersionV2 = 2
+
+// MaxSupportedConfigVersion is the newest config.toml layout this binary can act
+// on. A file recording a higher version was written by a newer CLI, whose layout
+// this build has no way to know. This line does not write v2, but it does read and
+// update one, so v2 is still the ceiling rather than v1.
+const MaxSupportedConfigVersion = ConfigVersionV2
 
 const UATKeychainItemKey = "uat"
 

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -89,7 +89,25 @@ const (
 	SandboxClaimURLName        = "sandbox_claim_url"
 	SandboxExpiresAtName       = "sandbox_expires_at"
 	UserInfoName               = "user_info" // TODO: remove with legacy RAK/OIDC flow
+
+	// ConfigVersionName is the top-level key recording the config file's schema
+	// version. It is absent from v1 files, which is how an unmigrated file is
+	// recognized.
+	ConfigVersionName = "config_version"
+
+	// ProfilesTableName is the reserved top-level table that holds every profile
+	// in a v2 config file.
+	ProfilesTableName = "profiles"
 )
+
+// ConfigVersionV2 is the schema version in which every profile moved under the
+// reserved ProfilesTableName table, so that profile names can no longer collide
+// with top-level CLI settings.
+//
+// This release line never writes a v2 file and never migrates one. It only reads
+// and updates a file that a v2 CLI already migrated, so that downgrading needs no
+// action from the user.
+const ConfigVersionV2 = 2
 
 const UATKeychainItemKey = "uat"
 
@@ -154,7 +172,7 @@ var authFieldNames = []string{
 // field, so that a partially written profile (one with no display_name, which a
 // profile abandoned part-way through login can be) is still recognized.
 func (p *Profile) profileExists() bool {
-	return viper.IsSet(p.ProfileName)
+	return viper.IsSet(p.nestedProfileTable()) || viper.IsSet(p.ProfileName)
 }
 
 // warnLegacyProfileNameOnce guards the deprecation warning so it prints at most
@@ -219,14 +237,11 @@ func (p *Profile) CreateProfile() error {
 
 func (p *Profile) deleteAuthFields(v *viper.Viper) *viper.Viper {
 	for _, field := range authFieldNames {
-		key := p.GetConfigField(field)
-		if v.IsSet(key) {
-			newViper, err := removeKey(v, key)
-			if err == nil {
-				// failure to remove a key should not break the login flow
-				v = newViper
-			}
-		}
+		// safeRemove clears the field from whichever layouts it appears in, so a
+		// file that a v2 CLI migrated (or that this CLI wrote a shadow copy into)
+		// is fully cleared rather than half-cleared. Failure to remove a key
+		// should not break the login flow.
+		v = p.safeRemove(v, field)
 	}
 	return v
 }
@@ -239,7 +254,7 @@ func (p *Profile) GetColor() (string, error) {
 		return color, nil
 	}
 
-	color = viper.GetString(p.GetConfigField("color"))
+	color = p.ReadProfileString("color")
 	switch color {
 	case "", ColorAuto:
 		return ColorAuto, nil
@@ -263,7 +278,7 @@ func (p *Profile) GetDeviceName() (string, error) {
 	}
 
 	if err := viper.ReadInConfig(); err == nil {
-		return viper.GetString(p.GetConfigField(DeviceNameName)), nil
+		return p.ReadProfileString(DeviceNameName), nil
 	}
 
 	return "", validators.ErrDeviceNameNotConfigured
@@ -276,7 +291,7 @@ func (p *Profile) GetAccountID() (string, error) {
 	}
 
 	if err := viper.ReadInConfig(); err == nil {
-		return viper.GetString(p.GetConfigField(AccountIDName)), nil
+		return p.ReadProfileString(AccountIDName), nil
 	}
 
 	return "", validators.ErrAccountIDNotConfigured
@@ -289,7 +304,7 @@ func (p *Profile) GetUserID() (string, error) {
 	}
 
 	if err := viper.ReadInConfig(); err == nil {
-		return viper.GetString(p.GetConfigField(UserIDName)), nil
+		return p.ReadProfileString(UserIDName), nil
 	}
 
 	return "", nil
@@ -323,12 +338,12 @@ func (p *Profile) HasAPIKey(livemode bool) bool {
 		if err := viper.ReadInConfig(); err != nil {
 			return false
 		}
-		if viper.IsSet(p.GetConfigField("secret_key")) {
+		if p.profileFieldIsSet("secret_key") {
 			p.RegisterAlias(TestModeAPIKeyName, "secret_key")
-		} else if viper.IsSet(p.GetConfigField("api_key")) {
+		} else if p.profileFieldIsSet("api_key") {
 			p.RegisterAlias(TestModeAPIKeyName, "api_key")
 		}
-		return viper.GetString(p.GetConfigField(TestModeAPIKeyName)) != ""
+		return p.ReadProfileString(TestModeAPIKeyName) != ""
 	}
 
 	if KeyRing == nil {
@@ -366,14 +381,14 @@ func (p *Profile) GetAPIKey(livemode bool) (string, error) {
 	if !livemode {
 		// If the user doesn't have an api_key field set, they might be using an
 		// old configuration so try to read from secret_key
-		if viper.IsSet(p.GetConfigField("secret_key")) {
+		if p.profileFieldIsSet("secret_key") {
 			p.RegisterAlias(TestModeAPIKeyName, "secret_key")
-		} else if viper.IsSet(p.GetConfigField("api_key")) {
+		} else if p.profileFieldIsSet("api_key") {
 			p.RegisterAlias(TestModeAPIKeyName, "api_key")
 		}
 
 		if err := viper.ReadInConfig(); err == nil {
-			key = viper.GetString(p.GetConfigField(TestModeAPIKeyName))
+			key = p.ReadProfileString(TestModeAPIKeyName)
 		}
 	} else {
 		p.redactAllLivemodeValues()
@@ -399,9 +414,9 @@ func (p *Profile) GetExpiresAt(livemode bool) (time.Time, error) {
 	var timeString string
 
 	if livemode {
-		timeString = viper.GetString(p.GetConfigField(LiveModeKeyExpiresAtName))
+		timeString = p.ReadProfileString(LiveModeKeyExpiresAtName)
 	} else {
-		timeString = viper.GetString(p.GetConfigField(TestModeKeyExpiresAtName))
+		timeString = p.ReadProfileString(TestModeKeyExpiresAtName)
 	}
 
 	if timeString != "" {
@@ -425,12 +440,12 @@ func (p *Profile) GetPublishableKey(livemode bool) (string, error) {
 	} else {
 		fieldID = TestModePubKeyName
 
-		if viper.IsSet(p.GetConfigField("publishable_key")) {
+		if p.profileFieldIsSet("publishable_key") {
 			p.RegisterAlias(TestModePubKeyName, "publishable_key")
 		}
 		// there is a bug with viper.GetStringMapString when the key name is too long, which makes
 		// `config --list --project-name <project_name>` unable to read the project specific config
-		if viper.IsSet(p.GetConfigField("test_mode_publishable_key")) {
+		if p.profileFieldIsSet("test_mode_publishable_key") {
 			p.RegisterAlias(TestModePubKeyName, "test_mode_publishable_key")
 		}
 	}
@@ -440,7 +455,7 @@ func (p *Profile) GetPublishableKey(livemode bool) (string, error) {
 		return "", err
 	}
 
-	key = viper.GetString(p.GetConfigField(fieldID))
+	key = p.ReadProfileString(fieldID)
 	if key != "" {
 		return key, nil
 	}
@@ -451,7 +466,7 @@ func (p *Profile) GetPublishableKey(livemode bool) (string, error) {
 // GetDisplayName returns the account display name of the user
 func (p *Profile) GetDisplayName() string {
 	if err := viper.ReadInConfig(); err == nil {
-		return viper.GetString(p.GetConfigField(DisplayNameName))
+		return p.ReadProfileString(DisplayNameName)
 	}
 
 	return ""
@@ -460,20 +475,113 @@ func (p *Profile) GetDisplayName() string {
 // GetTerminalPOSDeviceID returns the device id from the config for Terminal quickstart to use
 func (p *Profile) GetTerminalPOSDeviceID() string {
 	if err := viper.ReadInConfig(); err == nil {
-		return viper.GetString(p.GetConfigField("terminal_pos_device_id"))
+		return p.ReadProfileString("terminal_pos_device_id")
 	}
 
 	return ""
 }
 
-// GetConfigField returns the configuration field for the specific profile
+// GetConfigField returns the flat (v1) configuration path for a profile field,
+// e.g. "default.account_id".
+//
+// This same string is used verbatim as the keyring item ID for livemode
+// secrets, so it must not gain the v2 "profiles." prefix: changing it would
+// orphan every credential already stored in the OS keychain. To read a config
+// value, use ReadProfileString or profileFieldIsSet, which understand both the
+// v1 and v2 layouts. To write one, use configFieldForWrite.
 func (p *Profile) GetConfigField(field string) string {
 	return p.ProfileName + "." + field
 }
 
-// RegisterAlias registers an alias for a given key.
+// nestedProfileTable returns the v2 key of this profile's table, e.g.
+// "profiles.default". In v2, profiles live under a reserved top-level "profiles"
+// table so that profile names can no longer collide with CLI settings.
+func (p *Profile) nestedProfileTable() string {
+	return ProfilesTableName + "." + p.ProfileName
+}
+
+// nestedConfigField returns the v2 configuration path for a profile field,
+// e.g. "profiles.default.account_id".
+func (p *Profile) nestedConfigField(field string) string {
+	return p.nestedProfileTable() + "." + field
+}
+
+// ReadProfileString reads a profile field from the config file, preferring the
+// v2 nested layout and falling back to the v1 flat layout.
+//
+// Both layouts are supported indefinitely. A config file that has never been
+// migrated stays fully readable, and one that a v2 CLI migrated is readable from
+// this release line without the user having to undo anything.
+func (p *Profile) ReadProfileString(field string) string {
+	if value := viper.GetString(p.nestedConfigField(field)); value != "" {
+		return value
+	}
+
+	return viper.GetString(p.GetConfigField(field))
+}
+
+// ReadProfileStringMap reads a nested table inside a profile, such as the docs
+// preferences, from whichever layout holds it.
+func (p *Profile) ReadProfileStringMap(field string) map[string]string {
+	if value := viper.GetStringMapString(p.nestedConfigField(field)); len(value) > 0 {
+		return value
+	}
+
+	return viper.GetStringMapString(p.GetConfigField(field))
+}
+
+// profileFieldIsSet reports whether a profile field is present in either layout.
+func (p *Profile) profileFieldIsSet(field string) bool {
+	return viper.IsSet(p.nestedConfigField(field)) || viper.IsSet(p.GetConfigField(field))
+}
+
+// configFieldForWrite returns the path a profile field should be written to,
+// matching the layout the config file already uses.
+//
+// Reads tolerate either layout, but a write has to pick one. Writing a flat
+// field into a migrated file would create a second, shadow copy of the profile
+// at the top level, which the read above would then shadow in turn — so the
+// user's own write would be invisible to the CLI that just made it. An
+// unmigrated file has no config_version key, so GetInt returns 0 and writes stay
+// flat. Nothing here ever sets config_version: this release line follows the
+// layout it finds and never migrates.
+func (p *Profile) configFieldForWrite(field string) string {
+	// The layout is read from the global viper, which is the instance that has
+	// the config file loaded. writeProfile is handed a scratch viper that has not
+	// merged the file in yet at the point the fields are set.
+	if isMigrated(viper.GetViper()) {
+		return p.nestedConfigField(field)
+	}
+
+	return p.GetConfigField(field)
+}
+
+// deleteProfileField removes a profile field from both the v2 nested layout and
+// the v1 flat layout, so a delete cannot leave a stale copy of the field behind
+// in a file that happens to contain both.
+func (p *Profile) deleteProfileField(v *viper.Viper, field string) (*viper.Viper, error) {
+	for _, path := range []string{p.nestedConfigField(field), p.GetConfigField(field)} {
+		if !v.IsSet(path) {
+			continue
+		}
+
+		newViper, err := removeKey(v, path)
+		if err != nil {
+			return nil, err
+		}
+
+		v = newViper
+	}
+
+	return v, nil
+}
+
+// RegisterAlias registers an alias for a given key in both layouts, so that
+// legacy field names (secret_key, api_key, publishable_key) keep resolving in a
+// migrated config file as well as an unmigrated one.
 func (p *Profile) RegisterAlias(alias, key string) {
 	viper.RegisterAlias(p.GetConfigField(alias), p.GetConfigField(key))
+	viper.RegisterAlias(p.nestedConfigField(alias), p.nestedConfigField(key))
 }
 
 // WriteConfigField updates a configuration field and writes the updated
@@ -481,13 +589,13 @@ func (p *Profile) RegisterAlias(alias, key string) {
 func (p *Profile) WriteConfigField(field, value string) error {
 	viper.ReadInConfig()
 
-	viper.Set(p.GetConfigField(field), value)
+	viper.Set(p.configFieldForWrite(field), value)
 	return writeConfig(viper.GetViper())
 }
 
 // DeleteConfigField deletes a configuration field.
 func (p *Profile) DeleteConfigField(field string) error {
-	v, err := removeKey(viper.GetViper(), p.GetConfigField(field))
+	v, err := p.deleteProfileField(viper.GetViper(), field)
 	if err != nil {
 		return err
 	}
@@ -509,15 +617,15 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 	}
 
 	if p.DeviceName != "" {
-		runtimeViper.Set(p.GetConfigField(DeviceNameName), strings.TrimSpace(p.DeviceName))
+		runtimeViper.Set(p.configFieldForWrite(DeviceNameName), strings.TrimSpace(p.DeviceName))
 	}
 
 	if p.LiveModeAPIKey != "" {
 		expiresAt := getKeyExpiresAt()
-		runtimeViper.Set(p.GetConfigField(LiveModeKeyExpiresAtName), expiresAt)
+		runtimeViper.Set(p.configFieldForWrite(LiveModeKeyExpiresAtName), expiresAt)
 
 		// // store redacted key in config
-		runtimeViper.Set(p.GetConfigField(LiveModeAPIKeyName), RedactAPIKey(strings.TrimSpace(p.LiveModeAPIKey)))
+		runtimeViper.Set(p.configFieldForWrite(LiveModeAPIKeyName), RedactAPIKey(strings.TrimSpace(p.LiveModeAPIKey)))
 
 		// // store actual key in secure keyring
 		if err := p.saveLivemodeValue(LiveModeAPIKeyName, strings.TrimSpace(p.LiveModeAPIKey), "Live mode API key"); err != nil {
@@ -526,36 +634,36 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 	}
 
 	if p.LiveModePublishableKey != "" {
-		runtimeViper.Set(p.GetConfigField(LiveModePubKeyName), strings.TrimSpace(p.LiveModePublishableKey))
+		runtimeViper.Set(p.configFieldForWrite(LiveModePubKeyName), strings.TrimSpace(p.LiveModePublishableKey))
 	}
 
 	if p.TestModeAPIKey != "" {
-		runtimeViper.Set(p.GetConfigField(TestModeAPIKeyName), strings.TrimSpace(p.TestModeAPIKey))
-		runtimeViper.Set(p.GetConfigField(TestModeKeyExpiresAtName), getKeyExpiresAt())
+		runtimeViper.Set(p.configFieldForWrite(TestModeAPIKeyName), strings.TrimSpace(p.TestModeAPIKey))
+		runtimeViper.Set(p.configFieldForWrite(TestModeKeyExpiresAtName), getKeyExpiresAt())
 	}
 
 	if p.TestModePublishableKey != "" {
-		runtimeViper.Set(p.GetConfigField(TestModePubKeyName), strings.TrimSpace(p.TestModePublishableKey))
+		runtimeViper.Set(p.configFieldForWrite(TestModePubKeyName), strings.TrimSpace(p.TestModePublishableKey))
 	}
 
 	if p.DisplayName != "" {
-		runtimeViper.Set(p.GetConfigField(DisplayNameName), strings.TrimSpace(p.DisplayName))
+		runtimeViper.Set(p.configFieldForWrite(DisplayNameName), strings.TrimSpace(p.DisplayName))
 	}
 
 	if p.AccountID != "" {
-		runtimeViper.Set(p.GetConfigField(AccountIDName), strings.TrimSpace(p.AccountID))
+		runtimeViper.Set(p.configFieldForWrite(AccountIDName), strings.TrimSpace(p.AccountID))
 	}
 
 	if p.UserID != "" {
-		runtimeViper.Set(p.GetConfigField(UserIDName), strings.TrimSpace(p.UserID))
+		runtimeViper.Set(p.configFieldForWrite(UserIDName), strings.TrimSpace(p.UserID))
 	}
 
 	if p.SandboxClaimURL != "" {
-		runtimeViper.Set(p.GetConfigField(SandboxClaimURLName), strings.TrimSpace(p.SandboxClaimURL))
+		runtimeViper.Set(p.configFieldForWrite(SandboxClaimURLName), strings.TrimSpace(p.SandboxClaimURL))
 	}
 
 	if p.SandboxExpiresAt != "" {
-		runtimeViper.Set(p.GetConfigField(SandboxExpiresAtName), strings.TrimSpace(p.SandboxExpiresAt))
+		runtimeViper.Set(p.configFieldForWrite(SandboxExpiresAtName), strings.TrimSpace(p.SandboxExpiresAt))
 	}
 
 	if KeyRing != nil {
@@ -591,16 +699,14 @@ func (p *Profile) writeProfile(runtimeViper *viper.Viper) error {
 }
 
 func (p *Profile) safeRemove(v *viper.Viper, key string) *viper.Viper {
-	if v.IsSet(p.GetConfigField(key)) {
-		newViper, err := removeKey(v, p.GetConfigField(key))
-		if err == nil {
-			// I don't want to fail the entire login process on not being able to remove
-			// the old secret_key field so if there's no error
-			return newViper
-		}
+	newViper, err := p.deleteProfileField(v, key)
+	if err != nil {
+		// I don't want to fail the entire login process on not being able to remove
+		// the old secret_key field, so keep the viper we already have.
+		return v
 	}
 
-	return v
+	return newViper
 }
 
 // redactAllLivemodeValues redacts all livemode values in the local config file
@@ -609,8 +715,8 @@ func (p *Profile) redactAllLivemodeValues() {
 
 	if err := viper.ReadInConfig(); err == nil {
 		// if the config file has expires at date, then it is using the new livemode key storage
-		if viper.IsSet(p.GetConfigField(LiveModeAPIKeyName)) {
-			key := viper.GetString(p.GetConfigField(LiveModeAPIKeyName))
+		if p.profileFieldIsSet(LiveModeAPIKeyName) {
+			key := p.ReadProfileString(LiveModeAPIKeyName)
 			if key == "" || len(key) < 12 {
 				p.DeleteConfigField(LiveModeAPIKeyName)
 				return


### PR DESCRIPTION
### Reviewers
r? @
cc @stripe/developer-products

### Summary

Backports dual-layout `config.toml` handling to v1, so that downgrading after a v2 migration needs no action from the user. 

- reads: `profiles.<name>.<field>`, falling back to the flat `<name>.<field>`
- writes: follow the layout the file already uses
- deletes: clear both layouts
- enumeration: covers both layouts
- `GetConfigField` still returns the flat path, since it doubles as the keyring item ID

**Copied from [#1934](https://github.com/stripe/stripe-cli/pull/1934)** (dual-layout field access + write refusal):
- `pkg/config/profile.go`: `ReadProfileString`, `profileFieldIsSet`, `configFieldForWrite`, `deleteProfileField`, plus `nestedProfileTable` / `nestedConfigField` and the version constants
- `pkg/config/config.go`: `configVersion`, `isMigrated`, `warnedConfigVersion`, the `InitConfig` warning, and the `writeConfig` refusal
- `pkg/cmd/sandbox.go`: call sites switched to `ReadProfileString`

**Copied from [#1939](https://github.com/stripe/stripe-cli/pull/1939)** (profile enumeration):
- `pkg/config/config.go`: `listProfileEntries`, `profileEntry.matches`, `profileTableKeyForWrite`, `holdsProfileFields`, `toStringMap`
- same file, wired through `CopyProfile`, `ListProfiles`, `RemoveProfile` / `RemoveAllProfiles`, `RemoveAuthFields`, `PrintConfig`


Two behaviors we left alone on purpose. 
- `--remove-profile` still rejects reserved names like `installed_plugins`. The v2 layout would make that delete safe, but loosening a destructive guard on v1 is not worth it. A v2 CLI can remove that profile instead.
- A profile name containing dot such as [profiles."example.project"] does not show up in config `--list`. Viper reads that as nested tables, not as a profile. You can still remove it by the full name.

### Test Plan
`pkg/config/config_layout_test.go`