### PR TITLE
Support more clients in stripe agent setup

### DIFF
--- a/pkg/agentsetup/provider.go
+++ b/pkg/agentsetup/provider.go
@@ -17,6 +17,9 @@ const (
 	ActionNone      = "none"
 	ActionInstall   = "install"
 	ActionReinstall = "reinstall"
+	// ActionInstallSkills installs the shared Stripe skills for clients without
+	// an official Stripe plugin marketplace entry.
+	ActionInstallSkills = "install_skills"
 	// ActionManual means setup cannot be automated and the user must perform a
 	// step themselves (e.g. Cursor plugins are installed from inside Cursor).
 	ActionManual = "manual"
@@ -36,10 +39,18 @@ func DefaultProviders() map[string]Provider {
 	claude := NewClaudeProvider(scanner, RunCommand)
 	cursor := NewCursorProvider(scanner, RunCommand)
 	codex := NewCodexProvider(scanner, RunCommand)
+	grok := NewGrokProvider(scanner)
+	kimi := NewKimiProvider(scanner)
+	githubCopilot := NewGitHubCopilotProvider(scanner)
+	vsCode := NewVSCodeProvider(scanner)
 	return map[string]Provider{
-		claude.ID(): claude,
-		cursor.ID(): cursor,
-		codex.ID():  codex,
+		claude.ID():        claude,
+		cursor.ID():        cursor,
+		codex.ID():         codex,
+		grok.ID():          grok,
+		kimi.ID():          kimi,
+		githubCopilot.ID(): githubCopilot,
+		vsCode.ID():        vsCode,
 	}
 }
 
@@ -58,10 +69,15 @@ type Status struct {
 	DisplayName    string       `json:"display_name"`
 	Detected       bool         `json:"detected"`
 	ExecutablePath string       `json:"executable_path,omitempty"`
+	Setup          string       `json:"setup,omitempty"`
 	Plugin         PluginStatus `json:"plugin"`
 	Status         string       `json:"status"`
 	Error          string       `json:"error,omitempty"`
 }
+
+// SetupSkills identifies clients configured through the portable Agent Skills
+// directory rather than a native plugin marketplace.
+const SetupSkills = "skills"
 
 // PluginStatus is the plugin-specific part of a client setup status.
 type PluginStatus struct {

--- a/pkg/agentsetup/scanner.go
+++ b/pkg/agentsetup/scanner.go
@@ -27,6 +27,10 @@ type ReadDirFunc func(string) ([]os.DirEntry, error)
 // StatFunc matches os.Stat and exists to make file existence checks testable.
 type StatFunc func(string) (os.FileInfo, error)
 
+// GetenvFunc matches os.Getenv and exists to make environment-based install
+// locations testable.
+type GetenvFunc func(string) string
+
 // RunCommandFunc runs a command. The production implementation captures output
 // silently and returns a concise error on failure.
 type RunCommandFunc func(context.Context, string, ...string) error
@@ -39,6 +43,7 @@ type Scanner struct {
 	WorkDir  WorkDirFunc
 	ReadDir  ReadDirFunc
 	Stat     StatFunc
+	Getenv   GetenvFunc
 }
 
 // DefaultScanner returns a Scanner backed by the real OS.
@@ -50,6 +55,7 @@ func DefaultScanner() Scanner {
 		WorkDir:  os.Getwd,
 		ReadDir:  os.ReadDir,
 		Stat:     os.Stat,
+		Getenv:   os.Getenv,
 	}
 }
 
@@ -72,6 +78,9 @@ func (s Scanner) withDefaults() Scanner {
 	}
 	if s.Stat == nil {
 		s.Stat = defaults.Stat
+	}
+	if s.Getenv == nil {
+		s.Getenv = defaults.Getenv
 	}
 	return s
 }

