### PR TITLE
Categorize Codex hosts and close two agent detection gaps

### DIFF
--- a/pkg/cmd/agent_env_test.go
+++ b/pkg/cmd/agent_env_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import "testing"
+
+// clearAgentEnv unsets every variable useragent.DetectAIAgent reads, so a test asserting
+// "no agent" is not answering with the environment of whichever agent is running it.
+//
+// This covers the host variables as well as the agent-specific ones. DetectAIAgent falls
+// back to CLAUDE_CODE_ENTRYPOINT and CODEX_INTERNAL_ORIGINATOR_OVERRIDE when no
+// agent-specific variable matched, because some surfaces set only a host. That makes an
+// incomplete list here fail only when the suite runs inside an agent, which is the worst
+// time to find out.
+func clearAgentEnv(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{
+		"ANTIGRAVITY_CLI_ALIAS",
+		"CLAUDECODE",
+		"CLAUDE_CODE_ENTRYPOINT",
+		"CLINE_ACTIVE",
+		"CODEX_CI",
+		"CODEX_INTERNAL_ORIGINATOR_OVERRIDE",
+		"CODEX_SANDBOX",
+		"CODEX_SANDBOX_NETWORK_DISABLED",
+		"CODEX_THREAD_ID",
+		"CURSOR_AGENT",
+		"GEMINI_CLI",
+		"OPENCLAW_SHELL",
+		"OPENCODE",
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/pkg/cmd/templates_test.go
+++ b/pkg/cmd/templates_test.go
@@ -50,10 +50,7 @@ func TestIsAIAgent_Detected(t *testing.T) {
 }
 
 func TestIsAIAgent_NotDetected(t *testing.T) {
-	// Ensure none of the agent env vars are set
-	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
-		t.Setenv(key, "")
-	}
+	clearAgentEnv(t)
 	assert.False(t, isAIAgent())
 }
 
@@ -138,9 +135,7 @@ func TestAIAgentHelp_SubcommandOnly(t *testing.T) {
 }
 
 func TestAIAgentHelp_NotDetected(t *testing.T) {
-	for _, key := range []string{"ANTIGRAVITY_CLI_ALIAS", "CLAUDECODE", "CLINE_ACTIVE", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "CODEX_SANDBOX", "CODEX_THREAD_ID", "CODEX_SANDBOX_NETWORK_DISABLED", "CODEX_CI", "CURSOR_AGENT", "GEMINI_CLI", "OPENCODE"} {
-		t.Setenv(key, "")
-	}
+	clearAgentEnv(t)
 
 	root := &cobra.Command{Use: "stripe"}
 	child := &cobra.Command{Use: "listen"}

--- a/pkg/cmd/unknown_cmd_telemetry_test.go
+++ b/pkg/cmd/unknown_cmd_telemetry_test.go
@@ -33,18 +33,7 @@ func (m *mockUnknownCmdTelemetryClient) SendEvent(_ context.Context, eventName s
 }
 
 func TestRecordUnknownCommand_NotInAgentEnv(t *testing.T) {
-	t.Setenv("CLAUDECODE", "")
-	t.Setenv("CURSOR_AGENT", "")
-	t.Setenv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "")
-	t.Setenv("CODEX_SANDBOX", "")
-	t.Setenv("CODEX_THREAD_ID", "")
-	t.Setenv("CODEX_SANDBOX_NETWORK_DISABLED", "")
-	t.Setenv("CODEX_CI", "")
-	t.Setenv("CLINE_ACTIVE", "")
-	t.Setenv("GEMINI_CLI", "")
-	t.Setenv("OPENCODE", "")
-	t.Setenv("OPENCLAW_SHELL", "")
-	t.Setenv("ANTIGRAVITY_CLI_ALIAS", "")
+	clearAgentEnv(t)
 
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)

--- a/pkg/stripe/analytics_telemetry_test.go
+++ b/pkg/stripe/analytics_telemetry_test.go
@@ -409,3 +409,39 @@ func TestNewEventMetadata_ReportsRawHostWhenUncategorized(t *testing.T) {
 	require.Equal(t, "other", tel.AgentHostKind)
 	require.Equal(t, "some-future-surface", tel.AgentHostRaw)
 }
+
+func TestNewEventMetadata_InfersCodexTerminalFromAbsentOriginator(t *testing.T) {
+	// Codex sets its originator override only from non-default surfaces, so a terminal
+	// session reports no host at all. Without the inference this is indistinguishable
+	// from a CLI too old to report a host, and terminal Codex is invisible.
+	clearAgentEnv(t)
+	t.Setenv("CODEX_SANDBOX", "1")
+
+	tel := stripe.NewEventMetadata()
+	require.Equal(t, "codex_cli", tel.AIAgent)
+	require.Equal(t, "terminal", tel.AgentHostKind)
+	require.Equal(t, "codex-cli", tel.AgentHostRaw)
+}
+
+func TestNewEventMetadata_InfersAgentFromHostAlone(t *testing.T) {
+	// A Claude Code entrypoint with no CLAUDECODE: hosted and SDK surfaces do not always
+	// set it. The entrypoint names the agent, so the two fields stay consistent.
+	clearAgentEnv(t)
+	t.Setenv("CLAUDE_CODE_ENTRYPOINT", "remote-trigger")
+
+	tel := stripe.NewEventMetadata()
+	require.Equal(t, "claude_code", tel.AIAgent)
+	require.Equal(t, "remote", tel.AgentHostKind)
+	require.Equal(t, "remote-trigger", tel.AgentHostRaw)
+}
+
+func TestNewEventMetadata_CategorizesCodexVSCode(t *testing.T) {
+	clearAgentEnv(t)
+	t.Setenv("CODEX_CI", "1")
+	t.Setenv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "codex_vscode")
+
+	tel := stripe.NewEventMetadata()
+	require.Equal(t, "codex_cli", tel.AIAgent)
+	require.Equal(t, "ide", tel.AgentHostKind)
+	require.Equal(t, "codex-vscode", tel.AgentHostRaw)
+}

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -97,6 +97,9 @@ func DetectTerminalProgram(getEnv func(string) string) string {
 
 // DetectAIAgent detects if the CLI was invoked by a coding agent, based on well-known env vars.
 // It accepts an environment getter function to allow testing without modifying the actual environment.
+//
+// Agent-specific variables are checked first. When none match it falls back to the two host
+// variables DetectAgentHost reads, which identify an agent surface and so imply the agent.
 func DetectAIAgent(getEnv func(string) string) string {
 	if getEnv("ANTIGRAVITY_CLI_ALIAS") != "" {
 		return "antigravity"
@@ -122,11 +125,29 @@ func DetectAIAgent(getEnv func(string) string) string {
 	if getEnv("OPENCLAW_SHELL") != "" {
 		return "openclaw"
 	}
+
+	// No agent-specific variable matched. The two host variables below are set by these
+	// agents to name their own surface, so their presence is itself evidence of an agent.
+	//
+	// Some surfaces set a host without the matching agent variable. The four generic Codex
+	// signals above are sandbox-, permission- and CI-dependent, so a Codex Desktop session
+	// configured with full access can set none of them while still naming itself through
+	// the originator override. Claude Code's hosted and SDK entrypoints likewise do not
+	// always set CLAUDECODE. Without this fallback those sessions report a host and no
+	// agent, which also means the CLI treats them as interactive and tries to open a
+	// browser to log in.
+	if getEnv("CLAUDE_CODE_ENTRYPOINT") != "" {
+		return "claude_code"
+	}
+	if getEnv("CODEX_INTERNAL_ORIGINATOR_OVERRIDE") != "" {
+		return "codex_cli"
+	}
+
 	return ""
 }
 
 // DetectAgentHost reports where the agent ran, as a bounded category and as the host
-// value itself. Both are empty when no agent reported a host.
+// value itself. Both are empty when no agent reported a host and none can be inferred.
 //
 // kind is what to group by: "desktop", "terminal", "ide", "remote", "sdk", "mcp", or
 // "other" for a host we have not categorized. raw is the normalized host underneath it,
@@ -137,6 +158,9 @@ func DetectAIAgent(getEnv func(string) string) string {
 // Reporting raw also means an unmapped host can be identified from the data rather than
 // from a vendor's source, which matters because mapping one otherwise costs a code
 // change, a release, and users upgrading before it is even visible.
+//
+// One host is inferred rather than reported: Codex names every surface except the terminal,
+// so a detected Codex agent with no host is a terminal one. See the empty-host branch below.
 func DetectAgentHost(getEnv func(string) string) (kind string, raw string) {
 	host := getEnv("CLAUDE_CODE_ENTRYPOINT")
 	if host == "" {
@@ -147,6 +171,21 @@ func DetectAgentHost(getEnv func(string) string) (kind string, raw string) {
 
 	host = normalizeAgentHost(host)
 	if host == "" {
+		// Codex reports no host from a terminal. The override read above is set only by
+		// non-default surfaces -- Desktop, the SDKs, the VS Code extension -- so a plain
+		// `codex` run leaves it unset, and absence is the only signal the terminal case
+		// has. Inferring it here is what separates terminal Codex from a CLI too old to
+		// report a host at all, which otherwise arrives identically empty.
+		//
+		// Gated on the detected agent rather than on the Codex variables directly, so an
+		// inferred host cannot contradict the agent reported alongside it. This cannot
+		// recurse: DetectAIAgent reads only environment variables.
+		//
+		// Claude Code needs no equivalent because it names its terminal case "cli".
+		if DetectAIAgent(getEnv) == "codex_cli" {
+			return "terminal", "codex-cli"
+		}
+
 		return "", ""
 	}
 
@@ -228,17 +267,31 @@ const (
 
 // agentHostKinds categorizes the hosts we know about. "remote*" hosts are handled by
 // prefix in DetectAgentHost rather than enumerated here.
+//
+// The codex-* entries are the originators Codex itself enumerates in
+// KNOWN_ORIGINATOR_TAG_VALUES (codex-rs/otel/src/metrics/tags.rs), normalized. Mapping the
+// whole set rather than only the values we have observed costs nothing and keeps a surface
+// out of "other" the first time it appears. Codex's "none" is deliberately absent: it means
+// no originator, so reporting it as an uncategorized host is the honest answer.
 var agentHostKinds = map[string]string{
-	"claude-desktop":    "desktop",
-	"claude-desktop-3p": "desktop",
-	"claude-vscode":     "ide",
-	"cli":               "terminal",
-	"codex-desktop":     "desktop",
-	"codex-sdk-ts":      "sdk",
-	"mcp":               "mcp",
-	"sdk-cli":           "sdk",
-	"sdk-py":            "sdk",
-	"sdk-ts":            "sdk",
+	"claude-desktop":       "desktop",
+	"claude-desktop-3p":    "desktop",
+	"claude-vscode":        "ide",
+	"cli":                  "terminal",
+	"codex-app-server":     "sdk",
+	"codex-app-server-sdk": "sdk",
+	"codex-cli":            "terminal",
+	"codex-cli-rs":         "terminal",
+	"codex-desktop":        "desktop",
+	"codex-exec":           "terminal",
+	"codex-mcp-server":     "mcp",
+	"codex-sdk-ts":         "sdk",
+	"codex-tui":            "terminal",
+	"codex-vscode":         "ide",
+	"mcp":                  "mcp",
+	"sdk-cli":              "sdk",
+	"sdk-py":               "sdk",
+	"sdk-ts":               "sdk",
 }
 
 //

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -153,6 +153,28 @@ func TestDetectAgentHost(t *testing.T) {
 		{"uncategorized codex host", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Web"}, "other", "codex-web"},
 		{"no host", map[string]string{}, "", ""},
 
+		// The originators Codex enumerates, normalized. The VS Code extension is the one
+		// with observed traffic; it reported "other" until it was mapped here.
+		{"codex vscode", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "codex_vscode"}, "ide", "codex-vscode"},
+		{"codex tui", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "codex-tui"}, "terminal", "codex-tui"},
+		{"codex cli rs", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "codex_cli_rs"}, "terminal", "codex-cli-rs"},
+		{"codex exec", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "codex_exec"}, "terminal", "codex-exec"},
+		{"codex mcp server", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "codex_mcp_server"}, "mcp", "codex-mcp-server"},
+		{"codex app server", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "codex-app-server"}, "sdk", "codex-app-server"},
+		{"codex app server sdk", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "codex-app-server-sdk"}, "sdk", "codex-app-server-sdk"},
+		// "none" means Codex reported no originator, so it stays uncategorized rather
+		// than being mapped to a surface it does not name.
+		{"codex none stays uncategorized", map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "none"}, "other", "none"},
+
+		// Codex names every surface except the terminal, so a detected Codex agent with no
+		// originator is a terminal one. This is the only inferred host.
+		{"codex terminal inferred from sandbox signal", map[string]string{"CODEX_SANDBOX": "1"}, "terminal", "codex-cli"},
+		{"codex terminal inferred from thread signal", map[string]string{"CODEX_THREAD_ID": "thread-abc"}, "terminal", "codex-cli"},
+		// The inference is gated on the agent, so it does not fire for anyone else. Claude
+		// Code without an entrypoint has no host, rather than a guessed terminal.
+		{"claude code without entrypoint stays hostless", map[string]string{"CLAUDECODE": "1"}, "", ""},
+		{"cursor stays hostless", map[string]string{"CURSOR_AGENT": "1"}, "", ""},
+
 		// Normalization runs before reporting, so one host cannot arrive under several
 		// spellings -- including from different platforms.
 		{"raw is normalized, not verbatim", map[string]string{"CLAUDE_CODE_ENTRYPOINT": " Some_New HOST "}, "other", "some-new-host"},
@@ -165,6 +187,52 @@ func TestDetectAgentHost(t *testing.T) {
 			kind, raw := DetectAgentHost(mapEnv(tt.envs))
 			require.Equal(t, tt.kind, kind)
 			require.Equal(t, tt.raw, raw)
+		})
+	}
+}
+
+// TestDetectAIAgent_InferredFromHost covers the surfaces that name a host without setting
+// the agent variable that normally identifies them, which previously reported a host with
+// no agent attached.
+func TestDetectAIAgent_InferredFromHost(t *testing.T) {
+	tests := []struct {
+		name        string
+		envs        map[string]string
+		expected    string
+		description string
+	}{
+		{
+			name:        "claude code entrypoint without CLAUDECODE",
+			envs:        map[string]string{"CLAUDE_CODE_ENTRYPOINT": "remote-trigger"},
+			expected:    "claude_code",
+			description: "hosted and SDK entrypoints do not always set CLAUDECODE",
+		},
+		{
+			name:        "codex originator without the generic codex signals",
+			envs:        map[string]string{"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop"},
+			expected:    "codex_cli",
+			description: "the generic signals are sandbox-, permission- and CI-dependent",
+		},
+		{
+			name:        "uncategorized host still identifies the agent",
+			envs:        map[string]string{"CLAUDE_CODE_ENTRYPOINT": "some-future-surface"},
+			expected:    "claude_code",
+			description: "the fallback keys off presence, not off the host being mapped",
+		},
+		// The fallback is last, so a real agent variable still wins and the reported agent
+		// stays the process that set it rather than the surface it inherited.
+		{
+			name:        "agent variable wins over inherited host",
+			envs:        map[string]string{"CURSOR_AGENT": "1", "CLAUDE_CODE_ENTRYPOINT": "claude-vscode"},
+			expected:    "cursor",
+			description: "nested agents inherit an entrypoint from the session that launched them",
+		},
+		{"no agent and no host", map[string]string{}, "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, DetectAIAgent(mapEnv(tt.envs)), tt.description)
 		})
 	}
 }
