### PR TITLE
Add release notes to automatic updates

### DIFF
--- a/pkg/autoupdate/checker.go
+++ b/pkg/autoupdate/checker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,9 +28,10 @@ const checkInterval = 24 * time.Hour
 
 // UpdateMarker represents a staged update ready to be applied.
 type UpdateMarker struct {
-	Version     string
-	DownloadURL string
-	Checksum    string
+	Version      string `json:"version"`
+	DownloadURL  string `json:"download_url"`
+	Checksum     string `json:"checksum"`
+	ReleaseNotes string `json:"release_notes"`
 }
 
 // CheckForUpdate checks for a newer CLI version and writes a marker file
@@ -46,7 +48,7 @@ func CheckForUpdate() {
 		return
 	}
 
-	latest, url, checksum := fetchLatestRelease()
+	latest, url, checksum, releaseNotes := fetchLatestRelease()
 	if latest == "" {
 		return
 	}
@@ -66,9 +68,10 @@ func CheckForUpdate() {
 	}
 
 	WriteMarker(UpdateMarker{
-		Version:     latestClean,
-		DownloadURL: url,
-		Checksum:    checksum,
+		Version:      latestClean,
+		DownloadURL:  url,
+		Checksum:     checksum,
+		ReleaseNotes: releaseNotes,
 	})
 	sendTelemetryEvent("Auto-Update Available", fmt.Sprintf("from=%s to=%s", current, latestClean))
 }
@@ -115,7 +118,7 @@ func shouldCheck() bool {
 	return time.Since(time.Unix(ts, 0)) >= checkInterval
 }
 