--- a/pkg/agentsetup/skills_client.go
+++ b/pkg/agentsetup/skills_client.go
@@ -1,0 +1,128 @@
+package agentsetup
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"runtime"
+)
+
+const (
+	ClientGrok               = "grok"
+	GrokDisplayName          = "Grok Build"
+	ClientKimi               = "kimi"
+	KimiDisplayName          = "Kimi Code"
+	ClientGitHubCopilot      = "github-copilot"
+	GitHubCopilotDisplayName = "GitHub Copilot CLI"
+	ClientVSCode             = "vscode"
+	VSCodeDisplayName        = "Visual Studio Code"
+)
+
+type skillsClientProvider struct {
+	id          string
+	displayName string
+	binaries    []string
+	scanner     Scanner
+	fallbacks   func(Scanner) []string
+}
+
+// NewGrokProvider returns a Grok Build setup provider.
+func NewGrokProvider(scanner Scanner) Provider {
+	return newSkillsClientProvider(ClientGrok, GrokDisplayName, []string{"grok"}, scanner)
+}
+
+// NewKimiProvider returns a Kimi Code setup provider.
+func NewKimiProvider(scanner Scanner) Provider {
+	provider := newSkillsClientProvider(ClientKimi, KimiDisplayName, []string{"kimi"}, scanner)
+	provider.fallbacks = kimiFallbackPaths
+	return provider
+}
+
+// NewGitHubCopilotProvider returns a GitHub Copilot CLI setup provider.
+func NewGitHubCopilotProvider(scanner Scanner) Provider {
+	return newSkillsClientProvider(ClientGitHubCopilot, GitHubCopilotDisplayName, []string{"copilot"}, scanner)
+}
+
+// NewVSCodeProvider returns a Visual Studio Code setup provider.
+func NewVSCodeProvider(scanner Scanner) Provider {
+	return newSkillsClientProvider(ClientVSCode, VSCodeDisplayName, []string{"code", "code-insiders"}, scanner)
+}
+
+func newSkillsClientProvider(id, displayName string, binaries []string, scanner Scanner) skillsClientProvider {
+	return skillsClientProvider{
+		id:          id,
+		displayName: displayName,
+		binaries:    binaries,
+		scanner:     scanner,
+	}
+}
+
+func (p skillsClientProvider) ID() string { return p.id }
+
+func (p skillsClientProvider) Detect() Status {
+	status := Status{
+		Client:      p.id,
+		DisplayName: p.displayName,
+		Setup:       SetupSkills,
+		Status:      StatusNotDetected,
+	}
+
+	scanner := p.scanner.withDefaults()
+	for _, binary := range p.binaries {
+		path, err := scanner.LookPath(binary)
+		if err != nil {
+			continue
+		}
+		status.Detected = true
+		status.ExecutablePath = path
+		status.Status = StatusMissing
+		return status
+	}
+	if p.fallbacks != nil {
+		for _, path := range p.fallbacks(scanner) {
+			info, err := scanner.Stat(path)
+			if err != nil || info.IsDir() || runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
+				continue
+			}
+			status.Detected = true
+			status.ExecutablePath = path
+			status.Status = StatusMissing
+			return status
+		}
+	}
+	return status
+}
+
+func kimiFallbackPaths(scanner Scanner) []string {
+	home, err := scanner.HomeDir()
+	if err != nil {
+		return nil
+	}
+	kimiHome := scanner.Getenv("KIMI_CODE_HOME")
+	if kimiHome == "" {
+		kimiHome = filepath.Join(home, ".kimi-code")
+	}
+	binary := "kimi"
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+	return []string{
+		filepath.Join(kimiHome, "bin", binary),
+		filepath.Join(home, ".local", "bin", binary),
+		filepath.Join(home, ".kimi", "bin", binary),
+	}
+}
+
+func (p skillsClientProvider) Plan(status Status, _ bool) Plan {
+	if !status.Detected {
+		return Plan{Action: ActionNone}
+	}
+	return Plan{
+		Action:  ActionInstallSkills,
+		Command: []string{"stripe", "agent", "setup"},
+	}
+}
+
+func (p skillsClientProvider) Apply(_ context.Context, _ io.Writer, _ Plan) error {
+	return nil
+}

