### PR TITLE
Add self-update for a curl-installed CLI

### DIFF
--- a/.github/workflows/self-update-test.yml
+++ b/.github/workflows/self-update-test.yml
@@ -1,0 +1,131 @@
+on:
+  workflow_dispatch:
+name: Self-update test
+permissions:
+  contents: read
+jobs:
+  # Exercises the CLI replacing its own binary, end to end, against the real
+  # latest release. Windows is the reason this exists: it is the only platform
+  # where the outgoing binary cannot be deleted while a process is running from
+  # it, so it is the only one where the rename-aside step is load-bearing.
+  #
+  # Dispatch-only. It downloads a release archive per run and takes a couple of
+  # minutes, so it is not on a schedule; `go test` already covers the pieces.
+  self-update:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-latest
+            exe: ''
+          - platform: macos-latest
+            exe: ''
+          - platform: windows-latest
+            exe: '.exe'
+    runs-on: ${{ matrix.platform }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      EXE: ${{ matrix.exe }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: 1.26.5
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - name: Install an intentionally stale build where the install script puts it
+        run: |
+          set -eu
+          mkdir -p "$HOME/.stripe/bin"
+          go build \
+            -ldflags "-X github.com/stripe/stripe-cli/pkg/version.Version=1.0.0" \
+            -o "$HOME/.stripe/bin/stripe$EXE" ./cmd/stripe
+          "$HOME/.stripe/bin/stripe$EXE" version
+      - name: Update in the foreground
+        run: |
+          set -eu
+          STRIPE="$HOME/.stripe/bin/stripe$EXE"
+          installed() { "$STRIPE" version | sed -n 's/^stripe version \([^ ]*\).*/\1/p'; }
+
+          test "$(installed)" = "1.0.0"
+
+          # The process doing the replacing is itself running from the binary it
+          # replaces, which is the case Windows refuses to allow as an overwrite.
+          "$STRIPE" auto-update --now
+
+          updated="$(installed)"
+          echo "1.0.0 -> $updated"
+          test "$updated" != "1.0.0"
+
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            # Windows could not delete the moved-aside image while the updating
+            # process was still running from it, so it is still there...
+            test -f "$STRIPE.old"
+            # ...until any later invocation, which is a process that isn't.
+            "$STRIPE" version > /dev/null
+            test ! -f "$STRIPE.old"
+          else
+            test ! -f "$STRIPE.old"
+          fi
+      - name: Update in the background
+        run: |
+          set -eu
+          STRIPE="$HOME/.stripe/bin/stripe$EXE"
+          installed() { "$STRIPE" version | sed -n 's/^stripe version \([^ ]*\).*/\1/p'; }
+
+          go build \
+            -ldflags "-X github.com/stripe/stripe-cli/pkg/version.Version=1.0.0" \
+            -o "$STRIPE" ./cmd/stripe
+          rm -f "$HOME/.config/stripe/autoupdate-check"
+
+          # An ordinary command, which must not wait for the download.
+          time "$STRIPE" version > /dev/null
+
+          for _ in $(seq 1 45); do
+            sleep 2
+            if [ "$(installed)" != "1.0.0" ]; then
+              break
+            fi
+          done
+
+          echo "--- worker log ---"
+          cat "$HOME/.config/stripe/autoupdate.log" || echo "the worker wrote no log"
+          test "$(installed)" != "1.0.0"
+      - name: Respect the opt-outs
+        run: |
+          set -eu
+          STRIPE="$HOME/.stripe/bin/stripe$EXE"
+          installed() { "$STRIPE" version | sed -n 's/^stripe version \([^ ]*\).*/\1/p'; }
+
+          go build \
+            -ldflags "-X github.com/stripe/stripe-cli/pkg/version.Version=1.0.0" \
+            -o "$STRIPE" ./cmd/stripe
+          rm -f "$HOME/.config/stripe/autoupdate-check"
+
+          STRIPE_NO_AUTO_UPDATE=1 "$STRIPE" version > /dev/null
+          test ! -f "$HOME/.config/stripe/autoupdate-check"
+
+          "$STRIPE" auto-update --disable
+          "$STRIPE" version > /dev/null
+          test ! -f "$HOME/.config/stripe/autoupdate-check"
+
+          sleep 10
+          test "$(installed)" = "1.0.0"
+      - name: Leave a package-manager install alone
+        run: |
+          set -eu
+          mkdir -p "$HOME/elsewhere"
+          go build \
+            -ldflags "-X github.com/stripe/stripe-cli/pkg/version.Version=1.0.0" \
+            -o "$HOME/elsewhere/stripe$EXE" ./cmd/stripe
+          rm -rf "$HOME/.config/stripe"
+
+          "$HOME/elsewhere/stripe$EXE" version > /dev/null
+          sleep 10
+          test ! -f "$HOME/.config/stripe/autoupdate-check"
+          test "$("$HOME/elsewhere/stripe$EXE" version | sed -n 's/^stripe version \([^ ]*\).*/\1/p')" = "1.0.0"

--- a/.github/workflows/self-update-test.yml
+++ b/.github/workflows/self-update-test.yml
@@ -45,12 +45,22 @@ jobs:
           go build \
             -ldflags "-X github.com/stripe/stripe-cli/pkg/version.Version=1.0.0" \
             -o "$HOME/.stripe/bin/stripe$EXE" ./cmd/stripe
-          "$HOME/.stripe/bin/stripe$EXE" version
+          # Opted out, because a plain invocation of a stale install-script binary
+          # starts a background update — which is the next step's subject, not this
+          # step's, and two updates at once is a third scenario again.
+          STRIPE_NO_AUTO_UPDATE=1 "$HOME/.stripe/bin/stripe$EXE" version
       - name: Update in the foreground
         run: |
           set -eu
           STRIPE="$HOME/.stripe/bin/stripe$EXE"
-          installed() { "$STRIPE" version | sed -n 's/^stripe version \([^ ]*\).*/\1/p'; }
+          stale() {
+            go build \
+              -ldflags "-X github.com/stripe/stripe-cli/pkg/version.Version=1.0.0" \
+              -o "$STRIPE" ./cmd/stripe
+          }
+          # Every probe here opts out: they exist to read the version, and must not
+          # start an update of their own alongside the one under test.
+          installed() { STRIPE_NO_AUTO_UPDATE=1 "$STRIPE" version | sed -n 's/^stripe version \([^ ]*\).*/\1/p'; }
 
           test "$(installed)" = "1.0.0"
 
@@ -66,8 +76,10 @@ jobs:
             # Windows could not delete the moved-aside image while the updating
             # process was still running from it, so it is still there...
             test -f "$STRIPE.old"
-            # ...until any later invocation, which is a process that isn't.
-            "$STRIPE" version > /dev/null
+            # ...until the next invocation of a build that knows to clear it. The
+            # release just installed predates this feature, so put ours back.
+            stale
+            installed > /dev/null
             test ! -f "$STRIPE.old"
           else
             test ! -f "$STRIPE.old"
@@ -76,7 +88,7 @@ jobs:
         run: |
           set -eu
           STRIPE="$HOME/.stripe/bin/stripe$EXE"
-          installed() { "$STRIPE" version | sed -n 's/^stripe version \([^ ]*\).*/\1/p'; }
+          installed() { STRIPE_NO_AUTO_UPDATE=1 "$STRIPE" version | sed -n 's/^stripe version \([^ ]*\).*/\1/p'; }
 
           go build \
             -ldflags "-X github.com/stripe/stripe-cli/pkg/version.Version=1.0.0" \
@@ -100,7 +112,7 @@ jobs:
         run: |
           set -eu
           STRIPE="$HOME/.stripe/bin/stripe$EXE"
-          installed() { "$STRIPE" version | sed -n 's/^stripe version \([^ ]*\).*/\1/p'; }
+          installed() { STRIPE_NO_AUTO_UPDATE=1 "$STRIPE" version | sed -n 's/^stripe version \([^ ]*\).*/\1/p'; }
 
           go build \
             -ldflags "-X github.com/stripe/stripe-cli/pkg/version.Version=1.0.0" \

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -1,0 +1,338 @@
+// Package autoupdate keeps a self-owned stripe binary current.
+//
+// The CLI can only replace its own binary when it owns it. A Homebrew, apt,
+// Scoop, WinGet, or npm install belongs to that package manager, and rewriting
+// the file underneath it leaves the manager's metadata describing a version that
+// is no longer on disk. So every entry point here first checks that the running
+// binary sits in the directory scripts/install.sh and scripts/install.ps1 write
+// to, and does nothing at all otherwise.
+package autoupdate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/version"
+)
+
+const (
+	// EnvDisable turns auto-update off. Any value other than "0" or "false"
+	// disables it, so `STRIPE_NO_AUTO_UPDATE=1 stripe listen` works for a single
+	// invocation and exporting it works for a whole shell.
+	EnvDisable = "STRIPE_NO_AUTO_UPDATE"
+
+	// EnvInstallDir overrides where the install scripts put the binary. It is read
+	// here for the same reason they read it: a binary installed somewhere else is
+	// still self-owned and still updatable.
+	EnvInstallDir = "STRIPE_INSTALL_DIR"
+
+	// envWorker marks the detached child that performs the update so it does not
+	// spawn a worker of its own.
+	envWorker = "STRIPE_AUTO_UPDATE_WORKER"
+
+	// checkInterval is the minimum time between two checks. The design budget is
+	// "at most once a day"; a single stamp file enforces it across invocations.
+	checkInterval = 24 * time.Hour
+
+	stampFileName = "autoupdate-check"
+	logFileName   = "autoupdate.log"
+	lockFileName  = "autoupdate.lock"
+)
+
+// now is indirected so tests can move the clock without sleeping.
+var now = time.Now
+
+// MaybeRun starts a background update when one is due, then returns.
+//
+// It runs on every invocation, so it has to stay cheap and silent: in the common
+// case it stats two files and returns. When an update is due it hands the work to
+// a separate process, because the command the user actually typed must not wait
+// on a download — and on Windows a process cannot overwrite its own image anyway.
+func MaybeRun(cfg config.IConfig) {
+	exe, ok := SelfManaged()
+	if !ok {
+		return
+	}
+
+	// Done before the opt-out check, so that disabling auto-update does not leave a
+	// previous update's leftover file behind forever.
+	removeSupersededBinary(exe)
+
+	if os.Getenv(envWorker) != "" || !Enabled() || !dueForCheck(cfg) {
+		return
+	}
+
+	// Stamp before spawning rather than after the worker finishes: two commands
+	// started at the same moment would otherwise both read a stale stamp and both
+	// start downloading.
+	if err := writeStamp(cfg, now()); err != nil {
+		debugf("could not record the update check: %v", err)
+		return
+	}
+
+	if err := spawnWorker(cfg, exe); err != nil {
+		debugf("could not start the update worker: %v", err)
+	}
+}
+
+// Run performs one update attempt in the foreground and reports what it did to
+// out. It is what the detached worker executes, and what `stripe auto-update
+// --now` calls.
+//
+// Deliberately not gated on Enabled(): the worker is only ever spawned after
+// MaybeRun has checked, and a user who typed --now has asked for this update
+// regardless of the standing preference.
+func Run(ctx context.Context, cfg config.IConfig, out io.Writer) error {
+	exe, ok := SelfManaged()
+	if !ok {
+		return errorcategory.Errorf(errorcategory.UserInput,
+			"auto-update only applies to a stripe binary installed by the install script, which puts it in %s; upgrade this one with whatever installed it",
+			InstallDir())
+	}
+
+	release, err := acquireLock(cfg)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	latest, err := latestVersion(ctx)
+	if err != nil {
+		return errorcategory.Errorf(errorcategory.Network, "could not look up the latest version: %v", err)
+	}
+
+	if !isNewer(version.Version, latest) {
+		fmt.Fprintf(out, "stripe %s is already the latest version\n", version.Version)
+		_ = writeStamp(cfg, now())
+
+		return nil
+	}
+
+	// Stage inside the install directory, not the OS temp directory: the last step
+	// is a rename, and a rename across filesystems fails. On many machines
+	// (containers especially) /tmp is a different filesystem than $HOME.
+	staging, err := os.MkdirTemp(filepath.Dir(exe), ".stripe-update-")
+	if err != nil {
+		return errorcategory.Errorf(errorcategory.Filesystem, "could not create a staging directory: %v", err)
+	}
+
+	defer func() { _ = os.RemoveAll(staging) }()
+
+	binary, err := download(ctx, latest, staging)
+	if err != nil {
+		return err
+	}
+
+	if err := replaceBinary(exe, binary); err != nil {
+		return err
+	}
+
+	_ = writeStamp(cfg, now())
+
+	fmt.Fprintf(out, "Updated stripe %s -> %s\n", version.Version, latest)
+
+	return nil
+}
+
+// Enabled reports whether the CLI may replace its own binary, ignoring where the
+// binary happens to live. Callers that act on the answer should pair it with
+// SelfManaged.
+func Enabled() bool {
+	// A build from source reports version "master" and has no matching release to
+	// download; the same check keeps version.CheckLatestVersion quiet.
+	if IsDevBuild() {
+		return false
+	}
+
+	if envDisabled() {
+		return false
+	}
+
+	return config.AutoUpdateEnabled()
+}
+
+// IsDevBuild reports whether this binary was built from source rather than cut
+// by goreleaser, which stamps the release version into version.Version.
+func IsDevBuild() bool {
+	return version.Version == "master"
+}
+
+func envDisabled() bool {
+	value := strings.TrimSpace(os.Getenv(EnvDisable))
+
+	return value != "" && value != "0" && !strings.EqualFold(value, "false")
+}
+
+// InstallDir returns the directory the install scripts install stripe into.
+func InstallDir() string {
+	if dir := os.Getenv(EnvInstallDir); dir != "" {
+		return dir
+	}
+
+	home, err := homedir.Dir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(home, ".stripe", "bin")
+}
+
+// SelfManaged returns the path of the running binary and whether the install
+// scripts own it.
+func SelfManaged() (string, bool) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", false
+	}
+
+	return selfManaged(exe, InstallDir())
+}
+
+func selfManaged(exe, installDir string) (string, bool) {
+	// Resolve every side of the comparison. A user may have symlinked stripe onto
+	// their PATH, or symlinked a component of the install path (which macOS does
+	// itself for /tmp), and comparing unresolved paths would then read as "not
+	// ours" and silently switch updates off.
+	exe = resolveSymlinks(exe)
+
+	if installDir == "" {
+		return exe, false
+	}
+
+	return exe, sameDir(resolveSymlinks(filepath.Dir(exe)), resolveSymlinks(installDir))
+}
+
+func resolveSymlinks(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+
+	return path
+}
+
+func sameDir(left, right string) bool {
+	left, right = filepath.Clean(left), filepath.Clean(right)
+
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(left, right)
+	}
+
+	return left == right
+}
+
+func stateDir(cfg config.IConfig) string {
+	return cfg.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+}
+
+func dueForCheck(cfg config.IConfig) bool {
+	raw, err := os.ReadFile(filepath.Join(stateDir(cfg), stampFileName))
+	if err != nil {
+		return true
+	}
+
+	last, err := time.Parse(time.RFC3339, strings.TrimSpace(string(raw)))
+	if err != nil {
+		return true
+	}
+
+	// A stamp in the future means the clock moved backwards, not that a check is
+	// overdue. Waiting is the safe reading: the worst case is a delayed update.
+	return now().Sub(last) >= checkInterval
+}
+
+func writeStamp(cfg config.IConfig, at time.Time) error {
+	dir := stateDir(cfg)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(dir, stampFileName), []byte(at.Format(time.RFC3339)), 0600)
+}
+
+// acquireLock keeps two workers from downloading over each other. The returned
+// function releases the lock.
+func acquireLock(cfg config.IConfig) (func(), error) {
+	dir := stateDir(cfg)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, errorcategory.Errorf(errorcategory.Filesystem, "could not create %s: %v", dir, err)
+	}
+
+	path := filepath.Join(dir, lockFileName)
+
+	for attempt := 0; attempt < 2; attempt++ {
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+		if err == nil {
+			_ = file.Close()
+
+			return func() { _ = os.Remove(path) }, nil
+		}
+
+		if !os.IsExist(err) {
+			return nil, errorcategory.Errorf(errorcategory.Filesystem, "could not lock %s: %v", path, err)
+		}
+
+		// A worker killed mid-download leaves the lock behind, which would block
+		// every future update. Treat one older than the check interval as abandoned.
+		info, statErr := os.Stat(path)
+		if statErr != nil || now().Sub(info.ModTime()) < checkInterval {
+			return nil, errorcategory.Errorf(errorcategory.Filesystem, "another stripe update is already running")
+		}
+
+		_ = os.Remove(path)
+	}
+
+	return nil, errorcategory.Errorf(errorcategory.Filesystem, "another stripe update is already running")
+}
+
+func spawnWorker(cfg config.IConfig, exe string) error {
+	dir := stateDir(cfg)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	// The worker has no terminal of its own — the parent owns it, and writing
+	// there would interleave with the output of the command the user ran — so its
+	// output goes to a file that can be read after the fact.
+	logFile, err := os.OpenFile(filepath.Join(dir, logFileName), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(exe, "auto-update", "--now")
+	cmd.Env = append(os.Environ(), envWorker+"=1")
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	detach(cmd)
+
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+
+		return err
+	}
+
+	// Reap the child if this process outlives it, without blocking on it. If the
+	// parent exits first the goroutine dies with it and the kernel reparents the
+	// child, which is the whole point of detaching.
+	go func() {
+		_ = cmd.Wait()
+		_ = logFile.Close()
+	}()
+
+	return nil
+}
+
+func debugf(format string, args ...interface{}) {
+	log.WithField("prefix", "autoupdate").Debugf(format, args...)
+}

