### PR TITLE
Support support.stripe.com articles in `stripe docs` 

### DIFF
--- a/pkg/cmd/docs/root.go
+++ b/pkg/cmd/docs/root.go
@@ -263,14 +263,30 @@ func (r *RootCommand) run(cmd *cobra.Command, args []string) error {
 
 // parseDocsRef converts command-line arguments into a URL reference for FetchPage.
 //
-// If the first argument is a full docs.stripe.com URL, its path and query
-// string are extracted. Otherwise the arguments are joined as a path fragment,
-// prefixing a leading "/" if absent.
+// docs.stripe.com URLs are converted to path references, while support.stripe.com
+// URLs retain their host so FetchPage can route them directly. Other inputs are
+// treated as docs.stripe.com path fragments.
 func parseDocsRef(args []string) *url.URL {
 	first := args[0]
 	if u, err := url.Parse(first); err == nil && u.Host == "docs.stripe.com" {
 		return &url.URL{Path: u.Path, RawQuery: u.RawQuery, Fragment: u.Fragment}
 	}
+
+	supportRef, supportErr := url.Parse(first)
+	if supportErr == nil && supportRef.Host == "" {
+		supportRef, supportErr = url.Parse("//" + first)
+	}
+	if supportErr == nil && supportRef.Host == "support.stripe.com" &&
+		(supportRef.Scheme == "" || supportRef.Scheme == "http" || supportRef.Scheme == "https") {
+		return &url.URL{
+			Scheme:   "https",
+			Host:     supportRef.Host,
+			Path:     supportRef.Path,
+			RawQuery: supportRef.RawQuery,
+			Fragment: supportRef.Fragment,
+		}
+	}
+
 	path := first
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + strings.Join(args, "/")

--- a/pkg/cmd/docs/root_test.go
+++ b/pkg/cmd/docs/root_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -95,6 +96,94 @@ func TestRootParsesDocsURL(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantPath, gotPath)
 			assert.Equal(t, tc.wantQuery, gotQuery)
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestRootRoutesSupportURLs(t *testing.T) {
+	tests := []struct {
+		name      string
+		arg       string
+		wantHost  string
+		wantPath  string
+		wantQuery string
+	}{
+		{
+			name:     "bare support URL",
+			arg:      "support.stripe.com/questions/getting-started",
+			wantHost: "support.stripe.com",
+			wantPath: "/questions/getting-started",
+		},
+		{
+			name:      "schemed support URL with query",
+			arg:       "https://support.stripe.com/questions/search?topic=payments&source=cli",
+			wantHost:  "support.stripe.com",
+			wantPath:  "/questions/search",
+			wantQuery: "topic=payments&source=cli",
+		},
+		{
+			name:     "lookalike support subdomain is a docs path",
+			arg:      "support.stripe.com.example.com/questions",
+			wantPath: "/support.stripe.com.example.com/questions",
+		},
+		{
+			name:     "unsupported host is a docs path",
+			arg:      "https://example.com/questions",
+			wantPath: "/https://example.com/questions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/markdown")
+				fmt.Fprint(w, "# Support")
+			}))
+			defer server.Close()
+
+			target, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			require.NoError(t, err)
+
+			var gotHost, gotPath, gotQuery string
+			httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				gotHost = req.URL.Host
+				gotPath = req.URL.Path
+				gotQuery = req.URL.RawQuery
+
+				forwarded := req.Clone(req.Context())
+				forwarded.URL.Scheme = target.URL.Scheme
+				forwarded.URL.Host = target.URL.Host
+				return http.DefaultTransport.RoundTrip(forwarded)
+			})}
+
+			client := docs.NewClient("test").WithOptions(
+				docs.WithBaseURL(server.URL),
+				docs.WithHTTPClient(httpClient),
+			)
+			renderer, err := markdown.NewRenderer()
+			require.NoError(t, err)
+
+			root := cmd.New().WithOptions(
+				cmd.WithClient(client),
+				cmd.WithRenderer(renderer),
+			).Root()
+			root.SetOut(io.Discard)
+			root.SetArgs([]string{"--non-interactive", "--no-pager", tt.arg})
+
+			require.NoError(t, root.ExecuteContext(context.Background()))
+			wantHost := tt.wantHost
+			if wantHost == "" {
+				wantHost = target.URL.Host
+			}
+			assert.Equal(t, wantHost, gotHost)
+			assert.Equal(t, tt.wantPath, gotPath)
+			assert.Equal(t, tt.wantQuery, gotQuery)
 		})
 	}
 }