--- a/pkg/agentsetup/skills_client_test.go
+++ b/pkg/agentsetup/skills_client_test.go
@@ -1,0 +1,144 @@
+package agentsetup
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkillsClientProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    Provider
+		binary      string
+		client      string
+		displayName string
+	}{
+		{
+			name:        "Grok Build",
+			provider:    NewGrokProvider(scannerWithBinary("grok", "/usr/local/bin/grok")),
+			binary:      "/usr/local/bin/grok",
+			client:      ClientGrok,
+			displayName: GrokDisplayName,
+		},
+		{
+			name:        "Kimi Code",
+			provider:    NewKimiProvider(scannerWithBinary("kimi", "/usr/local/bin/kimi")),
+			binary:      "/usr/local/bin/kimi",
+			client:      ClientKimi,
+			displayName: KimiDisplayName,
+		},
+		{
+			name:        "GitHub Copilot CLI",
+			provider:    NewGitHubCopilotProvider(scannerWithBinary("copilot", "/usr/local/bin/copilot")),
+			binary:      "/usr/local/bin/copilot",
+			client:      ClientGitHubCopilot,
+			displayName: GitHubCopilotDisplayName,
+		},
+		{
+			name:        "Visual Studio Code",
+			provider:    NewVSCodeProvider(scannerWithBinary("code", "/usr/local/bin/code")),
+			binary:      "/usr/local/bin/code",
+			client:      ClientVSCode,
+			displayName: VSCodeDisplayName,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status := tc.provider.Detect()
+
+			require.Equal(t, tc.client, status.Client)
+			require.Equal(t, tc.displayName, status.DisplayName)
+			require.True(t, status.Detected)
+			require.Equal(t, tc.binary, status.ExecutablePath)
+			require.Equal(t, SetupSkills, status.Setup)
+			require.Equal(t, StatusMissing, status.Status)
+
+			plan := tc.provider.Plan(status, false)
+			require.Equal(t, ActionInstallSkills, plan.Action)
+			require.Equal(t, []string{"stripe", "agent", "setup"}, plan.Command)
+			require.NoError(t, tc.provider.Apply(context.Background(), io.Discard, plan))
+		})
+	}
+}
+
+func TestSkillsClientProviderNotDetected(t *testing.T) {
+	provider := NewGrokProvider(Scanner{
+		LookPath: func(string) (string, error) { return "", errors.New("not found") },
+	})
+
+	status := provider.Detect()
+
+	require.False(t, status.Detected)
+	require.Equal(t, StatusNotDetected, status.Status)
+	require.Equal(t, ActionNone, provider.Plan(status, false).Action)
+}
+
+func TestDefaultProvidersCoverPluginsPackageTargets(t *testing.T) {
+	providers := DefaultProviders()
+
+	require.Equal(t,
+		"claude-code,codex,cursor,github-copilot,grok,kimi,vscode",
+		SupportedProviderIDs(providers),
+	)
+}
+
+func TestVSCodeProviderDetectsInsiders(t *testing.T) {
+	provider := NewVSCodeProvider(Scanner{
+		LookPath: func(name string) (string, error) {
+			if name == "code-insiders" {
+				return "/usr/local/bin/code-insiders", nil
+			}
+			return "", errors.New("not found")
+		},
+	})
+
+	status := provider.Detect()
+
+	require.True(t, status.Detected)
+	require.Equal(t, "/usr/local/bin/code-insiders", status.ExecutablePath)
+}
+
+func TestKimiProviderDetectsConfiguredInstallOutsidePath(t *testing.T) {
+	kimiHome := t.TempDir()
+	binary := "kimi"
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+	kimiPath := filepath.Join(kimiHome, "bin", binary)
+	require.NoError(t, os.MkdirAll(filepath.Dir(kimiPath), 0755))
+	require.NoError(t, os.WriteFile(kimiPath, nil, 0755))
+
+	provider := NewKimiProvider(Scanner{
+		LookPath: func(string) (string, error) { return "", errors.New("not found") },
+		Getenv: func(name string) string {
+			if name == "KIMI_CODE_HOME" {
+				return kimiHome
+			}
+			return ""
+		},
+	})
+
+	status := provider.Detect()
+
+	require.True(t, status.Detected)
+	require.Equal(t, kimiPath, status.ExecutablePath)
+}
+
+func scannerWithBinary(wantName, path string) Scanner {
+	return Scanner{
+		LookPath: func(name string) (string, error) {
+			if name == wantName {
+				return path, nil
+			}
+			return "", errors.New("not found")
+		},
+	}
+}

