### PR TITLE
Fix bypassable --api-base/--dashboard-base allowlist validation

### DIFF
--- a/pkg/stripe/url.go
+++ b/pkg/stripe/url.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -10,60 +11,96 @@ import (
 
 const (
 	// DefaultAPIBaseURL is the default base URL for API requests
-	DefaultAPIBaseURL   = "https://api.stripe.com"
-	APIBaseURLRegexp    = `^https:\/\/api\.stripe\.com\/v\d+$`
-	qaAPIBaseURL        = "https://qa-api.stripe.com"
-	devAPIBaseURLRegexp = `http(s)?:\/\/[A-Za-z0-9\-]+.dev.stripe.me`
+	DefaultAPIBaseURL = "https://api.stripe.com"
+	qaAPIBaseURL      = "https://qa-api.stripe.com"
 
 	// DefaultFilesAPIBaseURL is the default base URL for Files API requsts
 	DefaultFilesAPIBaseURL = "https://files.stripe.com/"
 
 	// DefaultDashboardBaseURL is the default base URL for dashboard requests
-	DefaultDashboardBaseURL   = "https://dashboard.stripe.com"
-	qaDashboardBaseURL        = "https://qa-dashboard.stripe.com"
-	devDashboardBaseURLRegexp = `http(s)?:\/\/[A-Za-z0-9\-]+\.dev\.stripe\.me`
+	DefaultDashboardBaseURL = "https://dashboard.stripe.com"
+	qaDashboardBaseURL      = "https://qa-dashboard.stripe.com"
 
-	// localhostURLRegexp is used in tests
-	localhostURLRegexp = `http:\/\/127\.0\.0\.1(:[0-9]+)?`
+	// devHostSuffix matches Stripe's per-developer dev domains, e.g.
+	// foo-lv5r9y--api-mydev.dev.stripe.me
+	devHostSuffix = ".dev.stripe.me"
 )
 
 var (
 	errInvalidAPIBaseURL       = errorcategory.New(errorcategory.UserInput, "invalid API base URL")
 	errInvalidDashboardBaseURL = errorcategory.New(errorcategory.UserInput, "invalid dashboard base URL")
+
+	devHostLabelRegexp   = regexp.MustCompile(`^[A-Za-z0-9-]+$`)
+	apiVersionPathRegexp = regexp.MustCompile(`^/v\d+$`)
 )
 
-func isValid(url string, exactStrings []string, regexpStrings []string) bool {
-	for _, s := range exactStrings {
-		if url == s {
-			return true
-		}
+// parseBaseURL parses raw as a URL and rejects forms that let the parsed
+// host diverge from what a quick read of the string would suggest, namely
+// userinfo (`user@host`), which is never legitimate in a base URL flag.
+func parseBaseURL(raw string) (*url.URL, bool) {
+	u, err := url.Parse(raw)
+	if err != nil || u.User != nil || u.Hostname() == "" {
+		return nil, false
 	}
-	for _, r := range regexpStrings {
-		matched, err := regexp.Match(r, []byte(url))
-		if err == nil && matched {
-			return true
-		}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, false
 	}
-	return false
+	return u, true
+}
+
+func isDevHost(host string) bool {
+	label, ok := strings.CutSuffix(strings.ToLower(host), devHostSuffix)
+	return ok && devHostLabelRegexp.MatchString(label)
+}
+
+func isLoopbackHost(host string) bool {
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // ValidateAPIBaseURL returns an error if apiBaseURL isn't allowed
 func ValidateAPIBaseURL(apiBaseURL string) error {
-	exactStrings := []string{DefaultAPIBaseURL, qaAPIBaseURL, DefaultFilesAPIBaseURL}
-	regexpStrings := []string{APIBaseURLRegexp, devAPIBaseURLRegexp, localhostURLRegexp}
-	if isValid(apiBaseURL, exactStrings, regexpStrings) {
+	if apiBaseURL == DefaultAPIBaseURL || apiBaseURL == qaAPIBaseURL || apiBaseURL == DefaultFilesAPIBaseURL {
 		return nil
 	}
+
+	u, ok := parseBaseURL(apiBaseURL)
+	if !ok {
+		return errInvalidAPIBaseURL
+	}
+
+	host := strings.ToLower(u.Hostname())
+	switch {
+	case host == "api.stripe.com" && u.Scheme == "https" && apiVersionPathRegexp.MatchString(u.Path):
+		return nil
+	case isDevHost(host):
+		return nil
+	case isLoopbackHost(host) && u.Scheme == "http":
+		return nil
+	}
+
 	return errInvalidAPIBaseURL
 }
 
 // ValidateDashboardBaseURL returns an error if dashboardBaseURL isn't allowed
 func ValidateDashboardBaseURL(dashboardBaseURL string) error {
-	exactStrings := []string{DefaultDashboardBaseURL, qaDashboardBaseURL}
-	regexpStrings := []string{devDashboardBaseURLRegexp, localhostURLRegexp}
-	if isValid(dashboardBaseURL, exactStrings, regexpStrings) {
+	if dashboardBaseURL == DefaultDashboardBaseURL || dashboardBaseURL == qaDashboardBaseURL {
 		return nil
 	}
+
+	u, ok := parseBaseURL(dashboardBaseURL)
+	if !ok {
+		return errInvalidDashboardBaseURL
+	}
+
+	host := strings.ToLower(u.Hostname())
+	switch {
+	case isDevHost(host):
+		return nil
+	case isLoopbackHost(host) && u.Scheme == "http":
+		return nil
+	}
+
 	return errInvalidDashboardBaseURL
 }
 

--- a/pkg/stripe/url_test.go
+++ b/pkg/stripe/url_test.go
@@ -43,6 +43,36 @@ func TestValidateDashboardBaseURLWorks(t *testing.T) {
 	assert.ErrorIs(t, ValidateDashboardBaseURL("anything_else"), errInvalidDashboardBaseURL)
 }
 
+// TestValidateBaseURLRejectsAllowlistBypasses covers URLs where the raw
+// string contains an allowlisted substring (e.g. "foo.dev.stripe.me" or
+// "127.0.0.1") but net/url resolves the actual request host to something
+// else entirely — via userinfo, a suffix-grafted hostname, an unescaped
+// regex dot, or a query/fragment placement. Each of these previously
+// bypassed the byte-level regex allowlist.
+func TestValidateBaseURLRejectsAllowlistBypasses(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"suffix_graft_on_dev_domain", "https://foo.dev.stripe.me.evil.example"},
+		{"userinfo_dev_domain_to_loopback", "http://foo.dev.stripe.me@127.0.0.1:18080"},
+		{"userinfo_dev_domain_to_attacker", "http://foo.dev.stripe.me@attacker.example"},
+		{"dev_domain_in_query_string", "https://evil.example/?u=https://foo.dev.stripe.me"},
+		{"unescaped_dot_in_dev_regex", "https://fooXdevXstripeXme.evil.example"},
+		{"suffix_graft_on_loopback", "http://127.0.0.1.evil.example"},
+		{"userinfo_loopback_to_attacker", "http://127.0.0.1@attacker.example:80"},
+		{"dev_domain_in_fragment", "http://attacker.example/#http://foo.dev.stripe.me"},
+		{"suffix_graft_with_path", "http://foo-dev.stripe.me.attacker.test:8443/v1/customers"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.ErrorIs(t, ValidateAPIBaseURL(tc.url), errInvalidAPIBaseURL, "ValidateAPIBaseURL should reject %q", tc.url)
+			assert.ErrorIs(t, ValidateDashboardBaseURL(tc.url), errInvalidDashboardBaseURL, "ValidateDashboardBaseURL should reject %q", tc.url)
+		})
+	}
+}
+
 func TestIsV2PathRequiresTrailingSlash(t *testing.T) {
 	assert.True(t, IsV2Path("/v2/core/events"))
 	assert.True(t, IsV2Path("/v2/billing/meters"))


### PR DESCRIPTION
Makes the validation for the --api-base and --dashboard-base values more strict.

Tested these still work:

Default
<img width="922" height="692" alt="Screenshot 2026-08-31 at 1 07 38 PM" src="https://github.com/user-attachments/assets/ad8037e2-d4a3-46ac-a368-bc435c8e7108" />

QA
<img width="1179" height="255" alt="Screenshot 2026-08-31 at 1 07 43 PM" src="https://github.com/user-attachments/assets/bdee8d40-de06-4ed4-bfd8-7d7cc69f35c0" />

Invalid
<img width="1045" height="45" alt="Screenshot 2026-08-31 at 1 07 50 PM" src="https://github.com/user-attachments/assets/fcb99608-0c8b-49ec-b7f6-d409cc3cfe5b" />