### PR TITLE
Enforce min_core_version when installing a plugin

### DIFF
--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -102,6 +102,15 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	isLatest := len(version) == 0
 	resolvedPlugin, err := plugins.ResolvePluginForInstall(cmd.Context(), ic.cfg, ic.fs, pluginName, version, ic.apiBaseURL, dashboardBaseURL)
 	if err != nil {
+		// Reported before the branches below, which read every other failure as
+		// possibly an authentication problem and offer to log in. Logging in cannot
+		// make this CLI new enough to run the release, so prompting for it would send
+		// the user somewhere that never resolves.
+		var requiresNewerCLI *plugins.ErrPluginRequiresNewerCLI
+		if errors.As(err, &requiresNewerCLI) {
+			return err
+		}
+
 		var pluginNotFound *plugins.ErrPluginNotFound
 		if errors.As(err, &pluginNotFound) {
 			accountID, aErr := ic.cfg.GetProfile().GetAccountID()

--- a/pkg/cmd/plugin/install.go
+++ b/pkg/cmd/plugin/install.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"strings"
@@ -23,6 +24,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/plugins"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 // InstallCmd is the struct used for configuring the plugin install command
@@ -182,6 +184,9 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 	if prevVersion != "" {
 		sendPluginLifecycleEvent(cmd.Context(), "Plugin Upgraded", version)
 		fmt.Println(color.Green(fmt.Sprintf("✔ %s from v%s to v%s.", versionChangeVerb(prevVersion, version), prevVersion, version)))
+		if isLatest {
+			printUnrequestedDowngradeNote(os.Stdout, plugin.Shortname, prevVersion, version)
+		}
 	} else {
 		sendPluginLifecycleEvent(cmd.Context(), "Plugin Installed", version)
 		fmt.Println(color.Green(fmt.Sprintf("✔ installation of v%s complete.", version)))
@@ -192,12 +197,41 @@ func (ic *InstallCmd) runInstallCmd(cmd *cobra.Command, args []string) error {
 }
 
 func versionChangeVerb(from, to string) string {
-	prev, prevErr := goversion.NewVersion(from)
-	next, nextErr := goversion.NewVersion(to)
-	if prevErr == nil && nextErr == nil && prev.GreaterThan(next) {
+	if isVersionDowngrade(from, to) {
 		return "downgraded"
 	}
 	return "upgraded"
+}
+
+func isVersionDowngrade(from, to string) bool {
+	prev, prevErr := goversion.NewVersion(from)
+	next, nextErr := goversion.NewVersion(to)
+
+	return prevErr == nil && nextErr == nil && prev.GreaterThan(next)
+}
+
+// printUnrequestedDowngradeNote explains a rollback the user did not ask for: they
+// asked for the latest release and got one older than what was already installed.
+// Callers that install a version the user named skip it, since nothing there is
+// surprising.
+//
+// A core CLI that no longer meets a plugin's min_core_version is the reason this
+// happens on its own -- the API withholds the releases this CLI cannot run, so
+// "latest" moves backwards after a CLI downgrade. But the API only sends back the
+// release it chose, not why the newer ones were left out, and a withdrawn release
+// looks identical from here. So this names what the CLI can actually vouch for --
+// the newest release offered to this version of the CLI -- and points at the
+// upgrade without claiming to know it is the fix.
+func printUnrequestedDowngradeNote(w io.Writer, pluginName, prevVersion, newVersion string) {
+	if !isVersionDowngrade(prevVersion, newVersion) {
+		return
+	}
+
+	color := ansi.Color(w)
+	fmt.Fprintln(w, color.Yellow(fmt.Sprintf(
+		"v%s is the newest %s release available to Stripe CLI %s. Newer releases may require a newer Stripe CLI: https://docs.stripe.com/stripe-cli/upgrade",
+		newVersion, pluginName, version.Version,
+	)).String())
 }
 
 func (ic *InstallCmd) setInstallTelemetryMetadata(ctx context.Context, pluginName string) {

--- a/pkg/cmd/plugin/install_test.go
+++ b/pkg/cmd/plugin/install_test.go
@@ -2,14 +2,20 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stripe/stripe-cli/pkg/plugins"
 	"github.com/stripe/stripe-cli/pkg/stripe"
+	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 func TestParseArg(t *testing.T) {
@@ -67,6 +73,67 @@ func TestRunInstallCmdNonExistentPluginNotLoggedIn(t *testing.T) {
 	err := ic.runInstallCmd(ic.Cmd, []string{"nonexistent-plugin"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "login canceled")
+}
+
+// TestRunInstallCmdPluginRequiresNewerCLI pins that a version problem is reported
+// as one. Not being logged in is the other reason a plugin can fail to resolve, and
+// the command cannot tell the two apart from the error alone -- so without the
+// typed check it offers to log in, which can never make this CLI new enough.
+func TestRunInstallCmdPluginRequiresNewerCLI(t *testing.T) {
+	cfg, fs, cleanup := setupPluginCommandTest(t)
+	defer cleanup()
+	cfg.Profile.APIKey = ""
+	cfg.Profile.AccountID = ""
+
+	originalVersion := version.Version
+	version.Version = "1.29.0"
+	defer func() { version.Version = originalVersion }()
+
+	// A release hidden for being incompatible makes the endpoint 404, which is what
+	// sends the install to cached metadata in the first place. That cache was written
+	// by whichever CLI installed the plugin last, possibly a newer one.
+	configPath := cfg.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+	metadataPath := filepath.Join(configPath, "plugin-metadata", "appA.toml")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(metadataPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, metadataPath, []byte(fmt.Sprintf(`[[Plugin]]
+  Shortname = "appA"
+  Binary = "stripe-cli-app-a"
+  MagicCookieValue = "APP-A-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "2.0.1"
+    Sum = "abc123"
+    MinCoreVersion = "1.30.0"
+`, runtime.GOARCH, runtime.GOOS)), 0644))
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusNotFound)
+		_, _ = res.Write([]byte(`{"error":{"message":"not found"}}`))
+	}))
+	defer server.Close()
+
+	// Left empty on purpose: anything reading stdin here is the login prompt, and it
+	// would read EOF and go on to open a browser.
+	origStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	_ = w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	ic := NewInstallCmd(cfg)
+	ic.fs = fs
+	ic.apiBaseURL = server.URL
+	ic.dashboardBaseURL = server.URL
+	ic.Cmd.SetContext(context.Background())
+
+	err := ic.runInstallCmd(ic.Cmd, []string{"appA@2.0.1"})
+
+	var requiresNewerCLI *plugins.ErrPluginRequiresNewerCLI
+	require.ErrorAs(t, err, &requiresNewerCLI)
+	require.Equal(t, "1.30.0", requiresNewerCLI.MinCoreVersion)
+	require.NotContains(t, err.Error(), "logged in")
 }
 
 func TestRunInstallCmdNonExistentPluginLoggedIn(t *testing.T) {

--- a/pkg/cmd/plugin/install_test.go
+++ b/pkg/cmd/plugin/install_test.go
@@ -89,9 +89,8 @@ func TestRunInstallCmdPluginRequiresNewerCLI(t *testing.T) {
 	version.Version = "1.29.0"
 	defer func() { version.Version = originalVersion }()
 
-	// A release hidden for being incompatible makes the endpoint 404, which is what
-	// sends the install to cached metadata in the first place. That cache was written
-	// by whichever CLI installed the plugin last, possibly a newer one.
+	// Cached metadata that could satisfy the install, so the endpoint's refusal is
+	// shown to outrank an available fallback rather than being the only thing left.
 	configPath := cfg.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
 	metadataPath := filepath.Join(configPath, "plugin-metadata", "appA.toml")
 	require.NoError(t, fs.MkdirAll(filepath.Dir(metadataPath), 0755))
@@ -105,12 +104,12 @@ func TestRunInstallCmdPluginRequiresNewerCLI(t *testing.T) {
     OS = "%s"
     Version = "2.0.1"
     Sum = "abc123"
-    MinCoreVersion = "1.30.0"
 `, runtime.GOARCH, runtime.GOOS)), 0644))
 
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		res.WriteHeader(http.StatusNotFound)
-		_, _ = res.Write([]byte(`{"error":{"message":"not found"}}`))
+		res.Header().Set("Content-Type", "application/json")
+		res.WriteHeader(http.StatusBadRequest)
+		_, _ = res.Write([]byte(`{"error":{"code":"plugin_requires_newer_cli","message":"Version 2.0.1 of the appA plugin requires Stripe CLI 1.30.0 or later.","min_core_version":"1.30.0","param":"version","type":"invalid_request_error"}}`))
 	}))
 	defer server.Close()
 

--- a/pkg/cmd/plugin/install_test.go
+++ b/pkg/cmd/plugin/install_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -161,4 +162,38 @@ func TestRunInstallCmdNonExistentPluginLoggedIn(t *testing.T) {
 	require.Contains(t, err.Error(), "no plugin named")
 	require.Contains(t, err.Error(), "nonexistent-plugin")
 	require.Contains(t, err.Error(), "exists")
+}
+
+func TestPrintUnrequestedDowngradeNote(t *testing.T) {
+	originalVersion := version.Version
+	version.Version = "1.20.0"
+	defer func() { version.Version = originalVersion }()
+
+	tests := []struct {
+		name        string
+		prevVersion string
+		newVersion  string
+		expectNote  bool
+	}{
+		{name: "rollback to an older release", prevVersion: "2.0.0", newVersion: "1.5.0", expectNote: true},
+		{name: "ordinary upgrade", prevVersion: "1.5.0", newVersion: "2.0.0"},
+		{name: "same version", prevVersion: "2.0.0", newVersion: "2.0.0"},
+		{name: "unparseable versions", prevVersion: "not-a-version", newVersion: "1.5.0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var out strings.Builder
+			printUnrequestedDowngradeNote(&out, "appA", test.prevVersion, test.newVersion)
+
+			if !test.expectNote {
+				require.Empty(t, out.String())
+				return
+			}
+
+			require.Contains(t, out.String(), "v1.5.0 is the newest appA release available to Stripe CLI 1.20.0")
+			require.Contains(t, out.String(), "Newer releases may require a newer Stripe CLI")
+			require.Contains(t, out.String(), "https://docs.stripe.com/stripe-cli/upgrade")
+		})
+	}
 }

--- a/pkg/cmd/plugin/upgrade.go
+++ b/pkg/cmd/plugin/upgrade.go
@@ -95,6 +95,9 @@ func (uc *UpgradeCmd) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 
 	if prevVersion != "" {
 		fmt.Println(color.Green(fmt.Sprintf("✔ %s from v%s to v%s.", versionChangeVerb(prevVersion, version), prevVersion, version)))
+		// Always eligible here: upgrade takes no version, so the user only ever asked
+		// for the latest.
+		printUnrequestedDowngradeNote(os.Stdout, plugin.Shortname, prevVersion, version)
 	} else {
 		fmt.Println(color.Green(fmt.Sprintf("✔ upgrade to v%s complete.", version)))
 	}

--- a/pkg/cmd/pluginhints/pluginhints.go
+++ b/pkg/cmd/pluginhints/pluginhints.go
@@ -4,6 +4,7 @@ package pluginhints
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -245,13 +246,23 @@ func (p *pluginHintCmd) run(cmd *cobra.Command, args []string) error {
 		return p.refuseAutoInstall()
 	}
 
-	if resolved, err := p.lookupFn(ctx); err == nil {
+	resolved, lookupErr := p.lookupFn(ctx)
+	if lookupErr == nil {
 		switch {
 		case p.autoInstallEnabled(resolved) && p.invokedByName(cmd):
 			return p.autoInstallAndRun(ctx, cmd, p.pluginArgs())
 		default:
 			return p.promptInstall(ctx)
 		}
+	}
+
+	// A plugin that exists but needs a newer core CLI is a version problem with one
+	// fix, so say so. Everything below treats a failed lookup as the plugin being
+	// unavailable or the user being logged out, and both of those answers would send
+	// the user after something that cannot help.
+	var requiresNewerCLI *plugins.ErrPluginRequiresNewerCLI
+	if errors.As(lookupErr, &requiresNewerCLI) {
+		return lookupErr
 	}
 
 	if p.privatePreview {

--- a/pkg/cmd/pluginhints/pluginhints_test.go
+++ b/pkg/cmd/pluginhints/pluginhints_test.go
@@ -582,6 +582,42 @@ func TestRun_AutoInstall_LookupFailureStillFallsBackToHints(t *testing.T) {
 	assert.Contains(t, p.output(), "stripe plugin install directory")
 }
 
+// TestRun_PluginRequiresNewerCLI_ReportsVersionInsteadOfHints covers a lookup that
+// failed for a reason with exactly one fix. The hint and login paths below both read
+// a failed lookup as the plugin being unavailable or the user being logged out, so
+// either would send the user after something that cannot help.
+func TestRun_PluginRequiresNewerCLI_ReportsVersionInsteadOfHints(t *testing.T) {
+	for _, name := range []string{"logged in", "not logged in"} {
+		t.Run(name, func(t *testing.T) {
+			p := newTestCmd("directory")
+			if name == "not logged in" {
+				p.accountIDFn = func() (string, error) { return "", nil }
+			}
+			loginCalled, installCalled := false, false
+			p.loginFn = func(ctx context.Context) error { loginCalled = true; return nil }
+			p.installFn = func(ctx context.Context) error { installCalled = true; return nil }
+			p.lookupFn = func(context.Context) (*plugins.ResolvedPluginVersion, error) {
+				return nil, &plugins.ErrPluginRequiresNewerCLI{
+					Name:           "directory",
+					Version:        "2.0.1",
+					MinCoreVersion: "1.30.0",
+					CoreVersion:    "1.29.0",
+				}
+			}
+
+			err := p.run(p.Command, nil)
+
+			var requiresNewerCLI *plugins.ErrPluginRequiresNewerCLI
+			require.ErrorAs(t, err, &requiresNewerCLI)
+			assert.Equal(t, "1.30.0", requiresNewerCLI.MinCoreVersion)
+			assert.False(t, loginCalled)
+			assert.False(t, installCalled)
+			assert.NotContains(t, p.output(), "stripe plugin install directory")
+			assert.NotContains(t, p.output(), "stripe login")
+		})
+	}
+}
+
 // TestRun_AutoInstall_ServerDecisionGatesInstalling pins that opting a plugin into
 // auto-install only makes it eligible: the metadata endpoint decides per machine,
 // so a machine the rollout has not reached gets the same prompt as every other

--- a/pkg/plugins/min_core_version.go
+++ b/pkg/plugins/min_core_version.go
@@ -1,0 +1,124 @@
+package plugins
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	goversion "github.com/hashicorp/go-version"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/version"
+)
+
+// developmentCoreVersion is the version a CLI built from source reports. The
+// plugin metadata API treats it as newer than every published release, so the
+// same allowance is made here: otherwise a local build could not install a
+// restricted release the API happily hands it.
+const developmentCoreVersion = "master"
+
+// coreVersionSemver bounds what counts as a comparable core CLI version. It
+// matches the API's own VALID_SEMVER so that a release the API considers
+// reachable is never rejected here, and vice versa.
+var coreVersionSemver = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+// ErrPluginRequiresNewerCLI is returned when a plugin release declares a minimum
+// core CLI version that the running CLI does not meet.
+type ErrPluginRequiresNewerCLI struct {
+	Name           string
+	Version        string
+	MinCoreVersion string
+	CoreVersion    string
+}
+
+func (e *ErrPluginRequiresNewerCLI) Error() string {
+	return fmt.Sprintf(
+		"the %s plugin v%s requires Stripe CLI v%s or newer, but this is Stripe CLI %s. Upgrade the Stripe CLI to install it: https://docs.stripe.com/stripe-cli/upgrade",
+		e.Name, e.Version, e.MinCoreVersion, e.CoreVersion,
+	)
+}
+
+// coreVersionSupports reports whether the running core CLI satisfies a release's
+// MinCoreVersion constraint. An empty constraint means the release places no
+// requirement on the core CLI, which is every release that predates the field.
+//
+// This deliberately mirrors the plugin metadata API's own compatibility check
+// (PluginMetadata.core_version_supports_release?). The API already hides
+// incompatible releases from live responses, so the two must agree or the same
+// release would be installable from one source and not the other.
+//
+// It is enforced again on this side because cached plugin metadata outlives the
+// CLI that wrote it. A CLI that was downgraded, or that cannot reach the API,
+// resolves installs from `plugin-metadata/*.toml` and `plugins.toml` instead --
+// caches a newer CLI populated -- and nothing in that path consults the API.
+// Being hidden from the API is itself what sends an older CLI down it, since a
+// hidden release makes the metadata endpoint 404.
+//
+// Anything unparseable counts as unsupported rather than unconstrained: a
+// constraint that cannot be evaluated is precisely the case where installing
+// anyway risks a binary that will not run.
+func coreVersionSupports(minCoreVersion string) bool {
+	if minCoreVersion == "" {
+		return true
+	}
+
+	current := normalizeCoreVersion(version.Version)
+	if current == developmentCoreVersion {
+		return true
+	}
+	if !coreVersionSemver.MatchString(current) {
+		return false
+	}
+
+	currentVersion, err := goversion.NewVersion(current)
+	if err != nil {
+		return false
+	}
+
+	minimumVersion, err := goversion.NewVersion(normalizeCoreVersion(minCoreVersion))
+	if err != nil {
+		return false
+	}
+
+	return currentVersion.GreaterThanOrEqual(minimumVersion)
+}
+
+// normalizeCoreVersion tolerates a leading "v" on either side of the comparison.
+// Published versions carry no prefix, but pkg/version already strips one when
+// comparing CLI versions, so accepting it here keeps the two consistent.
+func normalizeCoreVersion(rawVersion string) string {
+	return strings.TrimPrefix(strings.TrimSpace(rawVersion), "v")
+}
+
+// checkCoreVersionForRelease returns an *ErrPluginRequiresNewerCLI when the
+// release for pluginVersion on this platform declares a MinCoreVersion the
+// running CLI does not meet.
+//
+// A version with no matching release returns nil. Whether a release exists is
+// not this check's question, and every caller already reports that case itself
+// with more context than this could.
+func (p *Plugin) checkCoreVersionForRelease(pluginVersion string) error {
+	if pluginVersion == "" || isLocalDevelopmentVersion(pluginVersion) {
+		return nil
+	}
+
+	release := p.getReleaseForVersion(pluginVersion)
+	if release == nil || coreVersionSupports(release.MinCoreVersion) {
+		return nil
+	}
+
+	return errorcategory.With(&ErrPluginRequiresNewerCLI{
+		Name:           p.Shortname,
+		Version:        pluginVersion,
+		MinCoreVersion: release.MinCoreVersion,
+		CoreVersion:    version.Version,
+	}, errorcategory.UserInput)
+}
+
+// checkCoreVersionForLatestRelease reports the requires-a-newer-CLI case behind
+// an empty LookUpLatestVersion result. It exists so that "every release for this
+// platform needs a newer CLI" is not reported as "this plugin has no releases",
+// which reads as though the plugin were unavailable altogether.
+func (p *Plugin) checkCoreVersionForLatestRelease() error {
+	return p.checkCoreVersionForRelease(p.lookUpLatestVersion(false))
+}

--- a/pkg/plugins/min_core_version.go
+++ b/pkg/plugins/min_core_version.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -64,6 +65,17 @@ func newErrPluginRequiresNewerCLI(name, pluginVersion, minCoreVersion string) er
 		MinCoreVersion: minCoreVersion,
 		CoreVersion:    version.Version,
 	}, errorcategory.UserInput)
+}
+
+// requiresNewerCLI reports whether err is the requires-a-newer-CLI answer.
+//
+// The resolve paths check it to stop before their cached fallback. That fallback is
+// there to survive a source that could not answer, not to overrule one that did,
+// and cached metadata can predate the constraint entirely -- so letting it win here
+// would drop the constraint on exactly the machines it exists to stop.
+func requiresNewerCLI(err error) bool {
+	var requiresNewer *ErrPluginRequiresNewerCLI
+	return errors.As(err, &requiresNewer)
 }
 
 // coreVersionSupports reports whether the running core CLI satisfies a release's

--- a/pkg/plugins/min_core_version.go
+++ b/pkg/plugins/min_core_version.go
@@ -9,7 +9,8 @@ import (
 )
 
 // ErrPluginRequiresNewerCLI is returned when the plugin metadata endpoint answers
-// that the requested plugin version needs a newer core CLI than this one.
+// that the plugin needs a newer core CLI than this one. Version is the release the
+// caller asked for, and is empty when the caller asked for no particular one.
 //
 // Whether a release meets its own min_core_version is decided entirely by the API,
 // which knows the constraint for every release and hides the ones this CLI cannot

--- a/pkg/plugins/min_core_version.go
+++ b/pkg/plugins/min_core_version.go
@@ -3,28 +3,19 @@ package plugins
 import (
 	"errors"
 	"fmt"
-	"regexp"
-	"strings"
-
-	goversion "github.com/hashicorp/go-version"
 
 	"github.com/stripe/stripe-cli/pkg/errorcategory"
 	"github.com/stripe/stripe-cli/pkg/version"
 )
 
-// developmentCoreVersion is the version a CLI built from source reports. The
-// plugin metadata API treats it as newer than every published release, so the
-// same allowance is made here: otherwise a local build could not install a
-// restricted release the API happily hands it.
-const developmentCoreVersion = "master"
-
-// coreVersionSemver bounds what counts as a comparable core CLI version. It
-// matches the API's own VALID_SEMVER so that a release the API considers
-// reachable is never rejected here, and vice versa.
-var coreVersionSemver = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
-
-// ErrPluginRequiresNewerCLI is returned when a plugin release declares a minimum
-// core CLI version that the running CLI does not meet.
+// ErrPluginRequiresNewerCLI is returned when the plugin metadata endpoint answers
+// that the requested plugin version needs a newer core CLI than this one.
+//
+// Whether a release meets its own min_core_version is decided entirely by the API,
+// which knows the constraint for every release and hides the ones this CLI cannot
+// run. Nothing here re-derives that judgment: an install cannot complete without a
+// binary URL from a live metadata response, so there is no path that reaches a
+// download the API did not agree to.
 type ErrPluginRequiresNewerCLI struct {
 	Name           string
 	Version        string
@@ -52,9 +43,8 @@ func (e *ErrPluginRequiresNewerCLI) Error() string {
 	)
 }
 
-// newErrPluginRequiresNewerCLI builds the error every requires-a-newer-CLI report
-// goes through, so that the constraint the metadata endpoint states and the one
-// read out of a manifest are reported and routed identically.
+// newErrPluginRequiresNewerCLI builds the error both metadata lookups report, so
+// that the endpoint's answer is routed identically whichever one received it.
 //
 // It is categorized as user input because the actionable part belongs to the
 // caller: install a version this CLI supports, or upgrade the CLI.
@@ -71,89 +61,9 @@ func newErrPluginRequiresNewerCLI(name, pluginVersion, minCoreVersion string) er
 //
 // The resolve paths check it to stop before their cached fallback. That fallback is
 // there to survive a source that could not answer, not to overrule one that did,
-// and cached metadata can predate the constraint entirely -- so letting it win here
-// would drop the constraint on exactly the machines it exists to stop.
+// and the cache holds no constraint of its own to weigh against this -- so letting
+// it win here would trade a precise answer for "no such version".
 func requiresNewerCLI(err error) bool {
 	var requiresNewer *ErrPluginRequiresNewerCLI
 	return errors.As(err, &requiresNewer)
-}
-
-// coreVersionSupports reports whether the running core CLI satisfies a release's
-// MinCoreVersion constraint. An empty constraint means the release places no
-// requirement on the core CLI, which is every release that predates the field.
-//
-// This deliberately mirrors the plugin metadata API's own compatibility check
-// (PluginMetadata.core_version_supports_release?). The API already hides
-// incompatible releases from live responses, so the two must agree or the same
-// release would be installable from one source and not the other.
-//
-// It is enforced again on this side because cached plugin metadata outlives the
-// CLI that wrote it. A CLI that was downgraded, or that cannot reach the API,
-// resolves installs from `plugin-metadata/*.toml` and `plugins.toml` instead --
-// caches a newer CLI populated -- and nothing in that path consults the API.
-// Being hidden from the API is itself what sends an older CLI down it, since a
-// hidden release makes the metadata endpoint 404.
-//
-// Anything unparseable counts as unsupported rather than unconstrained: a
-// constraint that cannot be evaluated is precisely the case where installing
-// anyway risks a binary that will not run.
-func coreVersionSupports(minCoreVersion string) bool {
-	if minCoreVersion == "" {
-		return true
-	}
-
-	current := normalizeCoreVersion(version.Version)
-	if current == developmentCoreVersion {
-		return true
-	}
-	if !coreVersionSemver.MatchString(current) {
-		return false
-	}
-
-	currentVersion, err := goversion.NewVersion(current)
-	if err != nil {
-		return false
-	}
-
-	minimumVersion, err := goversion.NewVersion(normalizeCoreVersion(minCoreVersion))
-	if err != nil {
-		return false
-	}
-
-	return currentVersion.GreaterThanOrEqual(minimumVersion)
-}
-
-// normalizeCoreVersion tolerates a leading "v" on either side of the comparison.
-// Published versions carry no prefix, but pkg/version already strips one when
-// comparing CLI versions, so accepting it here keeps the two consistent.
-func normalizeCoreVersion(rawVersion string) string {
-	return strings.TrimPrefix(strings.TrimSpace(rawVersion), "v")
-}
-
-// checkCoreVersionForRelease returns an *ErrPluginRequiresNewerCLI when the
-// release for pluginVersion on this platform declares a MinCoreVersion the
-// running CLI does not meet.
-//
-// A version with no matching release returns nil. Whether a release exists is
-// not this check's question, and every caller already reports that case itself
-// with more context than this could.
-func (p *Plugin) checkCoreVersionForRelease(pluginVersion string) error {
-	if pluginVersion == "" || isLocalDevelopmentVersion(pluginVersion) {
-		return nil
-	}
-
-	release := p.getReleaseForVersion(pluginVersion)
-	if release == nil || coreVersionSupports(release.MinCoreVersion) {
-		return nil
-	}
-
-	return newErrPluginRequiresNewerCLI(p.Shortname, pluginVersion, release.MinCoreVersion)
-}
-
-// checkCoreVersionForLatestRelease reports the requires-a-newer-CLI case behind
-// an empty LookUpLatestVersion result. It exists so that "every release for this
-// platform needs a newer CLI" is not reported as "this plugin has no releases",
-// which reads as though the plugin were unavailable altogether.
-func (p *Plugin) checkCoreVersionForLatestRelease() error {
-	return p.checkCoreVersionForRelease(p.lookUpLatestVersion(false))
 }

--- a/pkg/plugins/min_core_version.go
+++ b/pkg/plugins/min_core_version.go
@@ -12,11 +12,21 @@ import (
 // that the plugin needs a newer core CLI than this one. Version is the release the
 // caller asked for, and is empty when the caller asked for no particular one.
 //
-// Whether a release meets its own min_core_version is decided entirely by the API,
-// which knows the constraint for every release and hides the ones this CLI cannot
-// run. Nothing here re-derives that judgment: an install cannot complete without a
-// binary URL from a live metadata response, so there is no path that reaches a
-// download the API did not agree to.
+// This is the one place min_core_version is explained. The rest of the package
+// points back here instead of restating it, so there is a single copy to keep true.
+//
+// The API owns the judgment: it knows the constraint for every release and withholds
+// the ones this CLI cannot run, sending this answer when that leaves nothing to hand
+// back. See requests.PluginRequiresNewerCLI for when it does so. Two things follow
+// for this package:
+//
+//   - Nothing re-derives the constraint. Releases carry MinCoreVersion in the
+//     manifest and it is deliberately left undecoded, and a manifest that came from
+//     the endpoint has already been filtered, so the newest release it lists is the
+//     newest one this CLI can install.
+//   - Nothing has to. An install cannot complete without a binary URL from a live
+//     metadata response, so no path reaches a download the API did not agree to.
+//     Reading this answer buys the reason, not the refusal.
 type ErrPluginRequiresNewerCLI struct {
 	Name           string
 	Version        string

--- a/pkg/plugins/min_core_version.go
+++ b/pkg/plugins/min_core_version.go
@@ -32,10 +32,38 @@ type ErrPluginRequiresNewerCLI struct {
 }
 
 func (e *ErrPluginRequiresNewerCLI) Error() string {
+	// Both versions are named whenever they are known, and the ones that come from
+	// the metadata endpoint are only as complete as its response. Degrading the
+	// wording beats rendering "the appA plugin v requires Stripe CLI v or newer".
+	subject := fmt.Sprintf("the %s plugin", e.Name)
+	if e.Version != "" {
+		subject = fmt.Sprintf("the %s plugin v%s", e.Name, e.Version)
+	}
+
+	requirement := "a newer Stripe CLI"
+	if e.MinCoreVersion != "" {
+		requirement = fmt.Sprintf("Stripe CLI v%s or newer", e.MinCoreVersion)
+	}
+
 	return fmt.Sprintf(
-		"the %s plugin v%s requires Stripe CLI v%s or newer, but this is Stripe CLI %s. Upgrade the Stripe CLI to install it: https://docs.stripe.com/stripe-cli/upgrade",
-		e.Name, e.Version, e.MinCoreVersion, e.CoreVersion,
+		"%s requires %s, but this is Stripe CLI %s. Upgrade the Stripe CLI to install it: https://docs.stripe.com/stripe-cli/upgrade",
+		subject, requirement, e.CoreVersion,
 	)
+}
+
+// newErrPluginRequiresNewerCLI builds the error every requires-a-newer-CLI report
+// goes through, so that the constraint the metadata endpoint states and the one
+// read out of a manifest are reported and routed identically.
+//
+// It is categorized as user input because the actionable part belongs to the
+// caller: install a version this CLI supports, or upgrade the CLI.
+func newErrPluginRequiresNewerCLI(name, pluginVersion, minCoreVersion string) error {
+	return errorcategory.With(&ErrPluginRequiresNewerCLI{
+		Name:           name,
+		Version:        pluginVersion,
+		MinCoreVersion: minCoreVersion,
+		CoreVersion:    version.Version,
+	}, errorcategory.UserInput)
 }
 
 // coreVersionSupports reports whether the running core CLI satisfies a release's
@@ -107,12 +135,7 @@ func (p *Plugin) checkCoreVersionForRelease(pluginVersion string) error {
 		return nil
 	}
 
-	return errorcategory.With(&ErrPluginRequiresNewerCLI{
-		Name:           p.Shortname,
-		Version:        pluginVersion,
-		MinCoreVersion: release.MinCoreVersion,
-		CoreVersion:    version.Version,
-	}, errorcategory.UserInput)
+	return newErrPluginRequiresNewerCLI(p.Shortname, pluginVersion, release.MinCoreVersion)
 }
 
 // checkCoreVersionForLatestRelease reports the requires-a-newer-CLI case behind

--- a/pkg/plugins/min_core_version_test.go
+++ b/pkg/plugins/min_core_version_test.go
@@ -47,6 +47,11 @@ func pluginWithRelease(pluginVersion string) Plugin {
 // requiresNewerCLIMetadataServer stands in for the metadata endpoint refusing a
 // release whose min_core_version this CLI does not meet. The body matches the shape
 // the API sends, which is asserted on in pay-server's own tests.
+//
+// An empty pluginVersion sends the answer to a request that named no version, where
+// minCoreVersion is the lowest floor among the plugin's releases. That body names no
+// plugin version and blames no parameter, so passing "" here is what keeps a test of
+// a versionless path from being handed more than the endpoint would give it.
 func requiresNewerCLIMetadataServer(t *testing.T, pluginVersion, minCoreVersion string) *httptest.Server {
 	t.Helper()
 
@@ -55,6 +60,20 @@ func requiresNewerCLIMetadataServer(t *testing.T, pluginVersion, minCoreVersion 
 		case "/v1/stripecli/get-plugin-metadata", "/ajax/stripecli/plugins_metadata":
 			res.Header().Set("Content-Type", "application/json")
 			res.WriteHeader(http.StatusBadRequest)
+
+			if pluginVersion == "" {
+				_, _ = fmt.Fprintf(res, `{
+  "error": {
+    "code": "plugin_requires_newer_cli",
+    "message": "The appA plugin requires Stripe CLI %s or later. Upgrade the Stripe CLI to install it.",
+    "min_core_version": %q,
+    "type": "invalid_request_error"
+  }
+}`, minCoreVersion, minCoreVersion)
+
+				return
+			}
+
 			_, _ = fmt.Fprintf(res, `{
   "error": {
     "code": "plugin_requires_newer_cli",
@@ -138,11 +157,37 @@ func TestResolvePluginForInstallEndpointRequiresNewerCLIOutranksCache(t *testing
 	requireRequiresNewerCLI(t, err, "1.30.0")
 }
 
+// TestResolvePluginForInstallWithoutAVersionReportsEndpointRequiresNewerCLI covers an
+// install that named no version, where every release the plugin has needs a newer CLI
+// than this one. The endpoint reports the lowest of their floors, since that is the
+// nearest version that would make any of them installable.
+//
+// It is a separate case from the named-version one because the answer arrives in a
+// different shape: no plugin version to attribute it to, and no parameter to blame.
+// Reading it still has to yield the minimum, which is the only actionable part.
+func TestResolvePluginForInstallWithoutAVersionReportsEndpointRequiresNewerCLI(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	server := requiresNewerCLIMetadataServer(t, "", "1.30.0")
+	defer server.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "", server.URL, server.URL)
+	require.Nil(t, resolvedPlugin)
+	requireRequiresNewerCLI(t, err, "1.30.0")
+
+	// The plugin is still named, and the sentence still reads, without a version for it.
+	require.Contains(t, err.Error(), "the appA plugin requires Stripe CLI v1.30.0 or newer")
+	require.NotContains(t, err.Error(), "plugin v ")
+	require.NotContains(t, err.Error(), "no plugin named")
+}
+
 // TestResolvePluginForUpgradeReportsEndpointRequiresNewerCLI and its auto-install
-// counterpart pin routing rather than a refusal the endpoint makes today: both paths
-// ask for no particular version, and the endpoint only answers this way for one it
-// was given. They exist so that if it ever does, the answer is reported instead of
-// the cache being allowed to contradict it.
+// counterpart cover the same answer reaching the paths that never name a version, and
+// pin that the cache is not allowed to contradict it there either.
 func TestResolvePluginForUpgradeReportsEndpointRequiresNewerCLI(t *testing.T) {
 	withCoreVersion(t, "1.29.0")
 
@@ -151,7 +196,7 @@ func TestResolvePluginForUpgradeReportsEndpointRequiresNewerCLI(t *testing.T) {
 	config.InitConfig()
 	require.NoError(t, writeLocalPluginMetadata(config, fs, pluginWithRelease("2.0.1")))
 
-	server := requiresNewerCLIMetadataServer(t, "2.0.1", "1.30.0")
+	server := requiresNewerCLIMetadataServer(t, "", "1.30.0")
 	defer server.Close()
 
 	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "appA", server.URL, server.URL)
@@ -167,7 +212,7 @@ func TestResolvePluginForAutoInstallReportsEndpointRequiresNewerCLI(t *testing.T
 	config.InitConfig()
 	require.NoError(t, writeLocalPluginMetadata(config, fs, pluginWithRelease("2.0.1")))
 
-	server := requiresNewerCLIMetadataServer(t, "2.0.1", "1.30.0")
+	server := requiresNewerCLIMetadataServer(t, "", "1.30.0")
 	defer server.Close()
 
 	resolvedPlugin, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", server.URL, server.URL)

--- a/pkg/plugins/min_core_version_test.go
+++ b/pkg/plugins/min_core_version_test.go
@@ -2,8 +2,6 @@ package plugins
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,13 +11,12 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/version"
 )
 
 // withCoreVersion makes the CLI under test report a specific published version.
-// Tests need it because a binary built from source reports "master", which
-// satisfies every MinCoreVersion by design.
+// Tests need it because a binary built from source reports "master", and the
+// version the CLI reports is what these messages are about.
 func withCoreVersion(t *testing.T, reportedVersion string) {
 	t.Helper()
 
@@ -28,43 +25,27 @@ func withCoreVersion(t *testing.T, reportedVersion string) {
 	t.Cleanup(func() { version.Version = previous })
 }
 
-// restrictedPlugin describes a plugin whose only release for this platform needs
-// a newer core CLI than any test here pretends to be.
-func restrictedPlugin(pluginVersion, minCoreVersion string) Plugin {
+// pluginWithRelease describes a plugin with a single release for this platform,
+// which is enough for a cached lookup to succeed. Tests use it to make sure the
+// fallback they are asserting does not happen was actually available.
+func pluginWithRelease(pluginVersion string) Plugin {
 	return Plugin{
 		Shortname:        "appA",
 		Binary:           "stripe-cli-app-a",
 		MagicCookieValue: "APP-A-COOKIE",
 		Releases: []Release{
 			{
-				Arch:           runtime.GOARCH,
-				OS:             runtime.GOOS,
-				Version:        pluginVersion,
-				Sum:            "abc123",
-				MinCoreVersion: minCoreVersion,
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: pluginVersion,
+				Sum:     "abc123",
 			},
 		},
 	}
 }
 
-// failingMetadataServer stands in for the metadata endpoint hiding a release from
-// a core CLI too old for it, which is what sends the install down the cached path.
-func failingMetadataServer(t *testing.T) *httptest.Server {
-	t.Helper()
-
-	return httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		switch req.URL.Path {
-		case "/v1/stripecli/get-plugin-metadata", "/ajax/stripecli/plugins_metadata":
-			res.WriteHeader(http.StatusNotFound)
-			_, _ = res.Write([]byte(`{"error":{"message":"not found"}}`))
-		default:
-			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
-		}
-	}))
-}
-
-// requiresNewerCLIMetadataServer stands in for the metadata endpoint naming the
-// constraint instead of hiding the release behind a 404. The body matches the shape
+// requiresNewerCLIMetadataServer stands in for the metadata endpoint refusing a
+// release whose min_core_version this CLI does not meet. The body matches the shape
 // the API sends, which is asserted on in pay-server's own tests.
 func requiresNewerCLIMetadataServer(t *testing.T, pluginVersion, minCoreVersion string) *httptest.Server {
 	t.Helper()
@@ -97,353 +78,10 @@ func requireRequiresNewerCLI(t *testing.T, err error, wantMinCoreVersion string)
 	require.Equal(t, wantMinCoreVersion, requiresNewerCLI.MinCoreVersion)
 }
 
-func TestCoreVersionSupports(t *testing.T) {
-	tests := []struct {
-		name           string
-		coreVersion    string
-		minCoreVersion string
-		supported      bool
-	}{
-		{name: "no constraint", coreVersion: "1.20.0", minCoreVersion: "", supported: true},
-		{name: "no constraint tolerates an odd core version", coreVersion: "not-a-version", minCoreVersion: "", supported: true},
-		{name: "newer core version", coreVersion: "1.31.0", minCoreVersion: "1.30.0", supported: true},
-		{name: "same core version", coreVersion: "1.30.0", minCoreVersion: "1.30.0", supported: true},
-		{name: "older patch", coreVersion: "1.30.0", minCoreVersion: "1.30.1", supported: false},
-		// Compared as semver, not as strings: "1.9.0" sorts after "1.10.0" lexically.
-		{name: "older minor", coreVersion: "1.9.0", minCoreVersion: "1.10.0", supported: false},
-		{name: "development build satisfies anything", coreVersion: "master", minCoreVersion: "99.0.0", supported: true},
-		{name: "leading v on the core version", coreVersion: "v1.30.0", minCoreVersion: "1.30.0", supported: true},
-		{name: "leading v on the constraint", coreVersion: "1.30.0", minCoreVersion: "v1.30.0", supported: true},
-		// Fails closed: an unevaluable constraint is exactly when installing anyway
-		// risks a binary this CLI cannot drive.
-		{name: "prerelease core version", coreVersion: "1.30.0-beta.1", minCoreVersion: "1.29.0", supported: false},
-		{name: "unparseable core version", coreVersion: "not-a-version", minCoreVersion: "1.30.0", supported: false},
-		{name: "unparseable constraint", coreVersion: "1.30.0", minCoreVersion: "latest", supported: false},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			withCoreVersion(t, test.coreVersion)
-			require.Equal(t, test.supported, coreVersionSupports(test.minCoreVersion))
-		})
-	}
-}
-
-func TestMinCoreVersionParsedFromManifest(t *testing.T) {
-	manifest := fmt.Sprintf(`[[Plugin]]
-  Shortname = "appA"
-  Binary = "stripe-cli-app-a"
-  MagicCookieValue = "APP-A-COOKIE"
-
-  [[Plugin.Release]]
-    Arch = "%s"
-    OS = "%s"
-    Version = "2.0.1"
-    Sum = "abc123"
-    MinCoreVersion = "1.30.0"
-`, runtime.GOARCH, runtime.GOOS)
-
-	pluginList, err := validatePluginManifest([]byte(manifest))
-	require.NoError(t, err)
-	plugin, err := findPlugin(*pluginList, "appA")
-	require.NoError(t, err)
-
-	release := plugin.getReleaseForVersion("2.0.1")
-	require.NotNil(t, release)
-	require.Equal(t, "1.30.0", release.MinCoreVersion)
-}
-
-// TestMinCoreVersionPreservedInLocalMetadataRoundTrip is what makes offline
-// enforcement possible at all: local metadata is re-encoded from the Release
-// struct, so a field that does not survive the round trip is not there to enforce
-// when the endpoint is unreachable.
-func TestMinCoreVersionPreservedInLocalMetadataRoundTrip(t *testing.T) {
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-
-	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
-
-	cached, err := readLocalPluginMetadata(config, fs, "appA")
-	require.NoError(t, err)
-	release := cached.getReleaseForVersion("2.0.1")
-	require.NotNil(t, release)
-	require.Equal(t, "1.30.0", release.MinCoreVersion)
-}
-
-func TestLookUpLatestVersionSkipsReleasesRequiringNewerCoreCLI(t *testing.T) {
-	plugin := Plugin{
-		Shortname: "appA",
-		Releases: []Release{
-			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.1"},
-			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "2.0.1", MinCoreVersion: "1.30.0"},
-		},
-	}
-
-	t.Run("core CLI too old falls back to the newest release it can run", func(t *testing.T) {
-		withCoreVersion(t, "1.29.0")
-		require.Equal(t, "1.0.1", plugin.LookUpLatestVersion())
-	})
-
-	t.Run("core CLI new enough gets the newest release", func(t *testing.T) {
-		withCoreVersion(t, "1.30.0")
-		require.Equal(t, "2.0.1", plugin.LookUpLatestVersion())
-	})
-
-	t.Run("ignoring the constraint reports the release that needs a newer CLI", func(t *testing.T) {
-		withCoreVersion(t, "1.29.0")
-		require.Equal(t, "2.0.1", plugin.lookUpLatestVersion(false))
-	})
-}
-
-// TestLookUpLatestVersionReturnsEmptyWhenEveryReleaseRequiresNewerCoreCLI covers
-// the case the callers have to tell apart from a plugin with no releases at all.
-func TestLookUpLatestVersionReturnsEmptyWhenEveryReleaseRequiresNewerCoreCLI(t *testing.T) {
-	withCoreVersion(t, "1.29.0")
-	plugin := restrictedPlugin("2.0.1", "1.30.0")
-
-	require.Empty(t, plugin.LookUpLatestVersion())
-	require.NoError(t, plugin.checkCoreVersionForRelease(""))
-	requireRequiresNewerCLI(t, plugin.checkCoreVersionForLatestRelease(), "1.30.0")
-}
-
-// TestCheckCoreVersionForReleaseSkipsLocalDevelopmentVersion covers a locally
-// built plugin, which is not something the registry published a constraint for.
-func TestCheckCoreVersionForReleaseSkipsLocalDevelopmentVersion(t *testing.T) {
-	withCoreVersion(t, "1.29.0")
-	plugin := restrictedPlugin(localDevelopmentVersion, "1.30.0")
-
-	require.NoError(t, plugin.checkCoreVersionForRelease(localDevelopmentVersion))
-}
-
-func TestErrPluginRequiresNewerCLIMessageNamesBothVersions(t *testing.T) {
-	withCoreVersion(t, "1.29.0")
-
-	plugin := restrictedPlugin("2.0.1", "1.30.0")
-	err := plugin.checkCoreVersionForRelease("2.0.1")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "appA plugin v2.0.1")
-	require.Contains(t, err.Error(), "Stripe CLI v1.30.0 or newer")
-	require.Contains(t, err.Error(), "1.29.0")
-}
-
-// TestInstallRefusesReleaseRequiringNewerCoreCLI checks the last line of defense.
-// The endpoint served the release here, so this is the case where filtering by
-// User-Agent did not happen or did not survive the request path.
-func TestInstallRefusesReleaseRequiringNewerCoreCLI(t *testing.T) {
-	withCoreVersion(t, "1.29.0")
-
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-
-	metadataManifest := fmt.Sprintf(`[[Plugin]]
-  Shortname = "appA"
-  Binary = "stripe-cli-app-a"
-  MagicCookieValue = "APP-A-COOKIE"
-
-  [[Plugin.Release]]
-    Arch = "%s"
-    OS = "%s"
-    Version = "2.0.1"
-    Sum = "abc123"
-    MinCoreVersion = "1.30.0"
-`, runtime.GOARCH, runtime.GOOS)
-
-	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		switch req.URL.Path {
-		case "/v1/stripecli/get-plugin-metadata":
-			body, err := json.Marshal(requests.PluginMetadata{
-				BinaryURL:      "https://example.test/appA/2.0.1",
-				PluginManifest: metadataManifest,
-			})
-			require.NoError(t, err)
-			_, _ = res.Write(body)
-		default:
-			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
-		}
-	}))
-	defer stripeServer.Close()
-
-	plugin := restrictedPlugin("2.0.1", "1.30.0")
-	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL, stripeServer.URL)
-	requireRequiresNewerCLI(t, err, "1.30.0")
-
-	// Refused before anything was downloaded or recorded.
-	binaryExists, existsErr := afero.Exists(fs, fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension()))
-	require.NoError(t, existsErr)
-	require.False(t, binaryExists)
-}
-
-func TestResolvePluginForInstallRejectsExplicitVersionRequiringNewerCoreCLI(t *testing.T) {
-	withCoreVersion(t, "1.29.0")
-
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
-
-	server := failingMetadataServer(t)
-	defer server.Close()
-
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", server.URL, server.URL)
-	require.Nil(t, resolvedPlugin)
-	requireRequiresNewerCLI(t, err, "1.30.0")
-}
-
-// TestResolvePluginForInstallReportsRequiresNewerCoreCLIForLatest guards the
-// message rather than the refusal: with every release filtered out, the resolve
-// would otherwise report the plugin as having no release for this platform.
-func TestResolvePluginForInstallReportsRequiresNewerCoreCLIForLatest(t *testing.T) {
-	withCoreVersion(t, "1.29.0")
-
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
-
-	server := failingMetadataServer(t)
-	defer server.Close()
-
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "", server.URL, server.URL)
-	require.Nil(t, resolvedPlugin)
-	requireRequiresNewerCLI(t, err, "1.30.0")
-}
-
-func TestResolvePluginForInstallAllowsCachedReleaseThisCoreCLISupports(t *testing.T) {
-	withCoreVersion(t, "1.30.0")
-
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
-
-	server := failingMetadataServer(t)
-	defer server.Close()
-
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", server.URL, server.URL)
-	require.NoError(t, err)
-	require.Equal(t, "2.0.1", resolvedPlugin.Version)
-}
-
-// TestResolvePluginForInstallSkipsRestrictedReleaseWhenAnotherIsSupported keeps
-// the constraint from reading as "this plugin is unavailable" when an older
-// release is still installable.
-func TestResolvePluginForInstallSkipsRestrictedReleaseWhenAnotherIsSupported(t *testing.T) {
-	withCoreVersion(t, "1.29.0")
-
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-	require.NoError(t, writeLocalPluginMetadata(config, fs, Plugin{
-		Shortname:        "appA",
-		Binary:           "stripe-cli-app-a",
-		MagicCookieValue: "APP-A-COOKIE",
-		Releases: []Release{
-			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.1", Sum: "abc123"},
-			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "2.0.1", Sum: "def456", MinCoreVersion: "1.30.0"},
-		},
-	}))
-
-	server := failingMetadataServer(t)
-	defer server.Close()
-
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "", server.URL, server.URL)
-	require.NoError(t, err)
-	require.Equal(t, "1.0.1", resolvedPlugin.Version)
-}
-
-// TestResolvePluginForInstallRejectsRestrictedReleaseFromLiveMetadata covers the
-// endpoint answering with a release it should have filtered out. The cache here
-// holds the same release without the constraint -- which is how a cache written
-// before the field existed looks -- so this also pins that the fallback cannot
-// overturn a definitive answer.
-func TestResolvePluginForInstallRejectsRestrictedReleaseFromLiveMetadata(t *testing.T) {
-	withCoreVersion(t, "1.29.0")
-
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "")))
-
-	metadataManifest := fmt.Sprintf(`[[Plugin]]
-  Shortname = "appA"
-  Binary = "stripe-cli-app-a"
-  MagicCookieValue = "APP-A-COOKIE"
-
-  [[Plugin.Release]]
-    Arch = "%s"
-    OS = "%s"
-    Version = "2.0.1"
-    Sum = "abc123"
-    MinCoreVersion = "1.30.0"
-`, runtime.GOARCH, runtime.GOOS)
-
-	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		switch req.URL.Path {
-		case "/v1/stripecli/get-plugin-metadata":
-			body, err := json.Marshal(requests.PluginMetadata{
-				BinaryURL:      "https://example.test/appA/2.0.1",
-				PluginManifest: metadataManifest,
-			})
-			require.NoError(t, err)
-			_, _ = res.Write(body)
-		default:
-			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
-		}
-	}))
-	defer server.Close()
-
-	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", server.URL, server.URL)
-	require.Nil(t, resolvedPlugin)
-	requireRequiresNewerCLI(t, err, "1.30.0")
-}
-
-func TestResolvePluginForUpgradeReportsRequiresNewerCoreCLI(t *testing.T) {
-	withCoreVersion(t, "1.29.0")
-
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
-
-	server := failingMetadataServer(t)
-	defer server.Close()
-
-	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "appA", server.URL, server.URL)
-	require.Nil(t, resolvedPlugin)
-	requireRequiresNewerCLI(t, err, "1.30.0")
-}
-
-// TestResolvePluginForAutoInstallReportsRequiresNewerCoreCLI checks that the
-// version the user needs is not buried in the auto-install path's combined
-// "latest lookup failed; cached lookup failed" wrapper.
-func TestResolvePluginForAutoInstallReportsRequiresNewerCoreCLI(t *testing.T) {
-	withCoreVersion(t, "1.29.0")
-
-	fs := afero.NewMemMapFs()
-	config := &TestConfig{}
-	config.InitConfig()
-	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
-
-	server := failingMetadataServer(t)
-	defer server.Close()
-
-	resolvedPlugin, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", server.URL, server.URL)
-	require.Nil(t, resolvedPlugin)
-	requireRequiresNewerCLI(t, err, "1.30.0")
-	require.NotContains(t, err.Error(), "cached lookup failed")
-
-	var requiresNewerCLI *ErrPluginRequiresNewerCLI
-	require.True(t, errors.As(err, &requiresNewerCLI))
-}
-
-// TestResolvePluginForInstallReportsEndpointRequiresNewerCLI covers the case no
-// local check can reach: a machine that has never held metadata for this plugin has
-// nothing recording the constraint, so the endpoint's answer is the only source of
-// it. Without reading that answer the install reports `no plugin named "appA"
-// exists`, which is what a 404 for a hidden release used to be indistinguishable
-// from.
+// TestResolvePluginForInstallReportsEndpointRequiresNewerCLI covers the endpoint's
+// answer for a version the caller named. Nothing on this side knows the constraint,
+// so reading the answer is the whole feature: without it the install reports `no
+// plugin named "appA" exists`, which is what a hidden release's 404 looks like.
 func TestResolvePluginForInstallReportsEndpointRequiresNewerCLI(t *testing.T) {
 	// Both endpoints, because the version a caller runs is the whole question here and
 	// being logged out must not change the answer.
@@ -480,17 +118,17 @@ func TestResolvePluginForInstallReportsEndpointRequiresNewerCLI(t *testing.T) {
 	}
 }
 
-// TestResolvePluginForInstallEndpointRequiresNewerCLIOutranksUnconstrainedCache
-// pins which side wins when they disagree. A cache written before MinCoreVersion
-// existed records the release as unconstrained, and the local check has nothing to
-// refuse on -- so the endpoint saying otherwise has to stick.
-func TestResolvePluginForInstallEndpointRequiresNewerCLIOutranksUnconstrainedCache(t *testing.T) {
+// TestResolvePluginForInstallEndpointRequiresNewerCLIOutranksCache pins that the
+// cached fallback cannot overturn the answer. The cache records no constraint of its
+// own, so resolving from it would happily hand back the very version the endpoint
+// just refused.
+func TestResolvePluginForInstallEndpointRequiresNewerCLIOutranksCache(t *testing.T) {
 	withCoreVersion(t, "1.29.0")
 
 	fs := afero.NewMemMapFs()
 	config := &TestConfig{}
 	config.InitConfig()
-	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "")))
+	require.NoError(t, writeLocalPluginMetadata(config, fs, pluginWithRelease("2.0.1")))
 
 	server := requiresNewerCLIMetadataServer(t, "2.0.1", "1.30.0")
 	defer server.Close()
@@ -500,9 +138,50 @@ func TestResolvePluginForInstallEndpointRequiresNewerCLIOutranksUnconstrainedCac
 	requireRequiresNewerCLI(t, err, "1.30.0")
 }
 
-// TestInstallReportsEndpointRequiresNewerCLI covers the same cold-cache gap on the
-// install path, where the plugin being installed carries no constraint of its own.
-// The lookup failing there otherwise surfaces as a missing download URL.
+// TestResolvePluginForUpgradeReportsEndpointRequiresNewerCLI and its auto-install
+// counterpart pin routing rather than a refusal the endpoint makes today: both paths
+// ask for no particular version, and the endpoint only answers this way for one it
+// was given. They exist so that if it ever does, the answer is reported instead of
+// the cache being allowed to contradict it.
+func TestResolvePluginForUpgradeReportsEndpointRequiresNewerCLI(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	require.NoError(t, writeLocalPluginMetadata(config, fs, pluginWithRelease("2.0.1")))
+
+	server := requiresNewerCLIMetadataServer(t, "2.0.1", "1.30.0")
+	defer server.Close()
+
+	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "appA", server.URL, server.URL)
+	require.Nil(t, resolvedPlugin)
+	requireRequiresNewerCLI(t, err, "1.30.0")
+}
+
+func TestResolvePluginForAutoInstallReportsEndpointRequiresNewerCLI(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	require.NoError(t, writeLocalPluginMetadata(config, fs, pluginWithRelease("2.0.1")))
+
+	server := requiresNewerCLIMetadataServer(t, "2.0.1", "1.30.0")
+	defer server.Close()
+
+	resolvedPlugin, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", server.URL, server.URL)
+	require.Nil(t, resolvedPlugin)
+	requireRequiresNewerCLI(t, err, "1.30.0")
+
+	// Not buried in this path's combined "latest lookup failed; cached lookup failed".
+	require.NotContains(t, err.Error(), "cached lookup failed")
+}
+
+// TestInstallReportsEndpointRequiresNewerCLI covers the install path, which fetches
+// metadata again for a version resolved without a binary URL. This is the only thing
+// standing between the endpoint's refusal and a download; without it the lookup
+// failure surfaces as a missing download URL.
 func TestInstallReportsEndpointRequiresNewerCLI(t *testing.T) {
 	withCoreVersion(t, "1.29.0")
 
@@ -513,7 +192,7 @@ func TestInstallReportsEndpointRequiresNewerCLI(t *testing.T) {
 	server := requiresNewerCLIMetadataServer(t, "2.0.1", "1.30.0")
 	defer server.Close()
 
-	plugin := restrictedPlugin("2.0.1", "")
+	plugin := pluginWithRelease("2.0.1")
 	err := plugin.Install(context.Background(), config, fs, "2.0.1", server.URL, server.URL)
 	requireRequiresNewerCLI(t, err, "1.30.0")
 	require.NotContains(t, err.Error(), "could not resolve download URL")
@@ -521,6 +200,15 @@ func TestInstallReportsEndpointRequiresNewerCLI(t *testing.T) {
 	binaryExists, existsErr := afero.Exists(fs, fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension()))
 	require.NoError(t, existsErr)
 	require.False(t, binaryExists)
+}
+
+func TestErrPluginRequiresNewerCLIMessageNamesBothVersions(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	err := newErrPluginRequiresNewerCLI("appA", "2.0.1", "1.30.0")
+	require.Contains(t, err.Error(), "appA plugin v2.0.1")
+	require.Contains(t, err.Error(), "Stripe CLI v1.30.0 or newer")
+	require.Contains(t, err.Error(), "this is Stripe CLI 1.29.0")
 }
 
 // TestErrPluginRequiresNewerCLIMessageDegradesWithoutAMinimumVersion guards the

--- a/pkg/plugins/min_core_version_test.go
+++ b/pkg/plugins/min_core_version_test.go
@@ -1,0 +1,413 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/version"
+)
+
+// withCoreVersion makes the CLI under test report a specific published version.
+// Tests need it because a binary built from source reports "master", which
+// satisfies every MinCoreVersion by design.
+func withCoreVersion(t *testing.T, reportedVersion string) {
+	t.Helper()
+
+	previous := version.Version
+	version.Version = reportedVersion
+	t.Cleanup(func() { version.Version = previous })
+}
+
+// restrictedPlugin describes a plugin whose only release for this platform needs
+// a newer core CLI than any test here pretends to be.
+func restrictedPlugin(pluginVersion, minCoreVersion string) Plugin {
+	return Plugin{
+		Shortname:        "appA",
+		Binary:           "stripe-cli-app-a",
+		MagicCookieValue: "APP-A-COOKIE",
+		Releases: []Release{
+			{
+				Arch:           runtime.GOARCH,
+				OS:             runtime.GOOS,
+				Version:        pluginVersion,
+				Sum:            "abc123",
+				MinCoreVersion: minCoreVersion,
+			},
+		},
+	}
+}
+
+// failingMetadataServer stands in for the metadata endpoint hiding a release from
+// a core CLI too old for it, which is what sends the install down the cached path.
+func failingMetadataServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata", "/ajax/stripecli/plugins_metadata":
+			res.WriteHeader(http.StatusNotFound)
+			_, _ = res.Write([]byte(`{"error":{"message":"not found"}}`))
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+}
+
+func requireRequiresNewerCLI(t *testing.T, err error, wantMinCoreVersion string) {
+	t.Helper()
+
+	var requiresNewerCLI *ErrPluginRequiresNewerCLI
+	require.ErrorAs(t, err, &requiresNewerCLI)
+	require.Equal(t, wantMinCoreVersion, requiresNewerCLI.MinCoreVersion)
+}
+
+func TestCoreVersionSupports(t *testing.T) {
+	tests := []struct {
+		name           string
+		coreVersion    string
+		minCoreVersion string
+		supported      bool
+	}{
+		{name: "no constraint", coreVersion: "1.20.0", minCoreVersion: "", supported: true},
+		{name: "no constraint tolerates an odd core version", coreVersion: "not-a-version", minCoreVersion: "", supported: true},
+		{name: "newer core version", coreVersion: "1.31.0", minCoreVersion: "1.30.0", supported: true},
+		{name: "same core version", coreVersion: "1.30.0", minCoreVersion: "1.30.0", supported: true},
+		{name: "older patch", coreVersion: "1.30.0", minCoreVersion: "1.30.1", supported: false},
+		// Compared as semver, not as strings: "1.9.0" sorts after "1.10.0" lexically.
+		{name: "older minor", coreVersion: "1.9.0", minCoreVersion: "1.10.0", supported: false},
+		{name: "development build satisfies anything", coreVersion: "master", minCoreVersion: "99.0.0", supported: true},
+		{name: "leading v on the core version", coreVersion: "v1.30.0", minCoreVersion: "1.30.0", supported: true},
+		{name: "leading v on the constraint", coreVersion: "1.30.0", minCoreVersion: "v1.30.0", supported: true},
+		// Fails closed: an unevaluable constraint is exactly when installing anyway
+		// risks a binary this CLI cannot drive.
+		{name: "prerelease core version", coreVersion: "1.30.0-beta.1", minCoreVersion: "1.29.0", supported: false},
+		{name: "unparseable core version", coreVersion: "not-a-version", minCoreVersion: "1.30.0", supported: false},
+		{name: "unparseable constraint", coreVersion: "1.30.0", minCoreVersion: "latest", supported: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			withCoreVersion(t, test.coreVersion)
+			require.Equal(t, test.supported, coreVersionSupports(test.minCoreVersion))
+		})
+	}
+}
+
+func TestMinCoreVersionParsedFromManifest(t *testing.T) {
+	manifest := fmt.Sprintf(`[[Plugin]]
+  Shortname = "appA"
+  Binary = "stripe-cli-app-a"
+  MagicCookieValue = "APP-A-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "2.0.1"
+    Sum = "abc123"
+    MinCoreVersion = "1.30.0"
+`, runtime.GOARCH, runtime.GOOS)
+
+	pluginList, err := validatePluginManifest([]byte(manifest))
+	require.NoError(t, err)
+	plugin, err := findPlugin(*pluginList, "appA")
+	require.NoError(t, err)
+
+	release := plugin.getReleaseForVersion("2.0.1")
+	require.NotNil(t, release)
+	require.Equal(t, "1.30.0", release.MinCoreVersion)
+}
+
+// TestMinCoreVersionPreservedInLocalMetadataRoundTrip is what makes offline
+// enforcement possible at all: local metadata is re-encoded from the Release
+// struct, so a field that does not survive the round trip is not there to enforce
+// when the endpoint is unreachable.
+func TestMinCoreVersionPreservedInLocalMetadataRoundTrip(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
+
+	cached, err := readLocalPluginMetadata(config, fs, "appA")
+	require.NoError(t, err)
+	release := cached.getReleaseForVersion("2.0.1")
+	require.NotNil(t, release)
+	require.Equal(t, "1.30.0", release.MinCoreVersion)
+}
+
+func TestLookUpLatestVersionSkipsReleasesRequiringNewerCoreCLI(t *testing.T) {
+	plugin := Plugin{
+		Shortname: "appA",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.1"},
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "2.0.1", MinCoreVersion: "1.30.0"},
+		},
+	}
+
+	t.Run("core CLI too old falls back to the newest release it can run", func(t *testing.T) {
+		withCoreVersion(t, "1.29.0")
+		require.Equal(t, "1.0.1", plugin.LookUpLatestVersion())
+	})
+
+	t.Run("core CLI new enough gets the newest release", func(t *testing.T) {
+		withCoreVersion(t, "1.30.0")
+		require.Equal(t, "2.0.1", plugin.LookUpLatestVersion())
+	})
+
+	t.Run("ignoring the constraint reports the release that needs a newer CLI", func(t *testing.T) {
+		withCoreVersion(t, "1.29.0")
+		require.Equal(t, "2.0.1", plugin.lookUpLatestVersion(false))
+	})
+}
+
+// TestLookUpLatestVersionReturnsEmptyWhenEveryReleaseRequiresNewerCoreCLI covers
+// the case the callers have to tell apart from a plugin with no releases at all.
+func TestLookUpLatestVersionReturnsEmptyWhenEveryReleaseRequiresNewerCoreCLI(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+	plugin := restrictedPlugin("2.0.1", "1.30.0")
+
+	require.Empty(t, plugin.LookUpLatestVersion())
+	require.NoError(t, plugin.checkCoreVersionForRelease(""))
+	requireRequiresNewerCLI(t, plugin.checkCoreVersionForLatestRelease(), "1.30.0")
+}
+
+// TestCheckCoreVersionForReleaseSkipsLocalDevelopmentVersion covers a locally
+// built plugin, which is not something the registry published a constraint for.
+func TestCheckCoreVersionForReleaseSkipsLocalDevelopmentVersion(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+	plugin := restrictedPlugin(localDevelopmentVersion, "1.30.0")
+
+	require.NoError(t, plugin.checkCoreVersionForRelease(localDevelopmentVersion))
+}
+
+func TestErrPluginRequiresNewerCLIMessageNamesBothVersions(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	plugin := restrictedPlugin("2.0.1", "1.30.0")
+	err := plugin.checkCoreVersionForRelease("2.0.1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "appA plugin v2.0.1")
+	require.Contains(t, err.Error(), "Stripe CLI v1.30.0 or newer")
+	require.Contains(t, err.Error(), "1.29.0")
+}
+
+// TestInstallRefusesReleaseRequiringNewerCoreCLI checks the last line of defense.
+// The endpoint served the release here, so this is the case where filtering by
+// User-Agent did not happen or did not survive the request path.
+func TestInstallRefusesReleaseRequiringNewerCoreCLI(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	metadataManifest := fmt.Sprintf(`[[Plugin]]
+  Shortname = "appA"
+  Binary = "stripe-cli-app-a"
+  MagicCookieValue = "APP-A-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "2.0.1"
+    Sum = "abc123"
+    MinCoreVersion = "1.30.0"
+`, runtime.GOARCH, runtime.GOOS)
+
+	stripeServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "https://example.test/appA/2.0.1",
+				PluginManifest: metadataManifest,
+			})
+			require.NoError(t, err)
+			_, _ = res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer stripeServer.Close()
+
+	plugin := restrictedPlugin("2.0.1", "1.30.0")
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", stripeServer.URL, stripeServer.URL)
+	requireRequiresNewerCLI(t, err, "1.30.0")
+
+	// Refused before anything was downloaded or recorded.
+	binaryExists, existsErr := afero.Exists(fs, fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension()))
+	require.NoError(t, existsErr)
+	require.False(t, binaryExists)
+}
+
+func TestResolvePluginForInstallRejectsExplicitVersionRequiringNewerCoreCLI(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
+
+	server := failingMetadataServer(t)
+	defer server.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", server.URL, server.URL)
+	require.Nil(t, resolvedPlugin)
+	requireRequiresNewerCLI(t, err, "1.30.0")
+}
+
+// TestResolvePluginForInstallReportsRequiresNewerCoreCLIForLatest guards the
+// message rather than the refusal: with every release filtered out, the resolve
+// would otherwise report the plugin as having no release for this platform.
+func TestResolvePluginForInstallReportsRequiresNewerCoreCLIForLatest(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
+
+	server := failingMetadataServer(t)
+	defer server.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "", server.URL, server.URL)
+	require.Nil(t, resolvedPlugin)
+	requireRequiresNewerCLI(t, err, "1.30.0")
+}
+
+func TestResolvePluginForInstallAllowsCachedReleaseThisCoreCLISupports(t *testing.T) {
+	withCoreVersion(t, "1.30.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
+
+	server := failingMetadataServer(t)
+	defer server.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", server.URL, server.URL)
+	require.NoError(t, err)
+	require.Equal(t, "2.0.1", resolvedPlugin.Version)
+}
+
+// TestResolvePluginForInstallSkipsRestrictedReleaseWhenAnotherIsSupported keeps
+// the constraint from reading as "this plugin is unavailable" when an older
+// release is still installable.
+func TestResolvePluginForInstallSkipsRestrictedReleaseWhenAnotherIsSupported(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	require.NoError(t, writeLocalPluginMetadata(config, fs, Plugin{
+		Shortname:        "appA",
+		Binary:           "stripe-cli-app-a",
+		MagicCookieValue: "APP-A-COOKIE",
+		Releases: []Release{
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "1.0.1", Sum: "abc123"},
+			{Arch: runtime.GOARCH, OS: runtime.GOOS, Version: "2.0.1", Sum: "def456", MinCoreVersion: "1.30.0"},
+		},
+	}))
+
+	server := failingMetadataServer(t)
+	defer server.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "", server.URL, server.URL)
+	require.NoError(t, err)
+	require.Equal(t, "1.0.1", resolvedPlugin.Version)
+}
+
+// TestResolvePluginForInstallRejectsRestrictedReleaseFromLiveMetadata covers the
+// endpoint answering with a release it should have filtered out. The cache here
+// holds the same release without the constraint -- which is how a cache written
+// before the field existed looks -- so this also pins that the fallback cannot
+// overturn a definitive answer.
+func TestResolvePluginForInstallRejectsRestrictedReleaseFromLiveMetadata(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "")))
+
+	metadataManifest := fmt.Sprintf(`[[Plugin]]
+  Shortname = "appA"
+  Binary = "stripe-cli-app-a"
+  MagicCookieValue = "APP-A-COOKIE"
+
+  [[Plugin.Release]]
+    Arch = "%s"
+    OS = "%s"
+    Version = "2.0.1"
+    Sum = "abc123"
+    MinCoreVersion = "1.30.0"
+`, runtime.GOARCH, runtime.GOOS)
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata":
+			body, err := json.Marshal(requests.PluginMetadata{
+				BinaryURL:      "https://example.test/appA/2.0.1",
+				PluginManifest: metadataManifest,
+			})
+			require.NoError(t, err)
+			_, _ = res.Write(body)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", server.URL, server.URL)
+	require.Nil(t, resolvedPlugin)
+	requireRequiresNewerCLI(t, err, "1.30.0")
+}
+
+func TestResolvePluginForUpgradeReportsRequiresNewerCoreCLI(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
+
+	server := failingMetadataServer(t)
+	defer server.Close()
+
+	resolvedPlugin, err := ResolvePluginForUpgrade(context.Background(), config, fs, "appA", server.URL, server.URL)
+	require.Nil(t, resolvedPlugin)
+	requireRequiresNewerCLI(t, err, "1.30.0")
+}
+
+// TestResolvePluginForAutoInstallReportsRequiresNewerCoreCLI checks that the
+// version the user needs is not buried in the auto-install path's combined
+// "latest lookup failed; cached lookup failed" wrapper.
+func TestResolvePluginForAutoInstallReportsRequiresNewerCoreCLI(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "1.30.0")))
+
+	server := failingMetadataServer(t)
+	defer server.Close()
+
+	resolvedPlugin, err := resolvePluginForAutoInstall(context.Background(), config, fs, "appA", server.URL, server.URL)
+	require.Nil(t, resolvedPlugin)
+	requireRequiresNewerCLI(t, err, "1.30.0")
+	require.NotContains(t, err.Error(), "cached lookup failed")
+
+	var requiresNewerCLI *ErrPluginRequiresNewerCLI
+	require.True(t, errors.As(err, &requiresNewerCLI))
+}

--- a/pkg/plugins/min_core_version_test.go
+++ b/pkg/plugins/min_core_version_test.go
@@ -63,6 +63,32 @@ func failingMetadataServer(t *testing.T) *httptest.Server {
 	}))
 }
 
+// requiresNewerCLIMetadataServer stands in for the metadata endpoint naming the
+// constraint instead of hiding the release behind a 404. The body matches the shape
+// the API sends, which is asserted on in pay-server's own tests.
+func requiresNewerCLIMetadataServer(t *testing.T, pluginVersion, minCoreVersion string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/stripecli/get-plugin-metadata", "/ajax/stripecli/plugins_metadata":
+			res.Header().Set("Content-Type", "application/json")
+			res.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(res, `{
+  "error": {
+    "code": "plugin_requires_newer_cli",
+    "message": "Version %s of the appA plugin requires Stripe CLI %s or later. Upgrade the Stripe CLI, or request a plugin version your CLI supports.",
+    "min_core_version": %q,
+    "param": "version",
+    "type": "invalid_request_error"
+  }
+}`, pluginVersion, minCoreVersion, minCoreVersion)
+		default:
+			t.Errorf("Received an unexpected request URL: %s", req.URL.String())
+		}
+	}))
+}
+
 func requireRequiresNewerCLI(t *testing.T, err error, wantMinCoreVersion string) {
 	t.Helper()
 
@@ -410,4 +436,101 @@ func TestResolvePluginForAutoInstallReportsRequiresNewerCoreCLI(t *testing.T) {
 
 	var requiresNewerCLI *ErrPluginRequiresNewerCLI
 	require.True(t, errors.As(err, &requiresNewerCLI))
+}
+
+// TestResolvePluginForInstallReportsEndpointRequiresNewerCLI covers the case no
+// local check can reach: a machine that has never held metadata for this plugin has
+// nothing recording the constraint, so the endpoint's answer is the only source of
+// it. Without reading that answer the install reports `no plugin named "appA"
+// exists`, which is what a 404 for a hidden release used to be indistinguishable
+// from.
+func TestResolvePluginForInstallReportsEndpointRequiresNewerCLI(t *testing.T) {
+	// Both endpoints, because the version a caller runs is the whole question here and
+	// being logged out must not change the answer.
+	for _, tt := range []struct {
+		name   string
+		apiKey string
+	}{
+		{name: "logged in", apiKey: "sk_test_1234"},
+		{name: "not logged in", apiKey: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			withCoreVersion(t, "1.29.0")
+
+			fs := afero.NewMemMapFs()
+			config := &TestConfig{}
+			config.InitConfig()
+			config.Profile.APIKey = tt.apiKey
+
+			server := requiresNewerCLIMetadataServer(t, "2.0.1", "1.30.0")
+			defer server.Close()
+
+			resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", server.URL, server.URL)
+			require.Nil(t, resolvedPlugin)
+			requireRequiresNewerCLI(t, err, "1.30.0")
+
+			var requiresNewerCLI *ErrPluginRequiresNewerCLI
+			require.ErrorAs(t, err, &requiresNewerCLI)
+			require.Equal(t, "2.0.1", requiresNewerCLI.Version)
+			require.Equal(t, "appA", requiresNewerCLI.Name)
+			require.Contains(t, err.Error(), "Stripe CLI v1.30.0 or newer")
+			require.NotContains(t, err.Error(), "no plugin named")
+			require.NotContains(t, err.Error(), "cached lookup failed")
+		})
+	}
+}
+
+// TestResolvePluginForInstallEndpointRequiresNewerCLIOutranksUnconstrainedCache
+// pins which side wins when they disagree. A cache written before MinCoreVersion
+// existed records the release as unconstrained, and the local check has nothing to
+// refuse on -- so the endpoint saying otherwise has to stick.
+func TestResolvePluginForInstallEndpointRequiresNewerCLIOutranksUnconstrainedCache(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+	require.NoError(t, writeLocalPluginMetadata(config, fs, restrictedPlugin("2.0.1", "")))
+
+	server := requiresNewerCLIMetadataServer(t, "2.0.1", "1.30.0")
+	defer server.Close()
+
+	resolvedPlugin, err := ResolvePluginForInstall(context.Background(), config, fs, "appA", "2.0.1", server.URL, server.URL)
+	require.Nil(t, resolvedPlugin)
+	requireRequiresNewerCLI(t, err, "1.30.0")
+}
+
+// TestInstallReportsEndpointRequiresNewerCLI covers the same cold-cache gap on the
+// install path, where the plugin being installed carries no constraint of its own.
+// The lookup failing there otherwise surfaces as a missing download URL.
+func TestInstallReportsEndpointRequiresNewerCLI(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	fs := afero.NewMemMapFs()
+	config := &TestConfig{}
+	config.InitConfig()
+
+	server := requiresNewerCLIMetadataServer(t, "2.0.1", "1.30.0")
+	defer server.Close()
+
+	plugin := restrictedPlugin("2.0.1", "")
+	err := plugin.Install(context.Background(), config, fs, "2.0.1", server.URL, server.URL)
+	requireRequiresNewerCLI(t, err, "1.30.0")
+	require.NotContains(t, err.Error(), "could not resolve download URL")
+
+	binaryExists, existsErr := afero.Exists(fs, fmt.Sprintf("/plugins/appA/2.0.1/stripe-cli-app-a%s", GetBinaryExtension()))
+	require.NoError(t, existsErr)
+	require.False(t, binaryExists)
+}
+
+// TestErrPluginRequiresNewerCLIMessageDegradesWithoutAMinimumVersion guards the
+// wording for an answer that names the problem without naming a target, which is
+// all a response missing the extra attribute can give.
+func TestErrPluginRequiresNewerCLIMessageDegradesWithoutAMinimumVersion(t *testing.T) {
+	withCoreVersion(t, "1.29.0")
+
+	err := newErrPluginRequiresNewerCLI("appA", "2.0.1", "")
+	require.Contains(t, err.Error(), "the appA plugin v2.0.1 requires a newer Stripe CLI")
+	require.Contains(t, err.Error(), "this is Stripe CLI 1.29.0")
+	require.NotContains(t, err.Error(), "v or newer")
 }

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -341,6 +341,15 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 
 		pluginMetadata, err := requests.GetPluginMetadata(ctx, apiBaseURL, dashboardBaseURL, stripe.APIVersion, apiKey, cfg.GetProfile(), p.Shortname, version, runtime.GOOS, runtime.GOARCH, cfg.GetMachineUUID())
 		if err != nil {
+			// Returned rather than kept as metadataLookupErr: every other lookup failure
+			// leaves open the possibility that cached metadata can still complete the
+			// install, and this one does not. It also states the minimum version, which
+			// the check below can only report when some manifest here already recorded it.
+			if minCoreVersion, requiresNewerCLI := requests.PluginRequiresNewerCLI(err); requiresNewerCLI {
+				ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stderr)
+				return newErrPluginRequiresNewerCLI(p.Shortname, version, minCoreVersion)
+			}
+
 			metadataLookupErr = err
 			log.WithFields(log.Fields{
 				"prefix": "plugins.plugin.Install",

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -62,19 +62,15 @@ type PluginList struct {
 }
 
 // Release is the type that holds release data for a specific build of a plugin
+//
+// The manifest also carries each release's MinCoreVersion, which is deliberately
+// not decoded: the metadata endpoint already withholds releases this core CLI
+// cannot run, and answers plugin_requires_newer_cli when one is asked for by name.
 type Release struct {
 	Arch    string `toml:"Arch" json:"arch"`
 	OS      string `toml:"OS" json:"os"`
 	Version string `toml:"Version" json:"version"`
 	Sum     string `toml:"Sum" json:"sum,omitempty"`
-	// MinCoreVersion is the lowest core CLI version that can run this release.
-	// Empty means the release places no requirement on the core CLI, which is
-	// how every release that predates the field arrives.
-	//
-	// Decoding it matters as much as enforcing it: local plugin metadata is
-	// re-encoded from this struct, so a field that is not read here is dropped
-	// from the cache the offline install path then resolves from.
-	MinCoreVersion string `toml:"MinCoreVersion,omitempty" json:"min_core_version,omitempty"`
 }
 
 // getPluginInterface computes the correct metadata needed for starting the hcplugin client
@@ -206,27 +202,18 @@ func (p *Plugin) getChecksum(version string) ([]byte, error) {
 	return decoded, nil
 }
 
-// LookUpLatestVersion gets the latest version of the plugin this core CLI can
-// run, skipping releases that require a newer one. Skipping rather than failing
-// matches what the metadata API does for a caller that asks for no particular
-// version: it hands back the newest release the caller supports.
+// LookUpLatestVersion gets the latest version of the plugin for this platform.
+// A manifest that came from the metadata endpoint has already had the releases
+// this core CLI cannot run withheld, so the newest release listed is the newest
+// one it can install.
 // note: assumes versions are listed in asc order
 func (p *Plugin) LookUpLatestVersion() string {
-	return p.lookUpLatestVersion(true)
-}
-
-// lookUpLatestVersion optionally ignores MinCoreVersion, which is how the
-// requires-a-newer-CLI case is told apart from having no release at all.
-func (p *Plugin) lookUpLatestVersion(requireCoreVersionSupport bool) string {
 	opsystem := runtime.GOOS
 	arch := runtime.GOARCH
 
 	var version string
 	for _, pkg := range p.Releases {
 		if pkg.OS != opsystem || pkg.Arch != arch {
-			continue
-		}
-		if requireCoreVersionSupport && !coreVersionSupports(pkg.MinCoreVersion) {
 			continue
 		}
 
@@ -342,9 +329,9 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 		pluginMetadata, err := requests.GetPluginMetadata(ctx, apiBaseURL, dashboardBaseURL, stripe.APIVersion, apiKey, cfg.GetProfile(), p.Shortname, version, runtime.GOOS, runtime.GOARCH, cfg.GetMachineUUID())
 		if err != nil {
 			// Returned rather than kept as metadataLookupErr: every other lookup failure
-			// leaves open the possibility that cached metadata can still complete the
-			// install, and this one does not. It also states the minimum version, which
-			// the check below can only report when some manifest here already recorded it.
+			// leaves open the possibility that a binary URL resolved earlier can still
+			// complete the install, and this one settles that the install must not happen
+			// at all. It is also the only place the minimum version is ever stated.
 			if minCoreVersion, requiresNewerCLI := requests.PluginRequiresNewerCLI(err); requiresNewerCLI {
 				ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stderr)
 				return newErrPluginRequiresNewerCLI(p.Shortname, version, minCoreVersion)
@@ -364,17 +351,6 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 			pluginToInstall = pluginFromMetadata
 			pluginDownloadURL = pluginMetadata.BinaryURL
 		}
-	}
-
-	// Checked before the download URL below, and after the metadata lookup that
-	// may have replaced pluginToInstall, so this is the last word on every install
-	// path regardless of where the metadata came from. Order matters: a release
-	// hidden for being incompatible makes the metadata endpoint 404, which leaves
-	// no download URL, and "could not resolve download URL" tells the user nothing
-	// about the version they actually need.
-	if err := pluginToInstall.checkCoreVersionForRelease(version); err != nil {
-		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stderr)
-		return err
 	}
 
 	if pluginDownloadURL == "" {

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -65,7 +65,8 @@ type PluginList struct {
 //
 // The manifest also carries each release's MinCoreVersion, which is deliberately
 // not decoded: the metadata endpoint already withholds releases this core CLI
-// cannot run, and answers plugin_requires_newer_cli when one is asked for by name.
+// cannot run, and answers plugin_requires_newer_cli when withholding them leaves
+// nothing to hand back -- whether the caller named one of them or named none.
 type Release struct {
 	Arch    string `toml:"Arch" json:"arch"`
 	OS      string `toml:"OS" json:"os"`

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -327,10 +327,11 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 
 		pluginMetadata, err := requests.GetPluginMetadata(ctx, apiBaseURL, dashboardBaseURL, stripe.APIVersion, apiKey, cfg.GetProfile(), p.Shortname, version, runtime.GOOS, runtime.GOARCH, cfg.GetMachineUUID())
 		if err != nil {
-			// Returned rather than kept as metadataLookupErr: every other lookup failure
-			// leaves open the possibility that a binary URL resolved earlier can still
-			// complete the install, and this one settles that the install must not happen
-			// at all. It is also the only place the minimum version is ever stated.
+			// Returned rather than kept as metadataLookupErr, which surfaces further down
+			// as a missing download URL. The install fails either way -- this lookup only
+			// runs when no binary URL was resolved earlier, and a refusal carries none --
+			// so what this branch changes is that the user is told their CLI version is
+			// the reason, which nothing below can state.
 			if minCoreVersion, requiresNewerCLI := requests.PluginRequiresNewerCLI(err); requiresNewerCLI {
 				ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stderr)
 				return newErrPluginRequiresNewerCLI(p.Shortname, version, minCoreVersion)

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -67,6 +67,14 @@ type Release struct {
 	OS      string `toml:"OS" json:"os"`
 	Version string `toml:"Version" json:"version"`
 	Sum     string `toml:"Sum" json:"sum,omitempty"`
+	// MinCoreVersion is the lowest core CLI version that can run this release.
+	// Empty means the release places no requirement on the core CLI, which is
+	// how every release that predates the field arrives.
+	//
+	// Decoding it matters as much as enforcing it: local plugin metadata is
+	// re-encoded from this struct, so a field that is not read here is dropped
+	// from the cache the offline install path then resolves from.
+	MinCoreVersion string `toml:"MinCoreVersion,omitempty" json:"min_core_version,omitempty"`
 }
 
 // getPluginInterface computes the correct metadata needed for starting the hcplugin client
@@ -198,17 +206,31 @@ func (p *Plugin) getChecksum(version string) ([]byte, error) {
 	return decoded, nil
 }
 
-// LookUpLatestVersion gets latest CLI version
+// LookUpLatestVersion gets the latest version of the plugin this core CLI can
+// run, skipping releases that require a newer one. Skipping rather than failing
+// matches what the metadata API does for a caller that asks for no particular
+// version: it hands back the newest release the caller supports.
 // note: assumes versions are listed in asc order
 func (p *Plugin) LookUpLatestVersion() string {
+	return p.lookUpLatestVersion(true)
+}
+
+// lookUpLatestVersion optionally ignores MinCoreVersion, which is how the
+// requires-a-newer-CLI case is told apart from having no release at all.
+func (p *Plugin) lookUpLatestVersion(requireCoreVersionSupport bool) string {
 	opsystem := runtime.GOOS
 	arch := runtime.GOARCH
 
 	var version string
 	for _, pkg := range p.Releases {
-		if pkg.OS == opsystem && pkg.Arch == arch {
-			version = pkg.Version
+		if pkg.OS != opsystem || pkg.Arch != arch {
+			continue
 		}
+		if requireCoreVersionSupport && !coreVersionSupports(pkg.MinCoreVersion) {
+			continue
+		}
+
+		version = pkg.Version
 	}
 
 	return version
@@ -333,6 +355,17 @@ func (p *Plugin) install(ctx context.Context, cfg config.IConfig, fs afero.Fs, v
 			pluginToInstall = pluginFromMetadata
 			pluginDownloadURL = pluginMetadata.BinaryURL
 		}
+	}
+
+	// Checked before the download URL below, and after the metadata lookup that
+	// may have replaced pluginToInstall, so this is the last word on every install
+	// path regardless of where the metadata came from. Order matters: a release
+	// hidden for being incompatible makes the metadata endpoint 404, which leaves
+	// no download URL, and "could not resolve download URL" tells the user nothing
+	// about the version they actually need.
+	if err := pluginToInstall.checkCoreVersionForRelease(version); err != nil {
+		ansi.StopSpinner(spinner, ansi.Faint(fmt.Sprintf("could not install plugin '%s'", p.Shortname)), os.Stderr)
+		return err
 	}
 
 	if pluginDownloadURL == "" {

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -214,11 +214,9 @@ func (p *Plugin) LookUpLatestVersion() string {
 
 	var version string
 	for _, pkg := range p.Releases {
-		if pkg.OS != opsystem || pkg.Arch != arch {
-			continue
+		if pkg.OS == opsystem && pkg.Arch == arch {
+			version = pkg.Version
 		}
-
-		version = pkg.Version
 	}
 
 	return version

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -64,9 +64,7 @@ type PluginList struct {
 // Release is the type that holds release data for a specific build of a plugin
 //
 // The manifest also carries each release's MinCoreVersion, which is deliberately
-// not decoded: the metadata endpoint already withholds releases this core CLI
-// cannot run, and answers plugin_requires_newer_cli when withholding them leaves
-// nothing to hand back -- whether the caller named one of them or named none.
+// not decoded; see ErrPluginRequiresNewerCLI for why the API owns that constraint.
 type Release struct {
 	Arch    string `toml:"Arch" json:"arch"`
 	OS      string `toml:"OS" json:"os"`
@@ -204,9 +202,7 @@ func (p *Plugin) getChecksum(version string) ([]byte, error) {
 }
 
 // LookUpLatestVersion gets the latest version of the plugin for this platform.
-// A manifest that came from the metadata endpoint has already had the releases
-// this core CLI cannot run withheld, so the newest release listed is the newest
-// one it can install.
+// It weighs no min_core_version of its own; see ErrPluginRequiresNewerCLI.
 // note: assumes versions are listed in asc order
 func (p *Plugin) LookUpLatestVersion() string {
 	opsystem := runtime.GOOS

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -525,6 +525,15 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 		return resolvedPlugin, nil
 	}
 
+	// The cached fallback below is skipped for this one: it is there to survive an
+	// endpoint that could not answer, not to overrule one that did. Cached metadata
+	// can predate the constraint entirely, so letting it win here would drop the
+	// constraint on exactly the machines it exists to stop.
+	var requiresNewerCLI *ErrPluginRequiresNewerCLI
+	if errors.As(err, &requiresNewerCLI) {
+		return nil, err
+	}
+
 	log.WithFields(log.Fields{
 		"prefix":  "plugins.ResolvePluginForInstall",
 		"plugin":  pluginName,
@@ -538,10 +547,20 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 			resolvedVersion = cachedPlugin.LookUpLatestVersion()
 		}
 		if resolvedVersion == "" {
+			if coreVersionErr := cachedPlugin.checkCoreVersionForLatestRelease(); coreVersionErr != nil {
+				return nil, coreVersionErr
+			}
 			return nil, errorcategory.Errorf(errorcategory.API, "could not determine latest version for plugin %s", pluginName)
 		}
 		if cachedPlugin.getReleaseForVersion(resolvedVersion) == nil {
 			return nil, errorcategory.Errorf(errorcategory.API, "cached plugin metadata did not include plugin %s version %s for %s/%s", pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
+		}
+		// Only reachable for an explicitly requested version, since the latest-version
+		// branch above already skips releases this CLI cannot run. This is the path the
+		// API cannot police: the cache was written by whichever CLI installed the plugin
+		// last, and may well have been a newer one than this.
+		if err := cachedPlugin.checkCoreVersionForRelease(resolvedVersion); err != nil {
+			return nil, err
 		}
 
 		return &ResolvedPluginVersion{
@@ -574,6 +593,13 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 	resolvedPlugin, endpointErr := resolvePluginFromMetadata(ctx, config, fs, pluginName, "", apiBaseURL, dashboardBaseURL, apiKey)
 	if endpointErr == nil {
 		return resolvedPlugin, nil
+	}
+
+	// See ResolvePluginForInstall: a definitive requires-a-newer-CLI answer is not
+	// something the cached fallback should be able to overturn.
+	var requiresNewerCLI *ErrPluginRequiresNewerCLI
+	if errors.As(endpointErr, &requiresNewerCLI) {
+		return nil, endpointErr
 	}
 
 	log.WithFields(log.Fields{
@@ -724,6 +750,15 @@ func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs 
 		return resolvedPlugin, nil
 	}
 
+	// The cached fallback below resolves from the same metadata this already
+	// consulted, so it can only reach the same verdict. Returning now keeps the
+	// version the user needs out of a "latest lookup failed; cached lookup failed"
+	// wrapper that buries it.
+	var requiresNewerCLI *ErrPluginRequiresNewerCLI
+	if errors.As(err, &requiresNewerCLI) {
+		return nil, err
+	}
+
 	log.WithFields(log.Fields{
 		"prefix": "plugins.resolvePluginForAutoInstall",
 		"plugin": pluginName,
@@ -815,10 +850,21 @@ func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs af
 		resolvedVersion = plugin.LookUpLatestVersion()
 	}
 	if resolvedVersion == "" {
+		if coreVersionErr := plugin.checkCoreVersionForLatestRelease(); coreVersionErr != nil {
+			return nil, coreVersionErr
+		}
 		return nil, errorcategory.Errorf(errorcategory.API, "plugin metadata response did not include a release for %s on %s/%s", pluginName, runtime.GOOS, runtime.GOARCH)
 	}
 	if plugin.getReleaseForVersion(resolvedVersion) == nil {
 		return nil, errorcategory.Errorf(errorcategory.API, "plugin metadata response did not include plugin %s version %s for %s/%s", pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
+	}
+	// The API already filters restricted releases out of live responses by
+	// User-Agent, so this should never fire. It is checked anyway because the
+	// filtering depends on a header surviving the whole request path and on the
+	// Vary: User-Agent that keeps a response cached for one CLI version from being
+	// served to another, neither of which this side can verify.
+	if err := plugin.checkCoreVersionForRelease(resolvedVersion); err != nil {
+		return nil, err
 	}
 
 	return &ResolvedPluginVersion{
@@ -852,6 +898,9 @@ func getLatestResolvedPluginVersion(pluginName string, plugin *Plugin) (string, 
 
 	version := plugin.LookUpLatestVersion()
 	if version == "" {
+		if err := plugin.checkCoreVersionForLatestRelease(); err != nil {
+			return "", err
+		}
 		return "", errorcategory.Errorf(errorcategory.API, "could not determine latest version for plugin %s", pluginName)
 	}
 

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -811,9 +811,9 @@ func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs af
 	pluginMetadata, err := requests.GetPluginMetadata(ctx, apiBaseURL, dashboardBaseURL, stripe.APIVersion, apiKey, config.GetProfile(), pluginName, version, runtime.GOOS, runtime.GOARCH, config.GetMachineUUID())
 	if err != nil {
 		// Translated here rather than left to normalizePluginMetadataError, which only
-		// runs once the cached lookup has failed too. The endpoint is the sole source of
-		// this constraint on a machine whose cache predates the field, or has none at
-		// all, and that is exactly the machine the answer is worth keeping.
+		// runs once the cached lookup has failed too. The endpoint is the only thing that
+		// knows this constraint, so its answer has to be captured where it arrives or it
+		// becomes an ordinary lookup failure and the cache gets to answer instead.
 		if minCoreVersion, requiresNewerCLI := requests.PluginRequiresNewerCLI(err); requiresNewerCLI {
 			return nil, newErrPluginRequiresNewerCLI(pluginName, version, minCoreVersion)
 		}
@@ -865,11 +865,12 @@ const (
 )
 
 // resolveVersionFromReleases picks the version to install out of a plugin's
-// releases: the one that was asked for, or the newest this core CLI can run.
+// releases: the one that was asked for, or the newest listed.
 //
-// This is the only place a resolved plugin's MinCoreVersion is weighed, so the live
-// and cached paths cannot drift apart on it, and their callers are left describing
-// where the metadata came from rather than repeating the constraint themselves.
+// Both callers share it so they cannot drift apart, and are left describing where
+// the metadata came from rather than repeating the lookup themselves. Neither
+// weighs a release's min_core_version, which the metadata endpoint has already
+// applied to whatever it returned.
 func resolveVersionFromReleases(plugin *Plugin, pluginName, requestedVersion, source string) (string, error) {
 	if plugin == nil {
 		return "", errorcategory.Errorf(errorcategory.API, "%s did not include plugin %s", source, pluginName)
@@ -878,28 +879,13 @@ func resolveVersionFromReleases(plugin *Plugin, pluginName, requestedVersion, so
 	resolvedVersion := requestedVersion
 	if resolvedVersion == "" {
 		resolvedVersion = plugin.LookUpLatestVersion()
-
-		// Nothing left can mean every release for this platform was skipped for needing
-		// a newer CLI, which must not be reported as the plugin having no release.
 		if resolvedVersion == "" {
-			if err := plugin.checkCoreVersionForLatestRelease(); err != nil {
-				return "", err
-			}
-
 			return "", errorcategory.Errorf(errorcategory.API, "%s did not include a release for %s on %s/%s", source, pluginName, runtime.GOOS, runtime.GOARCH)
 		}
 	}
 
 	if plugin.getReleaseForVersion(resolvedVersion) == nil {
 		return "", errorcategory.Errorf(errorcategory.API, "%s did not include plugin %s version %s for %s/%s", source, pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
-	}
-
-	// Only reachable for an explicitly requested version, since the lookup above
-	// already skips what this CLI cannot run, and the API filters live responses the
-	// same way. What is left is the cache: whichever CLI installed the plugin last
-	// wrote it, possibly a newer one than this.
-	if err := plugin.checkCoreVersionForRelease(resolvedVersion); err != nil {
-		return "", err
 	}
 
 	return resolvedVersion, nil

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -876,19 +876,23 @@ func resolveVersionFromReleases(plugin *Plugin, pluginName, requestedVersion, so
 		return "", errorcategory.Errorf(errorcategory.API, "%s did not include plugin %s", source, pluginName)
 	}
 
-	resolvedVersion := requestedVersion
-	if resolvedVersion == "" {
-		resolvedVersion = plugin.LookUpLatestVersion()
-		if resolvedVersion == "" {
+	// Only a version the caller named has to be looked for. LookUpLatestVersion
+	// reports a version it read off a release for this platform, so asking the same
+	// releases to produce that release again can only ever succeed.
+	if requestedVersion == "" {
+		latestVersion := plugin.LookUpLatestVersion()
+		if latestVersion == "" {
 			return "", errorcategory.Errorf(errorcategory.API, "%s did not include a release for %s on %s/%s", source, pluginName, runtime.GOOS, runtime.GOARCH)
 		}
+
+		return latestVersion, nil
 	}
 
-	if plugin.getReleaseForVersion(resolvedVersion) == nil {
-		return "", errorcategory.Errorf(errorcategory.API, "%s did not include plugin %s version %s for %s/%s", source, pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
+	if plugin.getReleaseForVersion(requestedVersion) == nil {
+		return "", errorcategory.Errorf(errorcategory.API, "%s did not include plugin %s version %s for %s/%s", source, pluginName, requestedVersion, runtime.GOOS, runtime.GOARCH)
 	}
 
-	return resolvedVersion, nil
+	return requestedVersion, nil
 }
 
 func lookUpPluginInCachedManifest(config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -867,10 +867,9 @@ const (
 // resolveVersionFromReleases picks the version to install out of a plugin's
 // releases: the one that was asked for, or the newest listed.
 //
-// Both callers share it so they cannot drift apart, and are left describing where
-// the metadata came from rather than repeating the lookup themselves. Neither
-// weighs a release's min_core_version, which the metadata endpoint has already
-// applied to whatever it returned.
+// Every resolve path shares it so they cannot drift apart, and is left describing
+// where the metadata came from rather than repeating the lookup itself. None of
+// them weighs a release's min_core_version; see ErrPluginRequiresNewerCLI.
 func resolveVersionFromReleases(plugin *Plugin, pluginName, requestedVersion, source string) (string, error) {
 	if plugin == nil {
 		return "", errorcategory.Errorf(errorcategory.API, "%s did not include plugin %s", source, pluginName)

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -525,12 +525,7 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 		return resolvedPlugin, nil
 	}
 
-	// The cached fallback below is skipped for this one: it is there to survive an
-	// endpoint that could not answer, not to overrule one that did. Cached metadata
-	// can predate the constraint entirely, so letting it win here would drop the
-	// constraint on exactly the machines it exists to stop.
-	var requiresNewerCLI *ErrPluginRequiresNewerCLI
-	if errors.As(err, &requiresNewerCLI) {
+	if requiresNewerCLI(err) {
 		return nil, err
 	}
 
@@ -542,25 +537,9 @@ func ResolvePluginForInstall(ctx context.Context, config config.IConfig, fs afer
 
 	cachedPlugin, cachedErr := resolveCachedPluginForInstall(config, fs, pluginName, version)
 	if cachedErr == nil {
-		resolvedVersion := version
-		if resolvedVersion == "" {
-			resolvedVersion = cachedPlugin.LookUpLatestVersion()
-		}
-		if resolvedVersion == "" {
-			if coreVersionErr := cachedPlugin.checkCoreVersionForLatestRelease(); coreVersionErr != nil {
-				return nil, coreVersionErr
-			}
-			return nil, errorcategory.Errorf(errorcategory.API, "could not determine latest version for plugin %s", pluginName)
-		}
-		if cachedPlugin.getReleaseForVersion(resolvedVersion) == nil {
-			return nil, errorcategory.Errorf(errorcategory.API, "cached plugin metadata did not include plugin %s version %s for %s/%s", pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
-		}
-		// Only reachable for an explicitly requested version, since the latest-version
-		// branch above already skips releases this CLI cannot run. This is the path the
-		// API cannot police: the cache was written by whichever CLI installed the plugin
-		// last, and may well have been a newer one than this.
-		if err := cachedPlugin.checkCoreVersionForRelease(resolvedVersion); err != nil {
-			return nil, err
+		resolvedVersion, versionErr := resolveVersionFromReleases(cachedPlugin, pluginName, version, cachedPluginMetadata)
+		if versionErr != nil {
+			return nil, versionErr
 		}
 
 		return &ResolvedPluginVersion{
@@ -595,10 +574,7 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 		return resolvedPlugin, nil
 	}
 
-	// See ResolvePluginForInstall: a definitive requires-a-newer-CLI answer is not
-	// something the cached fallback should be able to overturn.
-	var requiresNewerCLI *ErrPluginRequiresNewerCLI
-	if errors.As(endpointErr, &requiresNewerCLI) {
+	if requiresNewerCLI(endpointErr) {
 		return nil, endpointErr
 	}
 
@@ -609,7 +585,7 @@ func ResolvePluginForUpgrade(ctx context.Context, config config.IConfig, fs afer
 
 	cachedPlugin, cachedErr := resolveCachedPluginForUpgrade(config, fs, pluginName)
 	if cachedErr == nil {
-		version, versionErr := getLatestResolvedPluginVersion(pluginName, cachedPlugin)
+		version, versionErr := resolveVersionFromReleases(cachedPlugin, pluginName, "", cachedPluginMetadata)
 		if versionErr != nil {
 			return nil, versionErr
 		}
@@ -750,12 +726,9 @@ func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs 
 		return resolvedPlugin, nil
 	}
 
-	// The cached fallback below resolves from the same metadata this already
-	// consulted, so it can only reach the same verdict. Returning now keeps the
-	// version the user needs out of a "latest lookup failed; cached lookup failed"
-	// wrapper that buries it.
-	var requiresNewerCLI *ErrPluginRequiresNewerCLI
-	if errors.As(err, &requiresNewerCLI) {
+	// Returning now also keeps the version the user needs out of this path's combined
+	// "latest lookup failed; cached lookup failed" wrapper, which buries it.
+	if requiresNewerCLI(err) {
 		return nil, err
 	}
 
@@ -769,7 +742,7 @@ func resolvePluginForAutoInstall(ctx context.Context, config config.IConfig, fs 
 		return nil, fmt.Errorf("could not resolve plugin %s for auto-install: latest lookup failed: %v; cached lookup failed: %w", pluginName, err, cachedErr)
 	}
 
-	version, versionErr := getLatestResolvedPluginVersion(pluginName, cachedPlugin)
+	version, versionErr := resolveVersionFromReleases(cachedPlugin, pluginName, "", cachedPluginMetadata)
 	if versionErr != nil {
 		return nil, versionErr
 	}
@@ -853,25 +826,8 @@ func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs af
 		return nil, err
 	}
 
-	resolvedVersion := version
-	if resolvedVersion == "" {
-		resolvedVersion = plugin.LookUpLatestVersion()
-	}
-	if resolvedVersion == "" {
-		if coreVersionErr := plugin.checkCoreVersionForLatestRelease(); coreVersionErr != nil {
-			return nil, coreVersionErr
-		}
-		return nil, errorcategory.Errorf(errorcategory.API, "plugin metadata response did not include a release for %s on %s/%s", pluginName, runtime.GOOS, runtime.GOARCH)
-	}
-	if plugin.getReleaseForVersion(resolvedVersion) == nil {
-		return nil, errorcategory.Errorf(errorcategory.API, "plugin metadata response did not include plugin %s version %s for %s/%s", pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
-	}
-	// The API already filters restricted releases out of live responses by
-	// User-Agent, so this should never fire. It is checked anyway because the
-	// filtering depends on a header surviving the whole request path and on the
-	// Vary: User-Agent that keeps a response cached for one CLI version from being
-	// served to another, neither of which this side can verify.
-	if err := plugin.checkCoreVersionForRelease(resolvedVersion); err != nil {
+	resolvedVersion, err := resolveVersionFromReleases(plugin, pluginName, version, livePluginMetadata)
+	if err != nil {
 		return nil, err
 	}
 
@@ -899,20 +855,54 @@ func getCachedPluginList(config config.IConfig, fs afero.Fs) (PluginList, error)
 	return *validatedPluginList, nil
 }
 
-func getLatestResolvedPluginVersion(pluginName string, plugin *Plugin) (string, error) {
+// Where a plugin's releases came from. Resolution treats the two identically and
+// only needs to tell them apart when reporting a version it could not find, since
+// a response that omitted a release and a cache that never held one are different
+// problems for the user.
+const (
+	livePluginMetadata   = "plugin metadata response"
+	cachedPluginMetadata = "cached plugin metadata"
+)
+
+// resolveVersionFromReleases picks the version to install out of a plugin's
+// releases: the one that was asked for, or the newest this core CLI can run.
+//
+// This is the only place a resolved plugin's MinCoreVersion is weighed, so the live
+// and cached paths cannot drift apart on it, and their callers are left describing
+// where the metadata came from rather than repeating the constraint themselves.
+func resolveVersionFromReleases(plugin *Plugin, pluginName, requestedVersion, source string) (string, error) {
 	if plugin == nil {
-		return "", errorcategory.Errorf(errorcategory.API, "could not determine latest version for plugin %s", pluginName)
+		return "", errorcategory.Errorf(errorcategory.API, "%s did not include plugin %s", source, pluginName)
 	}
 
-	version := plugin.LookUpLatestVersion()
-	if version == "" {
-		if err := plugin.checkCoreVersionForLatestRelease(); err != nil {
-			return "", err
+	resolvedVersion := requestedVersion
+	if resolvedVersion == "" {
+		resolvedVersion = plugin.LookUpLatestVersion()
+
+		// Nothing left can mean every release for this platform was skipped for needing
+		// a newer CLI, which must not be reported as the plugin having no release.
+		if resolvedVersion == "" {
+			if err := plugin.checkCoreVersionForLatestRelease(); err != nil {
+				return "", err
+			}
+
+			return "", errorcategory.Errorf(errorcategory.API, "%s did not include a release for %s on %s/%s", source, pluginName, runtime.GOOS, runtime.GOARCH)
 		}
-		return "", errorcategory.Errorf(errorcategory.API, "could not determine latest version for plugin %s", pluginName)
 	}
 
-	return version, nil
+	if plugin.getReleaseForVersion(resolvedVersion) == nil {
+		return "", errorcategory.Errorf(errorcategory.API, "%s did not include plugin %s version %s for %s/%s", source, pluginName, resolvedVersion, runtime.GOOS, runtime.GOARCH)
+	}
+
+	// Only reachable for an explicitly requested version, since the lookup above
+	// already skips what this CLI cannot run, and the API filters live responses the
+	// same way. What is left is the cache: whichever CLI installed the plugin last
+	// wrote it, possibly a newer one than this.
+	if err := plugin.checkCoreVersionForRelease(resolvedVersion); err != nil {
+		return "", err
+	}
+
+	return resolvedVersion, nil
 }
 
 func lookUpPluginInCachedManifest(config config.IConfig, fs afero.Fs, pluginName string) (Plugin, error) {

--- a/pkg/plugins/utilities.go
+++ b/pkg/plugins/utilities.go
@@ -837,6 +837,14 @@ func resolvePluginFromMetadata(ctx context.Context, config config.IConfig, fs af
 
 	pluginMetadata, err := requests.GetPluginMetadata(ctx, apiBaseURL, dashboardBaseURL, stripe.APIVersion, apiKey, config.GetProfile(), pluginName, version, runtime.GOOS, runtime.GOARCH, config.GetMachineUUID())
 	if err != nil {
+		// Translated here rather than left to normalizePluginMetadataError, which only
+		// runs once the cached lookup has failed too. The endpoint is the sole source of
+		// this constraint on a machine whose cache predates the field, or has none at
+		// all, and that is exactly the machine the answer is worth keeping.
+		if minCoreVersion, requiresNewerCLI := requests.PluginRequiresNewerCLI(err); requiresNewerCLI {
+			return nil, newErrPluginRequiresNewerCLI(pluginName, version, minCoreVersion)
+		}
+
 		return nil, err
 	}
 

--- a/pkg/requests/plugin.go
+++ b/pkg/requests/plugin.go
@@ -125,9 +125,11 @@ func GetPluginMetadata(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVer
 }
 
 // PluginRequiresNewerCLI reports whether err is a plugin metadata response saying
-// the requested version needs a newer core CLI, along with the minimum version it
-// names. The endpoints only answer this way for an explicitly requested version;
-// resolving the latest version keeps skipping past incompatible releases silently.
+// the requested plugin needs a newer core CLI, along with the minimum version it
+// names. The endpoints answer this way for a version the caller named, and for a
+// request that named none when every release the plugin has needs a newer CLI --
+// reporting the lowest minimum among them, since that is the nearest version that
+// would make any of them installable.
 //
 // The minimum version rides on the error body as an extra attribute rather than in
 // RequestError, which is shared by every Stripe API request. An answer that names

--- a/pkg/requests/plugin.go
+++ b/pkg/requests/plugin.go
@@ -3,6 +3,7 @@ package requests
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -11,6 +12,15 @@ import (
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 )
+
+// ErrCodePluginRequiresNewerCLI is the error.code the plugin metadata endpoints
+// send when the requested plugin version declares a minimum core CLI version this
+// CLI does not meet.
+//
+// Such a release is otherwise hidden, so the request would 404 -- and a 404 says
+// only that the version does not exist, which is both wrong and the signal that
+// sends the CLI off to its cached metadata.
+const ErrCodePluginRequiresNewerCLI = "plugin_requires_newer_cli"
 
 // PluginMetadata contains plugin-specific manifest and binary information.
 type PluginMetadata struct {
@@ -112,6 +122,42 @@ func GetPluginMetadata(ctx context.Context, apiBaseURL, dashboardBaseURL, apiVer
 	}
 
 	return metadata, nil
+}
+
+// PluginRequiresNewerCLI reports whether err is a plugin metadata response saying
+// the requested version needs a newer core CLI, along with the minimum version it
+// names. The endpoints only answer this way for an explicitly requested version;
+// resolving the latest version keeps skipping past incompatible releases silently.
+//
+// The minimum version rides on the error body as an extra attribute rather than in
+// RequestError, which is shared by every Stripe API request. An answer that names
+// no minimum is still the same answer, so ok is true with an empty version: the
+// caller reports the upgrade without naming a target rather than losing the reason.
+func PluginRequiresNewerCLI(err error) (minCoreVersion string, ok bool) {
+	var requestErr RequestError
+	if !errors.As(err, &requestErr) {
+		return "", false
+	}
+
+	if requestErr.StatusCode != http.StatusBadRequest || requestErr.ErrorCode != ErrCodePluginRequiresNewerCLI {
+		return "", false
+	}
+
+	body, isString := requestErr.Body.(string)
+	if !isString {
+		return "", true
+	}
+
+	var errorBody struct {
+		Error struct {
+			MinCoreVersion string `json:"min_core_version"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &errorBody); err != nil {
+		return "", true
+	}
+
+	return errorBody.Error.MinCoreVersion, true
 }
 
 // GetPluginList returns the list of plugins visible to the current caller for

--- a/pkg/requests/plugin_test.go
+++ b/pkg/requests/plugin_test.go
@@ -1,0 +1,109 @@
+package requests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+)
+
+// requiresNewerCLIBody is the error body the plugin metadata endpoints send for a
+// release whose min_core_version this CLI does not meet, copied from the shape the
+// server's own tests assert on.
+const requiresNewerCLIBody = `{
+  "error": {
+    "code": "plugin_requires_newer_cli",
+    "message": "Version 2.0.1 of the appA plugin requires Stripe CLI 1.30.0 or later. Upgrade the Stripe CLI, or request a plugin version your CLI supports.",
+    "min_core_version": "1.30.0",
+    "param": "version",
+    "type": "invalid_request_error"
+  }
+}`
+
+func TestPluginRequiresNewerCLI(t *testing.T) {
+	tests := []struct {
+		name               string
+		err                error
+		wantMinCoreVersion string
+		wantOK             bool
+	}{
+		{
+			name:               "typed response",
+			err:                compileRequestError([]byte(requiresNewerCLIBody), http.StatusBadRequest),
+			wantMinCoreVersion: "1.30.0",
+			wantOK:             true,
+		},
+		{
+			// Still the same answer, so it is still recognized: the caller reports the
+			// upgrade without naming a target rather than losing the reason for it.
+			name:               "typed response without the extra attribute",
+			err:                compileRequestError([]byte(`{"error":{"code":"plugin_requires_newer_cli"}}`), http.StatusBadRequest),
+			wantMinCoreVersion: "",
+			wantOK:             true,
+		},
+		{
+			name:   "some other bad request",
+			err:    compileRequestError([]byte(`{"error":{"code":"parameter_invalid_string_empty","param":"version"}}`), http.StatusBadRequest),
+			wantOK: false,
+		},
+		{
+			// The status is checked as well as the code so that a hidden release, which
+			// answers 404 with no code at all, keeps being reported as a missing version.
+			name:   "not found",
+			err:    compileRequestError([]byte(`{"error":{"message":"not found"}}`), http.StatusNotFound),
+			wantOK: false,
+		},
+		{
+			name:   "right code on the wrong status",
+			err:    compileRequestError([]byte(requiresNewerCLIBody), http.StatusInternalServerError),
+			wantOK: false,
+		},
+		{
+			name:   "not a request error",
+			err:    errors.New("dial tcp: connection refused"),
+			wantOK: false,
+		},
+		{
+			name:               "wrapped request error",
+			err:                fmt.Errorf("could not fetch plugin metadata: %w", compileRequestError([]byte(requiresNewerCLIBody), http.StatusBadRequest)),
+			wantMinCoreVersion: "1.30.0",
+			wantOK:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			minCoreVersion, ok := PluginRequiresNewerCLI(tt.err)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantMinCoreVersion, minCoreVersion)
+		})
+	}
+}
+
+// TestGetPluginMetadataSurfacesRequiresNewerCLI pins the whole round trip. The
+// minimum version travels as an extra attribute on the error body, so it only
+// survives as long as the request layer keeps that body intact.
+func TestGetPluginMetadataSurfacesRequiresNewerCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		require.Equal(t, "/v1/stripecli/get-plugin-metadata", req.URL.Path)
+		res.Header().Set("Content-Type", "application/json")
+		res.WriteHeader(http.StatusBadRequest)
+		_, _ = res.Write([]byte(requiresNewerCLIBody))
+	}))
+	defer server.Close()
+
+	profile := &config.Profile{APIKey: "sk_test_1234"}
+
+	_, err := GetPluginMetadata(context.Background(), server.URL, server.URL, "2020-08-27", "sk_test_1234", profile, "appA", "2.0.1", "darwin", "arm64", "uuid")
+	require.Error(t, err)
+
+	minCoreVersion, ok := PluginRequiresNewerCLI(err)
+	require.True(t, ok)
+	require.Equal(t, "1.30.0", minCoreVersion)
+}

--- a/pkg/requests/plugin_test.go
+++ b/pkg/requests/plugin_test.go
@@ -26,6 +26,19 @@ const requiresNewerCLIBody = `{
   }
 }`
 
+// requiresNewerCLIWithoutVersionBody is the same answer for a request that named no
+// version, where the endpoint reports the lowest floor among the plugin's releases.
+// It blames no parameter, because the caller supplied none to blame, and names no
+// plugin version. Both are absent from the wire, not merely unused here.
+const requiresNewerCLIWithoutVersionBody = `{
+  "error": {
+    "code": "plugin_requires_newer_cli",
+    "message": "The appA plugin requires Stripe CLI 1.30.0 or later. Upgrade the Stripe CLI to install it.",
+    "min_core_version": "1.30.0",
+    "type": "invalid_request_error"
+  }
+}`
+
 func TestPluginRequiresNewerCLI(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -36,6 +49,15 @@ func TestPluginRequiresNewerCLI(t *testing.T) {
 		{
 			name:               "typed response",
 			err:                compileRequestError([]byte(requiresNewerCLIBody), http.StatusBadRequest),
+			wantMinCoreVersion: "1.30.0",
+			wantOK:             true,
+		},
+		{
+			// The code is what identifies this answer, so the minimum version still
+			// arrives for a request that named no version -- the case where the caller
+			// has nothing else to tell the user to do.
+			name:               "typed response for a request that named no version",
+			err:                compileRequestError([]byte(requiresNewerCLIWithoutVersionBody), http.StatusBadRequest),
 			wantMinCoreVersion: "1.30.0",
 			wantOK:             true,
 		},


### PR DESCRIPTION
 ### Summary

  Plugin releases can require a minimum Stripe CLI version. When the plugin metadata API returns a `400 plugin_requires_newer_cli` response, the CLI
  currently treats it as a generic lookup failure. This can trigger a fallback to stale cached metadata or produce misleading login, not-found, and
  availability guidance.

  This PR recognizes that API response and converts it into a typed `ErrPluginRequiresNewerCLI`. The error is preserved across plugin install,
  upgrade, auto-install, and plugin-hint flows, preventing cached metadata from overriding the API’s compatibility decision.

  Users now receive an actionable error that identifies the plugin version, current CLI version, required CLI version, and upgrade documentation.
  Versionless requests and responses that omit some metadata degrade gracefully.

  The change also centralizes version selection and validation for live and cached plugin metadata so these resolution paths behave consistently.

  ### Testing

  Added coverage for:

  - Parsing typed, wrapped, malformed, and unrelated API errors
  - Explicit and versionless plugin requests
  - Install, upgrade, auto-install, and plugin-hint flows
  - Ensuring the API response takes precedence over cached metadata
  - Complete and partial user-facing error messages

  Ran:

  `go test ./pkg/requests ./pkg/plugins ./pkg/cmd/plugin ./pkg/cmd/pluginhints`