@@ -287,8 +355,11 @@ func TestObservedAgentSessions(t *testing.T) {
 				"CODEX_SANDBOX":   "1",
 			},
 			agent:    "codex_cli",
-			hostKind: "",
+			hostKind: "terminal",
+			hostRaw:  "codex-cli",
 			version:  "",
+			description: "Codex sets no originator from a terminal, so the terminal host is " +
+				"inferred from its absence; every other Codex surface names itself",
 		},
 	}
 


### PR DESCRIPTION
### Reviewers
r? @
cc @stripe/developer-products

### Summary

Three gaps surfaced while reading `agent_host_kind` usage data.

**`codex_vscode` reported `other`.** It was Codex's third-largest bucket, and `agent_host_raw` identified it: `codex-vscode` (109 merchants), the VS Code extension, which is an IDE. The `codex-*` entries now come from the originator set Codex enumerates in [`KNOWN_ORIGINATOR_TAG_VALUES`](https://github.com/openai/codex/blob/main/codex-rs/otel/src/metrics/tags.rs) rather than only the values we have observed, so the next surface is categorized on arrival instead of after a release: `codex-tui`/`codex-cli-rs`/`codex-exec` → terminal, `codex-mcp-server` → mcp, both app-server originators → sdk.

Codex's `none` is left unmapped on purpose — it means no originator was reported, so an uncategorized host is the honest answer. `flora` (10 merchants) is left alone too: it is absent from Codex's own list, so a category would be a guess, and `agent_host_raw` already surfaces it.