-func fetchLatestRelease() (ver string, downloadURL string, checksum string) {
+func fetchLatestRelease() (ver string, downloadURL string, checksum string, releaseNotes string) {
 	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 
@@ -123,10 +126,11 @@ func fetchLatestRelease() (ver string, downloadURL string, checksum string) {
 	release, _, err := client.Repositories.GetLatestRelease(ctx, "stripe", "stripe-cli")
 	if err != nil {
 		log.Debug("autoupdate: failed to fetch latest release: ", err)
-		return "", "", ""
+		return "", "", "", ""
 	}
 
 	ver = release.GetTagName()
+	releaseNotes = release.GetBody()
 	assetName := binaryAssetName(strings.TrimPrefix(ver, "v"))
 	checksumAsset := checksumAssetName()
 
@@ -143,14 +147,14 @@ func fetchLatestRelease() (ver string, downloadURL string, checksum string) {
 
 	if binaryURL == "" {
 		log.Debug("autoupdate: binary asset not found: ", assetName)
-		return "", "", ""
+		return "", "", "", ""
 	}
 
 	if checksumURL != "" {
 		checksum = fetchChecksumForAsset(checksumURL, assetName)
 	}
 
-	return ver, binaryURL, checksum
+	return ver, binaryURL, checksum, releaseNotes
 }
 
 func fetchChecksumForAsset(checksumURL, assetName string) string {
@@ -230,9 +234,13 @@ func WriteMarker(m UpdateMarker) {
 		return
 	}
 
-	content := fmt.Sprintf("%s\n%s\n%s\n", m.Version, m.DownloadURL, m.Checksum)
+	content, err := json.Marshal(m)
+	if err != nil {
+		return
+	}
+
 	markerPath := filepath.Join(stateDir, "update-available")
-	_ = os.WriteFile(markerPath, []byte(content), 0644)
+	_ = os.WriteFile(markerPath, content, 0644)
 
 	recordLastCheck()
 }
@@ -261,19 +269,11 @@ func ReadMarker() *UpdateMarker {
 		return nil
 	}
 
-	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	if len(lines) < 2 {
+	var m UpdateMarker
+	if err := json.Unmarshal(data, &m); err != nil {
 		return nil
 	}
-
-	m := &UpdateMarker{
-		Version:     lines[0],
-		DownloadURL: lines[1],
-	}
-	if len(lines) >= 3 {
-		m.Checksum = lines[2]
-	}
-	return m
+	return &m
 }
 
 // ClearMarker removes the pending update marker.

--- a/pkg/autoupdate/checker_test.go
+++ b/pkg/autoupdate/checker_test.go
@@ -57,6 +57,39 @@ func TestMarkerReadWrite(t *testing.T) {
 	assert.Nil(t, ReadMarker())
 }
 
+func TestMarkerReadWriteWithReleaseNotes(t *testing.T) {
+	tmpDir := t.TempDir()
+	original := GetStateDirFn
+	defer func() { GetStateDirFn = original }()
+	GetStateDirFn = func() string { return tmpDir }
+
+	notes := "## Changes\n\n- Added one thing\n- Fixed another thing"
+	WriteMarker(UpdateMarker{
+		Version:      "1.24.0",
+		DownloadURL:  "https://example.com/stripe.tar.gz",
+		Checksum:     "abc123",
+		ReleaseNotes: notes,
+	})
+
+	got := ReadMarker()
+	require.NotNil(t, got)
+	assert.Equal(t, notes, got.ReleaseNotes)
+}
+
+func TestReadMarkerWithoutReleaseNotes(t *testing.T) {
+	tmpDir := t.TempDir()
+	original := GetStateDirFn
+	defer func() { GetStateDirFn = original }()
+	GetStateDirFn = func() string { return tmpDir }
+
+	marker := `{"version":"1.24.0","download_url":"https://example.com/stripe.tar.gz","checksum":"abc123"}`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "update-available"), []byte(marker), 0644))
+
+	got := ReadMarker()
+	require.NotNil(t, got)
+	assert.Empty(t, got.ReleaseNotes)
+}
+
 func TestRecordLastCheck(t *testing.T) {
 	tmpDir := t.TempDir()
 	original := GetStateDirFn

--- a/pkg/autoupdate/updater.go
+++ b/pkg/autoupdate/updater.go
@@ -16,6 +16,11 @@ import (
 	"github.com/stripe/stripe-cli/pkg/version"
 )
 
+const (
+	maxReleaseNoteLines = 15
+	maxReleaseNoteRunes = 1000
+)
+
 // ApplyIfPending checks for a pending update marker and applies it.
 // If an update is applied, it re-execs the current process with the new binary.
 // This function only returns if no update was applied.
@@ -68,9 +73,56 @@ func ApplyIfPending() {
 
 	ClearMarker()
 	fmt.Fprintf(os.Stderr, "Updated successfully ✓\n")
+	if releaseNotes := formatReleaseNotes(marker.ReleaseNotes, marker.Version); releaseNotes != "" {
+		fmt.Fprint(os.Stderr, releaseNotes)
+		if !strings.HasSuffix(releaseNotes, "\n") {
+			fmt.Fprintln(os.Stderr)
+		}
+	}
 	sendTelemetryEvent("Auto-Update Succeeded", fmt.Sprintf("from=%s to=%s", current, target))
 
 	reexec(exe)
+}
+
+func formatReleaseNotes(notes, markerVersion string) string {
+	if notes == "" {
+		return ""
+	}
+
+	runes := []rune(notes)
+	cutoff := len(runes)
+	truncated := false
+
+	if cutoff > maxReleaseNoteRunes {
+		cutoff = maxReleaseNoteRunes
+		truncated = true
+	}
+
+	lineCount := 0
+	for i, r := range runes {
+		if r != '\n' {
+			continue
+		}
+		lineCount++
+		if lineCount == maxReleaseNoteLines && i+1 < len(runes) {
+			if i+1 < cutoff {
+				cutoff = i + 1
+			}
+			truncated = true
+			break
+		}
+	}
+
+	formatted := string(runes[:cutoff])
+	if !truncated {
+		return formatted
+	}
+
+	if !strings.HasSuffix(formatted, "\n") {
+		formatted += "\n"
+	}
+	version := strings.TrimLeft(markerVersion, "v")
+	return fmt.Sprintf("%sFull release notes: https://github.com/stripe/stripe-cli/releases/tag/v%s", formatted, version)
 }
 
 func downloadAndReplace(marker *UpdateMarker, exePath string) error {

--- a/pkg/autoupdate/updater_test.go
+++ b/pkg/autoupdate/updater_test.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,6 +46,54 @@ func sha256sum(path string) string {
 	data, _ := os.ReadFile(path)
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])
+}
+
+func TestFormatReleaseNotes_Empty(t *testing.T) {
+	assert.Empty(t, formatReleaseNotes("", "1.24.0"))
+}
+
+func TestFormatReleaseNotes_ExactLineBoundary(t *testing.T) {
+	notes := strings.Join([]string{
+		"line 1", "line 2", "line 3", "line 4", "line 5",
+		"line 6", "line 7", "line 8", "line 9", "line 10",
+		"line 11", "line 12", "line 13", "line 14", "line 15",
+	}, "\n")
+
+	assert.Equal(t, notes, formatReleaseNotes(notes, "1.24.0"))
+}
+
+func TestFormatReleaseNotes_ExactCharacterBoundary(t *testing.T) {
+	notes := strings.Repeat("a", maxReleaseNoteRunes)
+
+	assert.Equal(t, notes, formatReleaseNotes(notes, "1.24.0"))
+}
+
+func TestFormatReleaseNotes_TruncatesLines(t *testing.T) {
+	lines := make([]string, maxReleaseNoteLines+1)
+	for i := range lines {
+		lines[i] = "release note"
+	}
+
+	got := formatReleaseNotes(strings.Join(lines, "\n"), "v1.24.0")
+	notes, pointer, found := strings.Cut(got, "\nFull release notes: ")
+	require.True(t, found)
+	assert.Equal(t, strings.Join(lines[:maxReleaseNoteLines], "\n"), notes)
+	assert.Equal(t, "https://github.com/stripe/stripe-cli/releases/tag/v1.24.0", pointer)
+	assert.LessOrEqual(t, strings.Count(notes, "\n")+1, maxReleaseNoteLines)
+	assert.LessOrEqual(t, utf8.RuneCountInString(notes), maxReleaseNoteRunes)
+}
+
+func TestFormatReleaseNotes_TruncatesCharactersWithoutSplittingUTF8(t *testing.T) {
+	notes := strings.Repeat("界", maxReleaseNoteRunes+1)
+
+	got := formatReleaseNotes(notes, "vv1.24.0")
+	retained, pointer, found := strings.Cut(got, "\nFull release notes: ")
+	require.True(t, found)
+	assert.True(t, utf8.ValidString(retained))
+	assert.Equal(t, strings.Repeat("界", maxReleaseNoteRunes), retained)
+	assert.Equal(t, "https://github.com/stripe/stripe-cli/releases/tag/v1.24.0", pointer)
+	assert.LessOrEqual(t, strings.Count(retained, "\n")+1, maxReleaseNoteLines)
+	assert.LessOrEqual(t, utf8.RuneCountInString(retained), maxReleaseNoteRunes)
 }
 
 func TestExtractFromTarGz(t *testing.T) {


### PR DESCRIPTION
### Summary
<!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
- Include GitHub release notes in automatic update metadata.
- Display bounded release notes after a successful update.
- Truncate notes to 15 lines or 1,000 characters and link to the full release when needed.