--- a/pkg/docs/client.go
+++ b/pkg/docs/client.go
@@ -20,6 +20,8 @@ import (
 
 const defaultBaseURL = "https://docs.stripe.com"
 const defaultAPIBaseURL = "https://api.stripe.com"
+const supportBaseURL = "https://support.stripe.com"
+const supportHost = "support.stripe.com"
 
 // Page holds the content and metadata of a fetched documentation page.
 type Page struct {
@@ -72,7 +74,7 @@ func WithCache(cache Cache) ClientOption { return func(c *Client) { c.cache = ca
 // WithLogger sets a custom logger.
 func WithLogger(logger *log.Entry) ClientOption { return func(c *Client) { c.logger = logger } }
 
-// WithAPIKey sets the Stripe API key sent as an Authorization header on every request.
+// WithAPIKey sets the Stripe API key used for authenticated API requests.
 func WithAPIKey(key string) ClientOption { return func(c *Client) { c.apiKey = key } }
 
 // WithAPIBaseURL overrides the Stripe API base URL used for authenticated requests
@@ -129,20 +131,32 @@ type retrieveDocResponse struct {
 //
 //	page, err := c.FetchPage(ctx, &url.URL{Path: "/payments/accept-a-payment", RawQuery: "api_version=2024-06-30"})
 func (c *Client) FetchPage(ctx context.Context, ref *url.URL) (Page, error) {
-	if c.apiKey != "" {
+	isSupport := ref.Host == supportHost
+	if c.apiKey != "" && !isSupport {
 		return c.fetchPageViaAPI(ctx, ref)
 	}
 
-	resolvedURL := c.baseURL.ResolveReference(ref)
-	// Merge stored prefs as query params, skipping any key already present in the ref.
-	// url.Values.Encode() sorts params, giving a consistent cache key.
-	q := resolvedURL.Query()
-	for k, v := range c.prefs {
-		if !q.Has(k) {
-			q.Set(k, v)
+	var resolvedURL *url.URL
+	if isSupport {
+		supportURL, _ := url.Parse(supportBaseURL)
+		resolvedURL = supportURL.ResolveReference(&url.URL{
+			Path:     ref.Path,
+			RawPath:  ref.RawPath,
+			RawQuery: ref.RawQuery,
+			Fragment: ref.Fragment,
+		})
+	} else {
+		resolvedURL = c.baseURL.ResolveReference(ref)
+		// Merge stored prefs as query params, skipping any key already present in the ref.
+		// url.Values.Encode() sorts params, giving a consistent cache key.
+		q := resolvedURL.Query()
+		for k, v := range c.prefs {
+			if !q.Has(k) {
+				q.Set(k, v)
+			}
 		}
+		resolvedURL.RawQuery = q.Encode()
 	}
-	resolvedURL.RawQuery = q.Encode()
 	rawURL := resolvedURL.String()
 	cacheKey := c.cacheKey(rawURL)
 
@@ -165,7 +179,12 @@ func (c *Client) FetchPage(ctx context.Context, ref *url.URL) (Page, error) {
 	if err != nil {
 		return Page{}, fmt.Errorf("docs: build request: %w", err)
 	}
-	req.Header.Set("Accept", "text/plain, text/markdown")
+	if isSupport {
+		req.Header.Set("Accept", "text/markdown")
+		req.Header.Set("Content-Type", "text/markdown")
+	} else {
+		req.Header.Set("Accept", "text/plain, text/markdown")
+	}
 
 	res, err := c.do(req)
 	if err != nil {
@@ -202,6 +221,7 @@ func (c *Client) fetchPageViaAPI(ctx context.Context, ref *url.URL) (Page, error
 		return Page{}, fmt.Errorf("docs: build request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Stripe-Version", requests.StripeVersionHeaderValue)
 
 	res, err := c.do(req)
@@ -241,9 +261,6 @@ func (c *Client) cacheKey(rawURL string) string {
 
 func (c *Client) do(req *http.Request) (response, error) {
 	req.Header.Set("User-Agent", c.userAgent)
-	if c.apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	}
 
 	start := time.Now()
 	resp, err := c.http.Do(req)
@@ -351,6 +368,9 @@ func (c *Client) Search(ctx context.Context, query string) (*SearchResponse, err
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Stripe-Version", requests.StripeVersionHeaderValue)
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
 
 	res, err := c.do(req)
 	if err != nil {

--- a/pkg/docs/client_test.go
+++ b/pkg/docs/client_test.go
@@ -63,6 +63,28 @@ func (m *mockCache) Set(key string, data []byte) error {
 	return nil
 }
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func routeRequestsTo(serverURL string) *http.Client {
+	target, _ := url.Parse(serverURL)
+	return &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		original := req.Clone(req.Context())
+		forwarded := req.Clone(req.Context())
+		forwarded.URL.Scheme = target.Scheme
+		forwarded.URL.Host = target.Host
+
+		resp, err := http.DefaultTransport.RoundTrip(forwarded)
+		if resp != nil {
+			resp.Request = original
+		}
+		return resp, err
+	})}
+}
+
 func TestNewClient_UserAgent(t *testing.T) {
 	got := NewClient("1.2.3")
 	assert.Equal(t, useragent.GetEncodedUserAgent(), got.userAgent)
@@ -230,6 +252,35 @@ func TestFetchPage(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFetchPage_SupportHost(t *testing.T) {
+	var gotPath, gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		assert.Equal(t, "text/markdown", r.Header.Get("Accept"))
+		assert.Equal(t, "text/markdown", r.Header.Get("Content-Type"))
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		fmt.Fprint(w, "# Support content")
+	}))
+	defer server.Close()
+
+	client := NewClient("0.1.0").WithOptions(WithHTTPClient(routeRequestsTo(server.URL)))
+	ref := &url.URL{
+		Scheme:   "https",
+		Host:     supportHost,
+		Path:     "/questions/search",
+		RawQuery: "topic=a+b&source=cli",
+		Fragment: "details",
+	}
+	got, err := client.FetchPage(context.Background(), ref)
+
+	require.NoError(t, err)
+	assert.Equal(t, "/questions/search", gotPath)
+	assert.Equal(t, "topic=a+b&source=cli", gotQuery)
+	assert.Equal(t, []byte("# Support content"), got.Content)
+	assert.Equal(t, "https://support.stripe.com/questions/search?topic=a+b&source=cli#details", got.URL.String())
 }
 
 func TestFetchPage_ContextCanceled(t *testing.T) {
@@ -663,6 +714,35 @@ func TestFetchPageWithPrefs(t *testing.T) {
 	}
 }
 
+func TestFetchPage_SupportHostDoesNotApplyPrefs(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "text/markdown")
+		fmt.Fprint(w, "content")
+	}))
+	defer server.Close()
+
+	cache := newMockCache()
+	client := NewClient("test").WithOptions(
+		WithHTTPClient(routeRequestsTo(server.URL)),
+		WithCache(cache),
+		WithPrefs(map[string]string{"lang": "go", "theme": "dark"}),
+	)
+	ref := &url.URL{
+		Scheme:   "https",
+		Host:     supportHost,
+		Path:     "/questions",
+		RawQuery: "lang=ruby&topic=payments",
+	}
+	_, err := client.FetchPage(context.Background(), ref)
+
+	require.NoError(t, err)
+	assert.Equal(t, "lang=ruby&topic=payments", gotQuery)
+	require.Len(t, cache.data, 1)
+	assert.Contains(t, cache.data, "https://support.stripe.com/questions?lang=ruby&topic=payments")
+}
+
 func TestFetchPage_Authenticated_UsesAPIEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v2/docs/page", r.URL.Path)
@@ -685,6 +765,59 @@ func TestFetchPage_Authenticated_UsesAPIEndpoint(t *testing.T) {
 	assert.Equal(t, []byte("page content"), got.Content)
 	assert.Equal(t, "docs.stripe.com", got.URL.Host)
 	assert.Equal(t, "/payments", got.URL.Path)
+}
+
+func TestFetchPage_Authenticated_SupportHostStaysDirect(t *testing.T) {
+	apiCalls := 0
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls++
+		http.Error(w, "unexpected API request", http.StatusInternalServerError)
+	}))
+	defer apiServer.Close()
+
+	supportCalls := 0
+	supportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		supportCalls++
+		assert.Equal(t, "/questions", r.URL.Path)
+		assert.Equal(t, "topic=payments", r.URL.RawQuery)
+		assert.Empty(t, r.Header.Get("Authorization"))
+		assert.Empty(t, r.Header.Get("Stripe-Version"))
+		w.Header().Set("Content-Type", "text/markdown")
+		fmt.Fprint(w, "support content")
+	}))
+	defer supportServer.Close()
+
+	target, err := url.Parse(supportServer.URL)
+	require.NoError(t, err)
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host != supportHost {
+			return http.DefaultTransport.RoundTrip(req)
+		}
+
+		original := req.Clone(req.Context())
+		forwarded := req.Clone(req.Context())
+		forwarded.URL.Scheme = target.Scheme
+		forwarded.URL.Host = target.Host
+		resp, err := http.DefaultTransport.RoundTrip(forwarded)
+		if resp != nil {
+			resp.Request = original
+		}
+		return resp, err
+	})}
+
+	client := NewClient("0.1.0").WithOptions(
+		WithAPIBaseURL(apiServer.URL),
+		WithAPIKey("test_key"),
+		WithHTTPClient(httpClient),
+	)
+	ref := &url.URL{Scheme: "https", Host: supportHost, Path: "/questions", RawQuery: "topic=payments"}
+	got, err := client.FetchPage(context.Background(), ref)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte("support content"), got.Content)
+	assert.Equal(t, "https://support.stripe.com/questions?topic=payments", got.URL.String())
+	assert.Equal(t, 1, supportCalls)
+	assert.Zero(t, apiCalls)
 }
 
 func TestFetchPage_Authenticated_ForwardsLocatorPath(t *testing.T) {

--- a/pkg/docs/tui/model.go
+++ b/pkg/docs/tui/model.go
@@ -393,7 +393,9 @@ func (m Model) handleSelected(msg palette.SelectedMsg) (Model, tea.Cmd) {
 		if hit.external {
 			u := hit.url
 			return m, func() tea.Msg {
-				_ = open.OpenURL(context.Background(), u, docsAllowedHosts)
+				if err := open.OpenURL(context.Background(), u, docsAllowedHosts); err != nil {
+					return statusMsg("Failed to open")
+				}
 				return statusMsg("Opened!")
 			}
 		}
@@ -457,11 +459,16 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.PageDown):
 		m.viewport.PageDown()
 	case key.Matches(msg, m.keys.OpenInBrowser):
+		var err error
 		if m.isLanding() {
-			_ = open.OpenURL(context.Background(), &url.URL{Scheme: "https", Host: docsHost, Path: "/"}, docsAllowedHosts)
+			err = open.OpenURL(context.Background(), &url.URL{Scheme: "https", Host: docsHost, Path: "/"}, docsAllowedHosts)
 		} else {
-			_ = m.page.Open(context.Background())
+			err = m.page.Open(context.Background())
 		}
+		if err != nil {
+			return m, func() tea.Msg { return statusMsg("Failed to open") }
+		}
+		return m, func() tea.Msg { return statusMsg("Opened!") }
 	case key.Matches(msg, m.keys.Back):
 		return m.handleBack()
 	}

