### PR TITLE
Added new provision command as an alias to stripe projects add

### DIFF
--- a/pkg/cmd/provision.go
+++ b/pkg/cmd/provision.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/plugins"
+	"github.com/stripe/stripe-cli/pkg/stripe"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+// isHelpRequest reports whether the raw, unparsed args passed to a
+// DisableFlagParsing command are a request for help rather than a real
+// invocation.
+func isHelpRequest(args []string) bool {
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+// provisionPluginName is the plugin that backs `stripe provision`.
+const provisionPluginName = "projects"
+
+// provisionPluginSubcommand is the projects plugin subcommand that
+// `stripe provision` aliases to.
+const provisionPluginSubcommand = "add"
+
+type provisionCmd struct {
+	cmd *cobra.Command
+}
+
+// newProvisionCmd is a thin alias for `stripe projects add`: it ensures the
+// projects plugin is installed, then forwards all args/flags to it.
+func newProvisionCmd() *provisionCmd {
+	pc := &provisionCmd{}
+
+	pc.cmd = &cobra.Command{
+		Use:   "provision [service]",
+		Short: "Provision a service (alias for `stripe projects add`)",
+		Long: `Provision a service via the projects plugin.
+
+This is an alias for 'stripe projects add' — all flags are forwarded as-is.
+If the projects plugin isn't installed yet, it must be installed via
+'stripe plugin install projects' before running.`,
+		Example: `stripe provision <provider>/<service>
+  stripe provision neon/postgres --config '{"region":"iad1"}'
+  stripe provision agentmail/api --json`,
+		RunE:               pc.runProvisionCmd,
+		DisableFlagParsing: true,
+	}
+
+	// Currently `stripe provision` only supports some of the flags supported
+	// by `stripe projects add`; actual parsing/forwarding happens
+	// raw in runProvisionCmd since DisableFlagParsing is set above.
+	flags := pc.cmd.Flags()
+	flags.String("name", "", "Logical resource name used for local resource references and environment variable prefixes")
+	flags.String("config", "", "Service configuration as a JSON string")
+	flags.Bool("json", false, "Output structured JSON and suppress interactive prompts")
+	flags.BoolP("yes", "y", false, "Skip confirmation prompts")
+	flags.Bool("accept-tos", false, "Accept provider terms of service without prompting")
+
+	return pc
+}
+
+func (pc *provisionCmd) runProvisionCmd(cmd *cobra.Command, args []string) error {
+	if isHelpRequest(args) {
+		return cmd.Help()
+	}
+
+	ctx := withSIGTERMCancel(commandContextOrBackground(cmd), func() {
+		log.WithFields(log.Fields{
+			"prefix": "cmd.provisionCmd.runProvisionCmd",
+		}).Debug("Ctrl+C received, cleaning up...")
+	})
+
+	fs := afero.NewOsFs()
+
+	plugin, err := plugins.LookUpPlugin(ctx, &Config, fs, provisionPluginName)
+	if err != nil {
+		return err
+	}
+
+	pluginArgs := append([]string{provisionPluginSubcommand}, args...)
+
+	err = plugin.Run(ctx, &Config, fs, pluginArgs, "", "")
+	plugins.CleanupAllClients()
+	if err == nil {
+		dashboardBaseURL := stripe.DashboardBaseURLForAPIBaseURL(stripe.DefaultAPIBaseURL)
+		plugins.CheckLatestPluginVersion(ctx, &Config, fs, plugin, stripe.DefaultAPIBaseURL, dashboardBaseURL)
+	}
+
+	if err != nil {
+		if err == validators.ErrAPIKeyNotConfigured {
+			return errorcategory.New(errorcategory.Auth, "provision failed due to API key not configured, please run `stripe login` or specify the `--api-key`")
+		}
+
+		log.WithFields(log.Fields{
+			"prefix": "provisionCmd.runProvisionCmd",
+		}).Debug(fmt.Sprintf("Provision command exited with error: %s", err))
+
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/pkg/cmd/provision.go
+++ b/pkg/cmd/provision.go
@@ -33,14 +33,23 @@ const provisionPluginName = "projects"
 // `stripe provision` aliases to.
 const provisionPluginSubcommand = "add"
 
+// buildProvisionPluginArgs prepends the aliased plugin subcommand to the raw
+// args forwarded from `stripe provision`.
+func buildProvisionPluginArgs(args []string) []string {
+	return append([]string{provisionPluginSubcommand}, args...)
+}
+
 type provisionCmd struct {
 	cmd *cobra.Command
+
+	runProvisionCmdFn func(cmd *cobra.Command, args []string) error
 }
 
 // newProvisionCmd is a thin alias for `stripe projects add`: it ensures the
 // projects plugin is installed, then forwards all args/flags to it.
 func newProvisionCmd() *provisionCmd {
 	pc := &provisionCmd{}
+	pc.runProvisionCmdFn = pc.runProvisionCmd
 
 	pc.cmd = &cobra.Command{
 		Use:   "provision [service]",
@@ -48,12 +57,14 @@ func newProvisionCmd() *provisionCmd {
 		Long: `Provision a service via the projects plugin.
 
 This is an alias for 'stripe projects add' — all flags are forwarded as-is.
-If the projects plugin isn't installed yet, it must be installed via
-'stripe plugin install projects' before running.`,
+If the projects plugin isn't installed yet, it will be installed
+automatically before running.`,
 		Example: `stripe provision <provider>/<service>
   stripe provision neon/postgres --config '{"region":"iad1"}'
   stripe provision agentmail/api --json`,
-		RunE:               pc.runProvisionCmd,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pc.runProvisionCmdFn(cmd, args)
+		},
 		DisableFlagParsing: true,
 	}
 
@@ -88,7 +99,7 @@ func (pc *provisionCmd) runProvisionCmd(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	pluginArgs := append([]string{provisionPluginSubcommand}, args...)
+	pluginArgs := buildProvisionPluginArgs(args)
 
 	err = plugin.Run(ctx, &Config, fs, pluginArgs, "", "")
 	plugins.CleanupAllClients()

--- a/pkg/cmd/provision_test.go
+++ b/pkg/cmd/provision_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsHelpRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected bool
+	}{
+		{"no args", []string{}, false},
+		{"unrelated args", []string{"neon/postgres", "--config", "{}"}, false},
+		{"short help flag", []string{"-h"}, true},
+		{"long help flag", []string{"--help"}, true},
+		{"help flag among other args", []string{"neon/postgres", "--help"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isHelpRequest(tt.args))
+		})
+	}
+}
+
+func TestBuildProvisionPluginArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{"no args", []string{}, []string{"add"}},
+		{
+			"service and flags",
+			[]string{"neon/postgres", "--config", `{"region":"iad1"}`, "--json"},
+			[]string{"add", "neon/postgres", "--config", `{"region":"iad1"}`, "--json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, buildProvisionPluginArgs(tt.args))
+		})
+	}
+}
+
+// TestProvisionHelpShortCircuitsBeforeInvokingPlugin ensures `stripe provision --help`
+// renders cobra's own help output and never attempts to look up or run the projects
+// plugin (which would fail/hang in a test environment without a real plugin installed).
+func TestProvisionHelpShortCircuitsBeforeInvokingPlugin(t *testing.T) {
+	pc := newProvisionCmd()
+
+	invoked := false
+	pc.runProvisionCmdFn = func(cmd *cobra.Command, args []string) error {
+		invoked = true
+		return pc.runProvisionCmd(cmd, args)
+	}
+
+	_, output, err := executeCommandC(pc.cmd, "--help")
+
+	require.NoError(t, err)
+	assert.True(t, invoked, "runProvisionCmdFn should still be called; the short-circuit happens inside it")
+	assert.Contains(t, output, "alias for 'stripe projects add'")
+	assert.Contains(t, output, "Examples:")
+}
+
+// TestProvisionCmdForwardsRawArgsUnchanged mirrors TestFlagsArePassedAsArgs for the
+// plugin template command: with DisableFlagParsing set, cobra must hand the raw,
+// unparsed args straight to the RunE func so they can be forwarded to the plugin.
+func TestProvisionCmdForwardsRawArgsUnchanged(t *testing.T) {
+	pc := newProvisionCmd()
+
+	var capturedArgs []string
+	pc.runProvisionCmdFn = func(cmd *cobra.Command, args []string) error {
+		capturedArgs = append([]string(nil), args...)
+		return nil
+	}
+
+	_, _, err := executeCommandC(pc.cmd, "neon/postgres", "--config", `{"region":"iad1"}`, "--json")
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"neon/postgres", "--config", `{"region":"iad1"}`, "--json"}, capturedArgs)
+}
+
+func TestProvisionCmdUsage(t *testing.T) {
+	pc := newProvisionCmd()
+
+	assert.Equal(t, "provision [service]", pc.cmd.Use)
+	assert.True(t, strings.Contains(pc.cmd.Long, "stripe projects add"))
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -307,6 +307,7 @@ func init() {
 	rootCmd.AddCommand(newVersionCmd().cmd)
 	rootCmd.AddCommand(newWhoamiCmd().cmd)
 	rootCmd.AddCommand(newPostinstallCmd(&Config).cmd)
+	rootCmd.AddCommand(newProvisionCmd().cmd)
 	rootCmd.AddCommand(newCommunityCmd().cmd)
 	rootCmd.AddCommand(newSandboxCmd().cmd)
 	rootCmd.AddCommand(newPluginCmd().cmd)


### PR DESCRIPTION
 ### Reviewers
r? @stripe/developer-products 
cc @stripe/developer-products

 ### Summary
This change creates a new `stripe provision` command within the core Stripe CLI which acts as an alias to the `stripe projects add` command. It is a lightweight command and only delegates all the requests to `stripe projects add` which contains the core business logic. The `stripe provision` command is meant to be used by Stripe Directory as an entry point to the Provisioning API to allow agents to provision services, and hence only allows a subset of the flags from `stripe projects add` which are all forwarded to `stripe projects add`.

cc @vickyfeng-stripe @vzhang-stripe 