### PR TITLE
Add a Windows job to the auto-upgrade canary

### DIFF
--- a/.github/workflows/autoupgrade-test.yml
+++ b/.github/workflows/autoupgrade-test.yml
@@ -192,9 +192,123 @@ jobs:
             echo "failed_step=auto-upgrade" >> "$GITHUB_OUTPUT"
           fi
 
+  # Windows earns a few steps the other two do not need. The outgoing binary
+  # cannot be deleted while a process is running from it, so an update there moves
+  # it aside instead and a later invocation clears it — which is the part of the
+  # sequence that leaves a trace on disk, and so the part worth asserting on.
+  upgrade-windows:
+    runs-on: windows-latest
+    needs: [resolve-versions]
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      failed_step: ${{ steps.result.outputs.failed_step }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.26.0'
+
+      - name: Build binary with fake old version
+        id: build
+        env:
+          STRIPE_NO_AUTO_UPDATE: "1"
+        run: |
+          go generate ./...
+          CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/stripe/stripe-cli/pkg/version.Version=1.0.0" \
+            -o "$HOME/.stripe/bin/stripe.exe" ./cmd/stripe
+          INSTALLED=$("$HOME/.stripe/bin/stripe.exe" --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ "$INSTALLED" != "1.0.0" ]; then
+            echo "Error: expected version 1.0.0, got $INSTALLED"
+            exit 1
+          fi
+          echo "Built binary with version v$INSTALLED"
+
+      - name: Stage update marker
+        id: update-check
+        run: |
+          LATEST="${{ needs.resolve-versions.outputs.latest }}"
+          # .goreleaser/windows.yml publishes x86_64 and i386 only; a Windows ARM
+          # machine runs the x64 archive under emulation, and the runners are x64.
+          URL="https://github.com/stripe/stripe-cli/releases/download/v${LATEST}/stripe_${LATEST}_windows_x86_64.zip"
+
+          # Must match autoupdate.UpdateMarker's JSON encoding in pkg/autoupdate/checker.go.
+          mkdir -p "$HOME/.stripe/state"
+          printf '{"version":"%s","download_url":"%s","checksum":"","release_notes":""}' \
+            "$LATEST" "$URL" > "$HOME/.stripe/state/update-available"
+          echo "Wrote update marker:"
+          cat "$HOME/.stripe/state/update-available"
+
+      - name: Verify auto-upgrade
+        id: upgrade
+        env:
+          STRIPE_INSTALL_METHOD: curl
+        run: |
+          OUTPUT=$("$HOME/.stripe/bin/stripe.exe" --version 2>&1)
+          echo "$OUTPUT"
+          UPGRADED=$(echo "$OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
+          if [ "$UPGRADED" != "${{ needs.resolve-versions.outputs.latest }}" ]; then
+            echo "Error: expected upgrade to v${{ needs.resolve-versions.outputs.latest }}, got v$UPGRADED"
+            exit 1
+          fi
+          echo "Successfully upgraded to v$UPGRADED"
+
+      - name: Verify the moved-aside binary is cleaned up
+        id: cleanup
+        env:
+          STRIPE_INSTALL_METHOD: curl
+        run: |
+          STRIPE="$HOME/.stripe/bin/stripe.exe"
+
+          # Windows could not delete the moved-aside image: the process doing the
+          # update was still running from it, and the one it re-exec'd could not
+          # delete it either while its parent lived.
+          if [ ! -f "$STRIPE.old" ]; then
+            echo "Error: expected $STRIPE.old to be left behind by the update"
+            ls -la "$HOME/.stripe/bin"
+            exit 1
+          fi
+
+          # A later invocation is what clears it. The release just installed
+          # predates the cleanup, so put a build that has it back in place.
+          CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/stripe/stripe-cli/pkg/version.Version=1.0.0" \
+            -o "$STRIPE" ./cmd/stripe
+
+          # Opted out, so that this also covers the cleanup running ahead of the
+          # opt-out check: turning auto-update off must not park the outgoing
+          # binary next to the new one forever.
+          STRIPE_NO_AUTO_UPDATE=1 "$STRIPE" --version
+
+          if [ -f "$STRIPE.old" ]; then
+            echo "Error: $STRIPE.old was not cleaned up"
+            ls -la "$HOME/.stripe/bin"
+            exit 1
+          fi
+          echo "Moved-aside binary was cleaned up"
+
+      - name: Record failed step
+        id: result
+        if: failure()
+        run: |
+          if [ "${{ steps.build.outcome }}" = "failure" ]; then
+            echo "failed_step=build" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.update-check.outcome }}" = "failure" ]; then
+            echo "failed_step=update-check" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.upgrade.outcome }}" = "failure" ]; then
+            echo "failed_step=auto-upgrade" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.cleanup.outcome }}" = "failure" ]; then
+            echo "failed_step=cleanup" >> "$GITHUB_OUTPUT"
+          fi
+
   notify:
     runs-on: ubuntu-latest
