### PR TITLE
Update OAuth login prompt

### DIFF
--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -53,6 +53,17 @@ func Bold(text string) string {
 	return color.Sprintf(color.Bold(text))
 }
 
+// stripeBlurpleIndex is the closest 8-bit terminal color (#5f5fff) to
+// Stripe's brand blurple (#635BFF).
+const stripeBlurpleIndex = 63
+
+// Blurple returns text in Stripe's brand blurple color if the writer
+// supports colors.
+func Blurple(text string) string {
+	color := Color(os.Stdout)
+	return color.Sprintf(color.Index(stripeBlurpleIndex, text))
+}
+
 // Color returns an aurora.Aurora instance with colors enabled or disabled
 // depending on whether the writer supports colors.
 func Color(w io.Writer) aurora.Aurora {

--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -53,15 +53,13 @@ func Bold(text string) string {
 	return color.Sprintf(color.Bold(text))
 }
 
-// stripeBlurpleIndex is the closest 8-bit terminal color (#5f5fff) to
-// Stripe's brand blurple (#635BFF).
-const stripeBlurpleIndex = 63
+// purpleIndex is the closest 8-bit terminal color (#875fff) to #746cff.
+const purpleIndex = 99
 
-// Blurple returns text in Stripe's brand blurple color if the writer
-// supports colors.
-func Blurple(text string) string {
+// Purple returns purple text if the writer supports colors.
+func Purple(text string) string {
 	color := Color(os.Stdout)
-	return color.Sprintf(color.Index(stripeBlurpleIndex, text))
+	return color.Sprintf(color.Index(purpleIndex, text))
 }
 
 // Color returns an aurora.Aurora instance with colors enabled or disabled

--- a/pkg/login/oauth_device.go
+++ b/pkg/login/oauth_device.go
@@ -182,7 +182,7 @@ func LoginWithDeviceCode(ctx context.Context, accessBaseURL string, cfg *config.
 	fmt.Printf("To authorize, visit %s\n\n", authResp.VerificationURI)
 	fmt.Println("When prompted, enter your verification code:")
 	fmt.Println()
-	fmt.Println(ansi.Blurple(authResp.UserCode))
+	fmt.Println(ansi.Purple(authResp.UserCode))
 	fmt.Println()
 
 	if !isSSH() && canOpenBrowser() {

--- a/pkg/login/oauth_device.go
+++ b/pkg/login/oauth_device.go
@@ -179,12 +179,14 @@ func LoginWithDeviceCode(ctx context.Context, accessBaseURL string, cfg *config.
 		return err
 	}
 
-	color := ansi.Color(os.Stdout)
-	fmt.Printf("Your pairing code is: %s\n", color.Bold(authResp.UserCode))
-	fmt.Printf("To authorize the CLI, visit: %s\n", authResp.VerificationURI)
+	fmt.Printf("To authorize, visit %s\n\n", authResp.VerificationURI)
+	fmt.Println("When prompted, enter your verification code:")
+	fmt.Println()
+	fmt.Println(ansi.Blurple(authResp.UserCode))
+	fmt.Println()
 
 	if !isSSH() && canOpenBrowser() {
-		fmt.Printf("Press Enter to open the browser (^C to quit)\n")
+		fmt.Printf("Press enter to open the browser (^C to quit)\n")
 		go func() {
 			fmt.Scanln() //nolint:errcheck
 			if err := openBrowser(authResp.VerificationURI); err != nil {


### PR DESCRIPTION
Based on feedback, make the verification code more obvious.

Examples:

<img width="989" height="611" alt="Screenshot 2026-08-21 at 10 55 18 AM" src="https://github.com/user-attachments/assets/a178dee4-4af7-4260-ac5d-540a7d125660" />

<img width="989" height="611" alt="Screenshot 2026-08-21 at 10 55 00 AM" src="https://github.com/user-attachments/assets/b20b769a-140a-499d-a4dd-6a0bc5eccefb" />

<img width="629" height="497" alt="Screenshot 2026-08-21 at 10 56 05 AM" src="https://github.com/user-attachments/assets/99eb967d-8a7b-45e2-9e1f-4daa388b6a22" />