### PR TITLE
Apply auto update on Windows

### DIFF
--- a/pkg/autoupdate/checker.go
+++ b/pkg/autoupdate/checker.go
@@ -189,25 +189,46 @@ func fetchChecksumForAsset(checksumURL, assetName string) string {
 }
 
 func binaryAssetName(ver string) string {
-	goos := runtime.GOOS
-	goarch := runtime.GOARCH
+	return binaryAssetNameFor(ver, runtime.GOOS, runtime.GOARCH)
+}
 
-	var archName string
-	switch goarch {
-	case "amd64":
-		archName = "x86_64"
-	case "arm64":
-		archName = "arm64"
-	default:
-		archName = goarch
-	}
-
+// binaryAssetNameFor is the release archive published for a platform.
+//
+// The names come from the archive templates in .goreleaser/, which do not use
+// the Go names for either half: darwin is published as "mac-os" and amd64 as
+// "x86_64". Passing runtime.GOOS straight through asks for an asset that does
+// not exist, and a missing asset stops the update silently.
+func binaryAssetNameFor(ver, goos, goarch string) string {
+	osLabel := goos
 	ext := "tar.gz"
-	if goos == "windows" {
+
+	switch goos {
+	case "darwin":
+		osLabel = "mac-os"
+	case "windows":
 		ext = "zip"
 	}
 
-	return fmt.Sprintf("stripe_%s_%s_%s.%s", ver, goos, archName, ext)
+	return fmt.Sprintf("stripe_%s_%s_%s.%s", ver, osLabel, archAssetLabel(goos, goarch), ext)
+}
+
+func archAssetLabel(goos, goarch string) string {
+	switch goarch {
+	case "amd64":
+		return "x86_64"
+	case "386":
+		return "i386"
+	case "arm64":
+		// .goreleaser/windows.yml builds amd64 and 386 only. Windows on ARM runs
+		// the x64 binary under emulation, so that is the archive to fetch.
+		if goos == "windows" {
+			return "x86_64"
+		}
+
+		return "arm64"
+	default:
+		return goarch
+	}
 }
 
 func checksumAssetName() string {

--- a/pkg/autoupdate/checker_test.go
+++ b/pkg/autoupdate/checker_test.go
@@ -3,6 +3,7 @@ package autoupdate
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -31,6 +32,50 @@ func TestIsMajorVersionChange(t *testing.T) {
 			assert.Equal(t, tt.expected, isMajorVersionChange(tt.current, tt.latest))
 		})
 	}
