### PR TITLE
fix(docs): restore telemetry and root pre-run for docs commands

### DIFF
--- a/pkg/cmd/docs/api.go
+++ b/pkg/cmd/docs/api.go
@@ -45,7 +45,7 @@ Look up by event type:
   stripe docs api charge.succeeded
   stripe docs api payment_intent.created`,
 		Args: cobra.MinimumNArgs(1),
-		RunE: r.runAPI,
+		RunE: r.withSetup(r.runAPI),
 	}
 }
 

--- a/pkg/cmd/docs/prefs.go
+++ b/pkg/cmd/docs/prefs.go
@@ -38,7 +38,7 @@ func (r *RootCommand) newPrefsListCmd() *cobra.Command {
 		Long:    `List available preferences for customizing rendered documentation and their allowed values.`,
 		Example: `  stripe docs prefs list`,
 		Args:    cobra.NoArgs,
-		RunE:    r.runPrefsList,
+		RunE:    r.withSetup(r.runPrefsList),
 	}
 }
 
@@ -49,7 +49,7 @@ func (r *RootCommand) newPrefsSetCmd() *cobra.Command {
 		Long:    `Set a documentation preference to a specific value.`,
 		Example: `  stripe docs prefs set server go`,
 		Args:    cobra.ExactArgs(2),
-		RunE:    r.runPrefsSet,
+		RunE:    r.withSetup(r.runPrefsSet),
 	}
 }
 
@@ -60,7 +60,7 @@ func (r *RootCommand) newPrefsUnsetCmd() *cobra.Command {
 		Long:    `Remove a previously set documentation preference, reverting to the default.`,
 		Example: `  stripe docs prefs unset server`,
 		Args:    cobra.ExactArgs(1),
-		RunE:    r.runPrefsUnset,
+		RunE:    r.withSetup(r.runPrefsUnset),
 	}
 }
 

--- a/pkg/cmd/docs/root.go
+++ b/pkg/cmd/docs/root.go
@@ -95,10 +95,9 @@ Read API Reference pages by their identifier:
   stripe docs api product
   stripe docs api GET /v1/products
   stripe docs api product.created`,
-		Args:              cobra.ArbitraryArgs,
-		PersistentPreRunE: r.preRun,
-		RunE:              r.run,
-		SilenceUsage:      true,
+		Args:         cobra.ArbitraryArgs,
+		RunE:         r.withSetup(r.run),
+		SilenceUsage: true,
 	}
 
 	agentDetected := useragent.DetectAIAgent(os.Getenv) != ""
@@ -205,7 +204,28 @@ func (r *RootCommand) initLogger() {
 	}
 }
 
