### PR TITLE
Add config file migration to v1

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,21 @@ import (
 	"github.com/stripe/stripe-cli/pkg/keyring"
 )
 
+// Top-level config.toml keys that belong to the CLI itself rather than to a
+// profile. A profile with one of these names is a collision, which is what
+// moving profiles under the reserved profiles table fixes.
+const (
+	// ColorName is the color setting. It is also a valid profile field, so it can
+	// appear both at the top level and inside a profile.
+	ColorName = "color"
+
+	// InstalledPluginsKey lists the locally installed plugins.
+	InstalledPluginsKey = "installed_plugins"
+
+	// MachineUUIDKey is the persistent machine identifier used for telemetry.
+	MachineUUIDKey = "machine_uuid"
+)
+
 // ColorOn represnets the on-state for colors
 const ColorOn = "on"
 
@@ -337,19 +352,19 @@ func (c *Config) PrintConfig() error {
 func (c *Config) GetInstalledPlugins() []string {
 	runtimeViper := viper.GetViper()
 
-	return runtimeViper.GetStringSlice("installed_plugins")
+	return runtimeViper.GetStringSlice(InstalledPluginsKey)
 }
 
 // GetMachineUUID returns the persistent machine UUID from config,
 // generating and saving one if it doesn't exist.
 func (c *Config) GetMachineUUID() string {
 	runtimeViper := viper.GetViper()
-	id := runtimeViper.GetString("machine_uuid")
+	id := runtimeViper.GetString(MachineUUIDKey)
 	if id != "" {
 		return id
 	}
 	id = uuid.NewString()
-	_ = c.WriteConfigField("machine_uuid", id)
+	_ = c.WriteConfigField(MachineUUIDKey, id)
 	return id
 }
 
@@ -648,9 +663,7 @@ func configVersion(v *viper.Viper) (int, error) {
 	}
 
 	if version > MaxSupportedConfigVersion {
-		return version, errorcategory.Errorf(errorcategory.Filesystem,
-			"%s is %d, but this Stripe CLI understands up to %d. Upgrade the CLI: https://docs.stripe.com/stripe-cli/upgrade",
-			ConfigVersionName, version, MaxSupportedConfigVersion)
+		return version, unsupportedConfigVersionError(version)
 	}
 
 	return version, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -399,12 +399,13 @@ func (c *Config) SwitchProfile(profileName string) error {
 // so that a name collision cannot destroy machine-wide settings — or, for
 // "profiles", the entire v2 profile table.
 var reservedTopLevelKeys = map[string]bool{
-	"color":             true,
-	"installed_plugins": true,
-	"machine_uuid":      true,
-	"plugin_configs":    true,
-	"project-name":      true,
+	ConfigVersionName:   true,
 	ProfilesTableName:   true,
+	ColorName:           true,
+	InstalledPluginsKey: true,
+	MachineUUIDKey:      true,
+	PluginConfigsKey:    true,
+	"project-name":      true,
 	UserInfoName:        true,
 }
 
@@ -670,14 +671,10 @@ func configVersion(v *viper.Viper) (int, error) {
 }
 
 // isMigrated reports whether the config file stores profiles in the v2 layout,
-// under the reserved profiles table. This release line never sets config_version;
-// it only recognizes a file that a v2 CLI already migrated.
-//
-// A version this binary cannot act on is not migrated: writeConfig refuses such a
-// file outright, so no write ever reaches the layout decision this gates.
+// under the reserved profiles table.
 func isMigrated(v *viper.Viper) bool {
 	version, err := configVersion(v)
-	return err == nil && version == ConfigVersionV2
+	return err == nil && version >= ConfigVersionV2
 }
 
 // profileTableKeyForWrite returns the key a whole profile table should be

--- a/pkg/config/migrate.go
+++ b/pkg/config/migrate.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 	"github.com/stripe/stripe-cli/pkg/fsutil"
 )
 
@@ -302,55 +303,55 @@ func verifyPlan(plan *migrationPlan, encoded []byte) error {
 	}
 
 	if got := configVersionOf(doc); got != ConfigVersionV2 {
-		return fmt.Errorf("migrated config has config_version %d, want %d", got, ConfigVersionV2)
+		return errorcategory.Errorf(errorcategory.Filesystem, "migrated config has config_version %d, want %d", got, ConfigVersionV2)
 	}
 
 	profiles, ok := toStringMap(doc[ProfilesTableName])
 	if !ok {
-		return fmt.Errorf("migrated config has no %s table", ProfilesTableName)
+		return errorcategory.Errorf(errorcategory.Filesystem, "migrated config has no %s table", ProfilesTableName)
 	}
 
 	for _, name := range sortedProfileNames(plan.profiles) {
 		table, ok := toStringMap(profiles[name])
 		if !ok {
-			return fmt.Errorf("profile %q is missing from the migrated config", name)
+			return errorcategory.Errorf(errorcategory.Filesystem, "profile %q is missing from the migrated config", name)
 		}
 
 		for _, field := range sortedKeys(plan.profiles[name]) {
 			want := plan.profiles[name][field]
 			got, present := table[field]
 			if !present {
-				return fmt.Errorf("profile %q lost field %q in the migrated config", name, field)
+				return errorcategory.Errorf(errorcategory.Filesystem, "profile %q lost field %q in the migrated config", name, field)
 			}
 
 			if !reflect.DeepEqual(want, got) {
-				return fmt.Errorf("profile %q field %q changed value in the migrated config", name, field)
+				return errorcategory.Errorf(errorcategory.Filesystem, "profile %q field %q changed value in the migrated config", name, field)
 			}
 		}
 
 		if len(table) != len(plan.profiles[name]) {
-			return fmt.Errorf("profile %q gained fields in the migrated config", name)
+			return errorcategory.Errorf(errorcategory.Filesystem, "profile %q gained fields in the migrated config", name)
 		}
 	}
 
 	if len(profiles) != len(plan.profiles) {
-		return fmt.Errorf("migrated config has %d profiles, want %d", len(profiles), len(plan.profiles))
+		return errorcategory.Errorf(errorcategory.Filesystem, "migrated config has %d profiles, want %d", len(profiles), len(plan.profiles))
 	}
 
 	for _, key := range sortedKeys(plan.settings) {
 		got, present := doc[key]
 		if !present {
-			return fmt.Errorf("setting %q is missing from the migrated config", key)
+			return errorcategory.Errorf(errorcategory.Filesystem, "setting %q is missing from the migrated config", key)
 		}
 
 		if !reflect.DeepEqual(plan.settings[key], got) {
-			return fmt.Errorf("setting %q changed value in the migrated config", key)
+			return errorcategory.Errorf(errorcategory.Filesystem, "setting %q changed value in the migrated config", key)
 		}
 	}
 
 	// The settings, plus config_version and the profiles table.
 	if len(doc) != len(plan.settings)+2 {
-		return fmt.Errorf("migrated config has %d top-level keys, want %d", len(doc), len(plan.settings)+2)
+		return errorcategory.Errorf(errorcategory.Filesystem, "migrated config has %d top-level keys, want %d", len(doc), len(plan.settings)+2)
 	}
 
 	return nil

--- a/pkg/config/migrate.go
+++ b/pkg/config/migrate.go
@@ -17,22 +17,6 @@ import (
 // the migration leaves behind, e.g. "config.toml.v1.bak".
 const ConfigBackupSuffix = ".v1.bak"
 
-// reservedTopLevelKeys are the top-level config.toml keys that belong to the CLI
-// itself. Every other top-level table in a v1 file is a candidate profile.
-//
-// Profiles are identified by exclusion rather than by looking for a display_name
-// as isProfile does, because a profile abandoned part-way through login has no
-// display_name and still needs to move.
-var reservedTopLevelKeys = map[string]bool{
-	ConfigVersionName:   true,
-	ProfilesTableName:   true,
-	UserInfoName:        true,
-	ColorName:           true,
-	InstalledPluginsKey: true,
-	MachineUUIDKey:      true,
-	PluginConfigsKey:    true,
-}
-
 // profileFieldNames are the field names that mark a table as a profile. A
 // top-level table is only migrated when it holds at least one of them, so an
 // unrecognized table is left where it is instead of being guessed into the

--- a/pkg/config/migrate.go
+++ b/pkg/config/migrate.go
@@ -1,0 +1,449 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/stripe/stripe-cli/pkg/fsutil"
+)
+
+// ConfigBackupSuffix is appended to the config file name to name the backup that
+// the migration leaves behind, e.g. "config.toml.v1.bak".
+const ConfigBackupSuffix = ".v1.bak"
+
+// reservedTopLevelKeys are the top-level config.toml keys that belong to the CLI
+// itself. Every other top-level table in a v1 file is a candidate profile.
+//
+// Profiles are identified by exclusion rather than by looking for a display_name
+// as isProfile does, because a profile abandoned part-way through login has no
+// display_name and still needs to move.
+var reservedTopLevelKeys = map[string]bool{
+	ConfigVersionName:   true,
+	ProfilesTableName:   true,
+	UserInfoName:        true,
+	ColorName:           true,
+	InstalledPluginsKey: true,
+	MachineUUIDKey:      true,
+	PluginConfigsKey:    true,
+}
+
+// profileFieldNames are the field names that mark a table as a profile. A
+// top-level table is only migrated when it holds at least one of them, so an
+// unrecognized table is left where it is instead of being guessed into the
+// profiles table. Dual-read means leaving it alone costs nothing: the CLI still
+// finds it at the top level.
+var profileFieldNames = map[string]bool{
+	AccountIDName:               true,
+	ColorName:                   true,
+	DeviceNameName:              true,
+	DisplayNameName:             true,
+	IsTermsAcceptanceValidName:  true,
+	LiveModeAPIKeyName:          true,
+	LiveModeKeyExpiresAtName:    true,
+	LiveModePubKeyName:          true,
+	SandboxClaimURLName:         true,
+	SandboxExpiresAtName:        true,
+	TestModeAPIKeyName:          true,
+	TestModeKeyExpiresAtName:    true,
+	TestModePubKeyName:          true,
+	UserIDName:                  true,
+	"api_key":                   true,
+	"experimental":              true,
+	"profile_name":              true,
+	"publishable_key":           true,
+	"secret_key":                true,
+	"test_mode_publishable_key": true,
+}
+
+// migrationPlan is the v2 document the migration intends to write: every profile
+// under the profiles table, and the CLI's own settings left at the top level.
+type migrationPlan struct {
+	profiles map[string]map[string]interface{}
+	settings map[string]interface{}
+}
+
+// MigrateConfigFile rewrites the config file at path in the v2 layout, moving
+// every profile under the reserved profiles table and recording
+// config_version = 2. It reports whether the file changed.
+//
+// The original file is copied to path + ConfigBackupSuffix first. The migrated
+// document is verified in memory and again after the write; a failure at either
+// point restores the backup and returns an error, so a partial or mangled file
+// is never left behind.
+//
+// A file whose config_version is newer than this binary understands is left
+// untouched and returns an error.
+//
+// This function does not decide *whether* to migrate. Callers own that: an
+// installed plugin too old to read the v2 layout, or a non-interactive session,
+// must not migrate.
+func MigrateConfigFile(path string) (bool, error) {
+	if err := fsutil.RefuseWriteThroughSymlinkOS(path, filepath.Dir(filepath.Dir(path)), filepath.Base(path)); err != nil {
+		return false, err
+	}
+
+	original, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		// Nothing to migrate. A file written from scratch gets its layout from
+		// the normal write path.
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	plan, changed, err := planMigration(original)
+	if err != nil {
+		return false, err
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	migrated, err := encodePlan(plan)
+	if err != nil {
+		return false, err
+	}
+
+	// Verify before touching the file at all, so an encoding bug costs the user
+	// nothing.
+	if err := verifyPlan(plan, migrated); err != nil {
+		return false, err
+	}
+
+	backupPath := path + ConfigBackupSuffix
+	if err := writeFileSync(backupPath, original); err != nil {
+		return false, fmt.Errorf("could not back up %s: %w", path, err)
+	}
+
+	if err := replaceFileAtomically(path, migrated); err != nil {
+		return false, err
+	}
+
+	// Re-read what actually landed on disk. A truncated write or a rename that
+	// did not take is worth catching here rather than on the next command.
+	written, err := os.ReadFile(path)
+	if err == nil {
+		err = verifyPlan(plan, written)
+	}
+
+	if err != nil {
+		if restoreErr := writeFileSync(path, original); restoreErr != nil {
+			return false, fmt.Errorf("config migration failed (%v) and the original could not be restored: %w; a copy is at %s", err, restoreErr, backupPath)
+		}
+
+		return false, fmt.Errorf("config migration failed and was rolled back: %w", err)
+	}
+
+	return true, nil
+}
+
+// planMigration reads a config document and returns the v2 document to write.
+// changed is false when there is nothing to do: an already-migrated file with no
+// stray top-level profiles. A config_version newer than this binary understands
+// returns an error.
+func planMigration(contents []byte) (*migrationPlan, bool, error) {
+	// Decode raw TOML rather than going through viper, which lowercases every
+	// key. Round-tripping profile names through viper would rename a profile the
+	// user created with capitals in it.
+	var doc map[string]interface{}
+	if err := toml.Unmarshal(contents, &doc); err != nil {
+		return nil, false, fmt.Errorf("could not parse config file: %w", err)
+	}
+
+	version := configVersionOf(doc)
+	if version > MaxSupportedConfigVersion {
+		return nil, false, unsupportedConfigVersionError(version)
+	}
+
+	plan := &migrationPlan{
+		profiles: make(map[string]map[string]interface{}),
+		settings: make(map[string]interface{}),
+	}
+
+	alreadyV2 := version == ConfigVersionV2
+
+	// Start from the profiles already in the v2 table, if there are any.
+	nested, nestedIsContainer := profilesContainer(doc, alreadyV2)
+	if nestedIsContainer {
+		for name, value := range nested {
+			if table, ok := toStringMap(value); ok {
+				plan.profiles[name] = table
+			}
+		}
+	}
+
+	moved := 0
+
+	for key, value := range doc {
+		if key == ConfigVersionName {
+			continue
+		}
+
+		if key == ProfilesTableName && nestedIsContainer {
+			continue
+		}
+
+		table, isTable := toStringMap(value)
+		if !isTable || reservedProfileNameException(key, nestedIsContainer) || !looksLikeProfile(table) {
+			plan.settings[key] = value
+			continue
+		}
+
+		// A field already present in the v2 table wins: it is the copy the
+		// current CLI reads and writes, so the top-level table is the stale one.
+		if existing, ok := plan.profiles[key]; ok {
+			for field, fieldValue := range table {
+				if _, taken := existing[field]; !taken {
+					existing[field] = fieldValue
+				}
+			}
+		} else {
+			plan.profiles[key] = table
+		}
+
+		moved++
+	}
+
+	return plan, moved > 0 || !alreadyV2, nil
+}
+
+// reservedProfileNameException reports whether a top-level key must be treated
+// as a setting rather than as a profile. Only the profiles table itself
+// qualifies, and only when it is acting as the v2 container.
+func reservedProfileNameException(key string, nestedIsContainer bool) bool {
+	if key == ProfilesTableName {
+		return nestedIsContainer
+	}
+
+	return reservedTopLevelKeys[key]
+}
+
+// profilesContainer returns the v2 profiles table, if the document has one.
+//
+// A v1 file can contain a profile literally named "profiles", which occupies the
+// same key as the v2 container: nothing stops `stripe login --project-name
+// profiles`. The two are distinguishable because a profile holds scalar fields
+// while the container holds only tables, and because a migrated file says so
+// with config_version.
+func profilesContainer(doc map[string]interface{}, alreadyV2 bool) (map[string]interface{}, bool) {
+	table, ok := toStringMap(doc[ProfilesTableName])
+	if !ok {
+		return nil, false
+	}
+
+	if alreadyV2 {
+		return table, true
+	}
+
+	// In a v1 file, treat it as the container only if it cannot be a profile.
+	if looksLikeProfile(table) {
+		return nil, false
+	}
+
+	for _, value := range table {
+		if _, isTable := toStringMap(value); !isTable {
+			return nil, false
+		}
+	}
+
+	return table, true
+}
+
+// looksLikeProfile reports whether a table holds at least one recognized profile
+// field.
+func looksLikeProfile(table map[string]interface{}) bool {
+	for field := range table {
+		if profileFieldNames[field] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// configVersionOf reads config_version out of a raw TOML document. TOML integers
+// decode as int64.
+func configVersionOf(doc map[string]interface{}) int {
+	switch version := doc[ConfigVersionName].(type) {
+	case int64:
+		return int(version)
+	case int:
+		return version
+	}
+
+	return 0
+}
+
+// encodePlan serializes a plan as a v2 TOML document.
+func encodePlan(plan *migrationPlan) ([]byte, error) {
+	doc := make(map[string]interface{}, len(plan.settings)+2)
+	for key, value := range plan.settings {
+		doc[key] = value
+	}
+
+	doc[ConfigVersionName] = ConfigVersionV2
+
+	profiles := make(map[string]interface{}, len(plan.profiles))
+	for name, table := range plan.profiles {
+		profiles[name] = table
+	}
+	doc[ProfilesTableName] = profiles
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(doc); err != nil {
+		return nil, fmt.Errorf("could not encode migrated config: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// verifyPlan re-parses an encoded document and checks that it says exactly what
+// the plan intended: every profile field under the profiles table with its
+// original value, every setting still at the top level, and nothing extra.
+//
+// This is what makes the migration safe to run unattended. A serialization bug
+// that folded a profile name's case or dropped a field would otherwise silently
+// cost the user a credential.
+func verifyPlan(plan *migrationPlan, encoded []byte) error {
+	var doc map[string]interface{}
+	if err := toml.Unmarshal(encoded, &doc); err != nil {
+		return fmt.Errorf("migrated config does not parse: %w", err)
+	}
+
+	if got := configVersionOf(doc); got != ConfigVersionV2 {
+		return fmt.Errorf("migrated config has config_version %d, want %d", got, ConfigVersionV2)
+	}
+
+	profiles, ok := toStringMap(doc[ProfilesTableName])
+	if !ok {
+		return fmt.Errorf("migrated config has no %s table", ProfilesTableName)
+	}
+
+	for _, name := range sortedProfileNames(plan.profiles) {
+		table, ok := toStringMap(profiles[name])
+		if !ok {
+			return fmt.Errorf("profile %q is missing from the migrated config", name)
+		}
+
+		for _, field := range sortedKeys(plan.profiles[name]) {
+			want := plan.profiles[name][field]
+			got, present := table[field]
+			if !present {
+				return fmt.Errorf("profile %q lost field %q in the migrated config", name, field)
+			}
+
+			if !reflect.DeepEqual(want, got) {
+				return fmt.Errorf("profile %q field %q changed value in the migrated config", name, field)
+			}
+		}
+
+		if len(table) != len(plan.profiles[name]) {
+			return fmt.Errorf("profile %q gained fields in the migrated config", name)
+		}
+	}
+
+	if len(profiles) != len(plan.profiles) {
+		return fmt.Errorf("migrated config has %d profiles, want %d", len(profiles), len(plan.profiles))
+	}
+
+	for _, key := range sortedKeys(plan.settings) {
+		got, present := doc[key]
+		if !present {
+			return fmt.Errorf("setting %q is missing from the migrated config", key)
+		}
+
+		if !reflect.DeepEqual(plan.settings[key], got) {
+			return fmt.Errorf("setting %q changed value in the migrated config", key)
+		}
+	}
+
+	// The settings, plus config_version and the profiles table.
+	if len(doc) != len(plan.settings)+2 {
+		return fmt.Errorf("migrated config has %d top-level keys, want %d", len(doc), len(plan.settings)+2)
+	}
+
+	return nil
+}
+
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	return keys
+}
+
+func sortedProfileNames(m map[string]map[string]interface{}) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return names
+}
+
+// replaceFileAtomically writes contents to a temp file in the same directory and
+// renames it over path, so a reader either sees the old file or the new one.
+func replaceFileAtomically(path string, contents []byte) error {
+	dir := filepath.Dir(path)
+
+	temp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+
+	// Best effort: a failure below leaves the temp file behind, but the config
+	// file itself is untouched.
+	defer os.Remove(tempPath)
+
+	if err := writeAndSync(temp, contents); err != nil {
+		temp.Close()
+		return err
+	}
+
+	if err := temp.Chmod(os.FileMode(0600)); err != nil {
+		temp.Close()
+		return err
+	}
+
+	if err := temp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tempPath, path)
+}
+
+// writeFileSync writes contents to path with the config file's permissions and
+// flushes them to disk before returning.
+func writeFileSync(path string, contents []byte) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(0600))
+	if err != nil {
+		return err
+	}
+
+	if err := writeAndSync(file, contents); err != nil {
+		file.Close()
+		return err
+	}
+
+	return file.Close()
+}
+
+func writeAndSync(file *os.File, contents []byte) error {
+	if _, err := file.Write(contents); err != nil {
+		return err
+	}
+
+	return file.Sync()
+}

--- a/pkg/config/migrate_test.go
+++ b/pkg/config/migrate_test.go
@@ -1,0 +1,358 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// writeConfigFileForMigration writes a config file to migrate and returns its
+// path. It deliberately does not initialize viper: the migration reads the file
+// directly.
+func writeConfigFileForMigration(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0600))
+
+	return path
+}
+
+const v1ConfigFileToMigrate = `installed_plugins = ['apps', 'projects']
+machine_uuid = 'f4a1c7de-0000-0000-0000-000000000000'
+
+[plugin_configs.__global]
+  updates = 'off'
+
+[user_info]
+  compartments = []
+
+[default]
+  account_id = 'acct_1'
+  device_name = 'device-1'
+  display_name = 'Account One'
+  test_mode_api_key = 'sk_test_one_key'
+
+["acme corp"]
+  account_id = 'acct_2'
+  display_name = 'Account Two'
+  test_mode_api_key = 'sk_test_two_key'
+`
+
+func TestMigrateConfigFileMovesProfilesUnderProfilesTable(t *testing.T) {
+	path := writeConfigFileForMigration(t, v1ConfigFileToMigrate)
+
+	changed, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	contents := string(helperLoadBytes(t, path))
+	require.Contains(t, contents, "config_version = 2")
+	require.Contains(t, contents, "[profiles.default]")
+	require.Contains(t, contents, `[profiles."acme corp"]`)
+	require.NotContains(t, contents, "\n[default]")
+}
+
+func TestMigrateConfigFileKeepsSettingsAtTopLevel(t *testing.T) {
+	path := writeConfigFileForMigration(t, v1ConfigFileToMigrate)
+
+	_, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	require.NoError(t, v.ReadInConfig())
+
+	require.Equal(t, []string{"apps", "projects"}, v.GetStringSlice(InstalledPluginsKey))
+	require.Equal(t, "f4a1c7de-0000-0000-0000-000000000000", v.GetString(MachineUUIDKey))
+	require.Equal(t, "off", v.GetString(PluginConfigKey(PluginConfigGlobalScope, PluginConfigUpdatesField)))
+	require.True(t, v.IsSet(UserInfoName))
+	require.Equal(t, ConfigVersionV2, v.GetInt(ConfigVersionName))
+}
+
+// The CLI has to be able to read what the migration writes. This is the seam
+// between the two, so assert it directly rather than through the file contents.
+func TestMigratedConfigIsReadableByProfile(t *testing.T) {
+	path := writeConfigFileForMigration(t, v1ConfigFileToMigrate)
+
+	_, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+
+	setupProfileConfig(t, string(helperLoadBytes(t, path)))
+
+	p := Profile{ProfileName: "default"}
+	apiKey, err := p.GetAPIKey(false)
+	require.NoError(t, err)
+	require.Equal(t, "sk_test_one_key", apiKey)
+	require.Equal(t, "Account One", p.GetDisplayName())
+
+	second := Profile{ProfileName: "acme corp"}
+	require.Equal(t, "Account Two", second.GetDisplayName())
+}
+
+func TestMigrateConfigFileLeavesBackup(t *testing.T) {
+	path := writeConfigFileForMigration(t, v1ConfigFileToMigrate)
+
+	_, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+
+	backup := helperLoadBytes(t, path+ConfigBackupSuffix)
+	require.Equal(t, v1ConfigFileToMigrate, string(backup))
+
+	// Windows has no Unix permission bits, so the mode the file was created with
+	// does not survive a Stat there.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	}
+}
+
+func TestMigrateConfigFileIsIdempotent(t *testing.T) {
+	path := writeConfigFileForMigration(t, v1ConfigFileToMigrate)
+
+	changed, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	firstPass := helperLoadBytes(t, path)
+
+	changed, err = MigrateConfigFile(path)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Equal(t, firstPass, helperLoadBytes(t, path))
+}
+
+// viper lowercases every key it reads, so the migration reads raw TOML. A
+// profile named with capitals must come out the other side unchanged.
+func TestMigrateConfigFilePreservesProfileNameCase(t *testing.T) {
+	path := writeConfigFileForMigration(t, `[AcmeCorp]
+  display_name = 'Acme Corp'
+  test_mode_api_key = 'sk_test_acme_key'
+`)
+
+	_, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+
+	require.Contains(t, string(helperLoadBytes(t, path)), "[profiles.AcmeCorp]")
+}
+
+// An older CLI or plugin writing a migrated file does not know about the
+// profiles table, so it leaves a v1 table behind. Folding it in is the only way
+// the file converges back to one copy of each profile.
+func TestMigrateConfigFileFoldsShadowTable(t *testing.T) {
+	path := writeConfigFileForMigration(t, `config_version = 2
+
+[profiles.default]
+  device_name = 'nested-device'
+  display_name = 'Nested Account'
+
+[default]
+  device_name = 'shadow-device'
+  test_mode_api_key = 'sk_test_shadow_key'
+`)
+
+	changed, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	require.NoError(t, v.ReadInConfig())
+
+	// The nested copy is the one the current CLI reads and writes, so it wins.
+	require.Equal(t, "nested-device", v.GetString("profiles.default.device_name"))
+	// A field only the old writer knew about is not thrown away.
+	require.Equal(t, "sk_test_shadow_key", v.GetString("profiles.default.test_mode_api_key"))
+	require.False(t, v.IsSet("default.device_name"))
+}
+
+// Nothing stops `stripe login --project-name profiles` on a v1 CLI, so the
+// reserved table name can already be taken by a profile.
+func TestMigrateConfigFileHandlesProfileNamedProfiles(t *testing.T) {
+	path := writeConfigFileForMigration(t, `[profiles]
+  display_name = 'Confusing Account'
+  test_mode_api_key = 'sk_test_confusing_key'
+`)
+
+	changed, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	require.NoError(t, v.ReadInConfig())
+
+	require.Equal(t, "sk_test_confusing_key", v.GetString("profiles.profiles.test_mode_api_key"))
+}
+
+// An unrecognized table might be anything, including a setting a newer CLI
+// writes. Dual-read means leaving it alone costs nothing, while guessing wrong
+// would move a setting into the profiles table.
+func TestMigrateConfigFileLeavesUnrecognizedTableAlone(t *testing.T) {
+	path := writeConfigFileForMigration(t, `[some_future_setting]
+  enabled = true
+
+[default]
+  display_name = 'Account One'
+  test_mode_api_key = 'sk_test_one_key'
+`)
+
+	_, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	require.NoError(t, v.ReadInConfig())
+
+	require.True(t, v.GetBool("some_future_setting.enabled"))
+	require.Equal(t, "Account One", v.GetString("profiles.default.display_name"))
+}
+
+// A dotted profile name parses as a nested table, so it is not recognizable as a
+// profile. It stays where it is and keeps working through the v1 read fallback.
+func TestMigrateConfigFileLeavesDottedProfileAlone(t *testing.T) {
+	path := writeConfigFileForMigration(t, `[example.project]
+  display_name = 'Dotted Account'
+  test_mode_api_key = 'sk_test_dotted_key'
+`)
+
+	_, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	require.NoError(t, v.ReadInConfig())
+
+	require.Equal(t, "sk_test_dotted_key", v.GetString("example.project.test_mode_api_key"))
+	require.False(t, v.IsSet("profiles.example"))
+}
+
+// A profile abandoned part-way through login has no display_name, so the
+// migration cannot use isProfile's rule to find it.
+func TestMigrateConfigFileMovesProfileWithoutDisplayName(t *testing.T) {
+	path := writeConfigFileForMigration(t, `[default]
+  device_name = 'partial-device'
+`)
+
+	_, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+
+	require.Contains(t, string(helperLoadBytes(t, path)), "[profiles.default]")
+}
+
+func TestMigrateConfigFileStampsVersionOnFileWithNoProfiles(t *testing.T) {
+	path := writeConfigFileForMigration(t, "installed_plugins = ['apps']\n")
+
+	changed, err := MigrateConfigFile(path)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	contents := string(helperLoadBytes(t, path))
+	require.Contains(t, contents, "config_version = 2")
+	require.Contains(t, contents, "installed_plugins")
+}
+
+// Stop migrating if the file's version is greater than the maximum this CLI
+// understands (currently 2).
+func TestMigrateConfigFileRefusesNewerThanSupportedVersion(t *testing.T) {
+	contents := `config_version = 3
+
+[profiles.default]
+  display_name = 'V3 Account'
+  test_mode_api_key = 'sk_test_v3_key'
+
+[default]
+  display_name = 'Shadow'
+  test_mode_api_key = 'sk_test_shadow'
+`
+	path := writeConfigFileForMigration(t, contents)
+
+	changed, err := MigrateConfigFile(path)
+	require.ErrorContains(t, err, "understands up to 2")
+	require.False(t, changed)
+
+	require.Equal(t, contents, string(helperLoadBytes(t, path)))
+	require.NoFileExists(t, path+ConfigBackupSuffix)
+}
+
+func TestMigrateConfigFileMissingFile(t *testing.T) {
+	changed, err := MigrateConfigFile(filepath.Join(t.TempDir(), "config.toml"))
+	require.NoError(t, err)
+	require.False(t, changed)
+}
+
+func TestMigrateConfigFileRejectsUnparseableFile(t *testing.T) {
+	contents := "this is not = = toml\n"
+	path := writeConfigFileForMigration(t, contents)
+
+	changed, err := MigrateConfigFile(path)
+	require.Error(t, err)
+	require.False(t, changed)
+
+	// The file the CLI cannot parse is still the file the user has.
+	require.Equal(t, contents, string(helperLoadBytes(t, path)))
+	require.NoFileExists(t, path+ConfigBackupSuffix)
+}
+
+// The migration rewrites the config file, so it has to refuse the same symlinked
+// destinations the normal write path refuses.
+func TestMigrateConfigFileRefusesSymlink(t *testing.T) {
+	profilesFile, victimFile := setupSymlinkedProfilesFile(t)
+
+	changed, err := MigrateConfigFile(profilesFile)
+	require.ErrorContains(t, err, "symlink")
+	require.False(t, changed)
+
+	require.Equal(t, "original = true\n", string(helperLoadBytes(t, victimFile)))
+	require.NoFileExists(t, profilesFile+ConfigBackupSuffix)
+}
+
+func TestMigrateConfigFileRefusesSymlinkedParent(t *testing.T) {
+	profilesFile, victimDir := setupProfilesFileWithSymlinkedParent(t)
+	require.NoError(t, os.WriteFile(profilesFile, []byte(v1ConfigFileToMigrate), 0600))
+
+	changed, err := MigrateConfigFile(profilesFile)
+	require.ErrorContains(t, err, "symlink")
+	require.False(t, changed)
+
+	require.Equal(t, v1ConfigFileToMigrate, string(helperLoadBytes(t, filepath.Join(victimDir, "config.toml"))))
+}
+
+func TestVerifyPlanCatchesADroppedField(t *testing.T) {
+	plan := &migrationPlan{
+		profiles: map[string]map[string]interface{}{
+			"default": {"display_name": "Account One", "test_mode_api_key": "sk_test_one_key"},
+		},
+		settings: map[string]interface{}{},
+	}
+
+	err := verifyPlan(plan, []byte("config_version = 2\n\n[profiles.default]\n  display_name = 'Account One'\n"))
+	require.ErrorContains(t, err, "lost field")
+}
+
+func TestVerifyPlanCatchesAChangedProfileName(t *testing.T) {
+	plan := &migrationPlan{
+		profiles: map[string]map[string]interface{}{
+			"AcmeCorp": {"display_name": "Acme Corp"},
+		},
+		settings: map[string]interface{}{},
+	}
+
+	err := verifyPlan(plan, []byte("config_version = 2\n\n[profiles.acmecorp]\n  display_name = 'Acme Corp'\n"))
+	require.ErrorContains(t, err, "missing from the migrated config")
+}
+
+func TestVerifyPlanCatchesADroppedSetting(t *testing.T) {
+	plan := &migrationPlan{
+		profiles: map[string]map[string]interface{}{},
+		settings: map[string]interface{}{InstalledPluginsKey: []interface{}{"apps"}},
+	}
+
+	err := verifyPlan(plan, []byte("config_version = 2\n\n[profiles]\n"))
+	require.ErrorContains(t, err, "is missing from the migrated config")
+}

