### PR TITLE
Print the upgrade command when the CLI is out of date

### DIFF
--- a/pkg/installmethod/installmethod.go
+++ b/pkg/installmethod/installmethod.go
@@ -1,0 +1,218 @@
+// Package installmethod detects how the CLI was installed: which package
+// manager, installer, or image put the running binary in place.
+//
+// The answer is reported to telemetry, and is the thing a caller needs to name
+// the command that upgrades an out-of-date CLI.
+package installmethod
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+//
+// Public constants
+//
+
+// The install methods this package reports. Unknown is a value rather than an
+// empty string on purpose: it separates "we looked and could not tell" from a
+// CLI old enough that it reported nothing at all.
+const (
+	APT       = "apt"
+	Docker    = "docker"
+	Homebrew  = "homebrew"
+	NPMGlobal = "npm_global"
+	NPMRun    = "npm_run"
+	NPX       = "npx"
+	Script    = "script"
+	Scoop     = "scoop"
+	Unknown   = "unknown"
+	Winget    = "winget"
+	YUM       = "yum"
+)
+
+//
+// Public types
+//
+
+// Env describes the host lookups Detect needs. Injected so that tests can drive
+// detection without touching the real environment or filesystem.
+type Env struct {
+	Getenv       func(string) string
+	Executable   func() (string, error)
+	EvalSymlinks func(string) (string, error)
+	Stat         func(string) error
+	ReadFile     func(string) ([]byte, error)
+}
+
+//
+// Public functions
+//
+
+// OSEnv returns an Env backed by the real process environment and filesystem.
+func OSEnv() Env {
+	return Env{
+		Getenv:       os.Getenv,
+		Executable:   os.Executable,
+		EvalSymlinks: filepath.EvalSymlinks,
+		Stat:         func(path string) error { _, err := os.Stat(path); return err },
+		ReadFile:     os.ReadFile,
+	}
+}
+
+// Detect reports how the CLI was installed, or Unknown when no signal matches.
+//
+// Signals are ordered strongest first: a value the installer set itself, then a
+// method it stamped next to the binary, then the binary's own location, then
+// traces left on the system. Everything after the first two is a heuristic, so
+// the order is what keeps a weaker signal from overriding a better one.
+func Detect(env Env) string {
+	if method := env.Getenv("STRIPE_INSTALL_METHOD"); method != "" {
+		// Set by the npm wrapper (npm/wrapper/bin/shim.js), which separates a global
+		// install from `npm run` and npx -- a difference only it can see. Reported
+		// as-is rather than checked against the constants above, so that a
+		// distributor setting its own value has that value reported.
+		return method
+	}
+
+	if method := detectFromExecutable(env); method != "" {
+		return method
+	}
+
+	// Package managers are checked before the container check below, because our
+	// deb and rpm install cleanly inside a container. When one of them did the
+	// install, the package manager is the answer and Docker is incidental.
+	if err := env.Stat("/var/lib/dpkg/info/stripe.list"); err == nil {
+		return APT
+	}
+
+	// rpm keeps no per-package file list to stat, so this looks for the repository
+	// the install instructions add. It is weaker than the dpkg check above --
+	// evidence the user configured Stripe's yum repo, not proof the CLI came from
+	// it -- which is why it runs after every stronger signal, including the
+	// executable-path checks that identify the other channels outright.
+	if err := env.Stat("/etc/yum.repos.d/stripe.repo"); err == nil {
+		return YUM
+	}
+
+	// The official image (see Dockerfile) copies the bare binary to /bin/stripe on
+	// alpine, leaving no packaging trace, so the container itself is the only
+	// signal left.
+	if err := env.Stat("/.dockerenv"); err == nil {
+		return Docker
+	}
+
+	return Unknown
+}
+
+//
+// Private constants
+//
+
+// methodFile is stamped next to the binary by an installer that knows how it
+// installed the CLI. scripts/install.sh and scripts/install.ps1 both do, because
+// both honor STRIPE_INSTALL_DIR and so install to a location that cannot be
+// recognized from here. Any distributor can stamp it to have its channel reported.
+const methodFile = ".stripe-install-method"
+
+// maxMethodLength bounds a value read from methodFile before it is reported, so
+// an unexpected or hostile file cannot bloat a telemetry request.
+const maxMethodLength = 32
+
+//
+// Private functions
+//
+
+// detectFromExecutable identifies the channels that leave their trace in the
+// binary's own location, either as a stamped method or as a recognizable path.
+func detectFromExecutable(env Env) string {
+	exe, err := env.Executable()
+	if err != nil {
+		return ""
+	}
+
+	// Both the launch path and the resolved path are checked, because each finds
+	// installs the other misses.
+	//
+	// os.Executable does not resolve symlinks on macOS or Windows: it reports the
+	// path used to launch the process. Homebrew on an Intel Mac leaves that at
+	// /usr/local/bin/stripe and WinGet at ...\WinGet\Links\stripe.exe, both links
+	// into the real install directory, so neither is identifiable without
+	// resolving. Resolving alone is not enough either -- EvalSymlinks fails on a
+	// broken link or an unreadable parent directory, and on Linux os.Executable
+	// reads /proc/self/exe, which is already resolved.
+	candidates := []string{exe}
+	if resolved, err := env.EvalSymlinks(exe); err == nil && resolved != exe {
+		candidates = append(candidates, resolved)
+	}
+
+	// A stamped method beats every path heuristic, so all candidates are checked
+	// for one before any path is inspected.
+	for _, path := range candidates {
+		if method := methodFromFile(env, filepath.Join(filepath.Dir(path), methodFile)); method != "" {
+			return method
+		}
+	}
+
+	for _, path := range candidates {
+		// Lowercased and slash-separated so that one set of checks covers Windows
+		// paths and the case-insensitive filesystems macOS and Windows default to.
+		//
+		// Backslashes are replaced directly rather than with filepath.ToSlash, which
+		// is a no-op anywhere but Windows. Doing it unconditionally means the Windows
+		// channels below are recognized -- and can be tested -- from any platform.
+		normalized := strings.ToLower(strings.ReplaceAll(path, `\`, "/"))
+
+		// "/cellar/" identifies every Homebrew prefix at once (/opt/homebrew,
+		// /usr/local, Linuxbrew) once the symlink is resolved. The two prefix
+		// checks catch an unresolved link on the prefixes that name themselves.
+		if strings.Contains(normalized, "/cellar/") ||
+			strings.Contains(normalized, "/homebrew/") ||
+			strings.Contains(normalized, "/linuxbrew/") {
+			return Homebrew
+		}
+
+		// Scoop runs the binary through a shim in scoop/shims, which is not a
+		// symlink, so the shim path has to be recognized on its own.
+		if strings.Contains(normalized, "/scoop/apps/") ||
+			strings.Contains(normalized, "/scoop/shims/") {
+			return Scoop
+		}
+
+		// Covers both the package directory WinGet extracts to and the Links
+		// directory it puts the launcher in.
+		if strings.Contains(normalized, "/winget/") {
+			return Winget
+		}
+	}
+
+	return ""
+}
+
+// methodFromFile reads a method stamped next to the binary by its installer,
+// returning "" when the file is absent or holds anything that is not a plausible
+// method name.
+//
+// Validating the shape rather than membership in the constants above keeps a
+// distributor we have never heard of reportable, while keeping arbitrary file
+// contents out of telemetry.
+func methodFromFile(env Env, path string) string {
+	contents, err := env.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+
+	method := strings.TrimSpace(string(contents))
+	if method == "" || len(method) > maxMethodLength {
+		return ""
+	}
+
+	for _, r := range method {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '_' && r != '-' {
+			return ""
+		}
+	}
+
+	return method
+}

--- a/pkg/installmethod/installmethod.go
+++ b/pkg/installmethod/installmethod.go
@@ -1,8 +1,7 @@
-// Package installmethod detects how the CLI was installed: which package
-// manager, installer, or image put the running binary in place.
-//
-// The answer is reported to telemetry, and is the thing a caller needs to name
-// the command that upgrades an out-of-date CLI.
+// Package installmethod detects how the CLI was installed -- which package
+// manager, installer, or image put the running binary in place -- and maps that
+// to the command that upgrades it, so an out-of-date CLI can tell a user what to
+// run rather than only that a newer version exists.
 package installmethod
 
 import (
@@ -46,6 +45,19 @@ type Env struct {
 	ReadFile     func(string) ([]byte, error)
 }
 
+// Advice is what to tell a user whose CLI is out of date.
+type Advice struct {
+	// Command upgrades the CLI, or is empty for an install method we cannot name
+	// a command for. Callers should still report that a new version exists in
+	// that case: knowing to upgrade is useful even without the command, and a
+	// wrong command is worse than no command.
+	Command string
+
+	// Suppress is set for a channel that resolves the latest version on every
+	// invocation, where an upgrade notice is noise the user cannot act on.
+	Suppress bool
+}
+
 //
 // Public functions
 //
@@ -72,7 +84,8 @@ func Detect(env Env) string {
 		// Set by the npm wrapper (npm/wrapper/bin/shim.js), which separates a global
 		// install from `npm run` and npx -- a difference only it can see. Reported
 		// as-is rather than checked against the constants above, so that a
-		// distributor setting its own value has that value reported.
+		// distributor setting its own value has that value reported. UpgradeAdvice
+		// names no command for a value it does not know.
 		return method
 	}
 
@@ -104,6 +117,47 @@ func Detect(env Env) string {
 	}
 
 	return Unknown
+}
+
+// UpgradeAdvice returns what to tell a user running an out-of-date CLI that was
+// installed by the given method. goos is the running platform, which the install
+// scripts' advice depends on; callers pass runtime.GOOS.
+func UpgradeAdvice(method, goos string) Advice {
+	switch method {
+	case Homebrew:
+		// "stripe" is both the formula name in stripe/homebrew-stripe-cli and an
+		// alias for homebrew-core's "stripe-cli", so this upgrades either one.
+		return Advice{Command: "brew upgrade stripe"}
+	case APT:
+		return Advice{Command: "sudo apt update && sudo apt upgrade stripe"}
+	case YUM:
+		return Advice{Command: "sudo yum update stripe"}
+	case Scoop:
+		return Advice{Command: "scoop update stripe"}
+	case Winget:
+		return Advice{Command: "winget upgrade Stripe.StripeCLI"}
+	case Docker:
+		return Advice{Command: "docker pull stripe/stripe-cli"}
+	case NPMGlobal:
+		return Advice{Command: "npm install -g @stripe/cli"}
+	case Script:
+		if goos == "windows" {
+			return Advice{Command: "irm https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.ps1 | iex"}
+		}
+		return Advice{Command: "curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh"}
+	case NPX:
+		// npx resolves the latest version on every invocation, so there is nothing
+		// to upgrade. Reaching here means a pinned version (`npx @stripe/cli@1.2.3`)
+		// or a stale npx cache, neither of which the notice would help with.
+		return Advice{Suppress: true}
+	case NPMRun:
+		// Run through a project's package.json, where the right change depends on
+		// that project's dependency range and lockfile. Naming a command risks
+		// telling the user to edit the wrong thing, so the notice stands alone.
+		return Advice{}
+	default:
+		return Advice{}
+	}
 }
 
 //

--- a/pkg/installmethod/installmethod_test.go
+++ b/pkg/installmethod/installmethod_test.go
@@ -1,0 +1,266 @@
+package installmethod
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	dpkgFile  = "/var/lib/dpkg/info/stripe.list"
+	yumFile   = "/etc/yum.repos.d/stripe.repo"
+	dockerEnv = "/.dockerenv"
+)
+
+// marker returns the path detection looks for a stamped method at, given the
+// executable it found. Built with the same expression detection uses rather than
+// written out, because filepath separates with backslashes on Windows: a
+// hand-written forward-slash key is never found there.
+func marker(exe string) string {
+	return filepath.Join(filepath.Dir(exe), methodFile)
+}
+
+// stubs describes a simulated host: the value of STRIPE_INSTALL_METHOD, where the
+// executable is and what it resolves to, which files exist, and what a stamped
+// method file holds.
+type stubs struct {
+	installMethod string
+	exe           string
+	exeErr        bool
+	links         map[string]string
+	files         map[string]string
+	present       []string
+}
+
+func (s stubs) env() Env {
+	return Env{
+		Getenv: func(string) string { return s.installMethod },
+		Executable: func() (string, error) {
+			if s.exeErr {
+				return "", errors.New("executable not found")
+			}
+			return s.exe, nil
+		},
+		EvalSymlinks: func(path string) (string, error) {
+			if target, ok := s.links[path]; ok {
+				return target, nil
+			}
+			return path, nil
+		},
+		Stat: func(path string) error {
+			for _, present := range s.present {
+				if present == path {
+					return nil
+				}
+			}
+			return errors.New("no such file")
+		},
+		ReadFile: func(path string) ([]byte, error) {
+			if contents, ok := s.files[path]; ok {
+				return []byte(contents), nil
+			}
+			return nil, errors.New("no such file")
+		},
+	}
+}
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     stubs
+		expected string
+	}{
+		{
+			name:     "npm_global via env",
+			host:     stubs{installMethod: "npm_global", exe: "/usr/local/bin/stripe"},
+			expected: NPMGlobal,
+		},
+		{
+			name:     "npm_run via env",
+			host:     stubs{installMethod: "npm_run", exe: "/any/path/stripe"},
+			expected: NPMRun,
+		},
+		{
+			name:     "npx via env",
+			host:     stubs{installMethod: "npx", exe: "/any/path/stripe"},
+			expected: NPX,
+		},
+		{
+			name:     "env wins over every other signal",
+			host:     stubs{installMethod: "npx", exe: "/opt/homebrew/Cellar/stripe/1.0/bin/stripe", present: []string{dpkgFile}},
+			expected: NPX,
+		},
+		{
+			name:     "homebrew cellar",
+			host:     stubs{exe: "/opt/homebrew/Cellar/stripe/1.0/bin/stripe"},
+			expected: Homebrew,
+		},
+		{
+			name:     "homebrew apple silicon prefix, symlink unresolved",
+			host:     stubs{exe: "/opt/homebrew/bin/stripe"},
+			expected: Homebrew,
+		},
+		{
+			// The Intel Mac case: os.Executable reports the launch path, which names
+			// neither Cellar nor Homebrew, so only the resolved link identifies it.
+			name: "homebrew intel mac, identified by resolving the symlink",
+			host: stubs{
+				exe:   "/usr/local/bin/stripe",
+				links: map[string]string{"/usr/local/bin/stripe": "/usr/local/Cellar/stripe-cli/1.50.0/bin/stripe"},
+			},
+			expected: Homebrew,
+		},
+		{
+			name:     "linuxbrew prefix",
+			host:     stubs{exe: "/home/linuxbrew/.linuxbrew/bin/stripe"},
+			expected: Homebrew,
+		},
+		{
+			name:     "scoop apps directory",
+			host:     stubs{exe: "C:/Users/foo/scoop/apps/stripe/current/stripe.exe"},
+			expected: Scoop,
+		},
+		{
+			name:     "scoop shim",
+			host:     stubs{exe: "C:/Users/foo/scoop/shims/stripe.exe"},
+			expected: Scoop,
+		},
+		{
+			name:     "winget package directory",
+			host:     stubs{exe: `C:\Users\foo\AppData\Local\Microsoft\WinGet\Packages\Stripe.StripeCLI_x\stripe.exe`},
+			expected: Winget,
+		},
+		{
+			name: "winget launcher, identified by resolving the link",
+			host: stubs{
+				exe: `C:\Users\foo\AppData\Local\Microsoft\WinGet\Links\stripe.exe`,
+				links: map[string]string{
+					`C:\Users\foo\AppData\Local\Microsoft\WinGet\Links\stripe.exe`: `C:\Users\foo\AppData\Local\Microsoft\WinGet\Packages\Stripe.StripeCLI_x\stripe.exe`,
+				},
+			},
+			expected: Winget,
+		},
+		{
+			name: "install script, from the method it stamped",
+			host: stubs{
+				exe:   "/home/user/.stripe/bin/stripe",
+				files: map[string]string{marker("/home/user/.stripe/bin/stripe"): "script\n"},
+			},
+			expected: Script,
+		},
+		{
+			// STRIPE_INSTALL_DIR lets the scripts install anywhere, so the stamped
+			// method is the only thing that identifies a non-default location.
+			name: "install script in a custom directory",
+			host: stubs{
+				exe:   "/opt/tools/bin/stripe",
+				files: map[string]string{marker("/opt/tools/bin/stripe"): "script"},
+			},
+			expected: Script,
+		},
+		{
+			name: "stamped method beats a path heuristic",
+			host: stubs{
+				exe:   "/opt/homebrew/bin/stripe",
+				files: map[string]string{marker("/opt/homebrew/bin/stripe"): "script"},
+			},
+			expected: Script,
+		},
+		{
+			name: "stamped method from an unrecognized distributor is still reported",
+			host: stubs{
+				exe:   "/opt/acme/bin/stripe",
+				files: map[string]string{marker("/opt/acme/bin/stripe"): "acme_internal"},
+			},
+			expected: "acme_internal",
+		},
+		{
+			name: "implausible stamped method is ignored",
+			host: stubs{
+				exe:     "/opt/acme/bin/stripe",
+				files:   map[string]string{marker("/opt/acme/bin/stripe"): "Deploy Script <v2>"},
+				present: []string{dpkgFile},
+			},
+			expected: APT,
+		},
+		{
+			name: "oversized stamped method is ignored",
+			host: stubs{
+				exe:   "/opt/acme/bin/stripe",
+				files: map[string]string{marker("/opt/acme/bin/stripe"): "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			},
+			expected: Unknown,
+		},
+		{
+			name:     "apt from the dpkg file list",
+			host:     stubs{exe: "/usr/bin/stripe", present: []string{dpkgFile}},
+			expected: APT,
+		},
+		{
+			name:     "yum from the stripe repo",
+			host:     stubs{exe: "/usr/bin/stripe", present: []string{yumFile}},
+			expected: YUM,
+		},
+		{
+			name:     "dpkg beats the weaker yum repo signal",
+			host:     stubs{exe: "/usr/bin/stripe", present: []string{dpkgFile, yumFile}},
+			expected: APT,
+		},
+		{
+			name:     "docker from the official image",
+			host:     stubs{exe: "/bin/stripe", present: []string{dockerEnv}},
+			expected: Docker,
+		},
+		{
+			// Our deb installs fine inside a container, and there apt is the answer.
+			name:     "apt inside a container reports apt, not docker",
+			host:     stubs{exe: "/usr/bin/stripe", present: []string{dpkgFile, dockerEnv}},
+			expected: APT,
+		},
+		{
+			name:     "unknown when nothing matches",
+			host:     stubs{exe: "/usr/bin/stripe"},
+			expected: Unknown,
+		},
+		{
+			name:     "unknown when the executable cannot be found",
+			host:     stubs{exeErr: true},
+			expected: Unknown,
+		},
+		{
+			name:     "system signals still apply when the executable cannot be found",
+			host:     stubs{exeErr: true, present: []string{dpkgFile}},
+			expected: APT,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, Detect(tt.host.env()))
+		})
+	}
+}
+
+func TestDetectReadsOnlyItsOwnEnvVar(t *testing.T) {
+	// The detected method is reported to telemetry, and this runs on every command
+	// in an environment that routinely holds keys and session identifiers. Detection
+	// reads one variable by name, so assert that nothing else in the environment can
+	// reach the reported value, however many variables are set.
+	//
+	// Deliberately not shaped like a real credential: secret scanning reads test
+	// files too, and a convincing literal blocks the push.
+	const secret = "sensitive-value-that-must-not-be-reported"
+
+	host := stubs{exe: "/usr/bin/stripe"}
+	env := host.env()
+	env.Getenv = func(name string) string {
+		if name == "STRIPE_INSTALL_METHOD" {
+			return ""
+		}
+		return secret
+	}
+
+	require.Equal(t, Unknown, Detect(env))
+}

--- a/pkg/installmethod/installmethod_test.go
+++ b/pkg/installmethod/installmethod_test.go
@@ -243,6 +243,47 @@ func TestDetect(t *testing.T) {
 	}
 }
 
+func TestUpgradeAdvice(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		goos     string
+		expected Advice
+	}{
+		{"homebrew", Homebrew, "darwin", Advice{Command: "brew upgrade stripe"}},
+		{"apt", APT, "linux", Advice{Command: "sudo apt update && sudo apt upgrade stripe"}},
+		{"yum", YUM, "linux", Advice{Command: "sudo yum update stripe"}},
+		{"scoop", Scoop, "windows", Advice{Command: "scoop update stripe"}},
+		{"winget", Winget, "windows", Advice{Command: "winget upgrade Stripe.StripeCLI"}},
+		{"docker", Docker, "linux", Advice{Command: "docker pull stripe/stripe-cli"}},
+		{"npm global", NPMGlobal, "darwin", Advice{Command: "npm install -g @stripe/cli"}},
+		{
+			"install script on unix",
+			Script, "darwin",
+			Advice{Command: "curl -sSL https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.sh | sh"},
+		},
+		{
+			"install script on windows",
+			Script, "windows",
+			Advice{Command: "irm https://raw.githubusercontent.com/stripe/stripe-cli/master/scripts/install.ps1 | iex"},
+		},
+		// npx resolves the latest version itself, so the notice is suppressed rather
+		// than printed without a command.
+		{"npx", NPX, "darwin", Advice{Suppress: true}},
+		// The remaining methods get the notice with no command: the right upgrade
+		// depends on a project's lockfile, or we could not tell how the CLI arrived.
+		{"npm run", NPMRun, "darwin", Advice{}},
+		{"unknown", Unknown, "linux", Advice{}},
+		{"unrecognized distributor", "acme_internal", "linux", Advice{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, UpgradeAdvice(tt.method, tt.goos))
+		})
+	}
+}
+
 func TestDetectReadsOnlyItsOwnEnvVar(t *testing.T) {
 	// The detected method is reported to telemetry, and this runs on every command
 	// in an environment that routinely holds keys and session identifiers. Detection

--- a/pkg/stripe/analytics_telemetry.go
+++ b/pkg/stripe/analytics_telemetry.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stripe/stripe-cli/pkg/installmethod"
 	"github.com/stripe/stripe-cli/pkg/useragent"
 	"github.com/stripe/stripe-cli/pkg/version"
 )
@@ -85,19 +86,15 @@ func NewEventMetadata() *CLIAnalyticsEventMetadata {
 	agentHostKind, agentHostRaw := useragent.DetectAgentHost(os.Getenv)
 
 	return &CLIAnalyticsEventMetadata{
-		InvocationID:  uuid.NewString(),
-		CLIVersion:    version.Version,
-		OS:            runtime.GOOS,
-		Arch:          runtime.GOARCH,
-		AIAgent:       useragent.DetectAIAgent(os.Getenv),
-		AgentHostKind: agentHostKind,
-		AgentHostRaw:  agentHostRaw,
-		AgentVersion:  useragent.DetectAgentVersion(os.Getenv),
-		InstallMethod: useragent.DetectInstallMethod(
-			os.Getenv,
-			os.Executable,
-			func(p string) error { _, err := os.Stat(p); return err },
-		),
+		InvocationID:    uuid.NewString(),
+		CLIVersion:      version.Version,
+		OS:              runtime.GOOS,
+		Arch:            runtime.GOARCH,
+		AIAgent:         useragent.DetectAIAgent(os.Getenv),
+		AgentHostKind:   agentHostKind,
+		AgentHostRaw:    agentHostRaw,
+		AgentVersion:    useragent.DetectAgentVersion(os.Getenv),
+		InstallMethod:   installmethod.Detect(installmethod.OSEnv()),
 		InTmux:          useragent.DetectInTmux(os.Getenv),
 		InScreen:        useragent.DetectInScreen(os.Getenv),
 		TerminalProgram: useragent.DetectTerminalProgram(os.Getenv),

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -26,34 +25,6 @@ func GetEncodedStripeUserAgent() string {
 // the `User-Agent` HTTP header.
 func GetEncodedUserAgent() string {
 	return encodedUserAgent
-}
-
-// DetectInstallMethod detects how the CLI was installed.
-// Returns one of: "npm_global", "npm_run", "npx", "homebrew", "scoop", "apt", or "unknown".
-func DetectInstallMethod(
-	getEnv func(string) string,
-	getExecutable func() (string, error),
-	statFile func(string) error,
-) string {
-	if method := getEnv("STRIPE_INSTALL_METHOD"); method != "" {
-		return method
-	}
-
-	if exe, err := getExecutable(); err == nil {
-		exeLower := strings.ToLower(filepath.ToSlash(exe))
-		if strings.Contains(exeLower, "/cellar/") || strings.Contains(exeLower, "/homebrew/") {
-			return "homebrew"
-		}
-		if strings.Contains(exeLower, "/scoop/apps/") {
-			return "scoop"
-		}
-	}
-
-	if err := statFile("/var/lib/dpkg/info/stripe.list"); err == nil {
-		return "apt"
-	}
-
-	return "unknown"
 }
 
 // DetectInTmux detects whether the CLI was invoked from within a tmux session.

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -1,69 +1,11 @@
 package useragent
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func noStat(string) error     { return errors.New("not found") }
-func yesStat(string) error    { return nil }
-func errExe() (string, error) { return "", errors.New("error") }
-
-func exe(path string) func() (string, error) {
-	return func() (string, error) { return path, nil }
-}
-
-func env(val string) func(string) string {
-	return func(string) string { return val }
-}
-
-func noEnv(string) string { return "" }
-
-func TestDetectInstallMethod(t *testing.T) {
-	tests := []struct {
-		name     string
-		envVal   string
-		exePath  string
-		exeErr   bool
-		hasStat  bool
-		expected string
-	}{
-		{"npm_global via env", "npm_global", "/any/path", false, false, "npm_global"},
-		{"npm_run via env", "npm_run", "/any/path", false, false, "npm_run"},
-		{"npx via env", "npx", "/any/path", false, false, "npx"},
-		{"homebrew cellar", "", "/opt/homebrew/Cellar/stripe/1.0/bin/stripe", false, false, "homebrew"},
-		{"homebrew usr local cellar", "", "/usr/local/Cellar/stripe/1.0/bin/stripe", false, false, "homebrew"},
-		{"scoop", "", "C:/Users/foo/scoop/apps/stripe/current/stripe.exe", false, false, "scoop"},
-		{"apt with dpkg file", "", "/usr/bin/stripe", false, true, "apt"},
-		{"unknown no dpkg file", "", "/usr/bin/stripe", false, false, "unknown"},
-		{"unknown exe error", "", "", true, false, "unknown"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			getEnv := noEnv
-			if tt.envVal != "" {
-				getEnv = env(tt.envVal)
-			}
-
-			getExe := exe(tt.exePath)
-			if tt.exeErr {
-				getExe = errExe
-			}
-
-			statFn := noStat
-			if tt.hasStat {
-				statFn = yesStat
-			}
-
-			result := DetectInstallMethod(getEnv, getExe, statFn)
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
 
 func TestDetectInTmux(t *testing.T) {
 	tests := []struct {
@@ -409,7 +351,6 @@ func TestObservedAgentSessions_NoSensitiveValuesReported(t *testing.T) {
 		DetectAIAgent(getEnv),
 		hostKind,
 		DetectAgentVersion(getEnv),
-		DetectInstallMethod(getEnv, errExe, noStat),
 		DetectTerminalProgram(getEnv),
 	}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/google/go-github/v72/github"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/installmethod"
 )
 
 // Version of the CLI.
@@ -33,9 +35,32 @@ func CheckLatestVersion() {
 		ansi.StopSpinner(s, "", os.Stdout)
 
 		if needsToUpgrade(Version, latest) {
-			fmt.Println(ansi.Italic("A newer version of the Stripe CLI is available, please update to:"), ansi.Italic(latest))
+			method := installmethod.Detect(installmethod.OSEnv())
+			if notice := upgradeNotice(latest, installmethod.UpgradeAdvice(method, runtime.GOOS)); notice != "" {
+				fmt.Println(notice)
+			}
 		}
 	}
+}
+
+// upgradeNotice builds the out-of-date message, naming the command that upgrades
+// the CLI when the install method is one we can name a command for. Returns ""
+// when the notice should not be printed at all.
+func upgradeNotice(latest string, advice installmethod.Advice) string {
+	if advice.Suppress {
+		return ""
+	}
+
+	notice := fmt.Sprintf("%s %s",
+		ansi.Italic("A newer version of the Stripe CLI is available, please update to:"),
+		ansi.Italic(latest),
+	)
+
+	if advice.Command != "" {
+		notice += fmt.Sprintf("\n%s %s %s", ansi.Italic("Run"), ansi.Bold(advice.Command), ansi.Italic("to upgrade."))
+	}
+
+	return notice
 }
 
 func needsToUpgrade(version, latest string) bool {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -4,7 +4,35 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/ansi"
+	"github.com/stripe/stripe-cli/pkg/installmethod"
 )
+
+func TestUpgradeNotice(t *testing.T) {
+	// ansi styling is on by default even when stdout is not a terminal, so turn it
+	// off to assert on the text itself.
+	ansi.DisableColors = true
+	t.Cleanup(func() { ansi.DisableColors = false })
+
+	t.Run("names the command for a known install method", func(t *testing.T) {
+		notice := upgradeNotice("v1.2.3", installmethod.UpgradeAdvice(installmethod.Homebrew, "darwin"))
+
+		require.Contains(t, notice, "A newer version of the Stripe CLI is available, please update to: v1.2.3")
+		require.Contains(t, notice, "Run brew upgrade stripe to upgrade.")
+	})
+
+	t.Run("reports the version alone when no command can be named", func(t *testing.T) {
+		notice := upgradeNotice("v1.2.3", installmethod.UpgradeAdvice(installmethod.Unknown, "linux"))
+
+		require.Contains(t, notice, "please update to: v1.2.3")
+		require.NotContains(t, notice, "Run")
+	})
+
+	t.Run("prints nothing for a self-updating install method", func(t *testing.T) {
+		require.Empty(t, upgradeNotice("v1.2.3", installmethod.UpgradeAdvice(installmethod.NPX, "darwin")))
+	})
+}
 
 func TestNeedsToUpgrade(t *testing.T) {
 	require.False(t, needsToUpgrade("4.2.4.2", "v4.2.4.2"))

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -130,6 +130,11 @@ function Install-Binary {
         Remove-Item $old -Force -ErrorAction SilentlyContinue
     }
 
+    # Record how the CLI was installed, so that an out-of-date binary can name the
+    # command that upgrades it. STRIPE_INSTALL_DIR makes the location configurable,
+    # so the CLI cannot infer this from its own path. Read by pkg/installmethod.
+    Set-Content -Path (Join-Path $InstallDir ".stripe-install-method") -Value "script" -NoNewline
+
     # Warn about existing scoop/winget installs
     $scoopStripe = Join-Path $env:USERPROFILE "scoop\shims\stripe.exe"
     if (Test-Path $scoopStripe) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -144,6 +144,11 @@ install_binary() {
   mv "$TMP_DIR/stripe" "$INSTALL_DIR/stripe"
   chmod +x "$INSTALL_DIR/stripe"
 
+  # Record how the CLI was installed, so that an out-of-date binary can name the
+  # command that upgrades it. STRIPE_INSTALL_DIR makes the location configurable,
+  # so the CLI cannot infer this from its own path. Read by pkg/installmethod.
+  echo "script" > "$INSTALL_DIR/.stripe-install-method"
+
   # Check for existing brew install and warn
   if command -v brew >/dev/null 2>&1; then
     BREW_STRIPE=$(brew --prefix 2>/dev/null)/bin/stripe


### PR DESCRIPTION
### Summary
Call the install method detector, map the method to an upgrade command, and print it in the out-of-date notice:

```
A newer version of the Stripe CLI is available, please update to: v1.32.0
Run brew upgrade stripe to upgrade.
```

`UpgradeAdvice` maps the method to `brew upgrade stripe`, `sudo apt update && sudo apt upgrade stripe`, `sudo yum update stripe`, `scoop update stripe`, `winget upgrade Stripe.StripeCLI`, `docker pull stripe/stripe-cli`, `npm install -g @stripe/cli`, or the install script for the running OS.

Two exceptions: npx prints nothing (it fetches the latest version every run), and `npm run` / `unknown` print the notice without an upgrade command 


### Test plan
Tests: 13 `UpgradeAdvice` cases, plus the 3 message shapes (command, version-only, suppressed).