### PR TITLE
Require release note labels on pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -4,3 +4,5 @@ cc @stripe/developer-products
 
  ### Summary
 <!-- Simple summary of what the code does or what you have changed. If this is a visual change consider including a screenshot/gif. See go/screencap for tips/tools. -->
+
+<!-- Apply one label to this pull request: breaking-change, security, deprecation, enhancement, bug, or release-notes. Release notes are generated from it. Use skip-release-notes if this is not a user-facing change and you do not want the commit title to show up in changelogs. -->

--- a/.github/workflows/release-note-label.yml
+++ b/.github/workflows/release-note-label.yml
@@ -1,0 +1,55 @@
+name: Release note label
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate release note label
+    runs-on: ubuntu-latest
+    env:
+      LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+    steps:
+      - name: Require a release note label
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          # Keep in sync with the labels in .github/release.yml. dependencies and
+          # documentation are already applied by dependabot and during triage, and
+          # both are excluded from the notes, so they count as a choice too.
+          allowed = {
+              "breaking-change",
+              "security",
+              "deprecation",
+              "enhancement",
+              "bug",
+              "release-notes",
+              "skip-release-notes",
+              "dependencies",
+              "documentation",
+          }
+          labels = set(json.loads(os.environ["LABELS"]))
+          selected = sorted(labels & allowed)
+
+          if selected:
+              print(f"Release note label: {', '.join(selected)}")
+              sys.exit(0)
+
+          print(
+              "::error::Please add a label to your pull request. We use it to generate "
+              "the changelog when releasing a new version."
+          )
+          print("Pick from:")
+          print("- breaking-change, security, deprecation, enhancement, or bug if one of these describes the change")
+          print("- release-notes for all other user-facing changes")
+          print("- skip-release-notes for non user-facing changes; the title will not show up in the changelog")
+          sys.exit(1)
+          PY


### PR DESCRIPTION
### Summary

- Ask pull request authors to select a release-note category.
- Require exactly one release-note category or the skip-release-notes label.
- Revalidate when labels are added or removed.


### Test plan
CI fails when PR has no tag. 
<img width="899" height="189" alt="Screenshot 2026-09-02 at 2 17 40 PM" src="https://github.com/user-attachments/assets/963a24e5-82e1-4c1e-b037-cd4a6eecde6d" />
https://github.com/stripe/stripe-cli/actions/runs/33683403455/job/100425032490?pr=1977

