### PR TITLE
[sandboxes cli] add workspace context request client

### DIFF
--- a/pkg/requests/workspace_context.go
+++ b/pkg/requests/workspace_context.go
@@ -1,0 +1,38 @@
+package requests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/stripe"
+)
+
+// WorkspaceContext is the response from GET /v1/stripecli/workspace_context.
+type WorkspaceContext struct {
+	WorkspaceID string `json:"workspace_id"`
+}
+
+// GetWorkspaceContext fetches the workspace associated with the active OAuth context.
+func GetWorkspaceContext(ctx context.Context, apiBaseURL string, profile *config.Profile, creds stripe.Credentials, livemode bool) (WorkspaceContext, error) {
+	base := &Base{
+		Profile:        profile,
+		Method:         http.MethodGet,
+		SuppressOutput: true,
+		APIBaseURL:     apiBaseURL,
+		Livemode:       livemode,
+	}
+
+	resp, err := base.MakeRequest(ctx, creds, "/v1/stripecli/workspace_context", &RequestParameters{}, nil, true, nil)
+	if err != nil {
+		return WorkspaceContext{}, err
+	}
+
+	var workspaceContext WorkspaceContext
+	if err := json.Unmarshal(resp, &workspaceContext); err != nil {
+		return WorkspaceContext{}, fmt.Errorf("failed to decode workspace context response: %w", err)
+	}
+	return workspaceContext, nil
+}

--- a/pkg/requests/workspace_context_test.go
+++ b/pkg/requests/workspace_context_test.go
@@ -1,0 +1,67 @@
+package requests
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/stripe"
+)
+
+func TestGetWorkspaceContext(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v1/stripecli/workspace_context", r.URL.Path)
+		require.Empty(t, r.URL.RawQuery)
+		require.Equal(t, "Bearer oak_test_123", r.Header.Get("Authorization"))
+		require.Equal(t, "acct_123", r.Header.Get("Stripe-Context"))
+		require.Equal(t, "true", r.Header.Get("Stripe-Livemode"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Empty(t, body)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"workspace_id":"wksp_live_123"}`))
+	}))
+	defer ts.Close()
+
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_123", true)
+	workspaceContext, err := GetWorkspaceContext(context.Background(), ts.URL, nil, creds, true)
+	require.NoError(t, err)
+	require.Equal(t, WorkspaceContext{WorkspaceID: "wksp_live_123"}, workspaceContext)
+}
+
+func TestGetWorkspaceContext_MalformedJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"workspace_id":`))
+	}))
+	defer ts.Close()
+
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_123", true)
+	_, err := GetWorkspaceContext(context.Background(), ts.URL, nil, creds, true)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to decode workspace context response")
+}
+
+func TestGetWorkspaceContext_Non2xx(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":{"message":"backend unavailable"}}`))
+	}))
+	defer ts.Close()
+
+	creds := stripe.NewOAKCredentials("oak_test_123", "acct_123", true)
+	_, err := GetWorkspaceContext(context.Background(), ts.URL, nil, creds, true)
+	require.Error(t, err)
+
+	var requestErr RequestError
+	require.True(t, errors.As(err, &requestErr))
+	require.Equal(t, http.StatusBadGateway, requestErr.StatusCode)
+}


### PR DESCRIPTION
cc @stripe/sandboxes-engineering 

### Summary

Adds a typed `WorkspaceContext` response and `GetWorkspaceContext` helper for `GET /v1/stripecli/workspace_context`. The helper uses the existing `requests.Base` stack with OAK credentials, active context headers, suppressed output, and no request parameters.

This PR is limited to M3a. It does not add GUAS discovery, sandbox normalization, Cobra list wiring, delete behavior, or OAuth retry changes.

### Test plan

- [x] `go test -count=1 ./pkg/requests -run WorkspaceContext`
- [x] `go test -count=1 ./pkg/requests`
- [x] `make fmt`
- [x] HTTP-fixture coverage for the exact request shape, OAK headers, successful decoding, malformed JSON, and non-2xx responses

### Rollout / revert plan

Safe to revert. The M2 endpoint does not need to be deployed for this fixture-tested transport helper.