**Terminal Codex was invisible.** Claude Code names its terminal case (`CLAUDE_CODE_ENTRYPOINT=cli`); Codex has no equivalent, since `CODEX_INTERNAL_ORIGINATOR_OVERRIDE` is set only by non-default surfaces. So a plain `codex` run reported no host, and there was no `codex_cli` + `terminal` combination in the data at all. Absence is the only signal that case has, and it was indistinguishable from a CLI too old to report a host — both arrive empty. Scoped to versions that report the field, that is **347 merchants, Codex's second-largest surface after Desktop.**

`DetectAgentHost` now infers `terminal` / `codex-cli` when a Codex agent is detected with no originator, gated on the detected agent rather than the Codex variables directly so an inferred host cannot contradict the agent reported beside it.

**A host could be reported with no agent.** 13 merchants reported `agent_host_kind` with an empty `ai_agent`, because the two detectors read disjoint variables and some surfaces set only a host. The four generic Codex signals are sandbox-, permission- and CI-dependent, so a full-access Codex Desktop session can set none of them while still naming itself through the originator override (`codex-desktop`, `codex-vscode`). Claude Code's hosted and SDK entrypoints do not always set `CLAUDECODE` (`sdk-dotnet-client`, `remote-trigger`, `remote-desktop`). `DetectAIAgent` now falls back to those two host variables, checked last so an agent-specific variable still wins and a nested agent keeps reporting the process that set it rather than the surface it inherited.