+}
+
+// The expected names are the ones the .goreleaser archive templates produce. An
+// asset name that does not match one of them is not a download that fails
+// loudly — fetchLatestRelease finds no matching asset and gives up silently, so
+// auto-update simply never happens on that platform.
+func TestBinaryAssetNameFor(t *testing.T) {
+	tests := []struct {
+		goos     string
+		goarch   string
+		expected string
+	}{
+		{"darwin", "amd64", "stripe_1.24.0_mac-os_x86_64.tar.gz"},
+		{"darwin", "arm64", "stripe_1.24.0_mac-os_arm64.tar.gz"},
+		{"linux", "amd64", "stripe_1.24.0_linux_x86_64.tar.gz"},
+		{"linux", "arm64", "stripe_1.24.0_linux_arm64.tar.gz"},
+		{"linux", "386", "stripe_1.24.0_linux_i386.tar.gz"},
+		{"windows", "amd64", "stripe_1.24.0_windows_x86_64.zip"},
+		{"windows", "386", "stripe_1.24.0_windows_i386.zip"},
+		// No arm64 Windows build is published; that machine runs the x64 one.
+		{"windows", "arm64", "stripe_1.24.0_windows_x86_64.zip"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.goos+"/"+tt.goarch, func(t *testing.T) {
+			assert.Equal(t, tt.expected, binaryAssetNameFor("1.24.0", tt.goos, tt.goarch))
+		})
+	}
+}
+
+func TestBinaryAssetNameUsesTheRunningPlatform(t *testing.T) {
+	assert.Equal(t, binaryAssetNameFor("1.24.0", runtime.GOOS, runtime.GOARCH), binaryAssetName("1.24.0"))
+}
+
+func TestChecksumAssetName(t *testing.T) {
+	// The checksums file the release publishes for this platform, which is where
+	// the archive's expected digest is read from.
+	expected := map[string]string{
+		"darwin":  "stripe-mac-checksums.txt",
+		"linux":   "stripe-linux-checksums.txt",
+		"windows": "stripe-windows-checksums.txt",
+	}[runtime.GOOS]
+
+	assert.Equal(t, expected, checksumAssetName())
 }
 
 func TestMarkerReadWrite(t *testing.T) {

--- a/pkg/autoupdate/reexec_unix.go
+++ b/pkg/autoupdate/reexec_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package autoupdate
+
+import (
+	"os"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// reexec hands the invocation to the binary that was just installed, so the
+// command the user typed runs on the new version.
+func reexec(exe string) {
+	err := syscall.Exec(exe, os.Args, os.Environ())
+	if err != nil {
+		log.Debug("autoupdate: re-exec failed: ", err)
+	}
+}

--- a/pkg/autoupdate/reexec_windows.go
+++ b/pkg/autoupdate/reexec_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package autoupdate
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"os/signal"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// reexec runs the binary that was just installed as a child process and exits
+// with its status.
+//
+// Windows has no execve. syscall.Exec is a stub there that always fails, so the
+// only way to hand the invocation to the new binary is to start it and forward
+// what it did. The child inherits this process's standard streams and console, so
+// an interactive command such as `stripe login` still works.
+//
+// Returning instead of exiting means the update landed but this invocation
+// carries on running the old image, which is a worse outcome than re-execing and
+// a better one than failing the command outright.
+func reexec(exe string) {
+	cmd := exec.Command(exe, os.Args[1:]...) //nolint:gosec // exe is this process's own path
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+	// Ctrl-C is delivered to every process attached to the console, this one
+	// included. Ignore it here so that the child, which is the process actually
+	// doing the work now, decides what a Ctrl-C means.
+	signal.Ignore(os.Interrupt)
+
+	err := cmd.Run()
+
+	var exitErr *exec.ExitError
+	if err != nil && !errors.As(err, &exitErr) {
+		log.Debug("autoupdate: could not run the updated binary: ", err)
+
+		return
+	}
+
+	os.Exit(cmd.ProcessState.ExitCode())
+}

--- a/pkg/autoupdate/replace.go
+++ b/pkg/autoupdate/replace.go
@@ -1,0 +1,111 @@
+package autoupdate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// oldSuffix names the outgoing binary while it is being replaced.
+const oldSuffix = ".old"
+
+// rename is indirected so tests can fail the second move and check that the
+// working binary comes back.
+var rename = os.Rename
+
+// replaceBinary moves staged into place at dst, which is the image of the process
+// calling it.
+//
+// The live binary is renamed aside first rather than overwritten. On Windows that
+// is the only thing that works: the OS locks the image of a running executable
+// against writes and deletes, but a rename only touches the directory entry, so
+// it is allowed. Unix would tolerate a plain rename over the target, but taking
+// the same path on both platforms means the interesting case is the one that runs
+// everywhere, including in the unit tests.
+func replaceBinary(dst, staged string) error {
+	if err := os.Chmod(staged, 0755); err != nil {
+		return fmt.Errorf("chmod failed: %w", err)
+	}
+
+	aside, err := asideName(dst)
+	if err != nil {
+		return fmt.Errorf("cannot make room next to %s: %w", dst, err)
+	}
+
+	movedAside := false
+
+	if _, err := os.Stat(dst); err == nil {
+		if err := rename(dst, aside); err != nil {
+			return fmt.Errorf("cannot move %s aside: %w", dst, err)
+		}
+
+		movedAside = true
+	}
+
+	if err := rename(staged, dst); err != nil {
+		if movedAside {
+			// Put the working binary back. Failing to install an update is
+			// recoverable; leaving no stripe on PATH at all is not.
+			_ = rename(aside, dst)
+		}
+
+		return fmt.Errorf("cannot replace binary: %w", err)
+	}
+
+	// Best effort: on Windows this fails while the calling process is still running
+	// from the old image. removeSupersededBinary clears it on a later invocation.
+	_ = os.Remove(aside)
+
+	return nil
+}
+
+// asideName returns a free path to move the outgoing binary to.
+//
+// The usual name is dst+".old", left over from a previous update or not there at
+// all. When it is there and cannot be deleted, the move has to go somewhere else:
+// Windows refuses to delete or replace a file while any process is running from
+// it, and after a concurrent update this process may be running from that very
+// file. Reusing the name in that case fails the whole update, so fall back to a
+// unique one, which a later invocation cleans up along with the rest.
+func asideName(dst string) (string, error) {
+	aside := dst + oldSuffix
+	if err := os.Remove(aside); err == nil || os.IsNotExist(err) {
+		return aside, nil
+	}
+
+	// Created rather than just named so that two updates racing here cannot pick
+	// the same path. Renaming over the empty placeholder is what claims it.
+	placeholder, err := os.CreateTemp(filepath.Dir(dst), filepath.Base(dst)+oldSuffix+".*")
+	if err != nil {
+		return "", err
+	}
+
+	name := placeholder.Name()
+	_ = placeholder.Close()
+
+	return name, nil
+}
+
+// removeSupersededBinary deletes the outgoing binaries earlier updates parked
+// next to the new one.
+//
+// On Windows those deletes could not happen at update time, because a process was
+// still running from each file. Any later invocation is a process that is not, so
+// this runs on every invocation and almost always finds nothing. It scans rather
+// than deleting one known name because asideName falls back to a suffixed name
+// when the usual one is occupied.
+func removeSupersededBinary(exe string) {
+	dir, base := filepath.Split(exe)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), base+oldSuffix) {
+			_ = os.Remove(filepath.Join(dir, entry.Name()))
+		}
+	}
+}