--- a/pkg/autoupdate/autoupdate_test.go
+++ b/pkg/autoupdate/autoupdate_test.go
@@ -1,0 +1,230 @@
+package autoupdate
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/version"
+)
+
+// newTestConfig returns a config whose state directory is a fresh temp dir, so
+// that stamp and lock files never touch the developer's real config folder.
+func newTestConfig(t *testing.T) config.IConfig {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	return &config.Config{}
+}
+
+// freezeClock pins now() so interval arithmetic does not depend on wall time.
+func freezeClock(t *testing.T, at time.Time) {
+	original := now
+	now = func() time.Time { return at }
+
+	t.Cleanup(func() { now = original })
+}
+
+// pretendRelease makes the tests look like a released build rather than a build
+// from source, which is otherwise excluded from updating at all.
+func pretendRelease(t *testing.T) {
+	original := version.Version
+	version.Version = "1.0.0"
+
+	t.Cleanup(func() { version.Version = original })
+}
+
+func TestSelfManaged(t *testing.T) {
+	dir := t.TempDir()
+	other := t.TempDir()
+
+	exe, ok := selfManaged(filepath.Join(dir, "stripe"), dir)
+	assert.True(t, ok)
+	assert.Equal(t, "stripe", filepath.Base(exe))
+
+	_, ok = selfManaged(filepath.Join(other, "stripe"), dir)
+	assert.False(t, ok, "a binary outside the install directory is owned by something else")
+
+	// A subdirectory is not the install directory.
+	_, ok = selfManaged(filepath.Join(dir, "nested", "stripe"), dir)
+	assert.False(t, ok)
+
+	// No resolvable home and no override means there is nothing to compare against.
+	_, ok = selfManaged(filepath.Join(dir, "stripe"), "")
+	assert.False(t, ok)
+}
+
+func TestSelfManagedFollowsASymlinkedInstallDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating a symlink on Windows needs elevation")
+	}
+
+	root := t.TempDir()
+	real := filepath.Join(root, "real")
+	link := filepath.Join(root, "link")
+
+	require.NoError(t, os.MkdirAll(real, 0755))
+	require.NoError(t, os.Symlink(real, link))
+
+	// The binary is reached through the symlink, but lives in the real directory.
+	_, ok := selfManaged(filepath.Join(link, "stripe"), real)
+	assert.True(t, ok)
+
+	// And the other way round: STRIPE_INSTALL_DIR points at the symlink.
+	_, ok = selfManaged(filepath.Join(real, "stripe"), link)
+	assert.True(t, ok)
+}
+
+func TestSameDirIsCaseInsensitiveOnlyOnWindows(t *testing.T) {
+	assert.True(t, sameDir(filepath.Join("a", "b"), filepath.Join("a", "b")))
+	assert.False(t, sameDir(filepath.Join("a", "b"), filepath.Join("a", "c")))
+	assert.Equal(t, runtime.GOOS == "windows", sameDir(filepath.Join("a", "b"), filepath.Join("A", "B")))
+}
+
+func TestInstallDirHonorsTheOverride(t *testing.T) {
+	t.Setenv(EnvInstallDir, filepath.Join("custom", "bin"))
+	assert.Equal(t, filepath.Join("custom", "bin"), InstallDir())
+}
+
+func TestEnvDisable(t *testing.T) {
+	for value, disabled := range map[string]bool{
+		"":      false,
+		"0":     false,
+		"false": false,
+		"FALSE": false,
+		"1":     true,
+		"true":  true,
+		"yes":   true,
+	} {
+		t.Setenv(EnvDisable, value)
+		assert.Equal(t, disabled, envDisabled(), "value %q", value)
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	pretendRelease(t)
+	viper.Reset()
+
+	t.Cleanup(viper.Reset)
+
+	assert.True(t, Enabled(), "on by default")
+
+	viper.Set(config.AutoUpdateSettingKey(), false)
+	assert.False(t, Enabled(), "settings.auto_update = false opts out")
+
+	viper.Set(config.AutoUpdateSettingKey(), true)
+	assert.True(t, Enabled())
+
+	t.Setenv(EnvDisable, "1")
+	assert.False(t, Enabled(), "the environment overrides an opted-in config")
+}
+
+func TestEnabledIsFalseForADevelopmentBuild(t *testing.T) {
+	original := version.Version
+	version.Version = "master"
+
+	t.Cleanup(func() { version.Version = original })
+
+	assert.True(t, IsDevBuild())
+	assert.False(t, Enabled())
+}
+
+func TestDueForCheck(t *testing.T) {
+	cfg := newTestConfig(t)
+	start := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+
+	freezeClock(t, start)
+
+	assert.True(t, dueForCheck(cfg), "no stamp yet")
+
+	require.NoError(t, writeStamp(cfg, start))
+	assert.False(t, dueForCheck(cfg), "just checked")
+
+	freezeClock(t, start.Add(checkInterval-time.Minute))
+	assert.False(t, dueForCheck(cfg))
+
+	freezeClock(t, start.Add(checkInterval))
+	assert.True(t, dueForCheck(cfg))
+
+	// A stamp from the future means the clock moved, not that a check is overdue.
+	freezeClock(t, start.Add(-48*time.Hour))
+	assert.False(t, dueForCheck(cfg))
+}
+
+func TestDueForCheckWithAnUnreadableStamp(t *testing.T) {
+	cfg := newTestConfig(t)
+	require.NoError(t, writeStamp(cfg, time.Now()))
+
+	stamp := filepath.Join(stateDir(cfg), stampFileName)
+	require.NoError(t, os.WriteFile(stamp, []byte("not a timestamp"), 0600))
+
+	assert.True(t, dueForCheck(cfg), "a stamp that cannot be read must not wedge updates off")
+}
+
+func TestAcquireLockIsExclusive(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	freezeClock(t, time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC))
+
+	release, err := acquireLock(cfg)
+	require.NoError(t, err)
+
+	_, err = acquireLock(cfg)
+	assert.ErrorContains(t, err, "already running")
+
+	release()
+
+	release, err = acquireLock(cfg)
+	require.NoError(t, err)
+	release()
+}
+
+func TestAcquireLockBreaksAnAbandonedLock(t *testing.T) {
+	cfg := newTestConfig(t)
+	start := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+
+	freezeClock(t, start)
+
+	release, err := acquireLock(cfg)
+	require.NoError(t, err)
+
+	defer release()
+
+	// A worker killed mid-download never releases the lock. Pretend enough time has
+	// passed that it cannot still be running.
+	freezeClock(t, start.Add(2*checkInterval))
+
+	stolen, err := acquireLock(cfg)
+	require.NoError(t, err)
+	stolen()
+}
+
+func TestMaybeRunDoesNothingForAnUnmanagedBinary(t *testing.T) {
+	pretendRelease(t)
+
+	cfg := newTestConfig(t)
+	// The test binary is not in here, which is the situation of every
+	// package-manager install.
+	t.Setenv(EnvInstallDir, t.TempDir())
+
+	MaybeRun(cfg)
+
+	assert.NoFileExists(t, filepath.Join(stateDir(cfg), stampFileName),
+		"an install the CLI does not own must not even record a check")
+}
+
+func TestRunRefusesAnUnmanagedBinary(t *testing.T) {
+	pretendRelease(t)
+
+	cfg := newTestConfig(t)
+	t.Setenv(EnvInstallDir, t.TempDir())
+
+	err := Run(t.Context(), cfg, os.Stdout)
+	assert.ErrorContains(t, err, "install script")
+}