-func (r *RootCommand) preRun(_ *cobra.Command, _ []string) error {
+// withSetup wraps a RunE so that setup runs after flag parsing but before the
+// command body.
+//
+// The docs tree deliberately does not use a PersistentPreRun hook for this. Cobra
+// runs only the closest such hook in the chain, so declaring one here shadows the
+// root command's, which silently disables config migration, --access-base
+// validation, Sentry command context, and command-invocation telemetry for every
+// command under `stripe docs`. Other CLI commands do their post-flag setup at the
+// top of RunE for the same reason; see runListenCmd.
+func (r *RootCommand) withSetup(run func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := r.setup(); err != nil {
+			return err
+		}
+
+		return run(cmd, args)
+	}
+}
+
+// setup initializes the logger, renderer, and docs client from parsed flags and
+// stored credentials. It runs once per invocation, via withSetup.
+func (r *RootCommand) setup() error {
 	r.initLogger()
 	r.initRenderer()
 	if r.client != nil {

--- a/pkg/cmd/docs/search.go
+++ b/pkg/cmd/docs/search.go
@@ -37,7 +37,7 @@ Search by keyword or phrase:
   stripe docs search "API keys"
   stripe docs search "dispute evidence"`,
 		Args: cobra.ArbitraryArgs,
-		RunE: r.runSearch,
+		RunE: r.withSetup(r.runSearch),
 	}
 }
 

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -166,6 +166,34 @@ func TestV2BillingOverrides(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestDocsRunsRootPersistentPreRun guards the root PersistentPreRunE against being
+// shadowed by a subcommand tree that declares its own. Cobra runs only the closest
+// such hook, so a subcommand that declares one silently disables config migration,
+// --access-base validation, Sentry command context, and command telemetry for
+// everything beneath it. `stripe docs` did exactly that from v1.43.3, when it was
+// inlined from a plugin, until its setup moved into RunE.
+//
+// The probe is --access-base: only the root hook rejects a non-Stripe value, so if
+// the root hook does not run, the invalid URL is accepted and the command proceeds.
+func TestDocsRunsRootPersistentPreRun(t *testing.T) {
+	previousAccessBase := rootAccessBaseURL
+	previousProfilesFile := Config.ProfilesFile
+	t.Cleanup(func() {
+		rootAccessBaseURL = previousAccessBase
+		Config.ProfilesFile = previousProfilesFile
+	})
+
+	// Keep any config migration triggered by the root hook off the real config file.
+	Config.ProfilesFile = filepath.Join(t.TempDir(), "config.toml")
+
+	Execute(context.Background())
+
+	// A nested subcommand, so that the hook is reached through more than one parent.
+	_, err := executeCommand(rootCmd, "docs", "prefs", "list", "--access-base", "https://evil.example.com")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid access base URL")
+}
+
 func TestDatabasesHiddenButDirectlyAddressable(t *testing.T) {
 	root := &cobra.Command{
 		Use:         "stripe",


### PR DESCRIPTION
## Problem

`stripe docs` declares its own `PersistentPreRunE` ([`pkg/cmd/docs/root.go`](https://github.com/stripe/stripe-cli/blob/master/pkg/cmd/docs/root.go)) — a shape it inherited from the **docs plugin** it was inlined from in v1.43.3 (#1663). In a standalone plugin binary that's correct: there's no CLI root above you, so nothing is shadowed.

Inside the CLI it is not. Cobra runs only the *closest* `PersistentPreRun` hook in the chain (`EnableTraverseRunHooks` is off), so that declaration shadows `rootCmd.PersistentPreRunE` and silently disables, for **every** command under `stripe docs`:

- command-invocation telemetry and all of its metadata (merchant, command path, user agent, machine UUID, flags)
- config file migration
- `--access-base` validation, plus the OAuth access base URL that the token refresher inside `ResolveCredentials` relies on
- Sentry command context via `reporting.SetCommandPath` (bears on #1970)
- the legacy profile name warning

`stripe docs` is currently the only command in the CLI that declares a pre-run hook, which is why it's the only one affected.

### Reproducing

Only the root hook rejects a non-Stripe `--access-base`, so it makes a clean probe:

```
$ stripe config --list --access-base https://evil.example.com
invalid access base URL: must be exactly https://access.stripe.com or https://qa-access.stripe.com

$ stripe docs prefs list --access-base https://evil.example.com
• api-version
  Your preferred API version for viewing version-specific content...
```

Rejected for `config`, silently accepted for `docs`.

## Fix

Normalize the docs tree to match every other command in the CLI, none of which declares a pre-run hook. The setup moves out of `PersistentPreRunE` and into `RunE` via a `withSetup` wrapper — the same place `runListenCmd` does its post-flag `--api-base` validation. That leaves the `PersistentPreRun` slot to the root command, so docs gets telemetry for free like everything else.

Setup still runs after flag parsing and before the command body, so behavior is unchanged; it simply no longer occupies a slot it was never entitled to. The root hook now also runs *before* docs resolves credentials, which is the correct order — it is what validates and publishes the access base URL the OAuth refresher uses.

Considered and rejected: `cobra.EnableTraverseRunHooks = true` (fixes the class, but changes hook semantics for every command to fix one), and having the docs hook reach up to invoke its ancestor's (contained, but inverted control flow that the next inlined plugin has to remember to repeat).

## Scope

This restores `Command Invoked` events. Docs page fetches still emit no `API Request` events, because `pkg/docs/client.go` builds its own `http.Client` instead of using the instrumented `pkg/stripe` client, so `SendAPIRequestEvent` is never reached. That's a separate change.

## Testing

- Added `TestDocsRunsRootPersistentPreRun`, which uses the `--access-base` probe through a nested subcommand (`docs prefs list`) so the hook is reached through more than one parent. Verified it **fails on master** and passes with this change.
- `go test ./pkg/cmd/ ./pkg/cmd/docs/...` passes, except `TestSearchCommand`, which **fails identically on master** (unrelated, pre-existing, and not agent-env dependent).
- Manually confirmed the probe is now rejected for docs, and that `stripe docs` and `stripe docs prefs list` still work normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)