### PR TITLE
Refuse config migration backup writes through symlinks

### DIFF
--- a/pkg/config/migrate.go
+++ b/pkg/config/migrate.go
@@ -151,6 +151,9 @@ func MigrateConfigFile(path string) (bool, error) {
 	}
 
 	backupPath := path + ConfigBackupSuffix
+	if err := fsutil.RefuseWriteThroughSymlinkOS(backupPath, filepath.Dir(filepath.Dir(path)), "backup"); err != nil {
+		return false, err
+	}
 	if err := writeFileSync(backupPath, original); err != nil {
 		return false, fmt.Errorf("could not back up %s: %w", path, err)
 	}

--- a/pkg/config/migrate_test.go
+++ b/pkg/config/migrate_test.go
@@ -352,6 +352,21 @@ func TestMigrateConfigFileRefusesSymlink(t *testing.T) {
 	require.NoFileExists(t, profilesFile+ConfigBackupSuffix)
 }
 
+func TestMigrateConfigFileRefusesBackupSymlink(t *testing.T) {
+	path := writeConfigFileForMigration(t, v1ConfigFileToMigrate)
+
+	victimFile := filepath.Join(filepath.Dir(path), "victim.toml")
+	require.NoError(t, os.WriteFile(victimFile, []byte("original = true\n"), 0600))
+	require.NoError(t, os.Symlink(victimFile, path+ConfigBackupSuffix))
+
+	changed, err := MigrateConfigFile(path)
+	require.ErrorContains(t, err, "symlink")
+	require.False(t, changed)
+
+	require.Equal(t, "original = true\n", string(helperLoadBytes(t, victimFile)))
+	require.Equal(t, v1ConfigFileToMigrate, string(helperLoadBytes(t, path)))
+}
+
 func TestMigrateConfigFileRefusesSymlinkedParent(t *testing.T) {
 	profilesFile, victimDir := setupProfilesFileWithSymlinkedParent(t)
 	require.NoError(t, os.WriteFile(profilesFile, []byte(v1ConfigFileToMigrate), 0600))


### PR DESCRIPTION
### Summary

`MigrateConfigFile` already refuses writes through a symlink at the config path, but the `.v1.bak` path was not checked. If the backup path pointed to another file, the backup write would follow the symlink and overwrite its target.

Apply the existing `fsutil.RefuseWriteThroughSymlinkOS` check to the backup path before writing it.

Add a regression test that verifies both the symlink target and original config remain unchanged when migration is refused.

Closes #1950.

### Test plan

- `go test -race ./pkg/config/...`
- `make lint`
- `make test` — `TestSearchCommand` fails in this non-TTY environment on both this branch and `upstream/master`

Made with [Cursor](https://cursor.com)