### PR TITLE
Stage the auto-upgrade canary marker as JSON

### DIFF
--- a/.github/workflows/autoupgrade-test.yml
+++ b/.github/workflows/autoupgrade-test.yml
@@ -79,8 +79,10 @@ jobs:
           esac
           URL="https://github.com/stripe/stripe-cli/releases/download/v${LATEST}/stripe_${LATEST}_mac-os_${ARCH_NAME}.tar.gz"
 
+          # Must match autoupdate.UpdateMarker's JSON encoding in pkg/autoupdate/checker.go.
           mkdir -p "$HOME/.stripe/state"
-          printf '%s\n%s\n%s\n' "$LATEST" "$URL" "" > "$HOME/.stripe/state/update-available"
+          printf '{"version":"%s","download_url":"%s","checksum":"","release_notes":""}' \
+            "$LATEST" "$URL" > "$HOME/.stripe/state/update-available"
           echo "Wrote update marker:"
           cat "$HOME/.stripe/state/update-available"
 
@@ -156,8 +158,10 @@ jobs:
           esac
           URL="https://github.com/stripe/stripe-cli/releases/download/v${LATEST}/stripe_${LATEST}_linux_${ARCH_NAME}.tar.gz"
 
+          # Must match autoupdate.UpdateMarker's JSON encoding in pkg/autoupdate/checker.go.
           mkdir -p "$HOME/.stripe/state"
-          printf '%s\n%s\n%s\n' "$LATEST" "$URL" "" > "$HOME/.stripe/state/update-available"
+          printf '{"version":"%s","download_url":"%s","checksum":"","release_notes":""}' \
+            "$LATEST" "$URL" > "$HOME/.stripe/state/update-available"
           echo "Wrote update marker:"
           cat "$HOME/.stripe/state/update-available"
 


### PR DESCRIPTION
### Summary

#1967 switched the update marker at `~/.stripe/state/update-available` from three newline-delimited fields to a JSON object, but the auto-upgrade canary still staged the old format. `ReadMarker()` couldn't parse it and returned `nil`, so the CLI saw no pending update and stayed at the fake `1.0.0` the test asserts against ([failing run](https://github.com/stripe/stripe-cli/actions/runs/33689946960)). Stage JSON instead.

### Test plan

Built a `1.0.0` binary into a throwaway `$HOME`, staged the marker byte-for-byte as the workflow does, ran `STRIPE_INSTALL_METHOD=curl stripe --version`:

- Old format → `stripe version 1.0.0`, no update attempted (reproduces the failure).
- New format → `Automatically updating Stripe CLI from 1.0.0 to 1.50.10.` / `Updated successfully ✓` / `stripe version 1.50.10`, marker cleared.

Triggered a new workflow and it passed
https://github.com/stripe/stripe-cli/actions/runs/33692270847