### PR TITLE
[sandboxes cli] add sandbox management client

### DIFF
--- a/pkg/sandbox/management.go
+++ b/pkg/sandbox/management.go
@@ -1,0 +1,255 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/stripe"
+)
+
+const (
+	accessibleSandboxesPath = "/v2/compartments/user_accessible_sandboxes"
+	workspaceIDPrefix       = "wksp_"
+	testmodeWorkspacePrefix = "wksp_test_"
+	accountIDPrefix         = "acct_"
+)
+
+// AccessLevel describes the OAuth account's access in the workspace hierarchy.
+type AccessLevel int
+
+const (
+	AccessLevelDirect          AccessLevel = 1
+	AccessLevelSandboxChildren AccessLevel = 2
+	AccessLevelNone            AccessLevel = 3
+)
+
+// ManagedSandbox is the normalized representation shared by sandbox list and
+// delete. WorkspaceID is retained for later targeting but must not be shown to
+// users.
+type ManagedSandbox struct {
+	WorkspaceID string
+	AccountID   string
+	Name        string
+	AccessLevel AccessLevel
+}
+
+// ManagementClient discovers sandboxes authorized by the active live OAuth
+// account.
+type ManagementClient struct {
+	APIBaseURL string
+	Profile    *config.Profile
+}
+
+// NewManagementClient creates a sandbox management client using the supplied
+// Stripe API base URL and CLI profile.
+func NewManagementClient(apiBaseURL string, profile *config.Profile) *ManagementClient {
+	return &ManagementClient{APIBaseURL: apiBaseURL, Profile: profile}
+}
+
+// ListAccessible resolves the active live OAuth workspace and returns the
+// sandboxes accessible beneath it.
+func (c *ManagementClient) ListAccessible(ctx context.Context) ([]ManagedSandbox, error) {
+	creds, err := c.resolveCredentials()
+	if err != nil {
+		return nil, err
+	}
+
+	workspaceContext, err := requests.GetWorkspaceContext(ctx, c.APIBaseURL, c.Profile, creds, true)
+	if err != nil {
+		return nil, safeDependencyError("could not resolve the active live workspace", err)
+	}
+	if !validLiveWorkspaceID(workspaceContext.WorkspaceID) {
+		return nil, errorcategory.New(errorcategory.API, "could not resolve the active live workspace: the response was invalid")
+	}
+
+	base := &requests.Base{
+		Profile:        c.Profile,
+		Method:         http.MethodGet,
+		SuppressOutput: true,
+		APIBaseURL:     c.APIBaseURL,
+		Livemode:       true,
+	}
+	response, err := base.MakeRequest(
+		ctx,
+		creds,
+		accessibleSandboxesPath,
+		&requests.RequestParameters{},
+		map[string]interface{}{
+			"live_compartment_parent_id":            workspaceContext.WorkspaceID,
+			"recursively_resolve":                   false,
+			"include_legacy_testmode":               false,
+			"check_user_sandbox_management_actions": false,
+			"include_is_dashboard_accessible":       false,
+		},
+		true,
+		nil,
+	)
+	if err != nil {
+		return nil, safeDependencyError("could not list accessible sandboxes", err)
+	}
+
+	var parsed accessibleSandboxesResponse
+	if err := json.Unmarshal(response, &parsed); err != nil {
+		return nil, errorcategory.New(errorcategory.API, "could not list accessible sandboxes: the response was invalid")
+	}
+
+	return normalizeAccessibleSandboxes(parsed)
+}
+
+func (c *ManagementClient) resolveCredentials() (stripe.Credentials, error) {
+	if c == nil || c.Profile == nil {
+		return stripe.Credentials{}, errorcategory.New(errorcategory.Auth, "sandbox management requires an active live OAuth account; run `stripe login` first")
+	}
+
+	creds, err := c.Profile.ResolveCredentials(true)
+	if err != nil {
+		var mismatch *config.ActiveContextLivemodeMismatchError
+		if errors.As(err, &mismatch) {
+			return stripe.Credentials{}, errorcategory.UserInputErrorf("%s", mismatch.Error())
+		}
+		return stripe.Credentials{}, errorcategory.New(errorcategory.Auth, "sandbox management requires an active live OAuth account; run `stripe login` first")
+	}
+
+	if !strings.HasPrefix(creds.Token, "oak_") ||
+		creds.OAKLivemode == nil ||
+		!*creds.OAKLivemode ||
+		!validAccountID(creds.OAKContext) {
+		return stripe.Credentials{}, errorcategory.New(errorcategory.Auth, "sandbox management requires an active live OAuth account; run `stripe login` and select a live account")
+	}
+
+	return creds, nil
+}
+
+type accessibleSandboxesResponse struct {
+	Workspaces    []accessibleSandbox   `json:"workspaces"`
+	Organizations []sandboxOrganization `json:"organizations"`
+}
+
+type sandboxOrganization struct {
+	Workspaces []accessibleSandbox `json:"workspaces"`
+}
+
+type accessibleSandbox struct {
+	WorkspaceID string      `json:"id"`
+	AccountID   string      `json:"merchant_id"`
+	Name        string      `json:"name"`
+	AccessLevel AccessLevel `json:"access_level"`
+}
+
+func normalizeAccessibleSandboxes(response accessibleSandboxesResponse) ([]ManagedSandbox, error) {
+	records := make([]accessibleSandbox, 0, len(response.Workspaces))
+	records = append(records, response.Workspaces...)
+	for _, organization := range response.Organizations {
+		records = append(records, organization.Workspaces...)
+	}
+
+	validated := make([]ManagedSandbox, 0, len(records))
+	for _, record := range records {
+		if !validTestmodeWorkspaceID(record.WorkspaceID) ||
+			!validAccountID(record.AccountID) ||
+			strings.TrimSpace(record.Name) == "" ||
+			record.AccessLevel < AccessLevelDirect ||
+			record.AccessLevel > AccessLevelNone {
+			return nil, errorcategory.New(errorcategory.API, "could not list accessible sandboxes: the response contained an invalid sandbox")
+		}
+
+		validated = append(validated, ManagedSandbox(record))
+	}
+
+	byWorkspaceID := make(map[string]ManagedSandbox, len(validated))
+	for _, sandbox := range validated {
+		if existing, ok := byWorkspaceID[sandbox.WorkspaceID]; ok {
+			if existing != sandbox {
+				return nil, errorcategory.New(errorcategory.API, "could not list accessible sandboxes: the response contained conflicting sandbox records")
+			}
+			continue
+		}
+		byWorkspaceID[sandbox.WorkspaceID] = sandbox
+	}
+
+	result := make([]ManagedSandbox, 0, len(byWorkspaceID))
+	for _, sandbox := range byWorkspaceID {
+		result = append(result, sandbox)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		leftName := strings.ToLower(result[i].Name)
+		rightName := strings.ToLower(result[j].Name)
+		if leftName != rightName {
+			return leftName < rightName
+		}
+		if result[i].AccountID != result[j].AccountID {
+			return result[i].AccountID < result[j].AccountID
+		}
+		return result[i].WorkspaceID < result[j].WorkspaceID
+	})
+
+	return result, nil
+}
+
+func validLiveWorkspaceID(id string) bool {
+	return len(id) > len(workspaceIDPrefix) &&
+		strings.HasPrefix(id, workspaceIDPrefix) &&
+		!strings.HasPrefix(id, testmodeWorkspacePrefix)
+}
+
+func validTestmodeWorkspaceID(id string) bool {
+	return len(id) > len(testmodeWorkspacePrefix) && strings.HasPrefix(id, testmodeWorkspacePrefix)
+}
+
+func validAccountID(id string) bool {
+	return len(id) > len(accountIDPrefix) && strings.HasPrefix(id, accountIDPrefix)
+}
+
+func safeDependencyError(operation string, err error) error {
+	if errors.Is(err, context.Canceled) {
+		return errorcategory.New(errorcategory.Network, operation+": request canceled")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return errorcategory.New(errorcategory.Network, operation+": request timed out")
+	}
+
+	if statusCode, ok := requestStatusCode(err); ok {
+		switch statusCode {
+		case http.StatusUnauthorized:
+			return errorcategory.Errorf(errorcategory.Auth, "%s: OAuth authorization is no longer valid; run `stripe login` or reauthorize the CLI", operation)
+		case http.StatusForbidden:
+			return errorcategory.Errorf(errorcategory.Auth, "%s: the active OAuth account is not authorized; switch context or reauthorize the CLI", operation)
+		case http.StatusTooManyRequests:
+			return errorcategory.Errorf(errorcategory.RateLimit, "%s: too many requests; try again later", operation)
+		default:
+			return errorcategory.Errorf(errorcategory.API, "%s: the Stripe API returned an unavailable response", operation)
+		}
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return errorcategory.Errorf(errorcategory.Network, "%s: network request failed", operation)
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return errorcategory.Errorf(errorcategory.Network, "%s: network request failed", operation)
+	}
+
+	return errorcategory.Errorf(errorcategory.API, "%s: the response was invalid", operation)
+}
+
+func requestStatusCode(err error) (int, bool) {
+	var value requests.RequestError
+	if errors.As(err, &value) {
+		return value.StatusCode, true
+	}
+	var pointer *requests.RequestError
+	if errors.As(err, &pointer) && pointer != nil {
+		return pointer.StatusCode, true
+	}
+	return 0, false
+}