--- a/pkg/autoupdate/autoupdate_test.go
+++ b/pkg/autoupdate/autoupdate_test.go
@@ -170,7 +170,9 @@ func TestDueForCheckWithAnUnreadableStamp(t *testing.T) {
 func TestAcquireLockIsExclusive(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	freezeClock(t, time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC))
+	// Anchored to the real clock, not a fixed date: staleness is judged against the
+	// lock file's modification time, which the filesystem stamps for itself.
+	freezeClock(t, time.Now())
 
 	release, err := acquireLock(cfg)
 	require.NoError(t, err)
@@ -187,7 +189,7 @@ func TestAcquireLockIsExclusive(t *testing.T) {
 
 func TestAcquireLockBreaksAnAbandonedLock(t *testing.T) {
 	cfg := newTestConfig(t)
-	start := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	start := time.Now()
 
 	freezeClock(t, start)
 

--- a/pkg/autoupdate/detach_unix.go
+++ b/pkg/autoupdate/detach_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package autoupdate
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detach puts the worker in its own session so that a Ctrl-C in the terminal
+// that started the parent, or the parent exiting, does not kill it mid-download.
+func detach(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/pkg/autoupdate/detach_windows.go
+++ b/pkg/autoupdate/detach_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package autoupdate
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachedProcess is DETACHED_PROCESS from the Windows process creation flags.
+// It is not exported by the syscall package.
+const detachedProcess = 0x00000008
+
+// detach severs the worker from the console this process is attached to, so that
+// the parent exiting does not take the worker with it and the worker never draws
+// a console window of its own.
+func detach(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: detachedProcess | syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}

--- a/pkg/autoupdate/release.go
+++ b/pkg/autoupdate/release.go
@@ -1,0 +1,364 @@
+package autoupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	goversion "github.com/hashicorp/go-version"
+
+	"github.com/google/go-github/v72/github"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/version"
+)
+
+const (
+	githubOwner = "stripe"
+	githubRepo  = "stripe-cli"
+
+	metadataTimeout = 10 * time.Second
+	downloadTimeout = 3 * time.Minute
+
+	// maxChecksumsSize and maxArchiveSize bound what a hostile or broken response
+	// can make the CLI buffer or write.
+	maxChecksumsSize = 1 << 20 // 1 MiB
+	maxArchiveSize   = 1 << 28 // 256 MiB
+)
+
+// releaseBaseURL is where release archives are downloaded from. Tests point it at
+// a local server.
+var releaseBaseURL = fmt.Sprintf("https://github.com/%s/%s/releases/download", githubOwner, githubRepo)
+
+var httpClient = &http.Client{Timeout: downloadTimeout}
+
+// latestVersion returns the newest published release, without a leading "v".
+func latestVersion(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, metadataTimeout)
+	defer cancel()
+
+	client := github.NewClient(nil)
+
+	// Unauthenticated GitHub API calls are capped at 60 per hour per IP, which
+	// shared egress and CI runners exhaust; the install scripts take a token for
+	// the same reason.
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		client = client.WithAuthToken(token)
+	}
+
+	release, _, err := client.Repositories.GetLatestRelease(ctx, githubOwner, githubRepo)
+	if err != nil {
+		return "", err
+	}
+
+	if release.TagName == nil {
+		return "", fmt.Errorf("latest release has no tag name")
+	}
+
+	return strings.TrimPrefix(*release.TagName, "v"), nil
+}
+
+func isNewer(current, latest string) bool {
+	from, err := goversion.NewVersion(strings.TrimPrefix(current, "v"))
+	if err != nil {
+		return false
+	}
+
+	to, err := goversion.NewVersion(strings.TrimPrefix(latest, "v"))
+	if err != nil {
+		return false
+	}
+
+	return to.GreaterThan(from)
+}
+
+// assetNames returns the archive and checksums file the release publishes for a
+// platform. These have to match what the .goreleaser configs emit and what
+// scripts/install.sh and scripts/install.ps1 download.
+func assetNames(release, goos, goarch string) (archive, checksums string, err error) {
+	var osLabel, extension string
+
+	switch goos {
+	case "darwin":
+		osLabel, extension, checksums = "mac-os", "tar.gz", "stripe-mac-checksums.txt"
+	case "linux":
+		osLabel, extension, checksums = "linux", "tar.gz", "stripe-linux-checksums.txt"
+	case "windows":
+		osLabel, extension, checksums = "windows", "zip", "stripe-windows-checksums.txt"
+	default:
+		return "", "", fmt.Errorf("unsupported operating system: %s", goos)
+	}
+
+	archLabel, err := archLabel(goos, goarch)
+	if err != nil {
+		return "", "", err
+	}
+
+	return fmt.Sprintf("stripe_%s_%s_%s.%s", release, osLabel, archLabel, extension), checksums, nil
+}
+
+func archLabel(goos, goarch string) (string, error) {
+	switch {
+	case goarch == "amd64":
+		return "x86_64", nil
+	case goarch == "arm64" && goos == "windows":
+		// .goreleaser/windows.yml builds amd64 and 386 only. Windows on ARM runs
+		// the x64 binary under emulation, which is also what install.ps1 fetches.
+		return "x86_64", nil
+	case goarch == "arm64":
+		return "arm64", nil
+	case goarch == "386" && goos == "windows":
+		return "i386", nil
+	default:
+		return "", fmt.Errorf("unsupported architecture: %s/%s", goos, goarch)
+	}
+}
+
+// binaryName is the name of the executable inside the release archive, which is
+// also the name it is installed under.
+func binaryName() string {
+	if runtime.GOOS == "windows" {
+		return "stripe.exe"
+	}
+
+	return "stripe"
+}
+
+// download fetches the release archive into destDir, verifies its checksum, and
+// returns the path of the extracted binary.
+func download(ctx context.Context, release, destDir string) (string, error) {
+	archive, checksums, err := assetNames(release, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return "", errorcategory.Errorf(errorcategory.Internal, "%v", err)
+	}
+
+	base := fmt.Sprintf("%s/v%s", releaseBaseURL, release)
+
+	archivePath := filepath.Join(destDir, archive)
+	if err := httpDownload(ctx, base+"/"+archive, archivePath); err != nil {
+		return "", errorcategory.Errorf(errorcategory.Network, "could not download %s: %v", archive, err)
+	}
+
+	raw, err := httpGet(ctx, base+"/"+checksums)
+	if err != nil {
+		return "", errorcategory.Errorf(errorcategory.Network, "could not download %s: %v", checksums, err)
+	}
+
+	expected, err := lookupChecksum(string(raw), archive)
+	if err != nil {
+		return "", errorcategory.Errorf(errorcategory.API, "%v", err)
+	}
+
+	if err := verifySHA256(archivePath, expected); err != nil {
+		return "", errorcategory.Errorf(errorcategory.API, "%v", err)
+	}
+
+	return extractBinary(archivePath, destDir)
+}
+
+// lookupChecksum finds the digest for exactly this asset name.
+//
+// The comparison is on the whole field, not a substring or a regex: asset names
+// differ only in an architecture suffix, and "." is a regex metacharacter, so a
+// loose match can silently verify a different archive than the one downloaded.
+func lookupChecksum(contents, asset string) (string, error) {
+	for _, line := range strings.Split(contents, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+
+		// Some checksum writers mark binary mode with a leading "*".
+		if strings.TrimPrefix(fields[1], "*") == asset {
+			return fields[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("no checksum published for %s", asset)
+}
+
+func verifySHA256(path, expected string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		return err
+	}
+
+	actual := hex.EncodeToString(digest.Sum(nil))
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", filepath.Base(path), expected, actual)
+	}
+
+	return nil
+}
+
+// extractBinary pulls the stripe executable out of a release archive. Only that
+// one entry is extracted, and it is written to a path this function chooses, so a
+// crafted archive cannot place a file anywhere else.
+func extractBinary(archivePath, destDir string) (string, error) {
+	name := binaryName()
+	dest := filepath.Join(destDir, name)
+
+	var err error
+	if strings.HasSuffix(archivePath, ".zip") {
+		err = extractFromZip(archivePath, name, dest)
+	} else {
+		err = extractFromTarGz(archivePath, name, dest)
+	}
+
+	if err != nil {
+		return "", errorcategory.Errorf(errorcategory.API, "could not extract %s from %s: %v", name, filepath.Base(archivePath), err)
+	}
+
+	return dest, nil
+}
+
+func extractFromZip(archivePath, name, dest string) error {
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+
+	defer reader.Close()
+
+	for _, entry := range reader.File {
+		if path.Base(entry.Name) != name {
+			continue
+		}
+
+		contents, err := entry.Open()
+		if err != nil {
+			return err
+		}
+
+		defer contents.Close()
+
+		return writeFile(dest, contents)
+	}
+
+	return fmt.Errorf("archive does not contain %s", name)
+}
+
+func extractFromTarGz(archivePath, name, dest string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
+
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			return fmt.Errorf("archive does not contain %s", name)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if header.Typeflag != tar.TypeReg || path.Base(header.Name) != name {
+			continue
+		}
+
+		return writeFile(dest, tarReader)
+	}
+}
+
+func writeFile(dest string, contents io.Reader) error {
+	file, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+
+	// Read one byte past the cap so that hitting it is an error rather than a
+	// silently truncated file, which for a binary means a broken install.
+	written, err := io.Copy(file, io.LimitReader(contents, maxArchiveSize+1))
+	if err == nil && written > maxArchiveSize {
+		err = fmt.Errorf("%s is larger than the %d byte limit", filepath.Base(dest), maxArchiveSize)
+	}
+
+	if err != nil {
+		_ = file.Close()
+
+		return err
+	}
+
+	return file.Close()
+}
+
+func httpGet(ctx context.Context, url string) ([]byte, error) {
+	body, err := httpBody(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	defer body.Close()
+
+	return io.ReadAll(io.LimitReader(body, maxChecksumsSize))
+}
+
+func httpDownload(ctx context.Context, url, dest string) error {
+	body, err := httpBody(ctx, url)
+	if err != nil {
+		return err
+	}
+
+	defer body.Close()
+
+	return writeFile(dest, body)
+}
+
+// httpBody performs the GET behind both helpers above.
+//
+// No Authorization header, even when GITHUB_TOKEN is set: release asset URLs
+// redirect to a pre-signed storage URL that rejects a request carrying a second
+// set of credentials. Only the API metadata call authenticates.
+func httpBody(ctx context.Context, url string) (io.ReadCloser, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Set("User-Agent", "stripe-cli/"+version.Version)
+
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		_ = response.Body.Close()
+
+		return nil, fmt.Errorf("GET %s: %s", url, response.Status)
+	}
+
+	return response.Body, nil
+}

--- a/pkg/autoupdate/release.go
+++ b/pkg/autoupdate/release.go
@@ -64,7 +64,7 @@ func latestVersion(ctx context.Context) (string, error) {
 	}
 
 	if release.TagName == nil {
-		return "", fmt.Errorf("latest release has no tag name")
+		return "", errorcategory.Errorf(errorcategory.API, "latest release has no tag name")
 	}
 
 	return strings.TrimPrefix(*release.TagName, "v"), nil
@@ -98,7 +98,7 @@ func assetNames(release, goos, goarch string) (archive, checksums string, err er
 	case "windows":
 		osLabel, extension, checksums = "windows", "zip", "stripe-windows-checksums.txt"
 	default:
-		return "", "", fmt.Errorf("unsupported operating system: %s", goos)
+		return "", "", errorcategory.Errorf(errorcategory.Internal, "unsupported operating system: %s", goos)
 	}
 
 	archLabel, err := archLabel(goos, goarch)
@@ -122,7 +122,7 @@ func archLabel(goos, goarch string) (string, error) {
 	case goarch == "386" && goos == "windows":
 		return "i386", nil
 	default:
-		return "", fmt.Errorf("unsupported architecture: %s/%s", goos, goarch)
+		return "", errorcategory.Errorf(errorcategory.Internal, "unsupported architecture: %s/%s", goos, goarch)
 	}
 }
 