--- a/pkg/autoupdate/replace_test.go
+++ b/pkg/autoupdate/replace_test.go
@@ -1,0 +1,135 @@
+package autoupdate
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceBinaryInstallsOverALiveBinary(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, binaryName())
+	staged := filepath.Join(dir, "staged")
+
+	require.NoError(t, os.WriteFile(dst, []byte("old"), 0755))
+	require.NoError(t, os.WriteFile(staged, []byte("new"), 0644))
+
+	require.NoError(t, replaceBinary(dst, staged))
+
+	installed, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(installed))
+
+	// Unix can unlink the moved-aside file immediately. Windows cannot while a
+	// process is running from the image, but nothing is running this one.
+	assert.NoFileExists(t, dst+oldSuffix)
+	assert.NoFileExists(t, staged)
+}
+
+func TestReplaceBinaryInstallsWhenNothingIsThere(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, binaryName())
+	staged := filepath.Join(dir, "staged")
+
+	require.NoError(t, os.WriteFile(staged, []byte("new"), 0644))
+
+	require.NoError(t, replaceBinary(dst, staged))
+
+	installed, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(installed))
+}
+
+func TestReplaceBinaryClearsAStaleOldFile(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, binaryName())
+	staged := filepath.Join(dir, "staged")
+
+	require.NoError(t, os.WriteFile(dst, []byte("old"), 0755))
+	require.NoError(t, os.WriteFile(dst+oldSuffix, []byte("older"), 0755))
+	require.NoError(t, os.WriteFile(staged, []byte("new"), 0644))
+
+	require.NoError(t, replaceBinary(dst, staged))
+
+	assert.NoFileExists(t, dst+oldSuffix)
+}
+
+func TestReplaceBinaryWhenTheOldNameCannotBeCleared(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, binaryName())
+	staged := filepath.Join(dir, "staged")
+
+	require.NoError(t, os.WriteFile(dst, []byte("old"), 0755))
+	require.NoError(t, os.WriteFile(staged, []byte("new"), 0644))
+
+	// Windows refuses to delete or replace a file while a process is running from
+	// it, which is the state of the .old file left behind by a concurrent update. A
+	// non-empty directory is refused by os.Remove and os.Rename on every platform,
+	// so it stands in for that obstacle in a test that can run anywhere.
+	require.NoError(t, os.MkdirAll(filepath.Join(dst+oldSuffix, "occupied"), 0755))
+
+	require.NoError(t, replaceBinary(dst, staged),
+		"an unusable .old name must not fail the update")
+
+	installed, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(installed))
+
+	// The outgoing binary went to a suffixed name, and whatever was holding the
+	// usual one was left alone rather than clobbered.
+	assert.DirExists(t, dst+oldSuffix)
+}
+
+func TestReplaceBinaryRestoresTheOldBinaryOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, binaryName())
+	staged := filepath.Join(dir, "staged")
+
+	require.NoError(t, os.WriteFile(dst, []byte("old"), 0755))
+	require.NoError(t, os.WriteFile(staged, []byte("new"), 0644))
+
+	// Fail the move of the new binary into place, after the live one has been moved
+	// aside: a full disk, a revoked permission, an antivirus hold on the download.
+	original := rename
+	rename = func(from, to string) error {
+		if from == staged {
+			return errors.New("cannot move the new binary into place")
+		}
+
+		return original(from, to)
+	}
+
+	t.Cleanup(func() { rename = original })
+
+	err := replaceBinary(dst, staged)
+	require.Error(t, err)
+
+	restored, readErr := os.ReadFile(dst)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old", string(restored), "a failed update has to leave a working binary behind")
+}
+
+func TestRemoveSupersededBinary(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, binaryName())
+
+	require.NoError(t, os.WriteFile(exe, []byte("current"), 0755))
+	require.NoError(t, os.WriteFile(exe+oldSuffix, []byte("previous"), 0755))
+	// What asideName falls back to when .old itself is occupied.
+	require.NoError(t, os.WriteFile(exe+oldSuffix+".2971828", []byte("older"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "unrelated"), []byte("keep"), 0644))
+
+	removeSupersededBinary(exe)
+
+	assert.NoFileExists(t, exe+oldSuffix)
+	assert.NoFileExists(t, exe+oldSuffix+".2971828")
+	assert.FileExists(t, exe)
+	assert.FileExists(t, filepath.Join(dir, "unrelated"))
+
+	// Nothing to remove is the common case and must not be an error.
+	removeSupersededBinary(exe)
+}

