### PR TITLE
Add `stripe plugin uninstall --all` and document uninstalling

### DIFF
--- a/.goreleaser/mac.yml
+++ b/.goreleaser/mac.yml
@@ -98,4 +98,3 @@ brews:
       Uninstalling: Homebrew preserves your Stripe CLI plugins and configuration when it
       removes the stripe binary. To remove plugins too, run `stripe plugin uninstall --all`
       before `brew uninstall stripe`, while the stripe binary is still available.
-      See https://docs.stripe.com/cli/uninstall for full cleanup instructions.

--- a/.goreleaser/mac.yml
+++ b/.goreleaser/mac.yml
@@ -92,4 +92,10 @@ brews:
           if [[ -f $e ]]; then source $e; fi
         }
       EOS
-    caveats: "❤ Thanks for installing the Stripe CLI! If this is your first time using the CLI, be sure to run `stripe login` first."
+    caveats: |-
+      ❤ Thanks for installing the Stripe CLI! If this is your first time using the CLI, be sure to run `stripe login` first.
+
+      Uninstalling: Homebrew preserves your Stripe CLI plugins and configuration when it
+      removes the stripe binary. To remove plugins too, run `stripe plugin uninstall --all`
+      before `brew uninstall stripe`, while the stripe binary is still available.
+      See https://docs.stripe.com/cli/uninstall for full cleanup instructions.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,76 @@ Because Docker containers are ephemeral, the `stripe login` command isn't suppor
 
 Download the latest release for your platform from the [GitHub Releases page](https://github.com/stripe/stripe-cli/releases/latest) and replace your existing binary.
 
+## Uninstalling
+
+### 1. Remove your plugins
+
+Package managers only remove the `stripe` binary; they leave installed plugins behind. Remove plugins first, while the `stripe` binary is still available:
+
+```sh
+stripe plugin uninstall --all
+```
+
+### 2. Remove the CLI
+
+**npm (macOS, Linux, Windows):**
+
+```sh
+npm uninstall -g @stripe/cli
+```
+
+**Homebrew (macOS):**
+
+```sh
+brew uninstall stripe
+```
+
+**apt (Debian, Ubuntu):**
+
+```sh
+sudo apt remove stripe
+```
+
+**yum/dnf (RedHat, Fedora, CentOS):**
+
+```sh
+sudo yum remove stripe
+```
+
+**WinGet (Windows):**
+
+```sh
+winget uninstall Stripe.StripeCLI
+```
+
+**Scoop (Windows):**
+
+```sh
+scoop uninstall stripe
+```
+
+**Docker:**
+
+```sh
+docker rmi stripe/stripe-cli
+```
+
+**Without package managers:**
+
+Delete the `stripe` binary you downloaded.
+
+### 3. Optionally remove configuration and credentials
+
+Uninstalling the CLI intentionally keeps your configuration, so reinstalling preserves your projects and settings. It is only removed if you remove it yourself:
+
+```sh
+# Clear stored credentials for every project you are logged into
+stripe logout --all
+
+# Remove all remaining CLI configuration
+rm -rf "${XDG_CONFIG_HOME:-$HOME/.config}/stripe"
+```
+
 ## Usage
 
 Installing the CLI provides access to the `stripe` command.

--- a/pkg/cmd/plugin/uninstall.go
+++ b/pkg/cmd/plugin/uninstall.go
@@ -1,8 +1,8 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 	"github.com/stripe/stripe-cli/pkg/plugins"
 	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/validators"
@@ -20,6 +21,17 @@ type UninstallCmd struct {
 	cfg *config.Config
 	Cmd *cobra.Command
 	fs  afero.Fs
+	all bool
+}
+
+// hookBaseURLs holds the base URLs forwarded to a plugin's PreUninstall hook. Each
+// field is empty unless the user explicitly passed the matching flag, so a plugin
+// only hears about an override the user actually chose. The values are resolved once
+// per invocation and shared by every plugin --all uninstalls.
+type hookBaseURLs struct {
+	api       string
+	dashboard string
+	access    string
 }
 
 // NewUninstallCmd creates a new command for uninstalling plugins
@@ -29,14 +41,38 @@ func NewUninstallCmd(config *config.Config) *UninstallCmd {
 	uc.cfg = config
 
 	uc.Cmd = &cobra.Command{
-		Use:   "uninstall",
-		Args:  validators.ExactArgs(1),
+		Use:   "uninstall [name]",
+		Args:  uc.validateArgs,
 		Short: "Uninstall a Stripe CLI plugin",
-		Long:  "Uninstall a Stripe CLI plugin.",
-		RunE:  uc.runUninstallCmd,
+		Long: `Uninstall a Stripe CLI plugin.
+
+Pass --all to uninstall every installed plugin, which is useful before removing
+the Stripe CLI itself: package managers leave plugins in place when they
+uninstall the stripe binary.`,
+		RunE: uc.runUninstallCmd,
 	}
 
+	uc.Cmd.Flags().BoolVar(&uc.all, "all", false, "Uninstall every installed Stripe CLI plugin")
+
 	return uc
+}
+
+// validateArgs requires exactly one plugin name, unless --all is set, in which
+// case a plugin name must not be provided.
+func (uc *UninstallCmd) validateArgs(cmd *cobra.Command, args []string) error {
+	if !uc.all {
+		return validators.ExactArgs(1)(cmd, args)
+	}
+
+	if len(args) > 0 {
+		return errorcategory.UserInputErrorf(
+			"`%s --all` does not take a plugin name. Remove `--all` to uninstall only `%s`, or remove the plugin name to uninstall every plugin",
+			cmd.CommandPath(),
+			args[0],
+		)
+	}
+
+	return nil
 }
 
 func (uc *UninstallCmd) runUninstallCmd(cmd *cobra.Command, args []string) error {
@@ -56,6 +92,13 @@ func (uc *UninstallCmd) runUninstallCmd(cmd *cobra.Command, args []string) error
 	if err := stripe.ValidateDashboardBaseURL(dashboardBaseURL); err != nil {
 		return err
 	}
+	accessBaseURL, _ := cmd.Flags().GetString("access-base")
+
+	baseURLs := hookBaseURLs{
+		api:       explicitFlagValue(cmd, "api-base", apiBaseURL),
+		dashboard: explicitFlagValue(cmd, "dashboard-base", rawDashboardBaseURL),
+		access:    explicitFlagValue(cmd, "access-base", accessBaseURL),
+	}
 
 	ctx := withSIGTERMCancel(cmd.Context(), func() {
 		log.WithFields(log.Fields{
@@ -63,11 +106,42 @@ func (uc *UninstallCmd) runUninstallCmd(cmd *cobra.Command, args []string) error
 		}).Debug("Ctrl+C received, cleaning up...")
 	})
 
+	if uc.all {
+		return uc.uninstallAllPlugins(ctx, cmd, baseURLs)
+	}
+
 	if err := plugins.ValidatePluginShortname(args[0]); err != nil {
 		return err
 	}
 
-	plugin := plugins.Plugin{Shortname: args[0]}
+	return uc.uninstallPlugin(ctx, cmd, args[0], baseURLs)
+}
+
+// uninstallAllPlugins uninstalls every plugin recorded in the config's installed
+// plugins list or recovered from local plugin metadata, stopping at the first
+// plugin that cannot be removed.
+func (uc *UninstallCmd) uninstallAllPlugins(ctx context.Context, cmd *cobra.Command, baseURLs hookBaseURLs) error {
+	pluginNames, err := plugins.GetInstalledPluginNames(uc.cfg, uc.fs)
+	if err != nil {
+		return err
+	}
+
+	if len(pluginNames) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No Stripe CLI plugins are installed, nothing to uninstall.")
+		return nil
+	}
+
+	for _, pluginName := range pluginNames {
+		if err := uc.uninstallPlugin(ctx, cmd, pluginName, baseURLs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (uc *UninstallCmd) uninstallPlugin(ctx context.Context, cmd *cobra.Command, pluginName string, baseURLs hookBaseURLs) error {
+	plugin := plugins.Plugin{Shortname: pluginName}
 
 	if m := stripe.GetEventMetadata(cmd.Context()); m != nil {
 		m.SetPluginName(plugin.Shortname)
@@ -76,21 +150,20 @@ func (uc *UninstallCmd) runUninstallCmd(cmd *cobra.Command, args []string) error
 	installedVersion := plugin.InstalledVersion(uc.cfg, uc.fs)
 
 	if installedVersion != "" {
-		accessBaseURL, _ := cmd.Flags().GetString("access-base")
 		runPreUninstallHook(ctx, uc.cfg, uc.fs, &plugin, installedVersion,
-			explicitFlagValue(cmd, "api-base", apiBaseURL),
-			explicitFlagValue(cmd, "dashboard-base", rawDashboardBaseURL),
-			explicitFlagValue(cmd, "access-base", accessBaseURL))
+			baseURLs.api, baseURLs.dashboard, baseURLs.access)
 	}
 
-	uninstallErr := plugin.Uninstall(ctx, uc.cfg, uc.fs)
-
-	if uninstallErr == nil {
-		sendPluginLifecycleEvent(cmd.Context(), "Plugin Uninstalled", installedVersion)
-		color := ansi.Color(os.Stdout)
-		successMsg := fmt.Sprintf("✔ %s has been uninstalled.", plugin.Shortname)
-		fmt.Println(color.Green(successMsg))
+	if err := plugin.Uninstall(ctx, uc.cfg, uc.fs); err != nil {
+		return err
 	}
 
-	return uninstallErr
+	sendPluginLifecycleEvent(cmd.Context(), "Plugin Uninstalled", installedVersion)
+
+	out := cmd.OutOrStdout()
+	color := ansi.Color(out)
+	successMsg := fmt.Sprintf("✔ %s has been uninstalled.", plugin.Shortname)
+	fmt.Fprintln(out, color.Green(successMsg))
+
+	return nil
 }

--- a/pkg/cmd/plugin/uninstall_test.go
+++ b/pkg/cmd/plugin/uninstall_test.go
@@ -1,0 +1,229 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/plugins"
+)
+
+func TestRunUninstallCmdAllUninstallsEveryInstalledPlugin(t *testing.T) {
+	cfg, fs, cleanup := setupPluginCommandTest(t)
+	defer cleanup()
+
+	appsBinary := installTestPlugin(t, cfg, fs, "apps")
+	generateBinary := installTestPlugin(t, cfg, fs, "generate")
+
+	// `generate` is only discoverable through its local metadata, like an
+	// installation whose installed_plugins entry did not survive a config
+	// migration from an older CLI version.
+	require.NoError(t, plugins.RemoveInstalledPlugin(cfg, "generate"))
+	require.Equal(t, []string{"apps"}, cfg.GetInstalledPlugins())
+
+	output, err := executeUninstallCmd(t, cfg, fs, "--all")
+	require.NoError(t, err)
+
+	require.Contains(t, output, "✔ apps has been uninstalled.")
+	require.Contains(t, output, "✔ generate has been uninstalled.")
+
+	requirePluginUninstalled(t, cfg, fs, "apps", appsBinary)
+	requirePluginUninstalled(t, cfg, fs, "generate", generateBinary)
+	require.Empty(t, cfg.GetInstalledPlugins())
+}
+
+func TestRunUninstallCmdAllUninstallsPluginRecordedOnlyInConfig(t *testing.T) {
+	cfg, fs, cleanup := setupPluginCommandTest(t)
+	defer cleanup()
+
+	appsBinary := installTestPlugin(t, cfg, fs, "apps")
+
+	// Older CLI versions recorded installed_plugins without local metadata.
+	require.NoError(t, fs.Remove(testPluginMetadataPath(cfg, "apps")))
+
+	output, err := executeUninstallCmd(t, cfg, fs, "--all")
+	require.NoError(t, err)
+
+	require.Contains(t, output, "✔ apps has been uninstalled.")
+	requirePluginUninstalled(t, cfg, fs, "apps", appsBinary)
+	require.Empty(t, cfg.GetInstalledPlugins())
+}
+
+func TestRunUninstallCmdAllReportsNoOpWhenNoPluginsAreInstalled(t *testing.T) {
+	cfg, fs, cleanup := setupPluginCommandTest(t)
+	defer cleanup()
+
+	output, err := executeUninstallCmd(t, cfg, fs, "--all")
+	require.NoError(t, err)
+
+	require.Contains(t, output, "No Stripe CLI plugins are installed, nothing to uninstall.")
+	require.NotContains(t, output, "has been uninstalled")
+}
+
+func TestRunUninstallCmdAllStopsWhenAPluginCannotBeRemoved(t *testing.T) {
+	cfg, fs, cleanup := setupPluginCommandTest(t)
+	defer cleanup()
+
+	appsBinary := installTestPlugin(t, cfg, fs, "apps")
+	generateBinary := installTestPlugin(t, cfg, fs, "generate")
+
+	output, err := executeUninstallCmd(t, cfg, afero.NewReadOnlyFs(fs), "--all")
+	require.Error(t, err)
+
+	require.NotContains(t, output, "has been uninstalled")
+	requirePluginInstalled(t, cfg, fs, "apps", appsBinary)
+	requirePluginInstalled(t, cfg, fs, "generate", generateBinary)
+	require.Equal(t, []string{"apps", "generate"}, cfg.GetInstalledPlugins())
+}
+
+func TestRunUninstallCmdUninstallsOnlyTheNamedPlugin(t *testing.T) {
+	cfg, fs, cleanup := setupPluginCommandTest(t)
+	defer cleanup()
+
+	appsBinary := installTestPlugin(t, cfg, fs, "apps")
+	generateBinary := installTestPlugin(t, cfg, fs, "generate")
+
+	output, err := executeUninstallCmd(t, cfg, fs, "apps")
+	require.NoError(t, err)
+
+	require.Contains(t, output, "✔ apps has been uninstalled.")
+	require.NotContains(t, output, "generate")
+
+	requirePluginUninstalled(t, cfg, fs, "apps", appsBinary)
+	requirePluginInstalled(t, cfg, fs, "generate", generateBinary)
+	require.Equal(t, []string{"generate"}, cfg.GetInstalledPlugins())
+}
+
+func TestUninstallCmdRejectsMissingAndConflictingArguments(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		errorContains string
+	}{
+		{
+			name:          "without a plugin name",
+			args:          nil,
+			errorContains: "requires exactly 1 positional argument",
+		},
+		{
+			name:          "with more than one plugin name",
+			args:          []string{"apps", "generate"},
+			errorContains: "requires exactly 1 positional argument",
+		},
+		{
+			name:          "with both --all and a plugin name",
+			args:          []string{"--all", "apps"},
+			errorContains: "does not take a plugin name",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, fs, cleanup := setupPluginCommandTest(t)
+			defer cleanup()
+
+			appsBinary := installTestPlugin(t, cfg, fs, "apps")
+
+			output, err := executeUninstallCmd(t, cfg, fs, test.args...)
+			require.ErrorContains(t, err, test.errorContains)
+
+			category, ok := errorcategory.Get(err)
+			require.True(t, ok)
+			require.Equal(t, errorcategory.UserInput, category)
+
+			require.NotContains(t, output, "has been uninstalled")
+			requirePluginInstalled(t, cfg, fs, "apps", appsBinary)
+		})
+	}
+}
+
+func executeUninstallCmd(t *testing.T, cfg *config.Config, fs afero.Fs, args ...string) (string, error) {
+	t.Helper()
+
+	uc := NewUninstallCmd(cfg)
+	uc.fs = fs
+
+	var output bytes.Buffer
+	uc.Cmd.SetOut(&output)
+	uc.Cmd.SetErr(&output)
+	uc.Cmd.SetContext(context.Background())
+	uc.Cmd.SetArgs(args)
+
+	err := uc.Cmd.Execute()
+
+	return output.String(), err
+}
+
+// installTestPlugin records a plugin as installed, writes its local metadata,
+// and creates its plugin binary on disk. It returns the binary's path.
+func installTestPlugin(t *testing.T, cfg *config.Config, fs afero.Fs, shortname string) string {
+	t.Helper()
+
+	plugin := plugins.Plugin{
+		Shortname:        shortname,
+		Binary:           "stripe-cli-" + shortname,
+		MagicCookieValue: shortname + "-cookie",
+		Releases: []plugins.Release{
+			{
+				Arch:    runtime.GOARCH,
+				OS:      runtime.GOOS,
+				Version: "1.0.0",
+				Sum:     "abc123",
+			},
+		},
+	}
+	require.NoError(t, plugins.PersistInstalledPluginState(cfg, fs, plugin))
+
+	binaryPath := filepath.Join(
+		testPluginDir(cfg, shortname),
+		"1.0.0",
+		plugin.Binary+plugins.GetBinaryExtension(),
+	)
+	require.NoError(t, fs.MkdirAll(filepath.Dir(binaryPath), 0755))
+	require.NoError(t, afero.WriteFile(fs, binaryPath, []byte("installed"), 0755))
+
+	return binaryPath
+}
+
+func requirePluginUninstalled(t *testing.T, cfg *config.Config, fs afero.Fs, shortname, binaryPath string) {
+	t.Helper()
+
+	paths := []string{binaryPath, testPluginDir(cfg, shortname), testPluginMetadataPath(cfg, shortname)}
+	for _, path := range paths {
+		exists, err := afero.Exists(fs, path)
+		require.NoError(t, err)
+		require.Falsef(t, exists, "expected %s to be removed", path)
+	}
+
+	require.NotContains(t, cfg.GetInstalledPlugins(), shortname)
+}
+
+func requirePluginInstalled(t *testing.T, cfg *config.Config, fs afero.Fs, shortname, binaryPath string) {
+	t.Helper()
+
+	for _, path := range []string{binaryPath, testPluginMetadataPath(cfg, shortname)} {
+		exists, err := afero.Exists(fs, path)
+		require.NoError(t, err)
+		require.Truef(t, exists, "expected %s to still exist", path)
+	}
+}
+
+func testPluginDir(cfg *config.Config, shortname string) string {
+	return filepath.Join(testConfigFolder(cfg), "plugins", shortname)
+}
+
+func testPluginMetadataPath(cfg *config.Config, shortname string) string {
+	return filepath.Join(testConfigFolder(cfg), "plugin-metadata", shortname+".toml")
+}
+
+func testConfigFolder(cfg *config.Config) string {
+	return cfg.GetConfigFolder(os.Getenv("XDG_CONFIG_HOME"))
+}


### PR DESCRIPTION
### Summary
`brew uninstall stripe-cli` removes Homebrew's formula-managed files but leaves plugins under the Stripe configuration directory. Homebrew formulas support neither per-package uninstall hooks nor caveats printed during `brew uninstall`, so plugin cleanup can't cascade from that command. Instead, make cleanup one command, warn at install time that plugins persist, and document the order while `stripe` is still present.

- `stripe plugin uninstall --all` uninstalls every plugin discovered by `plugins.GetInstalledPluginNames`, covering names recorded in `installed_plugins` and names recovered from local plugin metadata (including installs migrated from older CLI versions). It reuses `Plugin.Uninstall` per plugin, so metadata, config, directory removal, rollback, lifecycle telemetry, and per-plugin output are unchanged. An empty installation is an explicit no-op; the first plugin that cannot be removed stops the run and returns its categorized error.
- Argument validation requires exactly one plugin unless `--all` is set, and rejects combining the flag with a plugin name.
- The Homebrew caveat generated from `.goreleaser/mac.yml` now warns that plugins and configuration are preserved, and points at `stripe plugin uninstall --all` before `brew uninstall stripe`. The generated `stripe.rb` is regenerated by the next release; a matching change is needed in Homebrew/homebrew-core, which is maintained independently.
- README documents the uninstall order and that configuration is retained unless removed explicitly.

### Motivation

https://jira.corp.stripe.com/browse/RUN_DX-5523

### Test plan
- go test -race ./pkg/cmd/... ./pkg/plugins/...
- golangci-lint run pkg/cmd/plugin/...
- go run ./internal/lint/errorcategory/cmd ./...
- Manually verified:

<img width="756" height="108" alt="Screenshot 2026-09-02 at 11 09 25 AM" src="https://github.com/user-attachments/assets/16fc28be-cc1d-4655-8c4a-7f33ee6d8c30" />