@@ -186,7 +186,7 @@ func lookupChecksum(contents, asset string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("no checksum published for %s", asset)
+	return "", errorcategory.Errorf(errorcategory.API, "no checksum published for %s", asset)
 }
 
 func verifySHA256(path, expected string) error {
@@ -204,7 +204,7 @@ func verifySHA256(path, expected string) error {
 
 	actual := hex.EncodeToString(digest.Sum(nil))
 	if !strings.EqualFold(actual, expected) {
-		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", filepath.Base(path), expected, actual)
+		return errorcategory.Errorf(errorcategory.API, "checksum mismatch for %s: expected %s, got %s", filepath.Base(path), expected, actual)
 	}
 
 	return nil
@@ -254,7 +254,7 @@ func extractFromZip(archivePath, name, dest string) error {
 		return writeFile(dest, contents)
 	}
 
-	return fmt.Errorf("archive does not contain %s", name)
+	return errorcategory.Errorf(errorcategory.API, "archive does not contain %s", name)
 }
 
 func extractFromTarGz(archivePath, name, dest string) error {
@@ -277,7 +277,7 @@ func extractFromTarGz(archivePath, name, dest string) error {
 	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {
-			return fmt.Errorf("archive does not contain %s", name)
+			return errorcategory.Errorf(errorcategory.API, "archive does not contain %s", name)
 		}
 
 		if err != nil {
@@ -302,7 +302,7 @@ func writeFile(dest string, contents io.Reader) error {
 	// silently truncated file, which for a binary means a broken install.
 	written, err := io.Copy(file, io.LimitReader(contents, maxArchiveSize+1))
 	if err == nil && written > maxArchiveSize {
-		err = fmt.Errorf("%s is larger than the %d byte limit", filepath.Base(dest), maxArchiveSize)
+		err = errorcategory.Errorf(errorcategory.API, "%s is larger than the %d byte limit", filepath.Base(dest), maxArchiveSize)
 	}
 
 	if err != nil {
@@ -357,7 +357,7 @@ func httpBody(ctx context.Context, url string) (io.ReadCloser, error) {
 	if response.StatusCode != http.StatusOK {
 		_ = response.Body.Close()
 
-		return nil, fmt.Errorf("GET %s: %s", url, response.Status)
+		return nil, errorcategory.Errorf(errorcategory.API, "GET %s: %s", url, response.Status)
 	}
 
 	return response.Body, nil

--- a/pkg/autoupdate/release_test.go
+++ b/pkg/autoupdate/release_test.go
@@ -1,0 +1,274 @@
+package autoupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNewer(t *testing.T) {
+	assert.True(t, isNewer("1.2.3", "1.2.4"))
+	assert.True(t, isNewer("v1.2.3", "v1.3.0"))
+	assert.True(t, isNewer("1.9.0", "1.10.0"), "versions compare numerically, not lexically")
+	assert.False(t, isNewer("1.2.3", "1.2.3"))
+	assert.False(t, isNewer("1.2.4", "1.2.3"), "never downgrade")
+	assert.False(t, isNewer("master", "1.2.3"), "a build from source has no version to compare")
+	assert.False(t, isNewer("1.2.3", "not-a-version"))
+}
+
+func TestAssetNames(t *testing.T) {
+	tests := []struct {
+		goos, goarch       string
+		archive, checksums string
+	}{
+		{"darwin", "amd64", "stripe_1.2.3_mac-os_x86_64.tar.gz", "stripe-mac-checksums.txt"},
+		{"darwin", "arm64", "stripe_1.2.3_mac-os_arm64.tar.gz", "stripe-mac-checksums.txt"},
+		{"linux", "amd64", "stripe_1.2.3_linux_x86_64.tar.gz", "stripe-linux-checksums.txt"},
+		{"linux", "arm64", "stripe_1.2.3_linux_arm64.tar.gz", "stripe-linux-checksums.txt"},
+		{"windows", "amd64", "stripe_1.2.3_windows_x86_64.zip", "stripe-windows-checksums.txt"},
+		{"windows", "386", "stripe_1.2.3_windows_i386.zip", "stripe-windows-checksums.txt"},
+		// No Windows arm64 build is published, so ARM machines take the emulated
+		// x64 archive rather than 404ing.
+		{"windows", "arm64", "stripe_1.2.3_windows_x86_64.zip", "stripe-windows-checksums.txt"},
+	}
+
+	for _, test := range tests {
+		archive, checksums, err := assetNames("1.2.3", test.goos, test.goarch)
+		require.NoError(t, err, "%s/%s", test.goos, test.goarch)
+		assert.Equal(t, test.archive, archive)
+		assert.Equal(t, test.checksums, checksums)
+	}
+}
+
+func TestAssetNamesRejectsUnpublishedPlatforms(t *testing.T) {
+	_, _, err := assetNames("1.2.3", "plan9", "amd64")
+	assert.ErrorContains(t, err, "unsupported operating system")
+
+	// The mac and linux releases build amd64 and arm64 only.
+	_, _, err = assetNames("1.2.3", "linux", "386")
+	assert.ErrorContains(t, err, "unsupported architecture")
+
+	_, _, err = assetNames("1.2.3", "darwin", "386")
+	assert.ErrorContains(t, err, "unsupported architecture")
+}
+
+func TestLookupChecksum(t *testing.T) {
+	contents := strings.Join([]string{
+		"aaaa  stripe_1.2.3_windows_i386.zip",
+		"bbbb  stripe_1.2.3_windows_x86_64.zip",
+		"cccc *stripe_1.2.3_linux_x86_64.tar.gz",
+		"",
+	}, "\n")
+
+	sum, err := lookupChecksum(contents, "stripe_1.2.3_windows_x86_64.zip")
+	require.NoError(t, err)
+	assert.Equal(t, "bbbb", sum)
+
+	sum, err = lookupChecksum(contents, "stripe_1.2.3_linux_x86_64.tar.gz")
+	require.NoError(t, err)
+	assert.Equal(t, "cccc", sum)
+
+	// A partial name must not match a longer one, and "." must not act as a regex
+	// wildcard: either would verify a different archive than the one downloaded.
+	_, err = lookupChecksum(contents, "stripe_1.2.3_windows_x86_64.zi")
+	assert.ErrorContains(t, err, "no checksum published")
+
+	_, err = lookupChecksum(contents, "stripe_1_2_3_windows_x86_64.zip")
+	assert.ErrorContains(t, err, "no checksum published")
+
+	_, err = lookupChecksum(contents, "stripe_9.9.9_windows_x86_64.zip")
+	assert.ErrorContains(t, err, "no checksum published")
+}
+
+func TestVerifySHA256(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive")
+	require.NoError(t, os.WriteFile(path, []byte("payload"), 0600))
+
+	digest := sha256.Sum256([]byte("payload"))
+	expected := hex.EncodeToString(digest[:])
+
+	require.NoError(t, verifySHA256(path, expected))
+	require.NoError(t, verifySHA256(path, strings.ToUpper(expected)), "digest case is not significant")
+
+	err := verifySHA256(path, strings.Repeat("0", 64))
+	assert.ErrorContains(t, err, "checksum mismatch")
+}
+
+func TestExtractBinary(t *testing.T) {
+	dir := t.TempDir()
+
+	tarball := filepath.Join(dir, "release.tar.gz")
+	require.NoError(t, os.WriteFile(tarball, buildTarGz(t, binaryName(), "tar payload"), 0600))
+
+	extracted, err := extractBinary(tarball, dir)
+	require.NoError(t, err)
+	assertFileContents(t, extracted, "tar payload")
+
+	zipped := filepath.Join(dir, "release.zip")
+	require.NoError(t, os.WriteFile(zipped, buildZip(t, binaryName(), "zip payload"), 0600))
+
+	extracted, err = extractBinary(zipped, dir)
+	require.NoError(t, err)
+	assertFileContents(t, extracted, "zip payload")
+}
+
+func TestExtractBinaryRejectsAnArchiveWithoutTheBinary(t *testing.T) {
+	dir := t.TempDir()
+
+	tarball := filepath.Join(dir, "release.tar.gz")
+	require.NoError(t, os.WriteFile(tarball, buildTarGz(t, "README.md", "not a binary"), 0600))
+
+	_, err := extractBinary(tarball, dir)
+	assert.ErrorContains(t, err, "does not contain")
+
+	zipped := filepath.Join(dir, "release.zip")
+	require.NoError(t, os.WriteFile(zipped, buildZip(t, "README.md", "not a binary"), 0600))
+
+	_, err = extractBinary(zipped, dir)
+	assert.ErrorContains(t, err, "does not contain")
+}
+
+func TestDownloadVerifiesAndExtracts(t *testing.T) {
+	server, archive, checksums := serveRelease(t, "9.9.9", "the new binary", true)
+	defer server.Close()
+
+	dir := t.TempDir()
+
+	binary, err := download(t.Context(), "9.9.9", dir)
+	require.NoError(t, err)
+	assertFileContents(t, binary, "the new binary")
+
+	// Both assets were fetched under the names the release publishes.
+	assert.FileExists(t, filepath.Join(dir, archive))
+	assert.NotEmpty(t, checksums)
+}
+
+func TestDownloadRejectsATamperedArchive(t *testing.T) {
+	server, _, _ := serveRelease(t, "9.9.9", "the new binary", false)
+	defer server.Close()
+
+	_, err := download(t.Context(), "9.9.9", t.TempDir())
+	assert.ErrorContains(t, err, "checksum mismatch")
+}
+
+func TestDownloadReportsAMissingRelease(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	swapReleaseBaseURL(t, server.URL)
+
+	_, err := download(t.Context(), "9.9.9", t.TempDir())
+	assert.ErrorContains(t, err, "could not download")
+}
+
+// serveRelease stands up a stand-in for the GitHub release download host, serving
+// an archive built for the platform the test is running on. When honest is false
+// the published checksum does not match the archive.
+func serveRelease(t *testing.T, release, payload string, honest bool) (*httptest.Server, string, string) {
+	t.Helper()
+
+	archive, checksums, err := assetNames(release, runtime.GOOS, runtime.GOARCH)
+	require.NoError(t, err)
+
+	var body []byte
+	if strings.HasSuffix(archive, ".zip") {
+		body = buildZip(t, binaryName(), payload)
+	} else {
+		body = buildTarGz(t, binaryName(), payload)
+	}
+
+	digest := sha256.Sum256(body)
+	published := hex.EncodeToString(digest[:])
+
+	if !honest {
+		published = strings.Repeat("0", 64)
+	}
+
+	sums := fmt.Sprintf("%s  %s\n", published, archive)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, archive):
+			_, _ = w.Write(body)
+		case strings.HasSuffix(r.URL.Path, checksums):
+			_, _ = w.Write([]byte(sums))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	swapReleaseBaseURL(t, server.URL)
+
+	return server, archive, sums
+}
+
+func swapReleaseBaseURL(t *testing.T, url string) {
+	t.Helper()
+
+	original := releaseBaseURL
+	releaseBaseURL = url
+
+	t.Cleanup(func() { releaseBaseURL = original })
+}
+
+func buildTarGz(t *testing.T, name, contents string) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     0755,
+		Size:     int64(len(contents)),
+		Typeflag: tar.TypeReg,
+	}))
+
+	_, err := tarWriter.Write([]byte(contents))
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+
+	return buffer.Bytes()
+}
+
+func buildZip(t *testing.T, name, contents string) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+
+	zipWriter := zip.NewWriter(&buffer)
+
+	entry, err := zipWriter.Create(name)
+	require.NoError(t, err)
+
+	_, err = entry.Write([]byte(contents))
+	require.NoError(t, err)
+	require.NoError(t, zipWriter.Close())
+
+	return buffer.Bytes()
+}
+
+func assertFileContents(t *testing.T, path, expected string) {
+	t.Helper()
+
+	actual, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(actual))
+}

