### PR TITLE
Forward Stripe-Context/Stripe-Livemode headers in docs client

### DIFF
--- a/pkg/cmd/docs/root.go
+++ b/pkg/cmd/docs/root.go
@@ -158,8 +158,8 @@ func (r *RootCommand) initClient() {
 		if accountID, err := r.cfg.Profile.GetAccountID(); err == nil {
 			clientOpts = append(clientOpts, pkgdocs.WithCacheKeyPrefix(accountID))
 		}
-		if creds, err := r.cfg.Profile.ResolveCredentials(false); err == nil {
-			clientOpts = append(clientOpts, pkgdocs.WithAPIKey(creds.Token))
+		if creds, err := r.cfg.Profile.ResolveCredentialsForAnyMode(false); err == nil {
+			clientOpts = append(clientOpts, pkgdocs.WithCredentials(creds))
 		}
 	}
 	if r.apiBaseURL != "" {
@@ -211,8 +211,8 @@ func (r *RootCommand) preRun(_ *cobra.Command, _ []string) error {
 	if r.client != nil {
 		var credOpts []pkgdocs.ClientOption
 		if r.cfg != nil {
-			if creds, err := r.cfg.Profile.ResolveCredentials(false); err == nil {
-				credOpts = append(credOpts, pkgdocs.WithAPIKey(creds.Token))
+			if creds, err := r.cfg.Profile.ResolveCredentialsForAnyMode(false); err == nil {
+				credOpts = append(credOpts, pkgdocs.WithCredentials(creds))
 			}
 		}
 		if r.cmd.PersistentFlags().Changed("api-base") {

--- a/pkg/docs/client.go
+++ b/pkg/docs/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/errorcategory"
 	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/stripe"
 	"github.com/stripe/stripe-cli/pkg/useragent"
 )
 
@@ -48,7 +49,7 @@ type Client struct {
 	baseURL        *url.URL
 	apiBaseURL     *url.URL
 	userAgent      string
-	apiKey         string
+	creds          stripe.Credentials
 	cacheKeyPrefix string
 	cache          Cache
 	logger         *log.Entry
@@ -72,8 +73,18 @@ func WithCache(cache Cache) ClientOption { return func(c *Client) { c.cache = ca
 // WithLogger sets a custom logger.
 func WithLogger(logger *log.Entry) ClientOption { return func(c *Client) { c.logger = logger } }
 
-// WithAPIKey sets the Stripe API key sent as an Authorization header on every request.
-func WithAPIKey(key string) ClientOption { return func(c *Client) { c.apiKey = key } }
+// WithAPIKey sets a plain Stripe API key sent as an Authorization header on every request.
+func WithAPIKey(key string) ClientOption {
+	return func(c *Client) { c.creds = stripe.NewAPIKeyCredentials(key) }
+}
+
+// WithCredentials sets the Stripe credentials (API key or OAK/user-access-token)
+// used to authenticate every request. Unlike WithAPIKey, this forwards the
+// Stripe-Context and Stripe-Livemode headers needed for OAK credentials to
+// resolve to the correct account/sandbox context.
+func WithCredentials(creds stripe.Credentials) ClientOption {
+	return func(c *Client) { c.creds = creds }
+}
 
 // WithAPIBaseURL overrides the Stripe API base URL used for authenticated requests
 // (defaults to https://api.stripe.com).
@@ -129,7 +140,7 @@ type retrieveDocResponse struct {
 //
 //	page, err := c.FetchPage(ctx, &url.URL{Path: "/payments/accept-a-payment", RawQuery: "api_version=2024-06-30"})
 func (c *Client) FetchPage(ctx context.Context, ref *url.URL) (Page, error) {
-	if c.apiKey != "" {
+	if c.creds.Token != "" {
 		return c.fetchPageViaAPI(ctx, ref)
 	}
 
@@ -241,9 +252,7 @@ func (c *Client) cacheKey(rawURL string) string {
 
 func (c *Client) do(req *http.Request) (response, error) {
 	req.Header.Set("User-Agent", c.userAgent)
-	if c.apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	}
+	c.creds.SetRequestHeaders(req)
 
 	start := time.Now()
 	resp, err := c.http.Do(req)
@@ -338,7 +347,7 @@ func (c *Client) Search(ctx context.Context, query string) (*SearchResponse, err
 	}
 
 	var u *url.URL
-	if c.apiKey != "" {
+	if c.creds.Token != "" {
 		u = c.apiBaseURL.JoinPath("/v2/docs/search")
 	} else {
 		u = c.baseURL.JoinPath("/_endpoint/search")

--- a/pkg/docs/client_test.go
+++ b/pkg/docs/client_test.go
@@ -106,7 +106,7 @@ func TestWithOptions(t *testing.T) {
 			name: "set API key",
 			opts: []ClientOption{WithAPIKey("sk_test_abc123")},
 			wantCheck: func(t *testing.T, c *Client) {
-				assert.Equal(t, "sk_test_abc123", c.apiKey)
+				assert.Equal(t, "sk_test_abc123", c.creds.Token)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Fixes https://github.com/stripe/stripe-cli/issues/1983

`stripe docs` returned HTTP 403 when authenticated via `stripe login` (OAK/user-access-token), even though normal API requests and raw `stripe get` calls against the same docs endpoints succeeded.

Root causes:
1. The docs subcommand has it's own client (`pkg/docs/client.go`), and it only ever forwarded a bare `Authorization: Bearer <token>` header as it was built before support for OAuth was added. It doesn't send the `Stripe-Context` / `Stripe-Livemode` headers that OAK credentials need to resolve to the correct account/sandbox.
2. The docs command resolved credentials with `Profile.ResolveCredentials(false)`, hardcoding testmode. If the active OAuth context was in livemode, this returned an `ActiveContextLivemodeMismatchError` that was silently swallowed (`err != nil` just skipped setting any credentials), so the docs client fell back to sending no `Authorization` header at all. This meant OAK sandbox logins effectively only worked in testmode, and livemode contexts got no auth whatsoever.

To fix the above issues:
* Instead of passing plain API key credentials, we're passing the full `stripe.Credentials` struct which has functions to set proper request headers. Keeping the plain `WithAPIKey` option available as an API key could still be passed via environment variables or through existing configuration
* Use `Profile.ResolveCredentialsForAnyMode(false)` instead of `Profile.ResolveCredentials(false)` so credentials for test/livemode work and we don't have mismatch errors

## Test plan

Using the locally build Stripe binary:
* Authenticate with a sandbox and live account using `./stripe login`

<img width="802" height="132" alt="CleanShot 2026-09-02 at 09 21 06" src="https://github.com/user-attachments/assets/c1c1729e-5b6f-4e78-a32f-66342c2ea0bc" />

* Make a request `stripe docs /payments --log-level debug --non-interactive --no-pager`

<img width="1485" height="309" alt="CleanShot 2026-09-02 at 09 21 49" src="https://github.com/user-attachments/assets/f44a6f7f-a1f7-49a5-a6bc-200bba01f998" />

* Switch to the livemode account and make the request again

<img width="1486" height="309" alt="CleanShot 2026-09-02 at 09 22 24" src="https://github.com/user-attachments/assets/5918da0a-34cf-4a67-bdd3-468e18d66c74" />


Looking at the above test screenshots, you can see that the requests completed with status 200.