-    needs: [resolve-versions, upgrade-macos, upgrade-linux]
+    needs: [resolve-versions, upgrade-macos, upgrade-linux, upgrade-windows]
     if: always()
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -209,25 +323,28 @@ jobs:
         id: summary
         if: needs.resolve-versions.result == 'success' && contains(needs.*.result, 'failure')
         run: |
-          MACOS_STEP="${{ needs.upgrade-macos.outputs.failed_step }}"
-          LINUX_STEP="${{ needs.upgrade-linux.outputs.failed_step }}"
+          PLATFORMS=(macOS Linux Windows)
+          STEPS=(
+            "${{ needs.upgrade-macos.outputs.failed_step }}"
+            "${{ needs.upgrade-linux.outputs.failed_step }}"
+            "${{ needs.upgrade-windows.outputs.failed_step }}"
+          )
 
+          # One clause per failing step, naming every platform that failed in it, so
+          # that the same breakage everywhere stays a single clause. sort -u to keep
+          # the order the message is built in independent of which platform failed.
           MSG=""
-          if [ -n "$MACOS_STEP" ] && [ -n "$LINUX_STEP" ]; then
-            if [ "$MACOS_STEP" = "$LINUX_STEP" ]; then
-              MSG="Step '${MACOS_STEP}' failed on macOS and Linux"
-            else
-              MSG="Step '${MACOS_STEP}' failed on macOS, step '${LINUX_STEP}' failed on Linux"
-            fi
-          elif [ -n "$MACOS_STEP" ]; then
-            MSG="Step '${MACOS_STEP}' failed on macOS"
-          elif [ -n "$LINUX_STEP" ]; then
-            MSG="Step '${LINUX_STEP}' failed on Linux"
-          else
-            MSG="Unknown failure"
-          fi
+          for STEP in $(printf '%s\n' "${STEPS[@]}" | sed '/^$/d' | sort -u); do
+            WHERE=""
+            for i in "${!PLATFORMS[@]}"; do
+              if [ "${STEPS[$i]}" = "$STEP" ]; then
+                WHERE="${WHERE:+$WHERE, }${PLATFORMS[$i]}"
+              fi
+            done
+            MSG="${MSG:+$MSG; }Step '${STEP}' failed on ${WHERE}"
+          done
 
-          echo "msg=$MSG" >> "$GITHUB_OUTPUT"
+          echo "msg=${MSG:-Unknown failure}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger PagerDuty alert
         if: needs.resolve-versions.result == 'success' && contains(needs.*.result, 'failure')
@@ -243,7 +360,7 @@ jobs:
           DRYRUN: "true" # TODO: switch to ${{ inputs.dryrun }} once confirmed stable
 
       - name: Resolve PagerDuty alert
-        if: needs.upgrade-macos.result == 'success' && needs.upgrade-linux.result == 'success'
+        if: needs.upgrade-macos.result == 'success' && needs.upgrade-linux.result == 'success' && needs.upgrade-windows.result == 'success'
         run: bash scripts/notify.sh
         env:
           OVERALL_RESULT: success


### PR DESCRIPTION
### Summary

Adds a Windows job to the auto-upgrade canary. Beyond the version check the other two jobs do, it covers the cleanup that only Windows needs: the update leaves `stripe.exe.old` behind, and a later invocation removes it even with auto-update disabled.

The failure summary now groups platforms by the step they failed in, rather than enumerating the combinations.

`DRYRUN` stays hardcoded `true`, so this cannot page anyone yet.

### Test plan

Dispatched on this branch, green on all three platforms: https://github.com/stripe/stripe-cli/actions/runs/33808439270 — Windows went 1.0.0 -> 1.50.10.