--- a/pkg/config/plugin_configs.go
+++ b/pkg/config/plugin_configs.go
@@ -6,6 +6,10 @@ const (
 
 	// PluginConfigUpdatesField is the config field name controlling automatic updates.
 	PluginConfigUpdatesField = "updates"
+
+	// PluginConfigsKey is the top-level table holding every plugin config
+	// section. It is a CLI setting, not a profile.
+	PluginConfigsKey = "plugin_configs"
 )
 
 // isPluginConfigSection reports whether v is a plugin config section,
@@ -25,5 +29,5 @@ func isPluginConfigSection(v interface{}) bool {
 // Example: PluginConfigKey("__global", "updates") to read or set the global updates setting
 // Example: PluginConfigKey("apps", "updates") to read or set the updates setting for the "apps" plugin
 func PluginConfigKey(scope, field string) string {
-	return "plugin_configs." + scope + "." + field
+	return PluginConfigsKey + "." + scope + "." + field
 }

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -108,17 +108,19 @@ const ConfigVersionV1 = 1
 // ConfigVersionV2 is the schema version in which every profile moved under the
 // reserved ProfilesTableName table, so that profile names can no longer collide
 // with top-level CLI settings.
-//
-// This release line never writes a v2 file and never migrates one. It only reads
-// and updates a file that a v2 CLI already migrated, so that downgrading needs no
-// action from the user.
 const ConfigVersionV2 = 2
 
 // MaxSupportedConfigVersion is the newest config.toml layout this binary can act
 // on. A file recording a higher version was written by a newer CLI, whose layout
-// this build has no way to know. This line does not write v2, but it does read and
-// update one, so v2 is still the ceiling rather than v1.
+// this build has no way to know.
 const MaxSupportedConfigVersion = ConfigVersionV2
+
+func unsupportedConfigVersionError(version int) error {
+	return errorcategory.Errorf(errorcategory.Filesystem,
+		"%s is %d, but this Stripe CLI understands up to %d. Upgrade the CLI: https://docs.stripe.com/stripe-cli/upgrade",
+		ConfigVersionName, version, MaxSupportedConfigVersion,
+	)
+}
 
 const UATKeychainItemKey = "uat"
 
@@ -260,12 +262,12 @@ func (p *Profile) deleteAuthFields(v *viper.Viper) *viper.Viper {
 // GetColor gets the color setting for the user based on the flag or the
 // persisted color stored in the config file
 func (p *Profile) GetColor() (string, error) {
-	color := viper.GetString("color")
+	color := viper.GetString(ColorName)
 	if color != "" {
 		return color, nil
 	}
 
-	color = p.ReadProfileString("color")
+	color = p.ReadProfileString(ColorName)
 	switch color {
 	case "", ColorAuto:
 		return ColorAuto, nil


### PR DESCRIPTION
### Summary
- Adapt the migration from #1935 in v1. this PR does **not** invoke it yet.
-- Move flat profile tables under profiles and record config_version = 2 while preserving settings and unknown fields.
-- Verify the result before and after an atomic replacement, and preserve the original as config.toml.v1.bak.

### Test plan
- go test ./pkg/config
- go run ./internal/lint/errorcategory/cmd ./...