### PR TITLE
Pin auto-upgrade workflow actions

### DIFF
--- a/.github/workflows/autoupgrade-test.yml
+++ b/.github/workflows/autoupgrade-test.yml
@@ -41,10 +41,12 @@ jobs:
       failed_step: ${{ steps.result.outputs.failed_step }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26.0'
 
@@ -116,10 +118,12 @@ jobs:
       failed_step: ${{ steps.result.outputs.failed_step }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26.0'
 
@@ -189,9 +193,10 @@ jobs:
     needs: [resolve-versions, upgrade-macos, upgrade-linux]
     if: always()
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: needs.resolve-versions.result == 'success'
         with:
+          persist-credentials: false
           sparse-checkout: |
             scripts/notify.sh
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
 ### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
Fixes https://github.com/stripe/stripe-cli/actions/runs/33022751258
Pins the auto-upgrade workflow’s third-party actions to full commit SHAs so the jobs can run successfully.