--- a/pkg/autoupdate/replace.go
+++ b/pkg/autoupdate/replace.go
@@ -2,6 +2,8 @@ package autoupdate
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/stripe/stripe-cli/pkg/errorcategory"
 )
@@ -9,15 +11,31 @@ import (
 // oldSuffix names the outgoing binary while it is being replaced.
 const oldSuffix = ".old"
 
-// removeSupersededBinary deletes the outgoing binary a previous update parked
+// rename is indirected so tests can fail the second move and check that the
+// working binary comes back.
+var rename = os.Rename
+
+// removeSupersededBinary deletes the outgoing binaries previous updates parked
 // next to the new one.
 //
-// On Windows that delete could not happen at update time, because the process
-// being replaced was still running from the file. Any later invocation is a
-// process that is not, so this runs on every invocation and almost always finds
-// nothing.
+// On Windows those deletes could not happen at update time, because a process was
+// still running from each file. Any later invocation is a process that is not, so
+// this runs on every invocation and almost always finds nothing. It scans rather
+// than deleting one known name because asideName falls back to a suffixed name
+// when the usual one is occupied.
 func removeSupersededBinary(exe string) {
-	_ = os.Remove(exe + oldSuffix)
+	dir, base := filepath.Split(exe)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), base+oldSuffix) {
+			_ = os.Remove(filepath.Join(dir, entry.Name()))
+		}
+	}
 }
 
 // replaceBinary moves staged into place at dst, which is usually the image of a
@@ -34,26 +52,26 @@ func replaceBinary(dst, staged string) error {
 		return errorcategory.Errorf(errorcategory.Filesystem, "could not make %s executable: %v", staged, err)
 	}
 