--- a/pkg/docs/tui/page.go
+++ b/pkg/docs/tui/page.go
@@ -10,7 +10,10 @@ import (
 	"github.com/stripe/stripe-cli/pkg/open"
 )
 
-var docsAllowedHosts = map[string]bool{"docs.stripe.com": true}
+var docsAllowedHosts = map[string]bool{
+	"docs.stripe.com":    true,
+	"support.stripe.com": true,
+}
 
 // Page holds the raw content and metadata needed by the TUI to display a
 // documentation page. Callers construct a Page from a fetched docs response

--- a/pkg/docs/tui/palette.go
+++ b/pkg/docs/tui/palette.go
@@ -87,7 +87,9 @@ func newPalette(page Page, doc *markdown.Document, client *docs.Client) Palette 
 			Desc: "Open this page on docs.stripe.com",
 			Run: func() tea.Cmd {
 				return func() tea.Msg {
-					_ = page.Open(context.Background())
+					if err := page.Open(context.Background()); err != nil {
+						return statusMsg("Failed to open")
+					}
 					return statusMsg("Opened!")
 				}
 			},


### PR DESCRIPTION
 ### Summary

Developers and agents need to occasionally access articles on support.stripe.com which aren't represented or may be linked to from docs.stripe.com. This PR supports passing support.stripe.com articles and showing the Markdown:

**Before**
<img width="1077" height="620" alt="CleanShot 2026-08-21 at 12 03 20" src="https://github.com/user-attachments/assets/fc6d8dc0-3212-4b5e-bc62-f21ba5e2860b" />

**After**
<img width="800" height="278" alt="CleanShot 2026-08-21 at 12 02 00" src="https://github.com/user-attachments/assets/3bec304a-894e-4c09-a483-e8488085511e" />
