### PR TITLE
Fix data and reporting help so the examples work verbatim

### DIFF
--- a/pkg/cmd/analytics_help_examples_test.go
+++ b/pkg/cmd/analytics_help_examples_test.go
@@ -111,6 +111,15 @@ func helpExampleIsPlaceholder(ex helpExample) bool {
 	return helpExamplePlaceholder.MatchString(ex.Raw)
 }
 
+// groupByDimensionsVerifiedAgainstAPI lists the --group-by values confirmed to
+// be accepted by /v2/data/analytics/metric_query for revenue.mrr.
+//
+// Which dimensions a metric supports varies by metric, and the API rejects an
+// unsupported one with metric_invalid_parameter_value. "price", "product" and
+// "customer" all read plausibly but are rejected, so the help examples must not
+// use them — this list is what keeps a plausible-looking swap from shipping.
+var groupByDimensionsVerifiedAgainstAPI = []string{"subscription"}
+
 func analyticsHelpCommands() []*cobra.Command {
 	return []*cobra.Command{
 		newDataCmd().cmd,
@@ -176,7 +185,8 @@ func TestAnalyticsHelpExamples_NoRottingCopyPaste(t *testing.T) {
 					require.NotEmpty(t, groupBy)
 					_, isString := groupBy[0].(string)
 					require.True(t, isString, "group_by entries should be strings, got %T", groupBy[0])
-					assert.Equal(t, "price", groupBy[0])
+					assert.Contains(t, groupByDimensionsVerifiedAgainstAPI, groupBy[0],
+						"--group-by in a help example must use a dimension verified to work against the API")
 				}
 			})
 		}
@@ -184,19 +194,31 @@ func TestAnalyticsHelpExamples_NoRottingCopyPaste(t *testing.T) {
 	require.Greater(t, ran, 0, "expected at least one copy-pasteable help example to execute")
 }
 
