### PR TITLE
Enumerate profiles from both config.toml layouts

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -240,16 +240,25 @@ func (c *Config) CopyProfile(source string, target string) error {
 
 	runtimeViper := viper.GetViper()
 	safeSource := strings.ReplaceAll(source, ".", " ")
-	if !runtimeViper.IsSet(safeSource) {
-		return fmt.Errorf("source profile '%s' does not exist", source)
-	}
-	existing := runtimeViper.Get(safeSource)
-	if !isProfile(existing) {
-		return fmt.Errorf("source '%s' is not a profile", source)
+
+	// Prefer the v2 table, where any entry is a profile, and fall back to the
+	// top level, where a profile is only recognizable by its display_name.
+	sourceKey := ProfilesTableName + "." + safeSource
+	existing := runtimeViper.Get(sourceKey)
+	if _, ok := toStringMap(existing); !ok {
+		sourceKey = safeSource
+		if !runtimeViper.IsSet(sourceKey) {
+			return fmt.Errorf("source profile '%s' does not exist", source)
+		}
+
+		existing = runtimeViper.Get(sourceKey)
+		if !isProfile(existing) {
+			return fmt.Errorf("source '%s' is not a profile", source)
+		}
 	}
 
 	safeTarget := strings.ReplaceAll(target, ".", " ")
-	existingMap := existing.(map[string]interface{})
+	existingMap, _ := toStringMap(existing)
 	newProfile := make(map[string]interface{})
 	for k, v := range existingMap {
 		if isPluginConfigSection(v) {
@@ -260,7 +269,7 @@ func (c *Config) CopyProfile(source string, target string) error {
 	}
 	newProfile["profile_name"] = safeTarget
 
-	runtimeViper.Set(safeTarget, newProfile)
+	runtimeViper.Set(profileTableKeyForWrite(runtimeViper, safeTarget), newProfile)
 
 	return writeConfig(runtimeViper)
 }
@@ -269,17 +278,8 @@ func (c *Config) ListProfiles() error {
 	runtimeViper := viper.GetViper()
 	var profiles []string
 
-	for _, value := range runtimeViper.AllSettings() {
-		if !isProfile(value) {
-			continue
-		}
-		var displayName string
-		switch v := value.(type) {
-		case map[string]interface{}:
-			displayName, _ = v["display_name"].(string)
-		case map[string]string:
-			displayName = v["display_name"]
-		}
+	for _, entry := range listProfileEntries(runtimeViper) {
+		displayName, _ := entry.settings["display_name"].(string)
 		if displayName != "" && !slices.Contains(profiles, displayName) {
 			profiles = append(profiles, displayName)
 		}
@@ -318,7 +318,10 @@ func (c *Config) PrintConfig() error {
 
 		fmt.Print(string(configFile))
 	} else {
-		configs := viper.GetStringMapString(profileName)
+		configs := viper.GetStringMapString(ProfilesTableName + "." + profileName)
+		if len(configs) == 0 {
+			configs = viper.GetStringMapString(profileName)
+		}
 
 		if len(configs) > 0 {
 			fmt.Printf("[%s]\n", profileName)
@@ -384,26 +387,17 @@ func (c *Config) RemoveProfile(profileName string) error {
 	runtimeViper := viper.GetViper()
 	var err error
 
-	for field, value := range runtimeViper.AllSettings() {
-		if isProfile(value) {
-			var profileNameAttr string
-			switch v := value.(type) {
-			case map[string]interface{}:
-				if pn, ok := v["profile_name"].(string); ok {
-					profileNameAttr = pn
-				}
-			case map[string]string:
-				profileNameAttr = v["profile_name"]
-			}
-			if field == profileName || profileNameAttr == profileName {
-				runtimeViper, err = removeKey(runtimeViper, field)
-				if err != nil {
-					return err
-				}
-
-				deleteLivemodeKey(LiveModeAPIKeyName, field)
-			}
+	for _, entry := range listProfileEntries(runtimeViper) {
+		if !entry.matches(profileName) {
+			continue
 		}
+
+		runtimeViper, err = removeKey(runtimeViper, entry.key)
+		if err != nil {
+			return err
+		}
+
+		deleteLivemodeKey(LiveModeAPIKeyName, entry.name)
 	}
 
 	return writeConfig(runtimeViper)
@@ -414,15 +408,13 @@ func (c *Config) RemoveAllProfiles() error {
 	runtimeViper := viper.GetViper()
 	var err error
 
-	for field, value := range runtimeViper.AllSettings() {
-		if isProfile(value) {
-			runtimeViper, err = removeKey(runtimeViper, field)
-			if err != nil {
-				return err
-			}
-
-			deleteLivemodeKey(LiveModeAPIKeyName, field)
+	for _, entry := range listProfileEntries(runtimeViper) {
+		runtimeViper, err = removeKey(runtimeViper, entry.key)
+		if err != nil {
+			return err
 		}
+
+		deleteLivemodeKey(LiveModeAPIKeyName, entry.name)
 	}
 
 	return writeConfig(runtimeViper)
@@ -433,23 +425,14 @@ func (c *Config) RemoveAllProfiles() error {
 func (c *Config) RemoveAuthFields(profileName string) error {
 	runtimeViper := viper.GetViper()
 
-	for field, value := range runtimeViper.AllSettings() {
-		if isProfile(value) {
-			var profileNameAttr string
-			switch v := value.(type) {
-			case map[string]interface{}:
-				if pn, ok := v["profile_name"].(string); ok {
-					profileNameAttr = pn
-				}
-			case map[string]string:
-				profileNameAttr = v["profile_name"]
-			}
-			if field == profileName || profileNameAttr == profileName {
-				p := &Profile{ProfileName: field}
-				runtimeViper = p.deleteAuthFields(runtimeViper)
-				deleteLivemodeKey(LiveModeAPIKeyName, field)
-			}
+	for _, entry := range listProfileEntries(runtimeViper) {
+		if !entry.matches(profileName) {
+			continue
 		}
+
+		p := &Profile{ProfileName: entry.name}
+		runtimeViper = p.deleteAuthFields(runtimeViper)
+		deleteLivemodeKey(LiveModeAPIKeyName, entry.name)
 	}
 
 	deleteTopLevelLivemodeKey(UATKeychainItemKey)
@@ -466,12 +449,10 @@ func (c *Config) RemoveAuthFields(profileName string) error {
 func (c *Config) RemoveAllAuthFields() error {
 	runtimeViper := viper.GetViper()
 
-	for field, value := range runtimeViper.AllSettings() {
-		if isProfile(value) {
-			p := &Profile{ProfileName: field}
-			runtimeViper = p.deleteAuthFields(runtimeViper)
-			deleteLivemodeKey(LiveModeAPIKeyName, field)
-		}
+	for _, entry := range listProfileEntries(runtimeViper) {
+		p := &Profile{ProfileName: entry.name}
+		runtimeViper = p.deleteAuthFields(runtimeViper)
+		deleteLivemodeKey(LiveModeAPIKeyName, entry.name)
 	}
 
 	deleteTopLevelLivemodeKey(UATKeychainItemKey)
@@ -500,8 +481,13 @@ func deleteTopLevelLivemodeKey(key string) error {
 	return err
 }
 
-// isProfile identifies whether a config entry pertains to a user profile.
-// A profile is a map that contains a display_name field.
+// isProfile identifies whether a top-level config entry pertains to a user
+// profile. At the top level a profile is indistinguishable from a settings
+// table except by its contents, so it is identified by its display_name field.
+//
+// Entries inside the v2 profiles table need no such guess: every table in there
+// is a profile by definition. Use listProfileEntries to enumerate profiles in a
+// way that covers both layouts.
 func isProfile(value interface{}) bool {
 	switch v := value.(type) {
 	case map[string]interface{}:
@@ -556,6 +542,103 @@ func configVersion(v *viper.Viper) (int, error) {
 func isMigrated(v *viper.Viper) bool {
 	version, err := configVersion(v)
 	return err == nil && version == ConfigVersionV2
+}
+
+// profileTableKeyForWrite returns the key a whole profile table should be
+// written to, matching the layout the config file already uses.
+func profileTableKeyForWrite(v *viper.Viper, profileName string) string {
+	if isMigrated(v) {
+		return ProfilesTableName + "." + profileName
+	}
+
+	return profileName
+}
+
+// profileEntry is one profile found in the config file, in either layout.
+type profileEntry struct {
+	// name is the profile's name, e.g. "default". Keyring item IDs are prefixed
+	// with this name in both layouts, so it is what credential lookups need.
+	name string
+
+	// key is the viper key of the profile's table: "default" in a v1 file,
+	// "profiles.default" in a v2 file.
+	key string
+
+	// settings is the contents of the profile's table.
+	settings map[string]interface{}
+}
+
+// matches reports whether this entry is the profile the user named, either by
+// its table name or by its recorded profile_name.
+func (e profileEntry) matches(profileName string) bool {
+	if e.name == profileName {
+		return true
+	}
+
+	recorded, _ := e.settings["profile_name"].(string)
+
+	return recorded == profileName
+}
+
+// listProfileEntries returns every profile in the config file, reading both the
+// v2 profiles table and the v1 top level.
+//
+// Both layouts are scanned because a migrated file can still acquire a
+// top-level profile table: an older CLI or plugin writing the same file does
+// not know about the profiles table. A v1 entry is skipped when a v2 profile of
+// the same name exists, so the migrated copy always wins.
+func listProfileEntries(v *viper.Viper) []profileEntry {
+	settings := v.AllSettings()
+	entries := make([]profileEntry, 0, len(settings))
+	nestedNames := make(map[string]bool)
+
+	if nested, ok := toStringMap(settings[ProfilesTableName]); ok {
+		for name, value := range nested {
+			table, ok := toStringMap(value)
+			if !ok {
+				continue
+			}
+
+			nestedNames[name] = true
+			entries = append(entries, profileEntry{
+				name:     name,
+				key:      ProfilesTableName + "." + name,
+				settings: table,
+			})
+		}
+	}
+
+	for name, value := range settings {
+		if name == ProfilesTableName || nestedNames[name] || !isProfile(value) {
+			continue
+		}
+
+		table, _ := toStringMap(value)
+		entries = append(entries, profileEntry{name: name, key: name, settings: table})
+	}
+
+	// AllSettings returns a map, so sort for stable output and stable ordering of
+	// the writes that follow.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
+
+	return entries
+}
+
+// toStringMap normalizes the two map shapes viper hands back for a TOML table.
+func toStringMap(value interface{}) (map[string]interface{}, bool) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		return v, true
+	case map[string]string:
+		normalized := make(map[string]interface{}, len(v))
+		for key, item := range v {
+			normalized[key] = item
+		}
+
+		return normalized, true
+	}
+
+	return nil, false
 }
 
 // WriteConfigField updates a configuration field and writes the updated

--- a/pkg/config/config_layout_test.go
+++ b/pkg/config/config_layout_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+
+	original := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	fnErr := fn()
+
+	w.Close()
+	os.Stdout = original
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	require.NoError(t, fnErr)
+
+	return buf.String()
+}
+
+func TestListProfilesReadsBothLayouts(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile+`
+[legacy]
+  display_name = 'Legacy Account'
+`)
+	c.Profile = Profile{ProfileName: "default"}
+
+	output := captureStdout(t, c.ListProfiles)
+
+	require.Contains(t, output, "V2 Account")
+	require.Contains(t, output, "Collides With A Setting")
+	require.Contains(t, output, "Legacy Account")
+	require.Contains(t, output, "* V2 Account (active)")
+}
+
+func TestRemoveProfileInV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+
+	require.NoError(t, c.RemoveProfile("installed_plugins"))
+
+	require.False(t, viper.IsSet("profiles.installed_plugins"))
+	require.Equal(t, "V2 Account", viper.GetString("profiles.default.display_name"))
+	// Removing a profile that shares a name with a setting must not remove the
+	// setting.
+	require.Equal(t, []string{"apps"}, viper.GetStringSlice("installed_plugins"))
+}
+
+func TestRemoveAllProfilesInV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+
+	require.NoError(t, c.RemoveAllProfiles())
+
+	require.False(t, viper.IsSet("profiles.default"))
+	require.False(t, viper.IsSet("profiles.installed_plugins"))
+	require.Equal(t, []string{"apps"}, viper.GetStringSlice("installed_plugins"))
+}
+
+func TestRemoveAuthFieldsInV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, `config_version = 2
+
+[profiles.default]
+  color = 'on'
+  display_name = 'V2 Account'
+  test_mode_api_key = 'sk_test_v2_key'
+`)
+
+	require.NoError(t, c.RemoveAuthFields("default"))
+
+	require.False(t, viper.IsSet("profiles.default.test_mode_api_key"))
+	require.Equal(t, "on", viper.GetString("profiles.default.color"))
+}
+
+func TestCopyProfileInV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+
+	require.NoError(t, c.CopyProfile("default", "backup"))
+
+	require.Equal(t, "sk_test_v2_key", viper.GetString("profiles.backup.test_mode_api_key"))
+	require.Equal(t, "backup", viper.GetString("profiles.backup.profile_name"))
+	require.False(t, viper.IsSet("backup"))
+}
+
+func TestPrintConfigReadsV2Layout(t *testing.T) {
+	c, _ := setupProfileConfig(t, v2ConfigFile)
+	c.Profile = Profile{ProfileName: "installed_plugins"}
+
+	output := captureStdout(t, c.PrintConfig)
+
+	require.Contains(t, output, "[installed_plugins]")
+	require.Contains(t, output, "display_name=Collides With A Setting")
+}


### PR DESCRIPTION
### Reviewers
r? @
cc @stripe/developer-products

### Summary

Profile enumeration — `config --list`, `--unset`, `--remove-profile`, `login switch`, `PrintConfig` — now goes through `listProfileEntries`, which reads both the v2 `profiles` table and the v1 top level, so those commands behave the same on either layout.

- inside the `profiles` table every entry is a profile, so a partially written one with no
  `display_name` is found there too
- at the top level a profile is still identified by its `display_name`, since nothing else distinguishes
  it from a settings table
- a top-level entry is skipped when a profile of the same name exists in the `profiles` table, so the
  migrated copy wins
- `CopyProfile` writes the new profile table to whichever layout the file already uses

### Test Plan

`pkg/config/config_layout_test.go`
