### PR TITLE
Honor the opt-out the CLI tells users to write

### DIFF
--- a/pkg/autoupdate/config.go
+++ b/pkg/autoupdate/config.go
@@ -27,7 +27,17 @@ func IsOptedOut() bool {
 		return false
 	}
 
-	return !v.GetBool("settings.auto_update") && v.IsSet("settings.auto_update")
+	// Both spellings count. The install script tells users to write a [settings]
+	// table; the message the CLI prints when it updates tells them to write a
+	// top-level auto_update, which is also where every other CLI setting lives in
+	// config.toml. Someone who followed either has said what they want.
+	for _, key := range []string{"auto_update", "settings.auto_update"} {
+		if v.IsSet(key) && !v.GetBool(key) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // IsCurlInstall reports whether the current binary was installed via curl (lives in ~/.stripe/bin/).

--- a/pkg/autoupdate/config_test.go
+++ b/pkg/autoupdate/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsOptedOut_EnvVar(t *testing.T) {
@@ -19,24 +20,40 @@ func TestIsOptedOut_NoConfig(t *testing.T) {
 	assert.False(t, IsOptedOut())
 }
 
-func TestIsOptedOut_ConfigSetFalse(t *testing.T) {
-	t.Setenv("STRIPE_NO_AUTO_UPDATE", "")
-	configDir := t.TempDir()
-	stripeDir := filepath.Join(configDir, "stripe")
-	os.MkdirAll(stripeDir, 0755)
-	os.WriteFile(filepath.Join(stripeDir, "config.toml"), []byte("[settings]\nauto_update = false\n"), 0644)
-	t.Setenv("XDG_CONFIG_HOME", configDir)
-	assert.True(t, IsOptedOut())
-}
+// scripts/install.sh tells users to write a [settings] table; the message the CLI
+// prints when it updates tells them to write a top-level auto_update. Whichever
+// set of instructions a user followed has to opt them out.
+func TestIsOptedOut_Config(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		optedOut bool
+	}{
+		{"top-level false", "auto_update = false\n", true},
+		{"top-level true", "auto_update = true\n", false},
+		{"settings table false", "[settings]\nauto_update = false\n", true},
+		{"settings table true", "[settings]\nauto_update = true\n", false},
+		{
+			// Where it lands in a config.toml that already has profiles in it: with
+			// the other top-level settings, ahead of the first table.
+			"alongside the other top-level settings",
+			"color = ''\nauto_update = false\n\n[default]\ndevice_name = 'laptop'\n",
+			true,
+		},
+	}
 
-func TestIsOptedOut_ConfigSetTrue(t *testing.T) {
-	t.Setenv("STRIPE_NO_AUTO_UPDATE", "")
-	configDir := t.TempDir()
-	stripeDir := filepath.Join(configDir, "stripe")
-	os.MkdirAll(stripeDir, 0755)
-	os.WriteFile(filepath.Join(stripeDir, "config.toml"), []byte("[settings]\nauto_update = true\n"), 0644)
-	t.Setenv("XDG_CONFIG_HOME", configDir)
-	assert.False(t, IsOptedOut())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("STRIPE_NO_AUTO_UPDATE", "")
+			configDir := t.TempDir()
+			stripeDir := filepath.Join(configDir, "stripe")
+			require.NoError(t, os.MkdirAll(stripeDir, 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(stripeDir, "config.toml"), []byte(tt.config), 0644))
+			t.Setenv("XDG_CONFIG_HOME", configDir)
+
+			assert.Equal(t, tt.optedOut, IsOptedOut())
+		})
+	}
 }
 
 func TestIsCurlInstall_EnvOverride(t *testing.T) {


### PR DESCRIPTION
### Summary

`IsOptedOut` read only `settings.auto_update`, the spelling `scripts/install.sh` prints. But the message the CLI prints on every update says to add a top-level `auto_update = false` — which is also where the rest of the CLI's settings live in `config.toml`. Users who followed the on-screen instructions kept getting updates, with nothing to say their opt-out had been ignored.

Accept both spellings, so either set of instructions works and anyone already opted out stays opted out.

### Test plan

`go test ./pkg/autoupdate/...` — table over both spellings × both values, plus the top-level key in a `config.toml` that already has profile tables in it. The two new cases fail on `v2` without this change.