-	aside := dst + oldSuffix
-
-	// Left over from an update whose .old file was still in use at the time.
-	_ = os.Remove(aside)
+	aside, err := asideName(dst)
+	if err != nil {
+		return errorcategory.Errorf(errorcategory.Filesystem, "could not make room next to %s: %v", dst, err)
+	}
 
 	movedAside := false
 
 	if _, err := os.Stat(dst); err == nil {
-		if err := os.Rename(dst, aside); err != nil {
+		if err := rename(dst, aside); err != nil {
 			return errorcategory.Errorf(errorcategory.Filesystem, "could not move %s aside: %v", dst, err)
 		}
 
 		movedAside = true
 	}
 
-	if err := os.Rename(staged, dst); err != nil {
+	if err := rename(staged, dst); err != nil {
 		if movedAside {
 			// Put the working binary back. Failing to install an update is
 			// recoverable; leaving no stripe on PATH at all is not.
-			_ = os.Rename(aside, dst)
+			_ = rename(aside, dst)
 		}
 
 		return errorcategory.Errorf(errorcategory.Filesystem, "could not install %s: %v", dst, err)
@@ -64,4 +82,31 @@ func replaceBinary(dst, staged string) error {
 	_ = os.Remove(aside)
 
 	return nil
+}
+
+// asideName returns a free path to move the outgoing binary to.
+//
+// The usual name is dst+".old", left over from a previous update or not there at
+// all. When it is there and cannot be deleted, the move has to go somewhere else:
+// Windows refuses to delete or replace a file while any process is running from
+// it, and after a concurrent update this process may be running from that very
+// file. Reusing the name in that case fails the whole update, so fall back to a
+// unique one, which the next invocation cleans up along with the rest.
+func asideName(dst string) (string, error) {
+	aside := dst + oldSuffix
+	if err := os.Remove(aside); err == nil || os.IsNotExist(err) {
+		return aside, nil
+	}
+
+	// Created rather than just named so that two updates racing here cannot pick
+	// the same path. Renaming over the empty placeholder is what claims it.
+	placeholder, err := os.CreateTemp(filepath.Dir(dst), filepath.Base(dst)+oldSuffix+".*")
+	if err != nil {
+		return "", err
+	}
+
+	name := placeholder.Name()
+	_ = placeholder.Close()
+
+	return name, nil
 }

--- a/pkg/autoupdate/replace.go
+++ b/pkg/autoupdate/replace.go
@@ -1,0 +1,67 @@
+package autoupdate
+
+import (
+	"os"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+)
+
+// oldSuffix names the outgoing binary while it is being replaced.
+const oldSuffix = ".old"
+
+// removeSupersededBinary deletes the outgoing binary a previous update parked
+// next to the new one.
+//
+// On Windows that delete could not happen at update time, because the process
+// being replaced was still running from the file. Any later invocation is a
+// process that is not, so this runs on every invocation and almost always finds
+// nothing.
+func removeSupersededBinary(exe string) {
+	_ = os.Remove(exe + oldSuffix)
+}
+
+// replaceBinary moves staged into place at dst, which is usually the image of a
+// process that is still running.
+//
+// The live binary is renamed aside first rather than overwritten. On Windows
+// that is the only thing that works: the OS locks the image of a running
+// executable against writes and deletes, but a rename only touches the directory
+// entry, so it is allowed. Unix would tolerate a plain rename over the target,
+// but taking the same path on both platforms means the interesting case is the
+// one that runs everywhere, including in the unit tests.
+func replaceBinary(dst, staged string) error {
+	if err := os.Chmod(staged, 0755); err != nil {
+		return errorcategory.Errorf(errorcategory.Filesystem, "could not make %s executable: %v", staged, err)
+	}
+
+	aside := dst + oldSuffix
+
+	// Left over from an update whose .old file was still in use at the time.
+	_ = os.Remove(aside)
+
+	movedAside := false
+
+	if _, err := os.Stat(dst); err == nil {
+		if err := os.Rename(dst, aside); err != nil {
+			return errorcategory.Errorf(errorcategory.Filesystem, "could not move %s aside: %v", dst, err)
+		}
+
+		movedAside = true
+	}
+
+	if err := os.Rename(staged, dst); err != nil {
+		if movedAside {
+			// Put the working binary back. Failing to install an update is
+			// recoverable; leaving no stripe on PATH at all is not.
+			_ = os.Rename(aside, dst)
+		}
+
+		return errorcategory.Errorf(errorcategory.Filesystem, "could not install %s: %v", dst, err)
+	}
+
+	// Best effort: on Windows this fails while the calling process is still
+	// running from the old image. MaybeRun removes it on the next invocation.
+	_ = os.Remove(aside)
+
+	return nil
+}

--- a/pkg/autoupdate/replace_test.go
+++ b/pkg/autoupdate/replace_test.go
@@ -1,0 +1,90 @@
+package autoupdate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceBinaryInstallsOverALiveBinary(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "stripe")
+	staged := filepath.Join(dir, "staged")
+
+	require.NoError(t, os.WriteFile(dst, []byte("old"), 0755))
+	require.NoError(t, os.WriteFile(staged, []byte("new"), 0644))
+
+	require.NoError(t, replaceBinary(dst, staged))
+
+	installed, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(installed))
+
+	// Unix can unlink the moved-aside file immediately. Windows cannot while the
+	// image is running, but nothing is running it here either.
+	assert.NoFileExists(t, dst+oldSuffix)
+	assert.NoFileExists(t, staged)
+}
+
+func TestReplaceBinaryInstallsWhenNothingIsThere(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "stripe")
+	staged := filepath.Join(dir, "staged")
+
+	require.NoError(t, os.WriteFile(staged, []byte("new"), 0644))
+
+	require.NoError(t, replaceBinary(dst, staged))
+
+	installed, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(installed))
+}
+
+func TestReplaceBinaryClearsAStaleOldFile(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "stripe")
+	staged := filepath.Join(dir, "staged")
+
+	require.NoError(t, os.WriteFile(dst, []byte("old"), 0755))
+	require.NoError(t, os.WriteFile(dst+oldSuffix, []byte("older"), 0755))
+	require.NoError(t, os.WriteFile(staged, []byte("new"), 0644))
+
+	require.NoError(t, replaceBinary(dst, staged))
+
+	assert.NoFileExists(t, dst+oldSuffix)
+}
+
+func TestReplaceBinaryRestoresTheOldBinaryOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "stripe")
+
+	require.NoError(t, os.WriteFile(dst, []byte("old"), 0755))
+
+	// A staged path that does not exist stands in for any failure of the second
+	// rename. The point is that the working binary is still on disk afterwards.
+	err := replaceBinary(dst, filepath.Join(dir, "missing"))
+	require.Error(t, err)
+
+	restored, readErr := os.ReadFile(dst)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old", string(restored))
+}
+
+func TestRemoveSupersededBinary(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "stripe")
+
+	require.NoError(t, os.WriteFile(exe, []byte("current"), 0755))
+	require.NoError(t, os.WriteFile(exe+oldSuffix, []byte("previous"), 0755))
+
+	removeSupersededBinary(exe)
+
+	assert.NoFileExists(t, exe+oldSuffix)
+	assert.FileExists(t, exe)
+
+	// Nothing to remove is the common case and must not be an error.
+	removeSupersededBinary(exe)
+}

--- a/pkg/autoupdate/replace_test.go
+++ b/pkg/autoupdate/replace_test.go
@@ -1,6 +1,7 @@
 package autoupdate
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -57,20 +58,59 @@ func TestReplaceBinaryClearsAStaleOldFile(t *testing.T) {
 	assert.NoFileExists(t, dst+oldSuffix)
 }
 