--- a/pkg/cmd/agent.go
+++ b/pkg/cmd/agent.go
@@ -40,6 +40,10 @@ var providerOrder = []string{
 	agentsetup.ClientClaudeCode,
 	agentsetup.ClientCodex,
 	agentsetup.ClientCursor,
+	agentsetup.ClientGrok,
+	agentsetup.ClientKimi,
+	agentsetup.ClientGitHubCopilot,
+	agentsetup.ClientVSCode,
 }
 
 type agentCmd struct {
@@ -206,6 +210,9 @@ func (asc *agentSetupCmd) runSetup(cmd *cobra.Command, _ []string) error {
 	for _, s := range statuses {
 		if s.Detected {
 			sendAgentEvent(ctx, "Agent Setup: Client Detected", s.Client)
+			if s.Setup == agentsetup.SetupSkills {
+				continue
+			}
 			if s.Plugin.Installed {
 				sendAgentEvent(ctx, "Agent Setup: Plugin Detected", s.Client+":installed")
 			} else {
@@ -256,7 +263,7 @@ type skillsStatusView struct {
 }
 
 func (asc *agentSetupCmd) skillsStatusView(ctx context.Context, detected []agentsetup.Status) (skillsStatusView, error) {
-	if len(detected) == 0 {
+	if len(detected) == 0 || statusesUseSkills(detected) {
 		scopes, err := asc.loadSkillsScopes(ctx)
 		return skillsStatusView{scopes: scopes, show: true, allowInstall: true}, err
 	}
@@ -405,6 +412,7 @@ func (asc *agentSetupCmd) install(ctx context.Context, out io.Writer, providers 
 	warn := color.Yellow("⚠").String()
 
 	var installedCount, updatedCount, skipCount, errCount int
+	installSkills := sel.InstallSkills
 	for _, status := range sel.Agents {
 		provider := providers[status.Client]
 		plan := provider.Plan(status, asc.force)
@@ -423,6 +431,10 @@ func (asc *agentSetupCmd) install(ctx context.Context, out io.Writer, providers 
 			sendAgentEvent(ctx, "Agent Setup: Plugin Install", status.Client+":manual")
 			skipCount++
 			continue
+		case agentsetup.ActionInstallSkills:
+			fmt.Fprintln(out, "  uses shared Stripe skills")
+			installSkills = true
+			continue
 		}
 
 		err := spinner.New().
@@ -440,7 +452,10 @@ func (asc *agentSetupCmd) install(ctx context.Context, out io.Writer, providers 
 		installedCount++
 	}
 
-	if sel.InstallSkills {
+	if installSkills {
+		if scope == "" {
+			scope = skillsScopeLocal
+		}
 		ok, installed, updated, skipped := asc.installSkills(ctx, out, scope, check, cross)
 		if !ok {
 			errCount++
@@ -635,6 +650,11 @@ func (asc *agentSetupCmd) writeJSON(w io.Writer, providers map[string]agentsetup
 	}
 	for _, status := range statuses {
 		if plan := providers[status.Client].Plan(status, asc.force); plan.Action != agentsetup.ActionNone {
+			// The skills status below determines whether installation or update is
+			// actually needed and emits one shared action for every compatible client.
+			if plan.Action == agentsetup.ActionInstallSkills {
+				continue
+			}
 			result.Actions = append(result.Actions, plan)
 		}
 		if status.Status == agentsetup.StatusError {
@@ -731,13 +751,22 @@ func detectedStatuses(statuses []agentsetup.Status) []agentsetup.Status {
 	return detected
 }
 
+func statusesUseSkills(statuses []agentsetup.Status) bool {
+	for _, status := range statuses {
+		if status.Setup == agentsetup.SetupSkills {
+			return true
+		}
+	}
+	return false
+}
+
 // printStatusTable renders a compact, aligned, color-coded view of each client
 // and its Stripe plugin state. Colors are disabled automatically when the writer
 // is not a TTY (via ansi.Color).
 func printStatusTable(w io.Writer, statuses []agentsetup.Status) {
 	color := ansi.Color(w)
 
-	fmt.Fprintln(w, color.Bold("Detected agents with supported Stripe plugins:").String())
+	fmt.Fprintln(w, color.Bold("Detected supported agents:").String())
 	fmt.Fprintln(w)
 
 	nameWidth := 0
@@ -763,6 +792,9 @@ func printStatusTable(w io.Writer, statuses []agentsetup.Status) {
 			if detail := pluginDetail(s.Plugin); detail != "" {
 				state += "  " + color.Faint(detail).String()
 			}
+		case s.Setup == agentsetup.SetupSkills:
+			icon = color.Yellow("•").String()
+			state = "uses shared Stripe skills"
 		case s.Error != "":
 			icon = color.Yellow("•").String()
 			state = s.Error
@@ -775,7 +807,7 @@ func printStatusTable(w io.Writer, statuses []agentsetup.Status) {
 	}
 
 	if needsSetup {
-		fmt.Fprintf(w, "\nRun %s to install the Stripe plugin where it's missing.\n", color.Bold("stripe agent setup").String())
+		fmt.Fprintf(w, "\nRun %s to install the missing Stripe tooling.\n", color.Bold("stripe agent setup").String())
 	}
 }
 
@@ -858,6 +890,10 @@ Supported clients for automatic setup:
   • Claude Code   https://claude.ai/code
   • Cursor        https://cursor.com
   • Codex CLI     https://openai.com/codex/
+  • Grok Build    https://x.ai/grok
+  • Kimi Code     https://www.kimi.com/code
+  • Copilot CLI   https://github.com/features/copilot/cli
+  • VS Code       https://code.visualstudio.com
 
 You can still install Stripe skills.
 `)
@@ -870,6 +906,10 @@ Supported clients for automatic setup:
   • Claude Code   https://claude.ai/code
   • Cursor        https://cursor.com
   • Codex CLI     https://openai.com/codex/
+  • Grok Build    https://x.ai/grok
+  • Kimi Code     https://www.kimi.com/code
+  • Copilot CLI   https://github.com/features/copilot/cli
+  • VS Code       https://code.visualstudio.com
 
 Once a client is installed, re-run: stripe agent setup
 `)

--- a/pkg/cmd/agent_setup_tui.go
+++ b/pkg/cmd/agent_setup_tui.go
@@ -56,6 +56,8 @@ func newSelectModel(statuses []agentsetup.Status, skills skillsScopes) selectMod
 			label:  s.DisplayName,
 		}
 		switch {
+		case s.Setup == agentsetup.SetupSkills:
+			row.detail = "uses shared Stripe skills"
 		case s.Plugin.Installed:
 			row.disabled = true
 			row.hint = "plugin already installed"
@@ -69,13 +71,15 @@ func newSelectModel(statuses []agentsetup.Status, skills skillsScopes) selectMod
 		rows = append(rows, row)
 	}
 
-	skillsLabel, skillsDetail, skillsSelected := skillsRowPresentation(statuses, skills)
-	rows = append(rows, selectRow{
-		kind:     rowSkills,
-		label:    skillsLabel,
-		detail:   skillsDetail,
-		selected: skillsSelected,
-	})
+	if !statusesUseSkills(statuses) {
+		skillsLabel, skillsDetail, skillsSelected := skillsRowPresentation(statuses, skills)
+		rows = append(rows, selectRow{
+			kind:     rowSkills,
+			label:    skillsLabel,
+			detail:   skillsDetail,
+			selected: skillsSelected,
+		})
+	}
 
 	return selectModel{rows: rows}
 }
@@ -155,6 +159,9 @@ func (m selectModel) selection() Selection {
 		switch r.kind {
 		case rowAgent:
 			sel.Agents = append(sel.Agents, r.status)
+			if r.status.Setup == agentsetup.SetupSkills {
+				sel.InstallSkills = true
+			}
 		case rowSkills:
 			sel.InstallSkills = true
 		}
@@ -171,7 +178,7 @@ var (
 )
 
 func (m selectModel) View() tea.View {
-	body := "Select agents to install the Stripe plugin:\n\n"
+	body := "Select agents to set up Stripe tooling:\n\n"
 
 	skillsDividerShown := false
 	for i, r := range m.rows {

--- a/pkg/cmd/agent_setup_tui_test.go
+++ b/pkg/cmd/agent_setup_tui_test.go
@@ -51,6 +51,35 @@ func TestSelectModel_NoAgentsPreselectsSkills(t *testing.T) {
 	require.True(t, m.rows[0].selected)
 }
 
+func TestSelectModel_SkillsClientSelectsOneSharedSkillsInstall(t *testing.T) {
+	statuses := []agentsetup.Status{
+		{
+			Client:      agentsetup.ClientGrok,
+			DisplayName: agentsetup.GrokDisplayName,
+			Detected:    true,
+			Setup:       agentsetup.SetupSkills,
+			Status:      agentsetup.StatusMissing,
+		},
+		{
+			Client:      agentsetup.ClientKimi,
+			DisplayName: agentsetup.KimiDisplayName,
+			Detected:    true,
+			Setup:       agentsetup.SetupSkills,
+			Status:      agentsetup.StatusMissing,
+		},
+	}
+
+	m := newSelectModel(statuses, testSkillsScopes())
+
+	require.Len(t, m.rows, 2)
+	require.Equal(t, rowAgent, m.rows[0].kind)
+	require.Equal(t, "uses shared Stripe skills", m.rows[0].detail)
+	require.True(t, m.rows[0].selected)
+	require.Equal(t, rowAgent, m.rows[1].kind)
+	require.True(t, m.rows[1].selected)
+	require.True(t, m.selection().InstallSkills)
+}
+
 func TestSelectModel_SelectionSeparatesAgentsAndSkills(t *testing.T) {
 	m := newSelectModel(testStatuses(), testSkillsScopes())
 

--- a/pkg/cmd/agent_test.go
+++ b/pkg/cmd/agent_test.go
@@ -127,7 +127,7 @@ func TestAgentSetupStatusDoesNotInstall(t *testing.T) {
 	output, err := executeCommand(setup.cmd, "--status")
 
 	require.NoError(t, err)
-	require.Contains(t, output, "Detected agents with supported Stripe plugins:")
+	require.Contains(t, output, "Detected supported agents:")
 	require.Contains(t, output, "Claude Code")
 	require.Contains(t, output, "plugin not installed")
 }
@@ -648,6 +648,75 @@ func TestAgentSetupStatusWithNoClientsShowsSkills(t *testing.T) {
 	require.Contains(t, output, "No supported AI coding clients detected on this machine.")
 	require.Contains(t, output, "Stripe skills:")
 	require.Contains(t, output, "not installed")
+}
+
+func TestAgentSetupYesInstallsSkillsOnceForCompatibleClients(t *testing.T) {
+	var installCalls int
+	setup := testAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{
+		agentsetup.ClientGrok: agentsetup.NewGrokProvider(agentsetup.Scanner{
+			LookPath: func(string) (string, error) { return "/usr/local/bin/grok", nil },
+		}),
+		agentsetup.ClientKimi: agentsetup.NewKimiProvider(agentsetup.Scanner{
+			LookPath: func(string) (string, error) { return "/usr/local/bin/kimi", nil },
+		}),
+	}
+	setup.skillsInstall = func(context.Context, string) ([]string, error) {
+		installCalls++
+		return []string{"stripe-best-practices"}, nil
+	}
+	setup.callingAgent = func() string { return "" }
+	setup.cmd.SetContext(context.Background())
+
+	output, err := executeCommand(setup.cmd, "--yes")
+
+	require.NoError(t, err)
+	require.Equal(t, 1, installCalls)
+	require.Contains(t, output, "Grok Build")
+	require.Contains(t, output, "Kimi Code")
+	require.Contains(t, output, "Stripe skills (local)")
+	require.Contains(t, output, "1 installed, 0 updated, 0 skipped, 0 errors")
+}
+
+func TestAgentSetupJSONDeduplicatesCompatibleClientSkillsAction(t *testing.T) {
+	setup := testAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{
+		agentsetup.ClientGrok: agentsetup.NewGrokProvider(agentsetup.Scanner{
+			LookPath: func(string) (string, error) { return "/usr/local/bin/grok", nil },
+		}),
+		agentsetup.ClientKimi: agentsetup.NewKimiProvider(agentsetup.Scanner{
+			LookPath: func(string) (string, error) { return "/usr/local/bin/kimi", nil },
+		}),
+	}
+	setup.callingAgent = func() string { return "" }
+	setup.cmd.SetContext(context.Background())
+
+	output, err := executeCommand(setup.cmd, "--json")
+
+	require.NoError(t, err)
+	var result agentSetupJSON
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	require.Len(t, result.Actions, 1)
+	require.Equal(t, agentsetup.ActionInstallSkills, result.Actions[0].Action)
+}
+
+func TestAgentSetupJSONOmitsSkillsActionWhenCompatibleClientIsCurrent(t *testing.T) {
+	setup := testAgentSetupCmd()
+	setup.providers = map[string]agentsetup.Provider{
+		agentsetup.ClientGrok: agentsetup.NewGrokProvider(agentsetup.Scanner{
+			LookPath: func(string) (string, error) { return "/usr/local/bin/grok", nil },
+		}),
+	}
+	setup.skillsCheck = mockSkillsCheckCurrent
+	setup.callingAgent = func() string { return "" }
+	setup.cmd.SetContext(context.Background())
+
+	output, err := executeCommand(setup.cmd, "--json")
+
+	require.NoError(t, err)
+	var result agentSetupJSON
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	require.Empty(t, result.Actions)
 }
 
 func TestAgentSetupStatusWithNoClientsHidesUninstalledScopeWhenOtherInstalled(t *testing.T) {


### PR DESCRIPTION
### Reviewers
cc @stripe/developer-products

### Summary

Extend `stripe agent setup` to detect every client supported by the open-plugin compatibility ecosystem: Grok Build, Kimi Code, GitHub Copilot CLI, and Visual Studio Code, in addition to Claude Code, Codex, and Cursor.

Clients without an official Stripe plugin marketplace entry use the existing portable Stripe skills installer. Multiple compatible clients share one skills installation and one scope decision, and JSON/status output uses the skills freshness check as the source of truth. Native plugin behavior for Claude Code, Codex, and Cursor is unchanged.

### Testing

- `go test ./pkg/agentsetup ./pkg/cmd -count=1`
- `CGO_ENABLED=1 go test -race ./pkg/agentsetup ./pkg/cmd -run 'TestAgentSetup|TestSkillsClient|TestKimiProvider|TestVSCodeProvider|TestSelectModel' -count=1`\n- `make lint`\n- `go build ./...`\n- Verified `stripe agent setup --help` lists all seven supported client IDs.\n- `go test ./...` reached all packages; unrelated existing/environment-sensitive failures remain in `pkg/cmd/docs` (`TestSearchCommand` ANSI output) and `pkg/login` (`TestLogin` keyring state). The changed packages passed in that run.