### Worth explicit review

Two consequences reviewers should weigh rather than skim:

1. **The agent fallback reaches past telemetry.** `DetectAIAgent` has 16 callers, so a host-only session is now also treated as non-interactive: the CLI no longer tries to open a browser to log in, suppresses the pager, and `stripe agent setup` detects its provider. I believe all of that is more correct — `remote-trigger` and `sdk-dotnet-client` are non-interactive surfaces where opening a browser was wrong — but it is a behavior change, not only a reporting one.
2. **The terminal inference has a tradeoff.** A future hostless Codex surface would be labeled `terminal` rather than arriving empty: wrong and visible instead of invisible. `terminal_program` can validate the inference once this ships, since it is populated for inherited terminal environments.

This is forward-only. Existing rows do not re-bucket; the 347 become `terminal` as users upgrade.

### Testing

- `go test -count=1 ./...` (49 packages), `-race` on the changed packages, `make lint` 0 issues.
- The `codex cli` fixture in `TestObservedAgentSessions` now pins the inferred terminal host, and the inference is covered as *not* firing for Claude Code or Cursor.
- Three `pkg/cmd` tests failed on the agent fallback because they cleared every agent variable except `CLAUDE_CODE_ENTRYPOINT` — so they only failed when the suite ran inside an agent, which is the worst time to find out. Two were already missing `OPENCLAW_SHELL`. All three now share one `clearAgentEnv` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)