--- a/pkg/sandbox/management_test.go
+++ b/pkg/sandbox/management_test.go
@@ -1,0 +1,339 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/keyring"
+)
+
+func TestManagementClientListAccessible(t *testing.T) {
+	profile := managementTestProfile(t, "acct_live_123", true, "oak_test_123")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "Bearer oak_test_123", r.Header.Get("Authorization"))
+		require.Equal(t, "acct_live_123", r.Header.Get("Stripe-Context"))
+		require.Equal(t, "true", r.Header.Get("Stripe-Livemode"))
+
+		switch r.URL.Path {
+		case "/v1/stripecli/workspace_context":
+			require.Empty(t, r.URL.RawQuery)
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.Empty(t, body)
+			_, _ = w.Write([]byte(`{"workspace_id":"wksp_live_parent"}`))
+		case accessibleSandboxesPath:
+			require.Equal(t, "check_user_sandbox_management_actions=false&include_is_dashboard_accessible=false&include_legacy_testmode=false&live_compartment_parent_id=wksp_live_parent&recursively_resolve=false", r.URL.RawQuery)
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.Empty(t, body)
+			_, _ = w.Write([]byte(`{
+  "workspaces": [
+    {"id":"wksp_test_z","merchant_id":"acct_z","name":"Zeta","access_level":3},
+    {"id":"wksp_test_b","merchant_id":"acct_b","name":"Alpha","access_level":1}
+  ],
+  "organizations": [{"workspaces": [
+    {"id":"wksp_test_a","merchant_id":"acct_a","name":"alpha","access_level":2},
+    {"id":"wksp_test_b","merchant_id":"acct_b","name":"Alpha","access_level":1}
+  ]}]
+}`))
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewManagementClient(server.URL, profile)
+	got, err := client.ListAccessible(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []ManagedSandbox{
+		{WorkspaceID: "wksp_test_a", AccountID: "acct_a", Name: "alpha", AccessLevel: AccessLevelSandboxChildren},
+		{WorkspaceID: "wksp_test_b", AccountID: "acct_b", Name: "Alpha", AccessLevel: AccessLevelDirect},
+		{WorkspaceID: "wksp_test_z", AccountID: "acct_z", Name: "Zeta", AccessLevel: AccessLevelNone},
+	}, got)
+}
+
+func TestManagementClientListAccessibleEmpty(t *testing.T) {
+	profile := managementTestProfile(t, "acct_live_123", true, "oak_test_123")
+	server := managementTestServer(t, `{"workspace_id":"wksp_live_parent"}`, `{"workspaces":[],"organizations":[]}`)
+	defer server.Close()
+
+	got, err := NewManagementClient(server.URL, profile).ListAccessible(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Empty(t, got)
+}
+
+func TestManagementClientReusesProactivelyRefreshedCredentials(t *testing.T) {
+	profile := managementTestProfile(t, "acct_live_123", true, "oak_initial")
+	require.NoError(t, config.SaveUATExpiresAt(time.Now().Add(30*time.Second)))
+	refreshes := 0
+	config.OAuthTokenRefresher = func(p *config.Profile) error {
+		refreshes++
+		p.UAT = "oak_refreshed"
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer oak_refreshed", r.Header.Get("Authorization"))
+		switch r.URL.Path {
+		case "/v1/stripecli/workspace_context":
+			_, _ = w.Write([]byte(`{"workspace_id":"wksp_live_parent"}`))
+		case accessibleSandboxesPath:
+			_, _ = w.Write([]byte(`{"workspaces":[],"organizations":[]}`))
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	_, err := NewManagementClient(server.URL, profile).ListAccessible(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, refreshes)
+}
+
+func TestManagementClientRequiresActiveLiveOAuth(t *testing.T) {
+	tests := []struct {
+		name        string
+		profile     func(*testing.T) *config.Profile
+		category    errorcategory.Category
+		messagePart string
+	}{
+		{
+			name: "api key fallback",
+			profile: func(t *testing.T) *config.Profile {
+				profile := managementTestProfile(t, "acct_live_123", true, "")
+				profile.APIKey = "sk_live_12345"
+				return profile
+			},
+			category: errorcategory.Auth,
+		},
+		{
+			name: "testmode context",
+			profile: func(t *testing.T) *config.Profile {
+				return managementTestProfile(t, "acct_test_123", false, "oak_test_123")
+			},
+			category:    errorcategory.UserInput,
+			messagePart: "switch context",
+		},
+		{
+			name: "missing account context",
+			profile: func(t *testing.T) *config.Profile {
+				return managementTestProfile(t, "", true, "oak_test_123")
+			},
+			category: errorcategory.Auth,
+		},
+		{
+			name: "organization context",
+			profile: func(t *testing.T) *config.Profile {
+				return managementTestProfile(t, "org_123", true, "oak_test_123")
+			},
+			category: errorcategory.Auth,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			profile := test.profile(t)
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+			}))
+			defer server.Close()
+
+			got, err := NewManagementClient(server.URL, profile).ListAccessible(context.Background())
+			require.Error(t, err)
+			require.Nil(t, got)
+			assert.Equal(t, test.category, mustErrorCategory(t, err))
+			if test.messagePart != "" {
+				assert.Contains(t, err.Error(), test.messagePart)
+			}
+			assert.Equal(t, 0, requests)
+			assert.NotContains(t, err.Error(), "oak_")
+			assert.NotContains(t, err.Error(), "acct_")
+		})
+	}
+}
+
+func TestManagementClientRejectsInvalidWorkspaceContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "malformed JSON", response: `{"workspace_id":`},
+		{name: "missing workspace", response: `{}`},
+		{name: "not a workspace", response: `{"workspace_id":"acct_live_123"}`},
+		{name: "testmode workspace", response: `{"workspace_id":"wksp_test_123"}`},
+		{name: "prefix without an identifier", response: `{"workspace_id":"wksp_"}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			profile := managementTestProfile(t, "acct_live_123", true, "oak_test_123")
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				require.Equal(t, "/v1/stripecli/workspace_context", r.URL.Path)
+				_, _ = w.Write([]byte(test.response))
+			}))
+			defer server.Close()
+
+			got, err := NewManagementClient(server.URL, profile).ListAccessible(context.Background())
+			require.Error(t, err)
+			require.Nil(t, got)
+			assert.Equal(t, errorcategory.API, mustErrorCategory(t, err))
+			assert.Equal(t, 1, requests)
+			assert.NotContains(t, err.Error(), "wksp_")
+			assert.NotContains(t, err.Error(), "acct_")
+		})
+	}
+}
+
+func TestManagementClientRejectsInvalidSandboxResponses(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "malformed JSON", response: `{"workspaces":`},
+		{name: "missing workspace id", response: `{"workspaces":[{"merchant_id":"acct_1","name":"one","access_level":1}]}`},
+		{name: "missing account id", response: `{"workspaces":[{"id":"wksp_test_1","name":"one","access_level":1}]}`},
+		{name: "missing name", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","access_level":1}]}`},
+		{name: "live workspace", response: `{"workspaces":[{"id":"wksp_live_1","merchant_id":"acct_1","name":"one","access_level":1}]}`},
+		{name: "zero access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":0}]}`},
+		{name: "unknown access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":4}]}`},
+		{name: "string access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":"DIRECT"}]}`},
+		{name: "conflicting duplicate", response: `{"workspaces":[
+  {"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":1},
+  {"id":"wksp_test_1","merchant_id":"acct_2","name":"one","access_level":1}
+]}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			profile := managementTestProfile(t, "acct_live_123", true, "oak_test_123")
+			server := managementTestServer(t, `{"workspace_id":"wksp_live_parent"}`, test.response)
+			defer server.Close()
+
+			got, err := NewManagementClient(server.URL, profile).ListAccessible(context.Background())
+			require.Error(t, err)
+			require.Nil(t, got)
+			assert.Equal(t, errorcategory.API, mustErrorCategory(t, err))
+			assert.NotContains(t, err.Error(), "sentinel")
+			assert.NotContains(t, err.Error(), "wksp_")
+			assert.NotContains(t, err.Error(), "acct_")
+		})
+	}
+}
+
+func TestManagementClientSanitizesDependencyErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		stage    string
+		status   int
+		category errorcategory.Category
+	}{
+		{name: "M2 unauthorized", stage: "M2", status: http.StatusUnauthorized, category: errorcategory.Auth},
+		{name: "M2 forbidden", stage: "M2", status: http.StatusForbidden, category: errorcategory.Auth},
+		{name: "M2 not found", stage: "M2", status: http.StatusNotFound, category: errorcategory.API},
+		{name: "M2 rate limited", stage: "M2", status: http.StatusTooManyRequests, category: errorcategory.RateLimit},
+		{name: "M2 backend failure", stage: "M2", status: http.StatusBadGateway, category: errorcategory.API},
+		{name: "GUAS unauthorized", stage: "GUAS", status: http.StatusUnauthorized, category: errorcategory.Auth},
+		{name: "GUAS forbidden", stage: "GUAS", status: http.StatusForbidden, category: errorcategory.Auth},
+		{name: "GUAS not found", stage: "GUAS", status: http.StatusNotFound, category: errorcategory.API},
+		{name: "GUAS rate limited", stage: "GUAS", status: http.StatusTooManyRequests, category: errorcategory.RateLimit},
+		{name: "GUAS backend failure", stage: "GUAS", status: http.StatusBadGateway, category: errorcategory.API},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			profile := managementTestProfile(t, "acct_live_123", true, "oak_test_123")
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if test.stage == "M2" || r.URL.Path == "/v1/stripecli/workspace_context" {
+					if test.stage == "M2" {
+						w.WriteHeader(test.status)
+						_, _ = w.Write([]byte(`{"error":{"message":"sentinel response acct_secret wksp_secret"}}`))
+						return
+					}
+					_, _ = w.Write([]byte(`{"workspace_id":"wksp_live_parent"}`))
+					return
+				}
+
+				w.WriteHeader(test.status)
+				_, _ = w.Write([]byte(`{"error":{"message":"sentinel response acct_secret wksp_secret"}}`))
+			}))
+			defer server.Close()
+
+			got, err := NewManagementClient(server.URL, profile).ListAccessible(context.Background())
+			require.Error(t, err)
+			require.Nil(t, got)
+			assert.Equal(t, test.category, mustErrorCategory(t, err))
+			assert.NotContains(t, err.Error(), "sentinel")
+			assert.NotContains(t, err.Error(), "acct_secret")
+			assert.NotContains(t, err.Error(), "wksp_secret")
+		})
+	}
+}
+
+func TestManagementClientSanitizesTransportErrors(t *testing.T) {
+	profile := managementTestProfile(t, "acct_live_123", true, "oak_test_123")
+	server := httptest.NewServer(http.NotFoundHandler())
+	serverURL := server.URL
+	server.Close()
+
+	got, err := NewManagementClient(serverURL, profile).ListAccessible(context.Background())
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Equal(t, errorcategory.Network, mustErrorCategory(t, err))
+	assert.NotContains(t, err.Error(), serverURL)
+}
+
+func managementTestProfile(t *testing.T, accountID string, livemode bool, token string) *config.Profile {
+	t.Helper()
+	activeContext, err := json.Marshal(config.ActiveContext{AccountID: accountID, Livemode: livemode})
+	require.NoError(t, err)
+
+	previousKeyRing := config.KeyRing
+	previousRefresher := config.OAuthTokenRefresher
+	config.KeyRing = keyring.NewMemoryStore(map[string][]byte{
+		config.UATKeychainItemKey:            []byte(token),
+		config.OAuthActiveContextKeychainKey: activeContext,
+	})
+	config.OAuthTokenRefresher = nil
+	t.Cleanup(func() {
+		config.KeyRing = previousKeyRing
+		config.OAuthTokenRefresher = previousRefresher
+	})
+
+	return &config.Profile{ProfileName: "default"}
+}
+
+func managementTestServer(t *testing.T, workspaceResponse, sandboxesResponse string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/stripecli/workspace_context":
+			_, _ = w.Write([]byte(workspaceResponse))
+		case accessibleSandboxesPath:
+			_, _ = w.Write([]byte(sandboxesResponse))
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+}
+
+func mustErrorCategory(t *testing.T, err error) errorcategory.Category {
+	t.Helper()
+	category, ok := errorcategory.Get(err)
+	require.True(t, ok)
+	return category
+}


### PR DESCRIPTION
cc @stripe/sandboxes-engineering 
https://jira.corp.stripe.com/browse/SBX-4098

## Summary and motivation

Adds the shared OAuth sandbox management client used by the upcoming hidden `sandbox list` and `sandbox delete` commands. It requires an active livemode OAuth account, resolves the live workspace through the typed M2 helper, queries GUAS with the planned constrained request, and normalizes nested results into deterministic, safe-to-consume models.

This PR intentionally contains no Cobra wiring, presentation, or changes to the existing create and delete POC helpers.

## Test plan

- [x] `go test ./pkg/sandbox -count=1`
- [x] `go test ./pkg/requests ./pkg/sandbox -count=1`
- [x] `go test -race ./pkg/requests ./pkg/sandbox -count=1`
- [x] `go vet ./pkg/requests ./pkg/sandbox`
- [x] `make fmt`
- [x] `make lint`

## Rollout/revert plan

Safe to revert. The new client is not wired into a command in this PR.