-func TestExtractHelpExamples_GroupByPrice(t *testing.T) {
+func TestExtractHelpExamples_GroupByUsesSupportedDimension(t *testing.T) {
 	examples := extractHelpExamples(newDataMetricsRunCmd().cmd.Example)
 	var found bool
 	for _, ex := range examples {
 		if strings.Contains(ex.Raw, "--group-by") {
 			found = true
 			assert.Contains(t, ex.Argv, "--group-by")
-			assert.Contains(t, ex.Argv, "price")
-			assert.NotContains(t, ex.Argv, "product")
 			assert.False(t, helpExampleIsPlaceholder(ex))
+
+			i := indexOf(ex.Argv, "--group-by")
+			require.Less(t, i+1, len(ex.Argv), "--group-by needs a value: %s", ex.Raw)
+			assert.Contains(t, groupByDimensionsVerifiedAgainstAPI, ex.Argv[i+1],
+				"--group-by in a help example must use a dimension verified to work against the API")
 		}
 	}
 	require.True(t, found, "expected a group-by example")
+}
+
+func indexOf(s []string, want string) int {
+	for i, v := range s {
+		if v == want {
+			return i
+		}
+	}
+	return -1
 }
 
 func TestExtractHelpExamples_NoCopyPasteableMetricIDs(t *testing.T) {

--- a/pkg/cmd/data.go
+++ b/pkg/cmd/data.go
@@ -50,7 +50,7 @@ Use the metrics subcommands to query time-series Stripe metric data. This
 namespace is a Private Preview API.`,
 		Args: validators.NoArgs,
 	}
-	dc.cmd.SetUsageTemplate(dataUsageTemplate())
+	dc.cmd.SetUsageTemplate(previewUsageTemplate())
 
 	dc.cmd.AddCommand(newDataMetricsCmd().cmd)
 	return dc
@@ -77,11 +77,18 @@ https://docs.stripe.com/api/v2/data/analytics/metric-query-results/create?api-ve
 	return mc
 }
 
-// dataUsageTemplate is the help template for the data command tree.
+// previewUsageTemplate is the help template for the hand-written preview
+// command trees (data, reporting query-runs).
+//
 // Usage and the trailing hint use HasSubCommands so parent --help stays
 // populated if a child is later hidden. Available commands lists only
 // non-hidden children via IsAvailableCommand.
-func dataUsageTemplate() string {
+//
+// Set this explicitly on the root of each tree. Cobra otherwise inherits a
+// usage template from the nearest ancestor that sets one, and the templates
+// differ in whether they indent {{.Example}} — so a tree that relies on
+// inheritance silently changes indentation if it is ever reparented.
+func previewUsageTemplate() string {
 	return fmt.Sprintf(`%s{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
@@ -131,17 +138,32 @@ Private Preview API — the Stripe-Version preview header is set automatically.
 
 Metrics are specified by namespace.metric (e.g. revenue.mrr, revenue.arr).
 Multiple metrics can be queried together as long as they share the same
-namespace. Use --group-by to break down results by a dimension (at most one;
-valid names depend on the metric, e.g. price, product, customer). Use --filter
-to restrict results to specific dimension values.
+namespace. Use --group-by to break down results by a dimension (at most one)
+and --filter to restrict results to specific dimension values. Which
+dimensions a metric supports varies by metric, and an unsupported one is
+rejected, so check the metric's documentation before relying on it.
 
-Required API fields: metrics, starts_at, ends_at, granularity. Optional:
-currency, timezone, group_by, filters, limit. The API validates all parameters.
+Required: --metric, --starts-at, --ends-at. --granularity defaults to day.
+Optional: --currency, --timezone, --group-by, --filter, --limit. Only --metric
+is checked locally; the API validates everything else.
+
+Reading the results:
+  * A bucket's timestamp marks the END of its period, not the start. January
+    2026 at --granularity month is timestamped 2026-01-31, and the week of
+    March 1-7 is timestamped 2026-03-07. A period still in progress is
+    timestamped with the most recent day that has data.
+  * Buckets align to the result timezone (your account's, or --timezone), so
+    the first bucket can look like it precedes --starts-at. For an account in
+    UTC-8, --starts-at 2026-03-01T00:00:00Z is 16:00 on 2026-02-28 locally, so
+    the first daily bucket is that local day. Pass --timezone UTC to align
+    buckets to the UTC timestamps you asked for.
+  * API errors name dimensions with an _id suffix: --filter "price=..." is
+    reported against price_id.
 
 See the supported metrics at https://docs.stripe.com/data/analytics/supported-metrics
 and the API reference at
 https://docs.stripe.com/api/v2/data/analytics/metric-query-results/create?api-version=preview`,
-		Example: `  # Query daily MRR for March 2026
+		Example: `# Query daily MRR for March 2026
   stripe data metrics run \
     --metric revenue.mrr \
     --starts-at 2026-03-01T00:00:00Z \
@@ -157,14 +179,14 @@ https://docs.stripe.com/api/v2/data/analytics/metric-query-results/create?api-ve
     --granularity month \
     --currency usd
 
-  # Group by price dimension
+  # Break MRR down by a dimension the metric supports
   stripe data metrics run \
     --metric revenue.mrr \
     --starts-at 2026-01-01T00:00:00Z \
     --ends-at 2026-01-31T23:59:59Z \
     --granularity month \
     --currency usd \
-    --group-by price
+    --group-by subscription
 
   # Filter by price — replace price_<id> with a Price id from your account
   stripe data metrics run \
@@ -180,7 +202,7 @@ https://docs.stripe.com/api/v2/data/analytics/metric-query-results/create?api-ve
 	c.cmd.Flags().StringVar(&c.startsAt, "starts-at", "", "Start of the time range as an ISO 8601 datetime (e.g. 2026-01-01T00:00:00Z)")
 	c.cmd.Flags().StringVar(&c.endsAt, "ends-at", "", "End of the time range as an ISO 8601 datetime (e.g. 2026-01-31T23:59:59Z)")
 	c.cmd.Flags().StringVar(&c.granularity, "granularity", "day", "Time granularity: day, week, month, or year")
-	c.cmd.Flags().StringArrayVar(&c.groupBy, "group-by", []string{}, "Dimension to group by (at most one). Valid names depend on the metric (e.g. price, product, customer). See https://docs.stripe.com/data/analytics/supported-metrics")
+	c.cmd.Flags().StringArrayVar(&c.groupBy, "group-by", []string{}, "Dimension to group by (at most one). Which dimensions a metric supports varies by metric; an unsupported one is rejected. See https://docs.stripe.com/data/analytics/supported-metrics")
 	c.cmd.Flags().StringArrayVar(&c.filters, "filter", []string{}, "Filter results by dimension values, in key=value format (repeatable). E.g. --filter \"price=price_<id>\"")
 	c.cmd.Flags().StringVar(&c.currency, "currency", "", "Currency code to convert monetary values to (e.g. usd, eur). Defaults to your account's default currency.")
 	c.cmd.Flags().StringVar(&c.timezone, "timezone", "", "Timezone for result alignment (e.g. America/New_York). Defaults to your account timezone.")
@@ -212,7 +234,14 @@ func (c *dataMetricsRunCmd) runDataMetricsRunCmd(cmd *cobra.Command, args []stri
 		return errorcategory.Errorf(errorcategory.UserInput, "at least one --metric is required")
 	}
 
-	creds, err := c.rb.ResolveCredentials()
+	// A dry run sends nothing, so resolve credentials leniently: the live/sandbox
+	// context gate must not be the thing that stops you inspecting a request.
+	resolve := c.rb.ResolveCredentials
+	if c.rb.DryRun {
+		resolve = c.rb.ResolveCredentialsForPreview
+	}
+
+	creds, err := resolve()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/data_test.go
+++ b/pkg/cmd/data_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/config"
 	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 // --- Unit tests: metricRef ---
@@ -566,4 +568,67 @@ func TestDataMetricsRunCmd_HelpStillHasExamples(t *testing.T) {
 	assert.Contains(t, out, "--metric")
 	assert.Contains(t, out, "stripe data metrics run")
 	assert.Contains(t, out, "revenue.mrr")
+}
+
+func TestDataMetricsRunCmd_HelpDocumentsGranularityDefault(t *testing.T) {
+	out := dataHelpOutput(t, "data", "metrics", "run", "--help")
+
+	// The help used to claim --granularity was required. It has a default, and
+	// the two statements have to keep agreeing.
+	assert.Contains(t, out, "--granularity defaults to day")
+	assert.Equal(t, "day", newDataMetricsRunCmd().cmd.Flags().Lookup("granularity").DefValue)
+	assert.NotContains(t, out, "Required: --metric, --starts-at, --ends-at, --granularity")
+}
+
+func TestDataMetricsRunCmd_HelpExplainsBucketTimestamps(t *testing.T) {
+	out := dataHelpOutput(t, "data", "metrics", "run", "--help")
+
+	// Both surprises a first-time reader hits: bucket timestamps are period ends,
+	// and buckets align to the result timezone rather than the requested one.
+	assert.Contains(t, out, "marks the END of its period")
+	assert.Contains(t, out, "--timezone UTC")
+}
+
+func TestDataMetricsRunCmd_HelpDoesNotClaimGroupByIsUniversal(t *testing.T) {
+	usage := newDataMetricsRunCmd().cmd.Flags().Lookup("group-by").Usage
+
+	// Which dimensions a metric supports varies, and the API rejects an
+	// unsupported one rather than ignoring it.
+	assert.Contains(t, usage, "varies by metric")
+	assert.Contains(t, usage, "https://docs.stripe.com/data/analytics/supported-metrics")
+}
+
+func TestDataMetricsRunCmd_DryRunIgnoresActiveContextMode(t *testing.T) {
+	c := newDataMetricsRunCmd()
+	c.rb.Profile = profileWithLiveActiveContext(t)
+	c.rb.APIBaseURL = stripe.DefaultAPIBaseURL
+	c.rb.DryRun = true
+	c.metrics = []string{"revenue.mrr"}
+	c.startsAt = "2026-03-01T00:00:00Z"
+	c.endsAt = "2026-03-31T23:59:59Z"
+	c.granularity = "day"
+
+	var out bytes.Buffer
+	c.cmd.SetOut(&out)
+
+	require.NoError(t, c.runDataMetricsRunCmd(c.cmd, []string{}))
+
+	var output requests.DryRunOutput
+	require.NoError(t, json.Unmarshal(out.Bytes(), &output))
+	assert.Equal(t, http.MethodPost, output.DryRun.Method)
+	assert.Equal(t, stripe.DefaultAPIBaseURL+dataMetricsRunPath, output.DryRun.URL)
+	assert.Equal(t, "true", output.DryRun.Headers["Stripe-Livemode"])
+}
+
+func TestDataMetricsRunCmd_RealRequestStillGatedOnActiveContextMode(t *testing.T) {
+	c := newDataMetricsRunCmd()
+	c.rb.Profile = profileWithLiveActiveContext(t)
+	c.rb.APIBaseURL = stripe.DefaultAPIBaseURL
+	c.metrics = []string{"revenue.mrr"}
+	c.startsAt = "2026-03-01T00:00:00Z"
+	c.endsAt = "2026-03-31T23:59:59Z"
+
+	err := c.runDataMetricsRunCmd(c.cmd, []string{})
+	require.Error(t, err, "leniency must be scoped to --dry-run")
+	assert.Contains(t, err.Error(), "--live")
 }

--- a/pkg/cmd/docs/prefs.go
+++ b/pkg/cmd/docs/prefs.go
@@ -36,7 +36,7 @@ func (r *RootCommand) newPrefsListCmd() *cobra.Command {
 		Use:     "list",
 		Short:   "List available preferences for customizing rendered documentation",
 		Long:    `List available preferences for customizing rendered documentation and their allowed values.`,
-		Example: `  stripe docs prefs list`,
+		Example: `stripe docs prefs list`,
 		Args:    cobra.NoArgs,
 		RunE:    r.runPrefsList,
 	}
@@ -47,7 +47,7 @@ func (r *RootCommand) newPrefsSetCmd() *cobra.Command {
 		Use:     "set <id> <value>",
 		Short:   "Set a documentation preference",
 		Long:    `Set a documentation preference to a specific value.`,
-		Example: `  stripe docs prefs set server go`,
+		Example: `stripe docs prefs set server go`,
 		Args:    cobra.ExactArgs(2),
 		RunE:    r.runPrefsSet,
 	}
@@ -58,7 +58,7 @@ func (r *RootCommand) newPrefsUnsetCmd() *cobra.Command {
 		Use:     "unset <id>",
 		Short:   "Unset a documentation preference, reverting to the default",
 		Long:    `Remove a previously set documentation preference, reverting to the default.`,
-		Example: `  stripe docs prefs unset server`,
+		Example: `stripe docs prefs unset server`,
 		Args:    cobra.ExactArgs(1),
 		RunE:    r.runPrefsUnset,
 	}

--- a/pkg/cmd/map.go
+++ b/pkg/cmd/map.go
@@ -144,6 +144,21 @@ func parseMapMode(arg string) (mapMode, bool) {
 	}
 }
 
+// bareMapModeArg reports whether the args left over after stripping --map are
+// a lone mode name, i.e. the user wrote "--map compact" and meant
+// "--map=compact". pflag requires "=" to pass a value to a flag with an
+// optional value, so the mode name would otherwise be parsed as a command
+// name and silently fall through to the full tree.
+func bareMapModeArg(remaining []string) (string, bool) {
+	if len(remaining) != 1 {
+		return "", false
+	}
+	if _, ok := parseMapMode("--map=" + remaining[0]); ok {
+		return remaining[0], true
+	}
+	return "", false
+}
+
 // stderrOverride can be set in tests to capture error output.
 var stderrOverride io.Writer
 

--- a/pkg/cmd/map_test.go
+++ b/pkg/cmd/map_test.go
@@ -430,3 +430,28 @@ func TestParseMapMode(t *testing.T) {
 	assert.Equal(t, mapModeDefault, mode)
 	assert.False(t, ok)
 }
+
+func TestBareMapModeArg(t *testing.T) {
+	// "--map compact": pflag needs "=" to pass a value to a flag with an optional
+	// value, so the mode name is left over as if it were a command name.
+	for _, mode := range []string{"tree", "compact", "paths", "json"} {
+		val, ok := bareMapModeArg([]string{mode})
+		assert.True(t, ok, "%q should be recognized as a stranded --map mode", mode)
+		assert.Equal(t, mode, val)
+	}
+
+	// A real command that happens to be the only leftover arg must not be
+	// mistaken for a mode.
+	_, ok := bareMapModeArg([]string{"listen"})
+	assert.False(t, ok)
+
+	// A mode name followed by anything else is a genuine command path.
+	_, ok = bareMapModeArg([]string{"json", "extra"})
+	assert.False(t, ok)
+
+	_, ok = bareMapModeArg([]string{"data", "metrics"})
+	assert.False(t, ok)
+
+	_, ok = bareMapModeArg(nil)
+	assert.False(t, ok)
+}

--- a/pkg/cmd/metric_query_error.go
+++ b/pkg/cmd/metric_query_error.go
@@ -47,6 +47,12 @@ func metricQueryErrorMessage(reqErr requests.RequestError) string {
 
 	switch reqErr.ErrorCode {
 	case "metric_invalid_parameter_value":
+		// The API sometimes names the offending parameter ("limit cannot be
+		// greater than 1,000"), which beats anything we can guess. Only fall
+		// back to the checklist when it returns the useless retry boilerplate.
+		if apiMessage != "" && !isGenericRetryMessage(apiMessage) {
+			return apiMessage + "\nThis is a client error; retrying the same request will not succeed."
+		}
 		return strings.Join([]string{
 			"Invalid metric query parameter (metric_invalid_parameter_value).",
 			"Check:",

--- a/pkg/cmd/metric_query_error_test.go
+++ b/pkg/cmd/metric_query_error_test.go
@@ -29,6 +29,20 @@ func TestFormatMetricQueryError_InvalidParameterValueDropsRetryWording(t *testin
 	assert.Equal(t, "metric_invalid_parameter_value", reqErr.ErrorCode)
 }
 
+func TestFormatMetricQueryError_InvalidParameterValueKeepsSpecificMessage(t *testing.T) {
+	// The API sometimes names the offending parameter. That beats our checklist,
+	// so it must survive rather than being replaced by it.
+	err := formatMetricQueryError(requests.RequestError{
+		StatusCode: http.StatusBadRequest,
+		ErrorCode:  "metric_invalid_parameter_value",
+		Body:       `{"error":{"code":"metric_invalid_parameter_value","message":"limit cannot be greater than 1,000"}}`,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "limit cannot be greater than 1,000")
+	assert.Contains(t, err.Error(), "client error")
+	assert.NotContains(t, err.Error(), "--group-by", "the checklist must not displace a specific message")
+}
+
 func TestFormatMetricQueryError_NotFoundMetric(t *testing.T) {
 	err := formatMetricQueryError(requests.RequestError{
 		StatusCode: http.StatusNotFound,

--- a/pkg/cmd/reporting.go
+++ b/pkg/cmd/reporting.go
@@ -19,6 +19,17 @@ import (
 
 const queryRunsPath = "/v2/data/reporting/query_runs"
 
+// reportingNamespaceShort and reportingNamespaceLong describe the `reporting`
+// namespace, which mixes the generated Sigma API resources (report_runs,
+// report_types) with the hand-written query-runs commands.
+const reportingNamespaceShort = "Run Sigma report and ad hoc SQL queries"
+
+const reportingNamespaceLong = `Access Stripe reporting APIs.
+
+Use the query-runs subcommands to run ad hoc SQL queries against your Stripe
+data via the /v2/data/reporting/query_runs Public Preview API. Use the
+report_runs and report_types resources for scheduled Sigma reports.`
+
 type reportingCmd struct {
 	cmd *cobra.Command
 }
@@ -40,16 +51,46 @@ type reportingQueryRunsRetrieveCmd struct {
 	rb  requests.Base
 }
 
+// addReportingQueryRunsCmd hangs query-runs off the generated `reporting`
+// API-resource namespace rather than registering a second top-level command
+// with the same name.
+//
+// Two same-named root children make cobra's Find resolve `stripe reporting
+// report_runs list` to whichever sibling it reaches first. Because that
+// sibling has no `report_runs` child and no Run function, cobra printed the
+// wrong help and exited 0 — so the Sigma commands were silently unreachable
+// (and Args validation never ran, since Runnable() is checked first).
+//
+// Call this after the generated resource commands are registered.
+func addReportingQueryRunsCmd(rootCmd *cobra.Command) {
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() != "reporting" {
+			continue
+		}
+		// The generated namespace carries no descriptions; supply them so
+		// `--help` and `--map` agree on what the namespace does.
+		if cmd.Short == "" {
+			cmd.Short = reportingNamespaceShort
+		}
+		if cmd.Long == "" {
+			cmd.Long = reportingNamespaceLong
+		}
+		cmd.AddCommand(newReportingQueryRunsCmd().cmd)
+		return
+	}
+
+	// No generated namespace to merge into (e.g. a trimmed resource set):
+	// register a top-level command so query-runs stays reachable.
+	rootCmd.AddCommand(newReportingCmd().cmd)
+}
+
 func newReportingCmd() *reportingCmd {
 	rc := &reportingCmd{}
 	rc.cmd = &cobra.Command{
 		Use:   "reporting",
-		Short: "Run Stripe Sigma queries via the Data Reporting API (Public Preview)",
-		Long: `Run ad hoc SQL queries against your Stripe data using the Data Reporting API.
-
-Use the query-runs subcommands to kick off a new query and retrieve its
-results. This uses the /v2/data/reporting/query_runs Public Preview API.`,
-		Args: validators.NoArgs,
+		Short: reportingNamespaceShort,
+		Long:  reportingNamespaceLong,
+		Args:  validators.NoArgs,
 	}
 
 	rc.cmd.AddCommand(newReportingQueryRunsCmd().cmd)
@@ -68,6 +109,9 @@ to kick off a query, then retrieve it to poll its status and fetch the download
 URL of the result once the query has completed.`,
 		Args: validators.NoArgs,
 	}
+	// Set explicitly: this subtree hangs off the generated `reporting`
+	// namespace, whose template renders {{.Example}} unindented.
+	qrc.cmd.SetUsageTemplate(previewUsageTemplate())
 
 	qrc.cmd.AddCommand(newReportingQueryRunsCreateCmd().cmd)
 	qrc.cmd.AddCommand(newReportingQueryRunsRetrieveCmd().cmd)
@@ -93,8 +137,11 @@ API — the Stripe-Version preview header is set automatically.
 
 The query runs asynchronously. The response contains the query run's id and
 status ("running", "succeeded", or "failed"); poll it with
-"stripe reporting query-runs retrieve <id>" until the status is "succeeded",
-then use the result's download_url to fetch the output.
+"stripe reporting query-runs retrieve <id>" until the status is "succeeded".
+The output is then at result.file.download_url.url — download_url is an object
+holding the url and its expires_at, so the url itself is one level deeper than
+the field name suggests. The link is short-lived (a few minutes); retrieve the
+query run again for a fresh one.
 
 Provide the SQL inline with --sql, from a file with --sql-file, or via stdin
 by passing --sql-file -.
@@ -103,7 +150,7 @@ Nested API fields use bracket notation as flags (for example
 --result_options[compress_file]=true), not dotted names from the API
 reference (--result_options.compress_file). Prefer the dedicated
 --compress-file flag when one exists.`,
-		Example: `  # Run an ad hoc query
+		Example: `# Run an ad hoc query
   stripe reporting query-runs create --sql "SELECT * FROM charges LIMIT 10"
 
   # Compress the result file
@@ -149,9 +196,12 @@ func newReportingQueryRunsRetrieveCmd() *reportingQueryRunsRetrieveCmd {
 Sends a GET request to /v2/data/reporting/query_runs/{id}. This is a
 Public Preview API — the Stripe-Version preview header is set automatically.
 
-Once the query run's status is "succeeded", the result's download_url can be
-used to download the query output.`,
-		Example: `  # Retrieve a query run (replace <query_run_id> with an id from create)
+Once the query run's status is "succeeded", the output can be downloaded from
+result.file.download_url.url. download_url is an object holding the url and its
+expires_at, so the url itself is one level deeper than the field name suggests.
+The link is short-lived (a few minutes); retrieve the query run again for a
+fresh one.`,
+		Example: `# Retrieve a query run (replace <query_run_id> with an id from create)
   stripe reporting query-runs retrieve <query_run_id>`,
 		Args: validators.ExactArgs(1),
 		RunE: rc.runReportingQueryRunsRetrieveCmd,
@@ -176,7 +226,14 @@ func (cc *reportingQueryRunsCreateCmd) runReportingQueryRunsCreateCmd(cmd *cobra
 		return err
 	}
 
-	creds, err := cc.rb.ResolveCredentials()
+	// A dry run sends nothing, so resolve credentials leniently: the live/sandbox
+	// context gate must not be the thing that stops you inspecting a request.
+	resolve := cc.rb.ResolveCredentials
+	if cc.rb.DryRun {
+		resolve = cc.rb.ResolveCredentialsForPreview
+	}
+
+	creds, err := resolve()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/reporting_test.go
+++ b/pkg/cmd/reporting_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -12,11 +13,14 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/keyring"
 	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 )
 
 // --- Unit tests: buildRequestBody ---
@@ -366,4 +370,173 @@ func TestReportingQueryRunsRetrieveCmd_HelpDescribesPublicPreview(t *testing.T) 
 
 	assert.Contains(t, out, "Public Preview")
 	assert.Contains(t, out, "/v2/data/reporting/query_runs/{id}")
+}
+
+// --- Integration tests: --dry-run is not gated on the active context's mode ---
+
+// profileWithLiveActiveContext returns a profile whose keyring holds an OAK with
+// a live active context, so resolving test-mode credentials from it fails with
+// ActiveContextLivemodeMismatchError.
+func profileWithLiveActiveContext(t *testing.T) *config.Profile {
+	t.Helper()
+	t.Setenv("STRIPE_API_KEY", "")
+
+	profilesFile := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(profilesFile, []byte{}, 0600))
+
+	activeCtxJSON, err := json.Marshal(config.ActiveContext{AccountID: "acct_live123", Livemode: true})
+	require.NoError(t, err)
+
+	config.KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		config.UATKeychainItemKey:            []byte("oak_live_1234567890"),
+		config.OAuthActiveContextKeychainKey: activeCtxJSON,
+	})
+	t.Cleanup(func() {
+		config.KeyRing = nil
+		viper.Reset()
+	})
+	(&config.Config{LogLevel: "info", ProfilesFile: profilesFile}).InitConfig()
+
+	return &config.Profile{ProfileName: "default"}
+}
+
+func TestReportingCreateCmd_DryRunIgnoresActiveContextMode(t *testing.T) {
+	cc := newReportingQueryRunsCreateCmd()
+	cc.rb.Profile = profileWithLiveActiveContext(t)
+	cc.rb.APIBaseURL = stripe.DefaultAPIBaseURL
+	cc.rb.DryRun = true
+	cc.sql = "SELECT * FROM charges LIMIT 10"
+
+	var out bytes.Buffer
+	cc.cmd.SetOut(&out)
+
+	// A dry run sends nothing, so the live/sandbox gate must not stop you
+	// inspecting the request it would have sent.
+	require.NoError(t, cc.runReportingQueryRunsCreateCmd(cc.cmd, []string{}))
+
+	var output requests.DryRunOutput
+	require.NoError(t, json.Unmarshal(out.Bytes(), &output))
+	assert.Equal(t, http.MethodPost, output.DryRun.Method)
+	assert.Equal(t, stripe.DefaultAPIBaseURL+queryRunsPath, output.DryRun.URL)
+	assert.Equal(t, "SELECT * FROM charges LIMIT 10", output.DryRun.Params["sql"])
+	// Falls back to the mode that is actually active, so the preview reflects
+	// what would really be sent.
+	assert.Equal(t, "true", output.DryRun.Headers["Stripe-Livemode"])
+}
+
+func TestReportingCreateCmd_RealRequestStillGatedOnActiveContextMode(t *testing.T) {
+	cc := newReportingQueryRunsCreateCmd()
+	cc.rb.Profile = profileWithLiveActiveContext(t)
+	cc.rb.APIBaseURL = stripe.DefaultAPIBaseURL
+	cc.sql = "SELECT * FROM charges LIMIT 10"
+
+	err := cc.runReportingQueryRunsCreateCmd(cc.cmd, []string{})
+	require.Error(t, err, "leniency must be scoped to --dry-run")
+	assert.Contains(t, err.Error(), "--live")
+}
+
+// --- Unit tests: merging query-runs into the generated `reporting` namespace ---
+
+// generatedReportingNamespace mimics what resources_gen.go registers: a bare
+// namespace command with no descriptions, hosting the Sigma resources.
+func generatedReportingNamespace() *cobra.Command {
+	ns := &cobra.Command{Use: "reporting"}
+	reportRuns := &cobra.Command{Use: "report_runs"}
+	reportRuns.AddCommand(&cobra.Command{Use: "list", Run: func(*cobra.Command, []string) {}})
+	ns.AddCommand(reportRuns)
+	ns.AddCommand(&cobra.Command{Use: "report_types"})
+	return ns
+}
+
+func TestAddReportingQueryRunsCmd_MergesIntoGeneratedNamespace(t *testing.T) {
+	root := &cobra.Command{Use: "stripe"}
+	root.AddCommand(generatedReportingNamespace())
+
+	addReportingQueryRunsCmd(root)
+
+	var reportingCmds []*cobra.Command
+	for _, cmd := range root.Commands() {
+		if cmd.Name() == "reporting" {
+			reportingCmds = append(reportingCmds, cmd)
+		}
+	}
+	require.Len(t, reportingCmds, 1, "two root children named reporting shadow each other")
+
+	names := make([]string, 0, 3)
+	for _, child := range reportingCmds[0].Commands() {
+		names = append(names, child.Name())
+	}
+	assert.ElementsMatch(t, []string{"query-runs", "report_runs", "report_types"}, names)
+}
+
+func TestAddReportingQueryRunsCmd_SigmaResourcesStayReachable(t *testing.T) {
+	root := &cobra.Command{Use: "stripe"}
+	root.AddCommand(generatedReportingNamespace())
+
+	addReportingQueryRunsCmd(root)
+
+	// The bug this guards: the shadowing sibling had no report_runs child and no
+	// Run function, so cobra resolved this to the wrong command, printed help and
+	// exited 0.
+	listCmd, _, err := root.Find([]string{"reporting", "report_runs", "list"})
+	require.NoError(t, err)
+	assert.Equal(t, "stripe reporting report_runs list", listCmd.CommandPath())
+
+	createCmd, _, err := root.Find([]string{"reporting", "query-runs", "create"})
+	require.NoError(t, err)
+	assert.Equal(t, "stripe reporting query-runs create", createCmd.CommandPath())
+}
+
+func TestAddReportingQueryRunsCmd_DescribesTheMergedNamespace(t *testing.T) {
+	root := &cobra.Command{Use: "stripe"}
+	root.AddCommand(generatedReportingNamespace())
+
+	addReportingQueryRunsCmd(root)
+
+	ns, _, err := root.Find([]string{"reporting"})
+	require.NoError(t, err)
+	assert.Equal(t, reportingNamespaceShort, ns.Short, "--map lists Short; an empty one leaves the namespace undescribed")
+	assert.Contains(t, ns.Long, "query-runs")
+	assert.Contains(t, ns.Long, "report_runs")
+}
+
+func TestAddReportingQueryRunsCmd_KeepsGeneratedDescriptions(t *testing.T) {
+	root := &cobra.Command{Use: "stripe"}
+	ns := generatedReportingNamespace()
+	ns.Short = "Generated short"
+	ns.Long = "Generated long"
+	root.AddCommand(ns)
+
+	addReportingQueryRunsCmd(root)
+
+	assert.Equal(t, "Generated short", ns.Short, "do not overwrite descriptions the spec supplies")
+	assert.Equal(t, "Generated long", ns.Long)
+}
+
+func TestAddReportingQueryRunsCmd_FallsBackToTopLevel(t *testing.T) {
+	root := &cobra.Command{Use: "stripe"}
+
+	addReportingQueryRunsCmd(root)
+
+	createCmd, _, err := root.Find([]string{"reporting", "query-runs", "create"})
+	require.NoError(t, err)
+	assert.Equal(t, "stripe reporting query-runs create", createCmd.CommandPath())
+}
+
+func TestReportingQueryRunsCmd_ExampleIndentationMatchesTemplate(t *testing.T) {
+	// query-runs hangs off the generated namespace, whose template renders
+	// {{.Example}} unindented. Its own template must supply the indentation, and
+	// the Example's first line must not double up on it.
+	root := &cobra.Command{Use: "stripe"}
+	root.AddCommand(generatedReportingNamespace())
+	addReportingQueryRunsCmd(root)
+
+	out, err := executeCommand(root, "reporting", "query-runs", "create", "--help")
+	require.NoError(t, err)
+
+	lines := strings.Split(out, "\n")
+	i := indexOf(lines, "Examples:")
+	require.GreaterOrEqual(t, i, 0, "help should have an Examples section:\n%s", out)
+	require.Less(t, i+1, len(lines))
+	assert.Equal(t, "  # Run an ad hoc query", lines[i+1], "example lines should be indented exactly two spaces")
 }

--- a/pkg/cmd/resource/keys_permissions.go
+++ b/pkg/cmd/resource/keys_permissions.go
@@ -41,8 +41,8 @@ func NewKeysPermissionsCmd(parentCmd *cobra.Command, cfg *config.Config) {
 		Use:   "permissions [endpoints...]",
 		Short: "Resolve required restricted key permissions for API endpoints",
 		Long:  `Given one or more API endpoints (e.g. "GET /v1/customers"), resolves the minimal set of restricted key permissions required.`,
-		Example: `  stripe keys permissions "GET /v1/customers" "GET /v1/balance"
-    stripe keys permissions "GET /v1/charges/:id"`,
+		Example: `stripe keys permissions "GET /v1/customers" "GET /v1/balance"
+  stripe keys permissions "GET /v1/charges/:id"`,
 		Args:   cobra.MinimumNArgs(1),
 		RunE:   kpc.runKeysPermissionsCmd,
 		Hidden: true,

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -168,6 +168,13 @@ func Execute(ctx context.Context) {
 	// commands (namespaces, root) where PersistentPreRun never fires.
 	if mode := getMapMode(os.Args[1:]); mode != mapModeDefault {
 		remaining := stripMapFlag(os.Args[1:])
+		// "--map compact" is a mode passed without "=", not a command named
+		// "compact". Say so and fail, rather than printing the full tree and
+		// exiting 0 as if the request had been honored.
+		if val, ok := bareMapModeArg(remaining); ok {
+			fmt.Fprintf(os.Stderr, "--map needs \"=\" before its mode: use --map=%s, not --map %s.\n", val, val)
+			os.Exit(1)
+		}
 		targetCmd, _, _ := rootCmd.Find(remaining)
 		if targetCmd == nil || (targetCmd == rootCmd && len(remaining) > 0) {
 			fmt.Fprintf(os.Stderr, "Unknown command %q — showing full command tree.\n\n", strings.Join(remaining, " "))
@@ -291,7 +298,6 @@ func init() {
 	// also, bind flags to the environment variables
 	bindEnv("project-name", "STRIPE_PROJECT_NAME")
 
-	rootCmd.AddCommand(newReportingCmd().cmd)
 	rootCmd.AddCommand(newAgentCmd().cmd)
 	rootCmd.AddCommand(newDataCmd().cmd)
 	rootCmd.AddCommand(cmddocs.New().WithOptions(cmddocs.WithConfig(&Config)).Root())
@@ -333,6 +339,10 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Must run after the generated resource commands so query-runs merges into
+	// the existing `reporting` namespace instead of shadowing it.
+	addReportingQueryRunsCmd(rootCmd)
 
 	// config is not initialized by cobra at this point, so we need to temporarily initialize it
 	Config.InitConfig()

--- a/pkg/cmd/switch.go
+++ b/pkg/cmd/switch.go
@@ -35,7 +35,7 @@ Without an argument, shows an interactive list of your authorized accounts and
 modes. Navigate with ↑↓, confirm with enter, or cancel with esc.
 
 With an account ID, switches directly to that account. Add --live to switch to live mode.`,
-		Example: `  stripe switch context
+		Example: `stripe switch context
   stripe switch context acct_1234
   stripe switch context acct_1234 --live`,
 		RunE: ctxCmd.run,

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -242,6 +242,14 @@ func (rb *Base) ResolveCredentials() (stripe.Credentials, error) {
 	return creds, err
 }
 
+// ResolveCredentialsForPreview returns Credentials for a --dry-run preview.
+// A preview sends no request, so an active context in the other mode must not
+// block it. Fall back to whichever mode is actually active so the redacted key
+// and Stripe-Livemode header in the preview still reflect what would be used.
+func (rb *Base) ResolveCredentialsForPreview() (stripe.Credentials, error) {
+	return rb.Profile.ResolveCredentialsForAnyMode(rb.Livemode)
+}
+
 // MakeMultiPartRequest will make a multipart/form-data request to the Stripe API with the specific variables given to it.
 // Similar to making a multipart request using curl, add the local filepath to params arg with @ prefix.
 // e.g. params.AppendData([]string{"photo=@/path/to/local/file.png"})


### PR DESCRIPTION
Audited every example in `stripe data --help`, `stripe data metrics --help`, `stripe data metrics run --help`, `stripe reporting --help` and `stripe reporting query-runs create --help` by running each one against the API.

Two same-named root children called `reporting` made cobra's Find resolve `stripe reporting report_runs list` to whichever sibling it reached first. That sibling had no report_runs child and no Run function, so cobra printed the wrong help and exited 0 — the Sigma resources were silently unreachable, and Args validation never ran because Runnable() is checked first. Hang query-runs off the generated namespace instead of registering a second top-level command.

Other fixes:

  * `--dry-run` was blocked by the live/sandbox context gate. A dry run sends nothing, so resolve credentials leniently and fall back to whichever mode is active, keeping the previewed Stripe-Livemode header honest. The gate still applies to real requests.
  * `--group-by price` is rejected by the API; the example now uses `subscription`, the dimension verified to work for revenue.mrr.
  * metric_invalid_parameter_value discarded specific API messages in favor of a generic checklist, so `--limit 5000` lost "limit cannot be greater than 1,000". Only fall back when the API returns retry boilerplate.
  * `--map compact` parsed the mode as a command name and printed the whole tree with exit 0. pflag needs "=" to pass a value to a flag with an optional value, so say that and fail.
  * The help claimed --granularity was required (it defaults to day), and that download_url held the URL (it is an object holding url and expires_at). Documented that bucket timestamps mark the END of a period and align to the result timezone, which is why the first bucket can look like it precedes --starts-at.
  * De-indented single-line Examples whose first line double-counted the template's two spaces.