--- a/pkg/autoupdate/updater.go
+++ b/pkg/autoupdate/updater.go
@@ -2,14 +2,17 @@ package autoupdate
 
 import (
 	"archive/tar"
+	"archive/zip"
+	"bytes"
 	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
-	"syscall"
 
 	log "github.com/sirupsen/logrus"
 
@@ -23,15 +26,30 @@ const (
 
 // ApplyIfPending checks for a pending update marker and applies it.
 // If an update is applied, it re-execs the current process with the new binary.
-// This function only returns if no update was applied.
+// This function only returns if no update was applied — or, on Windows, if the
+// new binary could not be started, in which case this invocation carries on
+// running the image it already has.
 func ApplyIfPending() {
 	if version.Version == "master" {
 		return
 	}
-	if IsOptedOut() {
+	if !IsCurlInstall() {
 		return
 	}
-	if !IsCurlInstall() {
+
+	exe, err := resolvedExecutable()
+	if err != nil {
+		log.Debug("autoupdate: cannot determine executable path: ", err)
+		return
+	}
+
+	// Ahead of the opt-out check, so that turning auto-update off does not leave
+	// the outgoing binary from an earlier update parked next to the new one
+	// forever. On Windows the update that installed it could not delete it: a
+	// process was still running from that file. This one is not, so it can.
+	removeSupersededBinary(exe)
+
+	if IsOptedOut() {
 		return
 	}
 
@@ -43,20 +61,6 @@ func ApplyIfPending() {
 	current := strings.TrimPrefix(version.Version, "v")
 	target := strings.TrimPrefix(marker.Version, "v")
 	if current == target {
-		ClearMarker()
-		return
-	}
-
-	exe, err := os.Executable()
-	if err != nil {
-		log.Debug("autoupdate: cannot determine executable path: ", err)
-		ClearMarker()
-		return
-	}
-
-	exe, err = filepath.EvalSymlinks(exe)
-	if err != nil {
-		log.Debug("autoupdate: cannot resolve symlinks: ", err)
 		ClearMarker()
 		return
 	}
@@ -165,21 +169,70 @@ func downloadAndReplace(marker *UpdateMarker, exePath string) error {
 		return fmt.Errorf("extraction failed: %w", err)
 	}
 
-	if err := os.Chmod(tmpBinaryPath, 0755); err != nil {
+	if err := replaceBinary(exePath, tmpBinaryPath); err != nil {
 		os.Remove(tmpBinaryPath)
-		return fmt.Errorf("chmod failed: %w", err)
-	}
-
-	if err := os.Rename(tmpBinaryPath, exePath); err != nil {
-		os.Remove(tmpBinaryPath)
-		return fmt.Errorf("cannot replace binary: %w", err)
+		return err
 	}
 
 	return nil
 }
 
+// resolvedExecutable is the path of the running binary with every symlink
+// resolved. A user may have symlinked stripe onto their PATH, or a component of
+// the install path may itself be a link, and the update has to land on the real
+// file.
+func resolvedExecutable() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.EvalSymlinks(exe)
+}
+
+// binaryName is the name of the executable inside the release archive, which is
+// also the name it is installed under. goreleaser appends .exe to Windows builds.
+func binaryName() string {
+	if runtime.GOOS == "windows" {
+		return "stripe.exe"
+	}
+
+	return "stripe"
+}
+
+// extractBinary pulls the stripe executable out of a release archive.
+//
+// Which format that is is read off the file rather than its name: the archive was
+// downloaded to a temporary path whose name says nothing about its contents. Mac
+// and Linux releases ship a .tar.gz, Windows a .zip.
 func extractBinary(archivePath, destPath string) error {
+	zipped, err := isZipArchive(archivePath)
+	if err != nil {
+		return err
+	}
+
+	if zipped {
+		return extractFromZip(archivePath, destPath)
+	}
+
 	return extractFromTarGz(archivePath, destPath)
+}
+
+func isZipArchive(archivePath string) (bool, error) {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	magic := make([]byte, 4)
+	if _, err := io.ReadFull(f, magic); err != nil {
+		// Too short to be either format. Let the tar reader say so, so that the
+		// error names what the file was expected to be.
+		return false, nil
+	}
+
+	return bytes.Equal(magic, []byte("PK\x03\x04")), nil
 }
 
 func extractFromTarGz(archivePath, destPath string) error {
@@ -205,7 +258,7 @@ func extractFromTarGz(archivePath, destPath string) error {
 			return err
 		}
 
-		if filepath.Base(hdr.Name) == "stripe" && hdr.Typeflag == tar.TypeReg {
+		if path.Base(hdr.Name) == binaryName() && hdr.Typeflag == tar.TypeReg {
 			out, err := os.Create(destPath)
 			if err != nil {
 				return err
@@ -220,9 +273,36 @@ func extractFromTarGz(archivePath, destPath string) error {
 	return fmt.Errorf("stripe binary not found in archive")
 }
 
-func reexec(exe string) {
-	err := syscall.Exec(exe, os.Args, os.Environ())
+func extractFromZip(archivePath, destPath string) error {
+	r, err := zip.OpenReader(archivePath)
 	if err != nil {
-		log.Debug("autoupdate: re-exec failed: ", err)
+		return err
 	}
+	defer r.Close()
+
+	for _, entry := range r.File {
+		// Only this one entry is extracted, to a path this function chose, so a
+		// crafted archive cannot write anywhere else.
+		if entry.FileInfo().IsDir() || path.Base(entry.Name) != binaryName() {
+			continue
+		}
+
+		in, err := entry.Open()
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+
+		out, err := os.Create(destPath)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			out.Close()
+			return err
+		}
+		return out.Close()
+	}
+
+	return fmt.Errorf("stripe binary not found in archive")
 }

--- a/pkg/autoupdate/updater_test.go
+++ b/pkg/autoupdate/updater_test.go
@@ -2,6 +2,7 @@ package autoupdate
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
@@ -38,6 +39,24 @@ func createTestTarGz(t *testing.T, filename string, content []byte) string {
 
 	require.NoError(t, tw.Close())
 	require.NoError(t, gw.Close())
+	require.NoError(t, f.Close())
+	return path
+}
+
+// createTestZip writes the archive format the Windows release publishes.
+func createTestZip(t *testing.T, filename string, content []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.zip")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+
+	zw := zip.NewWriter(f)
+	entry, err := zw.Create(filename)
+	require.NoError(t, err)
+	_, err = entry.Write(content)
+	require.NoError(t, err)
+
+	require.NoError(t, zw.Close())
 	require.NoError(t, f.Close())
 	return path
 }
@@ -98,7 +117,7 @@ func TestFormatReleaseNotes_TruncatesCharactersWithoutSplittingUTF8(t *testing.T
 
 func TestExtractFromTarGz(t *testing.T) {
 	content := []byte("#!/bin/sh\necho hello\n")
-	archivePath := createTestTarGz(t, "stripe", content)
+	archivePath := createTestTarGz(t, binaryName(), content)
 
 	destPath := filepath.Join(t.TempDir(), "stripe")
 	err := extractFromTarGz(archivePath, destPath)
@@ -111,7 +130,7 @@ func TestExtractFromTarGz(t *testing.T) {
 
 func TestExtractFromTarGz_NestedPath(t *testing.T) {
 	content := []byte("binary content")
-	archivePath := createTestTarGz(t, "stripe_1.43.8_linux_arm64/stripe", content)
+	archivePath := createTestTarGz(t, "stripe_1.43.8_linux_arm64/"+binaryName(), content)
 
 	destPath := filepath.Join(t.TempDir(), "stripe")
 	err := extractFromTarGz(archivePath, destPath)
@@ -131,9 +150,79 @@ func TestExtractFromTarGz_NoBinary(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found in archive")
 }
 
+func TestExtractFromZip(t *testing.T) {
+	content := []byte("MZ windows binary")
+	archivePath := createTestZip(t, binaryName(), content)
+
+	destPath := filepath.Join(t.TempDir(), binaryName())
+	err := extractFromZip(archivePath, destPath)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+func TestExtractFromZip_NestedPath(t *testing.T) {
+	content := []byte("MZ windows binary")
+	// Zip entry names use forward slashes whatever the platform reading them.
+	archivePath := createTestZip(t, "stripe_1.43.8_windows_x86_64/"+binaryName(), content)
+
+	destPath := filepath.Join(t.TempDir(), binaryName())
+	err := extractFromZip(archivePath, destPath)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+func TestExtractFromZip_NoBinary(t *testing.T) {
+	archivePath := createTestZip(t, "not-stripe", []byte("nope"))
+
+	destPath := filepath.Join(t.TempDir(), binaryName())
+	err := extractFromZip(archivePath, destPath)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in archive")
+}
+
+// The archive is downloaded to a temporary name, so its format has to be read off
+// the bytes rather than an extension.
+func TestExtractBinary_PicksTheFormatFromTheContents(t *testing.T) {
+	for _, tt := range []struct {
+		format  string
+		archive func(*testing.T, string, []byte) string
+	}{
+		{"tar.gz", createTestTarGz},
+		{"zip", createTestZip},
+	} {
+		t.Run(tt.format, func(t *testing.T) {
+			content := []byte("binary for " + tt.format)
+			// A name that gives nothing away, as os.CreateTemp produces.
+			archivePath := tt.archive(t, binaryName(), content)
+			anonymous := filepath.Join(t.TempDir(), "stripe-update-archive-1234")
+			require.NoError(t, os.Rename(archivePath, anonymous))
+
+			destPath := filepath.Join(t.TempDir(), binaryName())
+			require.NoError(t, extractBinary(anonymous, destPath))
+
+			got, err := os.ReadFile(destPath)
+			require.NoError(t, err)
+			assert.Equal(t, content, got)
+		})
+	}
+}
+
+func TestExtractBinary_ShortFileIsAnError(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "stripe-update-archive-1234")
+	require.NoError(t, os.WriteFile(archivePath, []byte("PK"), 0644))
+
+	assert.Error(t, extractBinary(archivePath, filepath.Join(t.TempDir(), binaryName())))
+}
+
 func TestDownloadAndReplace(t *testing.T) {
 	content := []byte("#!/bin/sh\necho updated\n")
-	archivePath := createTestTarGz(t, "stripe", content)
+	archivePath := createTestTarGz(t, binaryName(), content)
 	archiveData, err := os.ReadFile(archivePath)
 	require.NoError(t, err)
 
@@ -145,7 +234,7 @@ func TestDownloadAndReplace(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	exePath := filepath.Join(dir, "stripe")
+	exePath := filepath.Join(dir, binaryName())
 	require.NoError(t, os.WriteFile(exePath, []byte("old binary"), 0755))
 
 	marker := &UpdateMarker{
@@ -166,11 +255,19 @@ func TestDownloadAndReplace(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
 	}
+
+	// Nothing staged is left in the install directory.
+	assert.NoFileExists(t, exePath+oldSuffix)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
 }
 
-func TestDownloadAndReplace_BadChecksum(t *testing.T) {
-	content := []byte("#!/bin/sh\necho updated\n")
-	archivePath := createTestTarGz(t, "stripe", content)
+// The Windows release ships a zip rather than a tar.gz, and the binary inside it
+// is named stripe.exe.
+func TestDownloadAndReplace_Zip(t *testing.T) {
+	content := []byte("MZ updated windows binary")
+	archivePath := createTestZip(t, binaryName(), content)
 	archiveData, err := os.ReadFile(archivePath)
 	require.NoError(t, err)
 
@@ -180,7 +277,35 @@ func TestDownloadAndReplace_BadChecksum(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	exePath := filepath.Join(dir, "stripe")
+	exePath := filepath.Join(dir, binaryName())
+	require.NoError(t, os.WriteFile(exePath, []byte("old binary"), 0755))
+
+	marker := &UpdateMarker{
+		Version:     "1.43.8",
+		DownloadURL: server.URL + "/stripe.zip",
+		Checksum:    sha256sum(archivePath),
+	}
+
+	require.NoError(t, downloadAndReplace(marker, exePath))
+
+	got, err := os.ReadFile(exePath)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+func TestDownloadAndReplace_BadChecksum(t *testing.T) {
+	content := []byte("#!/bin/sh\necho updated\n")
+	archivePath := createTestTarGz(t, binaryName(), content)
+	archiveData, err := os.ReadFile(archivePath)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archiveData)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, binaryName())
 	require.NoError(t, os.WriteFile(exePath, []byte("old binary"), 0755))
 
 	marker := &UpdateMarker{
@@ -204,7 +329,7 @@ func TestDownloadAndReplace_ServerError(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	exePath := filepath.Join(dir, "stripe")
+	exePath := filepath.Join(dir, binaryName())
 	require.NoError(t, os.WriteFile(exePath, []byte("old binary"), 0755))
 
 	marker := &UpdateMarker{


### PR DESCRIPTION
### Summary

Extends auto-update to Windows. Replacement there can't be a plain overwrite — Windows locks the image a running process was started from, and `syscall.Exec` is a stub — so the update renames the outgoing binary aside, moves the new one into place, hands the invocation to a child process, and clears the leftover `.old` on a later run. Extraction now also handles the `.zip` that Windows releases ship.

Fixes the asset name the check asks the release for. It passed `runtime.GOOS` through, but goreleaser publishes `mac-os`, so on a Mac it asked for `stripe_1.50.10_darwin_arm64.tar.gz`, matched no asset, and gave up — auto-update has never run there. The canary missed it because it stages the marker with a hardcoded URL.

### Test plan

- `go test ./pkg/autoupdate/...`; `GOOS=windows go build ./...`, `go vet`, `go test -c`
- On a real Windows runner, via the canary job in #1991: 1.0.0 → 1.50.10, `stripe.exe.old` left behind, cleared by the next invocation — https://github.com/stripe/stripe-cli/actions/runs/33808439270