+func TestReplaceBinaryWhenTheOldFileCannotBeCleared(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "stripe")
+	staged := filepath.Join(dir, "staged")
+
+	require.NoError(t, os.WriteFile(dst, []byte("old"), 0755))
+	require.NoError(t, os.WriteFile(staged, []byte("new"), 0644))
+
+	// Windows refuses to delete or replace a file while a process is running from
+	// it, which is the state of the .old file left by a concurrent update. A
+	// non-empty directory is refused by os.Remove and os.Rename on every platform,
+	// so it stands in for that obstacle in a test that can run anywhere.
+	require.NoError(t, os.MkdirAll(filepath.Join(dst+oldSuffix, "occupied"), 0755))
+
+	require.NoError(t, replaceBinary(dst, staged),
+		"an unusable .old name must not fail the update")
+
+	installed, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(installed))
+
+	// The outgoing binary went to a suffixed name, and whatever was holding the
+	// usual one was left alone rather than clobbered.
+	assert.DirExists(t, dst+oldSuffix)
+}
+
 func TestReplaceBinaryRestoresTheOldBinaryOnFailure(t *testing.T) {
 	dir := t.TempDir()
 	dst := filepath.Join(dir, "stripe")
+	staged := filepath.Join(dir, "staged")
 
 	require.NoError(t, os.WriteFile(dst, []byte("old"), 0755))
+	require.NoError(t, os.WriteFile(staged, []byte("new"), 0644))
 
-	// A staged path that does not exist stands in for any failure of the second
-	// rename. The point is that the working binary is still on disk afterwards.
-	err := replaceBinary(dst, filepath.Join(dir, "missing"))
+	// Fail the move of the new binary into place, after the live one has been moved
+	// aside: a full disk, a revoked permission, an antivirus hold on the download.
+	original := rename
+	rename = func(from, to string) error {
+		if from == staged {
+			return errors.New("cannot move the new binary into place")
+		}
+
+		return original(from, to)
+	}
+
+	t.Cleanup(func() { rename = original })
+
+	err := replaceBinary(dst, staged)
 	require.Error(t, err)
 
 	restored, readErr := os.ReadFile(dst)
 	require.NoError(t, readErr)
-	assert.Equal(t, "old", string(restored))
+	assert.Equal(t, "old", string(restored), "a failed update has to leave a working binary behind")
 }
 
 func TestRemoveSupersededBinary(t *testing.T) {
@@ -79,11 +119,16 @@ func TestRemoveSupersededBinary(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(exe, []byte("current"), 0755))
 	require.NoError(t, os.WriteFile(exe+oldSuffix, []byte("previous"), 0755))
+	// What asideName falls back to when .old itself is occupied.
+	require.NoError(t, os.WriteFile(exe+oldSuffix+".2971828", []byte("older"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "unrelated"), []byte("keep"), 0644))
 
 	removeSupersededBinary(exe)
 
 	assert.NoFileExists(t, exe+oldSuffix)
+	assert.NoFileExists(t, exe+oldSuffix+".2971828")
 	assert.FileExists(t, exe)
+	assert.FileExists(t, filepath.Join(dir, "unrelated"))
 
 	// Nothing to remove is the common case and must not be an error.
 	removeSupersededBinary(exe)

--- a/pkg/cmd/autoupdate.go
+++ b/pkg/cmd/autoupdate.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/autoupdate"
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/validators"
+)
+
+type autoUpdateCmd struct {
+	cmd *cobra.Command
+
+	enable  bool
+	disable bool
+	now     bool
+}
+
+func newAutoUpdateCmd() *autoUpdateCmd {
+	au := &autoUpdateCmd{}
+
+	au.cmd = &cobra.Command{
+		Use:   "auto-update",
+		Short: "Manage the Stripe CLI's background self-update",
+		Long: fmt.Sprintf(`Manage the background self-update of the Stripe CLI.
+
+A stripe binary installed by the install script keeps itself current: at most once
+a day, a detached background process checks for a newer release and, if there is
+one, downloads it, verifies its checksum, and replaces the binary in place. The
+command you ran is never blocked on that work.
+
+This does not apply to a stripe installed by Homebrew, apt, Scoop, WinGet, or npm.
+Those installs belong to the package manager, and the CLI leaves them alone.
+
+Auto-update is on by default. Turn it off with --disable, or per-invocation by
+setting %s=1.`, autoupdate.EnvDisable),
+		Example: `stripe auto-update
+  stripe auto-update --disable
+  stripe auto-update --now`,
+		Args:   validators.NoArgs,
+		RunE:   au.run,
+		Hidden: true,
+	}
+
+	au.cmd.Flags().BoolVar(&au.enable, "enable", false, "Allow the CLI to update itself in the background")
+	au.cmd.Flags().BoolVar(&au.disable, "disable", false, "Stop the CLI from updating itself")
+	au.cmd.Flags().BoolVar(&au.now, "now", false, "Update to the latest release right now, in the foreground")
+	au.cmd.MarkFlagsMutuallyExclusive("enable", "disable")
+
+	return au
+}
+
+func (au *autoUpdateCmd) run(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+
+	if au.enable || au.disable {
+		if err := Config.WriteConfigField(config.AutoUpdateSettingKey(), au.enable); err != nil {
+			return err
+		}
+
+		if au.enable {
+			fmt.Fprintln(out, "Auto-update enabled.")
+		} else {
+			fmt.Fprintln(out, "Auto-update disabled.")
+		}
+	}
+
+	if au.now {
+		return autoupdate.Run(cmd.Context(), &Config, out)
+	}
+
+	if !au.enable && !au.disable {
+		printAutoUpdateStatus(out)
+	}
+
+	return nil
+}
+
+func printAutoUpdateStatus(out io.Writer) {
+	exe, managed := autoupdate.SelfManaged()
+
+	switch {
+	case !managed:
+		fmt.Fprintf(out, "Auto-update is unavailable: %s is not an install-script install.\n", describeBinary(exe))
+		fmt.Fprintf(out, "Upgrade it with whatever installed it, or reinstall into %s.\n", autoupdate.InstallDir())
+	case autoupdate.IsDevBuild():
+		fmt.Fprintln(out, "Auto-update is unavailable: this is a development build, which has no matching release.")
+	case autoupdate.Enabled():
+		fmt.Fprintln(out, "Auto-update is enabled.")
+		fmt.Fprintf(out, "Turn it off with `stripe auto-update --disable`, or set %s=1.\n", autoupdate.EnvDisable)
+	default:
+		fmt.Fprintln(out, "Auto-update is disabled.")
+		fmt.Fprintln(out, "Turn it on with `stripe auto-update --enable`.")
+	}
+}
+
+func describeBinary(exe string) string {
+	if exe == "" {
+		return "this binary"
+	}
+
+	return exe
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/reporting"
 
+	"github.com/stripe/stripe-cli/pkg/autoupdate"
 	cmddocs "github.com/stripe/stripe-cli/pkg/cmd/docs"
 	"github.com/stripe/stripe-cli/pkg/cmd/pluginhints"
 	"github.com/stripe/stripe-cli/pkg/cmd/resource"
@@ -121,6 +122,15 @@ var rootCmd = &cobra.Command{
 			// record command invocation
 			sendCommandInvocationEvent(cmd.Context())
 		}
+
+		// Keep an install-script install current. This returns immediately: it does
+		// nothing at all for package-manager installs, development builds, and users
+		// who opted out, and otherwise hands the download to a detached process.
+		// Skipped for `stripe auto-update` itself, which is where that process ends up.
+		if cmd.Name() != "auto-update" {
+			autoupdate.MaybeRun(&Config)
+		}
+
 		return nil
 	},
 }
@@ -287,6 +297,7 @@ func init() {
 
 	rootCmd.AddCommand(newReportingCmd().cmd)
 	rootCmd.AddCommand(newAgentCmd().cmd)
+	rootCmd.AddCommand(newAutoUpdateCmd().cmd)
 	rootCmd.AddCommand(newDataCmd().cmd)
 	rootCmd.AddCommand(cmddocs.New().WithOptions(cmddocs.WithConfig(&Config)).Root())
 	rootCmd.AddCommand(newCompletionCmd().cmd)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -390,6 +390,7 @@ var reservedTopLevelKeys = map[string]bool{
 	"plugin_configs":    true,
 	"project-name":      true,
 	ProfilesTableName:   true,
+	SettingsTableName:   true,
 	UserInfoName:        true,
 }
 

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+)
+
+const (
+	// SettingsTableName is the reserved top-level table holding machine-wide CLI
+	// settings that belong to no profile.
+	SettingsTableName = "settings"
+
+	// AutoUpdateField is the settings key controlling whether the CLI may replace
+	// its own binary.
+	AutoUpdateField = "auto_update"
+)
+
+// AutoUpdateSettingKey is the config path of the auto-update opt-out, for use
+// with WriteConfigField.
+func AutoUpdateSettingKey() string {
+	return SettingsTableName + "." + AutoUpdateField
+}
+
+// AutoUpdateEnabled reports whether the config file allows the CLI to update
+// itself. It defaults to true, so a config file that says nothing opts in.
+//
+// Both the nested and the flat spelling are honored. scripts/install.sh prints
+// the [settings] form, but the flat form is what the design note showed and what
+// some users will therefore have written; reading only one of them would leave an
+// opt-out silently ignored, which is the worst possible failure for this setting.
+func AutoUpdateEnabled() bool {
+	for _, key := range []string{AutoUpdateSettingKey(), AutoUpdateField} {
+		if viper.IsSet(key) {
+			return viper.GetBool(key)
+		}
+	}
+
+	return true
+}

