### PR TITLE
Preserve display_name/account_id/user_id when refreshing UAT

### DIFF
--- a/pkg/login/oauth_refresh.go
+++ b/pkg/login/oauth_refresh.go
@@ -54,6 +54,7 @@ func refreshOAuthToken(p *config.Profile) error {
 	}
 
 	p.UAT = tokenResp.AccessToken
+	preserveProfileMetadata(p)
 	if err := p.CreateProfile(); err != nil {
 		return err
 	}
@@ -77,6 +78,32 @@ func refreshOAuthToken(p *config.Profile) error {
 	}
 
 	return nil
+}
+
+// preserveProfileMetadata carries forward the display name, account ID, user
+// ID, and device name already persisted for this profile. CreateProfile
+// deletes those fields before rewriting them from p, so unless they're
+// populated here first, a refresh (which only knows the new UAT) would wipe
+// them from the config file.
+func preserveProfileMetadata(p *config.Profile) {
+	if p.DisplayName == "" {
+		p.DisplayName = p.GetDisplayName()
+	}
+	if p.AccountID == "" {
+		if accountID, err := p.GetAccountID(); err == nil {
+			p.AccountID = accountID
+		}
+	}
+	if p.UserID == "" {
+		if userID, err := p.GetUserID(); err == nil {
+			p.UserID = userID
+		}
+	}
+	if p.DeviceName == "" {
+		if deviceName, err := p.GetDeviceName(); err == nil {
+			p.DeviceName = deviceName
+		}
+	}
 }
 
 // doRefreshToken calls the token endpoint with grant_type=refresh_token.

--- a/pkg/login/oauth_refresh_test.go
+++ b/pkg/login/oauth_refresh_test.go
@@ -1,0 +1,56 @@
+package login
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+// TestRefreshOAuthToken_PreservesProfileMetadata guards against a regression
+// where refreshing the UAT wiped display_name/account_id/user_id: the refresh
+// path only learns the new access token, but CreateProfile deletes those
+// fields before rewriting whatever is (or isn't) set on the Profile struct.
+func TestRefreshOAuthToken_PreservesProfileMetadata(t *testing.T) {
+	cfg, cleanup := setupOAuthTestConfig(t)
+	defer cleanup()
+
+	// Simulate a completed login: display name, account ID, and user ID are
+	// persisted alongside the access token.
+	cfg.Profile.UAT = "oaac_old_access"
+	cfg.Profile.DisplayName = "Acme Inc"
+	cfg.Profile.AccountID = "acct_123"
+	cfg.Profile.UserID = "user_123"
+	require.NoError(t, cfg.Profile.CreateProfile())
+
+	require.NoError(t, config.KeyRing.Set(config.OAuthRefreshTokenKeychainKey, []byte("oart_old_refresh"), "test"))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(OAuthTokenResponse{ //nolint:errcheck
+			AccessToken:  "oaac_new_access",
+			RefreshToken: "oart_new_refresh",
+			TokenType:    "Bearer",
+			ExpiresIn:    3600,
+		})
+	}))
+	defer ts.Close()
+
+	p := &config.Profile{
+		ProfileName:        cfg.Profile.ProfileName,
+		OAuthAccessBaseURL: ts.URL,
+	}
+	require.NoError(t, refreshOAuthToken(p))
+
+	assert.Equal(t, "oaac_new_access", p.UAT)
+	assert.Equal(t, "Acme Inc", viper.GetString(p.GetConfigField(config.DisplayNameName)))
+	assert.Equal(t, "acct_123", viper.GetString(p.GetConfigField(config.AccountIDName)))
+	assert.Equal(t, "user_123", viper.GetString(p.GetConfigField(config.UserIDName)))
+}


### PR DESCRIPTION
Fix a bug where when we refresh an expired UAT, we delete data in the profile. This causes us to lose the name of the account. For example:
```
stripe customers list --limit 1 --live
▸ Running in  · live (acct_1NRKwLLJDmqA11cn)
```

It's supposed to look like:
```
stripe customers list --limit 1 --live
▸ Running in Tomer's Chicken n' Waffles (v1 Workbench) · live (acct_1NRKwLLJDmqA11cn)
```