### PR TITLE
Skip interop events when listening for all thin events

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -88,7 +88,7 @@ Stripe account.`,
 	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward webhook events to")
 	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward. Ex: \"Key1:Value1, Key2:Value2\"")
 	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect webhook events to (default: same as normal events)")
-	lc.cmd.Flags().StringSliceVar(&lc.thinEvents, "thin-events", []string{}, "A comma-separated list of thin events to listen for.")
+	lc.cmd.Flags().StringSliceVar(&lc.thinEvents, "thin-events", []string{}, "A comma-separated list of thin events to listen for. Use \"*\" for all thin events, which excludes the v1.* events that duplicate snapshot events")
 	lc.cmd.Flags().StringVar(&lc.forwardThinURL, "forward-thin-to", "", "The URL to forward thin events to")
 	lc.cmd.Flags().StringVar(&lc.forwardThinConnectURL, "forward-thin-connect-to", "", "The URL to forward thin Connect events to")
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")

--- a/pkg/proxy/interop.go
+++ b/pkg/proxy/interop.go
@@ -1,0 +1,24 @@
+package proxy
+
+import "strings"
+
+// interopEventPrefix is prepended to a snapshot event type when that event is
+// delivered as a v2 event, e.g. charge.succeeded is delivered as
+// v1.charge.succeeded.
+const interopEventPrefix = "v1."
+
+// isInteropEvent reports whether eventType is the v2 rendering of a snapshot
+// event. Those "interop" events duplicate what the webhooks channel already
+// delivers, so a thin event wildcard subscription skips them and only forwards
+// them when the user asks for them by name.
+//
+// Thin events that are v1-prefixed but have no snapshot counterpart, such as
+// v1.billing.meter.no_meter_found, are not interop events.
+func isInteropEvent(eventType string) bool {
+	base, hasPrefix := strings.CutPrefix(eventType, interopEventPrefix)
+	if !hasPrefix || base == "*" {
+		return false
+	}
+
+	return validEvents[base]
+}

--- a/pkg/proxy/interop_test.go
+++ b/pkg/proxy/interop_test.go
@@ -1,0 +1,45 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsInteropEvent(t *testing.T) {
+	tests := []struct {
+		eventType string
+		expected  bool
+	}{
+		{"v1.charge.succeeded", true},
+		{"v1.customer.created", true},
+		{"charge.succeeded", false},
+		{"v1.billing.meter.no_meter_found", false},
+		{"v1.billing.meter.error_report_triggered", false},
+		{"v2.core.account.created", false},
+		{"v2.money_management.transaction.created", false},
+		{"v1.not.a.real.event", false},
+		{"v1.*", false},
+		{"*", false},
+		{"", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.eventType, func(t *testing.T) {
+			require.Equal(t, test.expected, isInteropEvent(test.eventType))
+		})
+	}
+}
+
+// Interop events are identified by prefixing a snapshot event type with "v1.",
+// so a thin event that collides with one would be dropped from wildcard
+// subscriptions. Guard against the generated event lists growing into one.
+func TestIsInteropEventDoesNotMatchThinEvents(t *testing.T) {
+	for event := range validThinEvents {
+		require.False(t, isInteropEvent(event), "thin event %s is treated as an interop event", event)
+	}
+
+	for event := range validPreviewThinEvents {
+		require.False(t, isInteropEvent(event), "preview thin event %s is treated as an interop event", event)
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -367,7 +367,9 @@ func Init(ctx context.Context, cfg *Config) (*Proxy, error) {
 				if _, foundInPreview := validPreviewThinEvents[event]; !foundInPreview {
 					if event == "*" {
 						cfg.Log.Infof("* is only supported in the CLI, thin event destinations do not support selecting all event types\n")
-					} else {
+					} else if !isInteropEvent(event) {
+						// interop events aren't in the generated thin event lists,
+						// but they can be listened for by name
 						cfg.Log.Warningf("You're attempting to listen for \"%s\", which isn't a valid thin event or preview event\n", event)
 					}
 				}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stripe/stripe-cli/pkg/errorcategory"
@@ -37,6 +39,37 @@ func TestFilterWebhookEvent(t *testing.T) {
 
 	require.True(t, proxyUseLatest.webhookEventProcessor.filterWebhookEvent(evtDefault))
 	require.False(t, proxyUseLatest.webhookEventProcessor.filterWebhookEvent(evtLatest))
+}
+
+func TestInitThinEventValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		thinEvents    []string
+		expectWarning bool
+	}{
+		{"thin event", []string{"v2.core.account.created"}, false},
+		{"preview thin event", []string{"v2.money_management.transaction.created"}, false},
+		{"interop event", []string{"v1.charge.succeeded"}, false},
+		{"wildcard", []string{"*"}, false},
+		{"unknown event", []string{"v1.not.a.real.event"}, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, hook := logtest.NewNullLogger()
+
+			_, err := Init(context.Background(), &Config{Log: logger, ThinEvents: test.thinEvents})
+			require.NoError(t, err)
+
+			var warned bool
+			for _, entry := range hook.AllEntries() {
+				if entry.Level == log.WarnLevel {
+					warned = true
+				}
+			}
+			require.Equal(t, test.expectWarning, warned)
+		})
+	}
 }
 
 func TestTruncate(t *testing.T) {

--- a/pkg/proxy/webhook_event_processor.go
+++ b/pkg/proxy/webhook_event_processor.go
@@ -192,8 +192,24 @@ func (p *WebhookEventProcessor) processV2Event(v2Event *websocket.StripeV2Event)
 	p.sendMessage(websocket.NewEventAck(evt.ID, "", v2Event.EventDestinationID))
 
 	// skip further event processing if the event type is not enabled
-	if !p.thinEvents[evt.Type] && !p.thinEvents["*"] {
-		return
+	if !p.thinEvents[evt.Type] {
+		if !p.thinEvents["*"] {
+			return
+		}
+
+		// Interop events are snapshot events rendered as v2 events, and the
+		// webhooks channel already delivers them. Skip them here so listening
+		// for all thin events doesn't show every snapshot event twice; users
+		// who want them can name them explicitly.
+		if isInteropEvent(evt.Type) {
+			p.cfg.Log.WithFields(log.Fields{
+				"prefix":     "proxy.WebhookEventProcessor.ProcessV2Event",
+				"event_id":   evt.ID,
+				"event_type": evt.Type,
+			}).Debugf("Skipping interop event, listen for %s explicitly to receive it", evt.Type)
+
+			return
+		}
 	}
 
 	// notify consumers

--- a/pkg/proxy/webhook_event_processor_test.go
+++ b/pkg/proxy/webhook_event_processor_test.go
@@ -1,0 +1,117 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/websocket"
+)
+
+func TestProcessV2EventFiltersEventTypes(t *testing.T) {
+	tests := []struct {
+		name       string
+		thinEvents []string
+		eventType  string
+		expectSent bool
+	}{
+		{"wildcard sends thin events", []string{"*"}, "v2.core.account.created", true},
+		{"wildcard sends preview thin events", []string{"*"}, "v2.money_management.transaction.created", true},
+		{"wildcard sends v1 thin events without a snapshot counterpart", []string{"*"}, "v1.billing.meter.no_meter_found", true},
+		{"wildcard skips interop events", []string{"*"}, "v1.charge.succeeded", false},
+		{"explicit interop event is sent", []string{"v1.charge.succeeded"}, "v1.charge.succeeded", true},
+		{"explicit interop event does not enable other interop events", []string{"v1.charge.succeeded"}, "v1.customer.created", false},
+		{"unsubscribed thin event is skipped", []string{"v2.core.account.created"}, "v2.core.account.updated", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			outCh := make(chan websocket.IElement, 1)
+			var ackedEventIDs []string
+
+			p := NewWebhookEventProcessor(
+				func(msg *websocket.OutgoingMessage) {
+					ackedEventIDs = append(ackedEventIDs, msg.EventID)
+				},
+				nil,
+				&WebhookEventProcessorConfig{
+					Log:        &log.Logger{Out: io.Discard},
+					ThinEvents: test.thinEvents,
+					OutCh:      outCh,
+				},
+			)
+
+			p.processV2Event(&websocket.StripeV2Event{
+				Payload:            fmt.Sprintf(`{"id":"evt_123","type":%q}`, test.eventType),
+				EventDestinationID: "we_123",
+			})
+
+			// events are acknowledged whether or not they're forwarded, so
+			// Stripe doesn't retry the ones we filter out
+			require.Equal(t, []string{"evt_123"}, ackedEventIDs)
+
+			if !test.expectSent {
+				require.Empty(t, outCh)
+				return
+			}
+
+			require.Len(t, outCh, 1)
+			data, ok := (<-outCh).(websocket.DataElement)
+			require.True(t, ok)
+			evt, ok := data.Data.(V2EventPayload)
+			require.True(t, ok)
+			require.Equal(t, test.eventType, evt.Type)
+		})
+	}
+}
+
+func TestProcessV2EventDoesNotForwardInteropEvents(t *testing.T) {
+	forwarded := make(chan string, 2)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		forwarded <- string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	// give the endpoint response handler room so its writes don't block
+	outCh := make(chan websocket.IElement, 8)
+
+	p := NewWebhookEventProcessor(
+		func(msg *websocket.OutgoingMessage) {},
+		[]EndpointRoute{{
+			URL:                ts.URL,
+			EventTypes:         []string{"*"},
+			IsEventDestination: true,
+		}},
+		&WebhookEventProcessorConfig{
+			Log:        &log.Logger{Out: io.Discard},
+			ThinEvents: []string{"*"},
+			OutCh:      outCh,
+			Timeout:    5,
+		},
+	)
+
+	p.processV2Event(&websocket.StripeV2Event{Payload: `{"id":"evt_interop","type":"v1.charge.succeeded"}`})
+	p.processV2Event(&websocket.StripeV2Event{Payload: `{"id":"evt_thin","type":"v2.core.account.created"}`})
+
+	select {
+	case body := <-forwarded:
+		// the interop event was processed first, so the thin event arriving
+		// first means the interop event was never forwarded
+		require.Contains(t, body, "evt_thin")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the thin event to be forwarded")
+	}
+
+	require.Empty(t, forwarded)
+}


### PR DESCRIPTION
### Reviewers
r? @
cc @stripe/developer-products

### Summary

Reported in bug bash: `stripe listen --all-thin` (v2) shows interop events. Same behavior exists on master today with `--thin-events '*'`, so the fix lands here and v2 inherits it on the next master merge.

Interop events are snapshot events rendered as v2 events (`charge.succeeded` is delivered on the v2 event channel as `v1.charge.succeeded`). A `*` thin event subscription therefore repeats everything the webhooks channel already delivers. That's noise today, and it gets worse in v2, where bare `stripe listen` opens both channels — every snapshot event would print twice.

This also matches what the CLI already believes: `validThinEvents` is generated from schemas marked `kind: thin` and contains no interop types, so `--thin-events v1.charge.succeeded` warns "isn't a valid thin event" while `--thin-events '*'` floods you with those same types.

Changes:

- `pkg/proxy/interop.go`: `isInteropEvent` identifies an interop event as `v1.` + a known snapshot event type. Verified against the generated lists: none of the 86 thin/preview-thin types collide with the 266 snapshot types, so the two native `v1.billing.meter.*` thin events are not caught. `TestIsInteropEventDoesNotMatchThinEvents` guards that assumption as the lists are regenerated.
- `pkg/proxy/webhook_event_processor.go`: a wildcard thin subscription skips interop events, for both terminal output and forwarding to `--forward-thin-to`. Naming an event explicitly still delivers it. Events are still acked before filtering, so nothing gets retried.
- `pkg/proxy/proxy.go`: stop warning that an explicitly requested interop event "isn't a valid thin event".
- `--thin-events` help text documents what `*` covers.

Deliberately best-effort: an interop event whose v1 type isn't yet in the generated `validEvents` list will still show up. That's preferable to the inverse approach (expanding `*` to the known thin event list), where a newly launched thin event would be silently hidden until the next spec regen.

Follow-up on the v2 branch: update the `--all-thin` flag description, and consider `--all-interop` if anyone wants the old behavior back in one flag.

### Test plan

- `pkg/proxy/webhook_event_processor_test.go` covers the filtering matrix (wildcard sends thin/preview/`v1.billing.meter.*`, wildcard skips interop, explicit interop is delivered, every event is acked) plus a forwarding test that an interop event never reaches a local event destination. Both new tests fail without the processor change.
- `pkg/proxy/interop_test.go` covers `isInteropEvent` and the no-collision invariant.
- `TestInitThinEventValidation` covers the warning suppression.
- `go test ./pkg/proxy/ ./pkg/cmd/` and `golangci-lint run` on both packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)