--- a/pkg/config/settings_test.go
+++ b/pkg/config/settings_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAutoUpdateEnabledDefaultsToTrue(t *testing.T) {
+	viper.Reset()
+
+	defer viper.Reset()
+
+	assert.True(t, AutoUpdateEnabled(), "a config file that says nothing opts in")
+}
+
+func TestAutoUpdateEnabledReadsTheSettingsTable(t *testing.T) {
+	viper.Reset()
+
+	defer viper.Reset()
+
+	viper.Set(AutoUpdateSettingKey(), false)
+	assert.False(t, AutoUpdateEnabled())
+
+	viper.Set(AutoUpdateSettingKey(), true)
+	assert.True(t, AutoUpdateEnabled())
+}
+
+func TestAutoUpdateEnabledReadsTheFlatKey(t *testing.T) {
+	viper.Reset()
+
+	defer viper.Reset()
+
+	// The design note showed a bare top-level key, so some users will have written
+	// that instead of the [settings] form the install script prints.
+	viper.Set(AutoUpdateField, false)
+	assert.False(t, AutoUpdateEnabled())
+}
+
+func TestAutoUpdateEnabledPrefersTheSettingsTable(t *testing.T) {
+	viper.Reset()
+
+	defer viper.Reset()
+
+	viper.Set(AutoUpdateSettingKey(), true)
+	viper.Set(AutoUpdateField, false)
+	assert.True(t, AutoUpdateEnabled(), "the documented spelling wins when both are present")
+}
+
+func TestSettingsIsNotRemovableAsAProfile(t *testing.T) {
+	assert.True(t, isReservedConfigKey(SettingsTableName),
+		"a profile named settings must not be able to delete machine-wide settings")
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,233 @@
+#!/usr/bin/env pwsh
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Invoke-WebRequest's progress bar dominates download time on Windows PowerShell
+# 5.1 (often by an order of magnitude). Suppress it.
+$ProgressPreference = "SilentlyContinue"
+
+$InstallDir = if ($env:STRIPE_INSTALL_DIR) { $env:STRIPE_INSTALL_DIR } else { Join-Path $env:USERPROFILE ".stripe\bin" }
+$GitHubRepo = "stripe/stripe-cli"
+
+function Get-ApiHeaders {
+    $headers = @{ "User-Agent" = "stripe-installer" }
+    # Unauthenticated api.github.com allows 60 requests/hour/IP, which the install
+    # test workflow exhausts on its own. Mirrors install.sh's http_get().
+    if ($env:GITHUB_TOKEN) {
+        $headers["Authorization"] = "Bearer $env:GITHUB_TOKEN"
+    }
+    return $headers
+}
+
+function Detect-Platform {
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower()
+    switch ($arch) {
+        "x64"   { $script:ArchLabel = "x86_64" }
+        "x86"   { $script:ArchLabel = "i386" }
+        "arm64" {
+            # No windows/arm64 binary is published — .goreleaser/windows.yml builds
+            # amd64 and 386 only. Windows on ARM runs x64 under emulation, so install
+            # the x86_64 build instead of failing on a 404.
+            $script:ArchLabel = "x86_64"
+        }
+        default { throw "Unsupported architecture: $arch. Supported: x64, x86, arm64." }
+    }
+    Write-Host "Detected: windows $script:ArchLabel"
+}
+
+function Get-LatestVersion {
+    $releaseUrl = "https://api.github.com/repos/$GitHubRepo/releases/latest"
+    try {
+        $release = Invoke-RestMethod -Uri $releaseUrl -Headers (Get-ApiHeaders) -UseBasicParsing
+        $script:Version = $release.tag_name -replace "^v", ""
+    } catch {
+        throw "Could not determine the latest version: $($_.Exception.Message)`nCheck your internet connection, or set GITHUB_TOKEN if you are being rate limited."
+    }
+
+    if (-not $script:Version) {
+        throw "Could not parse a version from the GitHub release response."
+    }
+    Write-Host "Latest version: v$script:Version"
+}
+
+function Download-And-Verify {
+    $archive = "stripe_${script:Version}_windows_${script:ArchLabel}.zip"
+    $baseUrl = "https://github.com/$GitHubRepo/releases/download/v${script:Version}"
+
+    $script:TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "stripe-install-$([System.Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $script:TmpDir | Out-Null
+
+    $archivePath = Join-Path $script:TmpDir $archive
+    $checksumsPath = Join-Path $script:TmpDir "checksums.txt"
+
+    Write-Host "Downloading stripe v${script:Version}..."
+    # No auth header here, deliberately: these URLs redirect to a signed object
+    # store URL that rejects a second set of credentials. install.sh does the same.
+    Invoke-WebRequest -Uri "$baseUrl/$archive" -OutFile $archivePath -UseBasicParsing
+    Invoke-WebRequest -Uri "$baseUrl/stripe-windows-checksums.txt" -OutFile $checksumsPath -UseBasicParsing
+
+    Write-Host "Verifying checksum..."
+    $expected = $null
+    foreach ($line in Get-Content $checksumsPath) {
+        # Format is "<sha256>  <filename>". Compare the filename exactly rather than
+        # regex-matching the whole line, whose dots would be metacharacters.
+        $parts = $line.Trim() -split "\s+", 2
+        if ($parts.Count -eq 2 -and $parts[1].Trim() -eq $archive) {
+            $expected = $parts[0].ToLower()
+            break
+        }
+    }
+    if (-not $expected) {
+        throw "Checksum entry not found for $archive"
+    }
+
+    $actual = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLower()
+
+    if ($actual -ne $expected) {
+        throw "Checksum verification failed.`n  Expected: $expected`n  Actual:   $actual`nThe downloaded file may be corrupted. Please try again."
+    }
+    Write-Host "Checksum verified."
+
+    Expand-Archive -Path $archivePath -DestinationPath $script:TmpDir -Force
+}
+
+function Install-Binary {
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+
+    $src = Join-Path $script:TmpDir "stripe.exe"
+    $dest = Join-Path $InstallDir "stripe.exe"
+    $old = "$dest.old"
+
+    # Left behind by an earlier upgrade whose binary was still running.
+    if (Test-Path $old) {
+        Remove-Item $old -Force -ErrorAction SilentlyContinue
+    }
+
+    # Windows locks a running image: stripe.exe cannot be overwritten while it is
+    # executing, but it can be renamed. Move it aside so re-running the installer
+    # over an in-use binary works.
+    $movedAside = $false
+    if (Test-Path $dest) {
+        Move-Item -Path $dest -Destination $old -Force
+        $movedAside = $true
+    }
+
+    try {
+        Move-Item -Path $src -Destination $dest -Force
+    } catch {
+        # Restore the previous binary rather than leaving the user with no stripe.exe.
+        if ($movedAside -and -not (Test-Path $dest)) {
+            Move-Item -Path $old -Destination $dest -Force
+        }
+        throw
+    }
+
+    # Best effort: fails harmlessly if the old binary is still running, and the next
+    # install cleans it up.
+    if (Test-Path $old) {
+        Remove-Item $old -Force -ErrorAction SilentlyContinue
+    }
+
+    # Warn about existing scoop/winget installs
+    $scoopStripe = Join-Path $env:USERPROFILE "scoop\shims\stripe.exe"
+    if (Test-Path $scoopStripe) {
+        Write-Host ""
+        Write-Host "Note: stripe is also installed via Scoop at $scoopStripe"
+        Write-Host "You may want to run 'scoop uninstall stripe' to avoid confusion."
+    }
+}
+
+function Send-EnvironmentChange {
+    # Writing the registry directly does not notify running processes, so new
+    # terminals would not see the PATH change until sign-out.
+    # [Environment]::SetEnvironmentVariable does this for us; doing it by hand is the
+    # cost of preserving the value's registry type below.
+    try {
+        if (-not ("Win32.NativeMethods" -as [type])) {
+            Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @'
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+'@
+        }
+        $result = [UIntPtr]::Zero
+        # HWND_BROADCAST, WM_SETTINGCHANGE, SMTO_ABORTIFHUNG, 5s timeout
+        [Win32.NativeMethods]::SendMessageTimeout([IntPtr]0xffff, 0x1A, [UIntPtr]::Zero, "Environment", 2, 5000, [ref]$result) | Out-Null
+    } catch {
+        # Purely a convenience; the success message already tells the user to restart
+        # their terminal.
+    }
+}
+
+function Setup-Path {
+    $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+    if (-not $key) {
+        throw "Could not open HKCU\Environment to update PATH."
+    }
+
+    try {
+        # DoNotExpandEnvironmentNames keeps entries like %USERPROFILE%\bin intact;
+        # reading them expanded and writing them back would bake in the expansion.
+        $current = [string]$key.GetValue("Path", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+
+        $entries = @($current -split ";" | Where-Object { $_ -ne "" })
+        if ($entries -contains $InstallDir) {
+            return
+        }
+
+        # [Environment]::SetEnvironmentVariable(..., "User") always writes REG_SZ,
+        # which silently breaks %VAR% expansion for every other PATH entry (and
+        # truncates past ~2047 chars). Preserve whatever type is already there.
+        $kind = [Microsoft.Win32.RegistryValueKind]::ExpandString
+        try { $kind = $key.GetValueKind("Path") } catch { }
+
+        $newPath = if ([string]::IsNullOrEmpty($current)) { $InstallDir } else { "$InstallDir;$current" }
+        $key.SetValue("Path", $newPath, $kind)
+    } finally {
+        $key.Dispose()
+    }
+
+    Send-EnvironmentChange
+
+    $env:Path = "$InstallDir;$env:Path"
+    Write-Host "Added $InstallDir to user PATH."
+    $script:PathUpdated = $true
+}
+
+function Print-Success {
+    Write-Host ""
+    Write-Host "stripe v${script:Version} installed to $InstallDir\stripe.exe"
+    Write-Host ""
+    if ($script:PathUpdated) {
+        Write-Host "Restart your terminal for PATH changes to take effect, then:"
+    }
+    Write-Host "  stripe login    - authenticate with your Stripe account"
+    Write-Host "  stripe --help   - see available commands"
+}
+
+function Cleanup {
+    if ($script:TmpDir -and (Test-Path $script:TmpDir)) {
+        Remove-Item -Recurse -Force $script:TmpDir
+    }
+}
+
+# Main
+$script:Version = ""
+$script:ArchLabel = ""
+$script:TmpDir = ""
+$script:PathUpdated = $false
+
+# Failures throw rather than calling exit: a terminating error still yields a
+# non-zero exit code under `pwsh -File`, but does not tear down the caller's
+# session the way `exit` does when this script is run via `irm ... | iex`.
+try {
+    Detect-Platform
+    Get-LatestVersion
+    Download-And-Verify
+    Install-Binary
+    Setup-Path
+    Print-Success
+} finally {
+    Cleanup
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ detect_platform() {
     linux)  OS_LABEL="linux" ;;
     *)
       echo "Error: unsupported operating system: $OS"
-      echo "Supported: macOS, Linux."
+      echo "Supported: macOS, Linux. For Windows, use scripts/install.ps1."
       exit 1
       ;;
   esac


### PR DESCRIPTION
Stacked on #1799 — review that first; the base flips to `master` once it merges.

M2 of the curl install + auto-update work. A binary installed by `install.sh` / `install.ps1` lives in `~/.stripe/bin` and is self-owned, so it can keep itself current. A Homebrew, apt, Scoop, WinGet, or npm install is not touched.

The mechanism is cross-platform rather than Windows-only. M2 did not exist for any platform, and the only genuinely Windows-specific part is the binary swap — building it for one OS would have meant writing the shared 90% twice.

### Behavior

- Every invocation, an install-script binary checks at most once a day (stamp file in the config folder) and hands the download to a **detached process**, so the command the user typed never blocks. Locally: `stripe version` returns in 0.1s and the update lands a few seconds later.
- Downloads the release archive, verifies its SHA256 against the published checksums file, extracts, and swaps the binary in.
- Skipped for builds from source, for `STRIPE_NO_AUTO_UPDATE`, and for `auto_update = false`.
- `stripe auto-update` (hidden, mirroring `stripe plugin auto-update`) shows the state; `--enable` / `--disable` write it; `--now` updates in the foreground.

### Decisions worth a look

- **Windows cannot overwrite a running image, but it can rename one.** The outgoing binary is moved to `stripe.exe.old`, the new one takes its place, and the next invocation deletes the leftover. Both platforms take that path so the interesting case is the one the unit tests cover.
- **A detached worker, not a goroutine.** A short-lived command exits before a background download finishes, and on Windows a process cannot replace its own image at all.
- **Staged inside the install directory**, not the OS temp dir: the last step is a rename, and `/tmp` is often a different filesystem.
- **Both spellings of the opt-out are read.** `install.sh` prints the `[settings]` form; the design note showed a bare `auto_update`. An ignored opt-out is the worst failure this setting has. `settings` also joins the reserved top-level config keys so a profile cannot collide with it.
- **Release downloads stay unauthenticated** even when `GITHUB_TOKEN` is set — asset URLs redirect to a pre-signed URL that rejects a second credential. Only the API version lookup authenticates, which is what avoids the 60/hour rate limit.
- **Windows arm64 gets the x64 archive**, matching `install.ps1`: `.goreleaser/windows.yml` publishes amd64 and 386 only.

### Testing

Unit tests cover the swap (including the restore-on-failure path), the daily cadence, the lock, install-source detection, asset naming for all seven published platform/arch pairs, exact checksum matching, and both archive formats — against a local release server. `test.yml` already runs `go test` on `windows-latest`, so the rename-aside primitive is covered on real Windows on every PR.

End-to-end verified on macOS against the real v1.50.6 release: foreground update, detached background update, the daily stamp suppressing a second check, and both opt-outs.

`self-update-test.yml` (added here, dispatch-only) does the same end to end on `windows-latest`, `macos-latest`, and `ubuntu-latest`, including the case unit tests cannot reach — the process performing the update running from the file it replaces — and asserts `stripe.exe.old` lingers on Windows until the next invocation clears it.

Run on all three: [33098843861](https://github.com/stripe/stripe-cli/actions/runs/33098843861), dispatched from a scratch branch because `gh` can only dispatch a workflow that already exists on `master`. Windows updated 1.0.0 → 1.50.6 in the foreground, returned from a background-updating `stripe version` in 0.35s, and cleared `stripe.exe.old` on the next invocation.

Its first run failed on Windows with `rename stripe.exe stripe.exe.old: Access is denied`, which was a real bug rather than a test artifact: the test's own setup had left a second update in flight, so the updating process was running from `stripe.exe.old` itself, and a name that can be neither deleted nor replaced took the whole update down. The last commit falls back to a unique aside name in that case.
