### PR TITLE
[sandboxes cli] add sandbox list command

### DIFF
--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -483,11 +483,14 @@ type sandboxNewCmd struct {
 	apiBase          string
 }
 
+type sandboxListClient interface {
+	ListAccessible(context.Context) ([]sandbox.ManagedSandbox, error)
+}
+
 type sandboxListCmd struct {
-	cmd           *cobra.Command
-	stripeAccount string
-	stripeVersion string
-	apiBase       string
+	cmd     *cobra.Command
+	apiBase string
+	client  sandboxListClient
 }
 
 type sandboxDeleteCmd struct {
@@ -946,140 +949,30 @@ func newSandboxListCmd() *sandboxListCmd {
 		Hidden: true,
 	}
 
-	slc.cmd.Flags().StringVar(&slc.stripeAccount, "stripe-account", "", "Live account (acct_...) whose sandboxes to list; defaults to your logged-in account")
-	slc.cmd.Flags().StringVar(&slc.stripeVersion, "stripe-version", requests.StripeVersionHeaderValue, "Sets the Stripe-Version header")
-	_ = slc.cmd.Flags().MarkHidden("stripe-version")
-
 	slc.cmd.Flags().StringVar(&slc.apiBase, "api-base", stripe.DefaultAPIBaseURL, "Sets the Stripe API base URL")
 	_ = slc.cmd.Flags().MarkHidden("api-base")
 
 	return slc
 }
 
-//nolint:gocyclo // The hidden POC keeps OAuth and legacy fallback paths together until M3c.
 func (slc *sandboxListCmd) runSandboxListCmd(cmd *cobra.Command, args []string) error {
-	if config.KeyRing == nil {
-		return errorcategory.Errorf(errorcategory.Auth, "credential store unavailable; run `stripe login` first")
-	}
-	uatBytes, err := config.KeyRing.Get(config.UATKeychainItemKey)
-	if err != nil || len(uatBytes) == 0 {
-		return errorcategory.Errorf(errorcategory.Auth, "no user access token found; run `stripe login` first")
-	}
-	uat := strings.TrimSpace(string(uatBytes))
-
-	stripeAccount := strings.TrimSpace(slc.stripeAccount)
-	if stripeAccount != "" {
-		if strings.HasPrefix(stripeAccount, "org_") {
-			return errorcategory.Errorf(errorcategory.UserInput, "--stripe-account must be an account (acct_...), not an organization (org_...)")
-		}
-		if !strings.HasPrefix(stripeAccount, "acct_") {
-			return errorcategory.Errorf(errorcategory.UserInput, "--stripe-account must be an account id (acct_...), got %q", stripeAccount)
-		}
+	client := slc.client
+	if client == nil {
+		client = sandbox.NewManagementClient(slc.apiBase, Config.GetProfile())
 	}
 
-	baseURL, err := url.Parse(slc.apiBase)
-	if err != nil {
-		return fmt.Errorf("invalid --api-base %q: %w", slc.apiBase, err)
-	}
-
-	oauthAccounts, isOAuth, err := slc.oauthAuthorizedAccounts(cmd.Context())
-	if err != nil {
-		return err
-	}
-	if isOAuth {
-		return slc.printOAuthSandboxes(cmd, oauthAccounts, stripeAccount)
-	}
-
-	client := &stripe.Client{
-		BaseURL: baseURL,
-	}
-
-	authConfigure := func(req *http.Request) error {
-		req.Header.Set("Authorization", "STRIPE-V2-SIG "+uat)
-		req.Header.Set("Stripe-Version", slc.stripeVersion)
-		req.Header.Set("Content-Type", stripe.V2ContentType)
-		return nil
-	}
-
-	// Fetch accessible workspaces once and build maps for translation
-	accessible, err := fetchAccessibleWorkspaces(cmd.Context(), client, authConfigure)
-	if err != nil {
-		return err
-	}
-	acctByWksp := make(map[string]string, len(accessible))
-	nameByWksp := make(map[string]string, len(accessible))
-	for _, w := range accessible {
-		if w.ID != "" {
-			acctByWksp[w.ID] = w.MerchantID
-			nameByWksp[w.ID] = w.Name
-		}
-	}
-
-	// Resolve the live parent (workspace id, acct_, and name)
-	var liveWorkspace, liveAccount, liveName string
-	if stripeAccount != "" {
-		for _, w := range accessible {
-			if w.MerchantID == stripeAccount && strings.HasPrefix(w.ID, "wksp_") {
-				liveWorkspace, liveName = w.ID, w.Name
-				break
-			}
-		}
-		if liveWorkspace == "" {
-			return errorcategory.Errorf(errorcategory.UserInput, "no accessible live account matches %s; check the id or run `stripe login` again", stripeAccount)
-		}
-		liveAccount = stripeAccount
-	} else {
-		liveWorkspace, err = resolveLiveWorkspace(cmd.Context(), client, authConfigure)
-		if err != nil {
-			return err
-		}
-		liveAccount = acctByWksp[liveWorkspace]
-		liveName = nameByWksp[liveWorkspace]
-	}
-	if !strings.HasPrefix(liveWorkspace, "wksp_") {
-		return errorcategory.Errorf(errorcategory.API, "resolved live parent %q is not a workspace (wksp_...)", liveWorkspace)
-	}
-
-	// Transparency line (stderr): prefer name, then acct_, never show wksp_ unless nothing else
-	switch {
-	case liveName != "":
-		fmt.Fprintf(cmd.ErrOrStderr(), "Listing sandboxes under live account %q (%s)\n", liveName, liveAccount)
-	case liveAccount != "":
-		fmt.Fprintf(cmd.ErrOrStderr(), "Listing sandboxes under live account %s\n", liveAccount)
-	default:
-		fmt.Fprintf(cmd.ErrOrStderr(), "Listing sandboxes under live workspace %s\n", liveWorkspace)
-	}
-
-	query := "live_compartment_parent_id=" + url.QueryEscape(liveWorkspace)
-	resp, err := client.PerformRequest(cmd.Context(), http.MethodGet, "/v2/compartments/user_accessible_sandboxes", query, authConfigure)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	respBytes, err := io.ReadAll(resp.Body)
+	sandboxes, err := client.ListAccessible(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return errorcategory.Errorf(errorcategory.API, "list sandboxes failed: %s\n%s", resp.Status, string(respBytes))
-	}
-
-	var parsed struct {
-		Workspaces    []accessibleWorkspace `json:"workspaces"`
-		Organizations []struct {
-			Workspaces []accessibleWorkspace `json:"workspaces"`
-		} `json:"organizations"`
-	}
-	if err := json.Unmarshal(respBytes, &parsed); err != nil {
-		return fmt.Errorf("could not parse sandboxes response: %w", err)
-	}
-
-	var sandboxes []accessibleWorkspace
-	sandboxes = append(sandboxes, parsed.Workspaces...)
-	for _, org := range parsed.Organizations {
-		sandboxes = append(sandboxes, org.Workspaces...)
+	accessLevels := make([]string, len(sandboxes))
+	for i, managedSandbox := range sandboxes {
+		var ok bool
+		accessLevels[i], ok = sandboxAccessLevelLabel(managedSandbox.AccessLevel)
+		if !ok {
+			return errorcategory.New(errorcategory.API, "could not render sandbox list: the response contained an invalid access level")
+		}
 	}
 
 	if len(sandboxes) == 0 {
@@ -1088,101 +981,24 @@ func (slc *sandboxListCmd) runSandboxListCmd(cmd *cobra.Command, args []string) 
 	}
 
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ACCOUNT\tNAME\tREPLICA OF")
-	for _, s := range sandboxes {
-		replicaAcct := ""
-		if s.ReplicaOf != "" {
-			replicaAcct = acctByWksp[s.ReplicaOf] // parent's acct_; empty if not found — never show wksp_
-		}
-		fmt.Fprintf(w, "%s\t%s\t%s\n", s.MerchantID, s.Name, replicaAcct)
-	}
-	w.Flush()
-
-	return nil
-}
-
-func (slc *sandboxListCmd) oauthAuthorizedAccounts(ctx context.Context) ([]config.AuthorizedAccount, bool, error) {
-	uat, err := Config.Profile.GetUAT()
-	if err != nil {
-		return nil, false, err
-	}
-	if !strings.HasPrefix(uat, "oak_") {
-		return nil, false, nil
-	}
-
-	livemode := true
-	activeContext, err := config.GetActiveContext()
-	if err != nil {
-		return nil, true, err
-	}
-	if activeContext != nil {
-		livemode = activeContext.Livemode
-	}
-
-	credentials, err := Config.Profile.ResolveCredentials(livemode)
-	if err != nil {
-		return nil, true, err
-	}
-	accessBaseURL := Config.Profile.OAuthAccessBaseURL
-	if accessBaseURL == "" {
-		accessBaseURL = login.DefaultAccessBaseURL
-	}
-	accounts, err := login.ListAuthorizedAccounts(ctx, accessBaseURL, credentials.Token)
-	if err == nil || !login.IsAuthorizedAccountsUnauthorized(err) || config.OAuthTokenRefresher == nil {
-		return accounts, true, err
-	}
-
-	if err := config.OAuthTokenRefresher(&Config.Profile); err != nil {
-		return nil, true, err
-	}
-	credentials, err = Config.Profile.ResolveCredentials(livemode)
-	if err != nil {
-		return nil, true, err
-	}
-	accounts, err = login.ListAuthorizedAccounts(ctx, accessBaseURL, credentials.Token)
-	return accounts, true, err
-}
-
-func (slc *sandboxListCmd) printOAuthSandboxes(cmd *cobra.Command, accounts []config.AuthorizedAccount, stripeAccount string) error {
-	if stripeAccount != "" {
-		isAuthorizedLiveAccount := false
-		for _, account := range accounts {
-			if account.ID == stripeAccount && authorizedAccountHasMode(account, "live") {
-				isAuthorizedLiveAccount = true
-				break
-			}
-		}
-		if !isAuthorizedLiveAccount {
-			return errorcategory.Errorf(errorcategory.Auth, "no accessible live account matches %s; check the id or run `stripe login` again", stripeAccount)
-		}
-	}
-
-	var sandboxes []config.AuthorizedAccount
-	for _, account := range accounts {
-		if authorizedAccountHasMode(account, "test") && !authorizedAccountHasMode(account, "live") {
-			sandboxes = append(sandboxes, account)
-		}
-	}
-	if len(sandboxes) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "No sandboxes found.")
-		return nil
-	}
-
-	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ACCOUNT\tNAME\tREPLICA OF")
-	for _, account := range sandboxes {
-		fmt.Fprintf(w, "%s\t%s\t\n", account.ID, account.Name)
+	fmt.Fprintln(w, "NAME\tACCOUNT\tACCESS LEVEL")
+	for i, managedSandbox := range sandboxes {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", managedSandbox.Name, managedSandbox.AccountID, accessLevels[i])
 	}
 	return w.Flush()
 }
 
-func authorizedAccountHasMode(account config.AuthorizedAccount, mode string) bool {
-	for _, accountMode := range account.Modes {
-		if accountMode == mode {
-			return true
-		}
+func sandboxAccessLevelLabel(accessLevel sandbox.AccessLevel) (string, bool) {
+	switch accessLevel {
+	case sandbox.AccessLevelDirect:
+		return "DIRECT_ACCESS", true
+	case sandbox.AccessLevelSandboxChildren:
+		return "ACCESS_TO_SANDBOX_CHILDREN", true
+	case sandbox.AccessLevelNone:
+		return "NO_ACCESS", true
+	default:
+		return "", false
 	}
-	return false
 }
 
 func newSandboxDeleteCmd() *sandboxDeleteCmd {

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -1440,357 +1439,97 @@ func TestSandboxNewCmd_StripeAccountRejectsOrg(t *testing.T) {
 	assert.Contains(t, err.Error(), "not an organization")
 }
 
-func TestSandboxListCmd_ByStripeAccount(t *testing.T) {
-	cleanup := setupSandboxTestConfig(t)
-	defer cleanup()
-
-	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
-	require.NoError(t, err)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
-			assert.Equal(t, "STRIPE-V2-SIG keyinfo_live_faketoken", r.Header.Get("Authorization"))
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"standalone_workspaces": []map[string]interface{}{
-					{"id": "wksp_target", "name": "Acme", "merchant_id": "acct_target"},
-				},
-			})
-		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible_sandboxes":
-			if r.URL.RawQuery != "live_compartment_parent_id=wksp_target" {
-				t.Errorf("expected live_compartment_parent_id=wksp_target, got %s", r.URL.RawQuery)
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"workspaces": []map[string]interface{}{
-					{"id": "wksp_test_a", "name": "sbxA", "merchant_id": "acct_a", "replica_of": "wksp_target"},
-					{"id": "wksp_test_b", "name": "sbxB", "merchant_id": "acct_b", "replica_of": "wksp_target"},
-				},
-			})
-		default:
-			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-
-	output, err := executeCommand(
-		rootCmd,
-		"sandbox", "list",
-		"--api-base="+server.URL,
-		"--stripe-account=acct_target",
-	)
-
-	require.NoError(t, err)
-	assert.Contains(t, output, "acct_a")
-	assert.Contains(t, output, "acct_b")
-	assert.Contains(t, output, "sbxA")
-	assert.Contains(t, output, "sbxB")
-	assert.Contains(t, output, "acct_target")
-	assert.NotContains(t, output, "wksp_")
+type fakeSandboxListClient struct {
+	sandboxes []sandbox.ManagedSandbox
+	err       error
 }
 
-func TestSandboxListCmd_AutoResolve(t *testing.T) {
-	cleanup := setupSandboxTestConfig(t)
-	defer cleanup()
-
-	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
-	require.NoError(t, err)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"standalone_workspaces": []map[string]interface{}{
-					{"id": "wksp_solo", "name": "Solo", "merchant_id": "acct_solo"},
-				},
-			})
-		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible_sandboxes":
-			if r.URL.RawQuery != "live_compartment_parent_id=wksp_solo" {
-				t.Errorf("expected live_compartment_parent_id=wksp_solo, got %s", r.URL.RawQuery)
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"workspaces": []map[string]interface{}{
-					{"id": "wksp_child", "name": "ChildSbx", "merchant_id": "acct_child", "replica_of": "wksp_solo"},
-				},
-			})
-		default:
-			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-
-	output, err := executeCommand(
-		rootCmd,
-		"sandbox", "list",
-		"--api-base="+server.URL,
-		"--stripe-account=",
-	)
-
-	require.NoError(t, err)
-	assert.Contains(t, output, "acct_child")
-	assert.Contains(t, output, "ChildSbx")
-	assert.Contains(t, output, "acct_solo")
-	assert.NotContains(t, output, "wksp_")
+func (f fakeSandboxListClient) ListAccessible(context.Context) ([]sandbox.ManagedSandbox, error) {
+	return f.sandboxes, f.err
 }
 
-func TestSandboxListCmd_OrgNestedSandboxes(t *testing.T) {
-	cleanup := setupSandboxTestConfig(t)
-	defer cleanup()
+func TestSandboxListCmd_PresentsSandboxes(t *testing.T) {
+	cmd := newSandboxListCmd()
+	cmd.client = fakeSandboxListClient{
+		sandboxes: []sandbox.ManagedSandbox{
+			{WorkspaceID: "wksp_test_z", AccountID: "acct_z", Name: "Zeta", AccessLevel: sandbox.AccessLevelNone},
+			{WorkspaceID: "wksp_test_a", AccountID: "acct_a", Name: "Alpha", AccessLevel: sandbox.AccessLevelDirect},
+			{WorkspaceID: "wksp_test_b", AccountID: "acct_b", Name: "Beta", AccessLevel: sandbox.AccessLevelSandboxChildren},
+		},
+	}
 
-	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
-	require.NoError(t, err)
+	var stdout, stderr bytes.Buffer
+	cmd.cmd.SetOut(&stdout)
+	cmd.cmd.SetErr(&stderr)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible":
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"standalone_workspaces": []map[string]interface{}{
-					{"id": "wksp_target", "name": "Target", "merchant_id": "acct_target"},
-				},
-			})
-		case r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible_sandboxes":
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"workspaces": []map[string]interface{}{},
-				"organizations": []map[string]interface{}{
-					{
-						"workspaces": []map[string]interface{}{
-							{"id": "wksp_test_org", "name": "orgsbx", "merchant_id": "acct_o", "replica_of": "wksp_target"},
-						},
-					},
-				},
-			})
-		default:
-			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
+	require.NoError(t, cmd.cmd.Execute())
 
-	output, err := executeCommand(
-		rootCmd,
-		"sandbox", "list",
-		"--api-base="+server.URL,
-		"--stripe-account=acct_target",
-	)
-
-	require.NoError(t, err)
-	assert.Contains(t, output, "acct_o")
-	assert.Contains(t, output, "orgsbx")
-	assert.Contains(t, output, "acct_target")
-	assert.NotContains(t, output, "wksp_")
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	require.Len(t, lines, 4)
+	assert.Equal(t, []string{"NAME", "ACCOUNT", "ACCESS", "LEVEL"}, strings.Fields(lines[0]))
+	assert.Equal(t, []string{"Zeta", "acct_z", "NO_ACCESS"}, strings.Fields(lines[1]))
+	assert.Equal(t, []string{"Alpha", "acct_a", "DIRECT_ACCESS"}, strings.Fields(lines[2]))
+	assert.Equal(t, []string{"Beta", "acct_b", "ACCESS_TO_SANDBOX_CHILDREN"}, strings.Fields(lines[3]))
+	assert.NotContains(t, stdout.String(), "wksp_")
+	assert.Empty(t, stderr.String())
 }
 
 func TestSandboxListCmd_Empty(t *testing.T) {
-	cleanup := setupSandboxTestConfig(t)
-	defer cleanup()
-
-	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
-	require.NoError(t, err)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible" {
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"standalone_workspaces": []map[string]interface{}{
-					{"id": "wksp_solo", "name": "Solo", "merchant_id": "acct_solo"},
-				},
-			})
-			return
-		}
-		if r.Method == http.MethodGet && r.URL.Path == "/v2/compartments/user_accessible_sandboxes" {
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"workspaces":    []map[string]interface{}{},
-				"organizations": []map[string]interface{}{},
-			})
-			return
-		}
-		t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer server.Close()
-
-	output, err := executeCommand(
-		rootCmd,
-		"sandbox", "list",
-		"--api-base="+server.URL,
-		"--stripe-account=",
-	)
-
-	require.NoError(t, err)
-	assert.Contains(t, output, "No sandboxes found")
-}
-
-func TestSandboxListCmd_OAuthListsOnlyTestOnlyAccounts(t *testing.T) {
-	cleanup := setupSandboxTestConfig(t)
-	defer cleanup()
-
-	require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte("oak_list_test"), "test uat"))
-	require.NoError(t, config.SaveActiveContext("acct_live", true))
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "Bearer oak_list_test", r.Header.Get("Authorization"))
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"accounts": []map[string]interface{}{
-				{"id": "acct_live", "name": "Live account", "modes": []string{"live", "test"}},
-				{"id": "acct_sandbox", "name": "Authorized sandbox", "modes": []string{"test"}},
-				{"id": "acct_live_only", "name": "Live only", "modes": []string{"live"}},
-			},
-		})
-	}))
-	defer server.Close()
-
-	originalAccessBaseURL := Config.Profile.OAuthAccessBaseURL
-	Config.Profile.OAuthAccessBaseURL = server.URL
-	t.Cleanup(func() { Config.Profile.OAuthAccessBaseURL = originalAccessBaseURL })
-
 	cmd := newSandboxListCmd()
-	var output bytes.Buffer
-	cmd.cmd.SetOut(&output)
+	cmd.client = fakeSandboxListClient{sandboxes: []sandbox.ManagedSandbox{}}
+
+	var stdout, stderr bytes.Buffer
+	cmd.cmd.SetOut(&stdout)
+	cmd.cmd.SetErr(&stderr)
+
 	require.NoError(t, cmd.cmd.Execute())
-	assert.Contains(t, output.String(), "acct_sandbox")
-	assert.Contains(t, output.String(), "Authorized sandbox")
-	assert.NotContains(t, output.String(), "acct_live")
-	assert.NotContains(t, output.String(), "Live only")
+
+	assert.Equal(t, "No sandboxes found.\n", stdout.String())
+	assert.Empty(t, stderr.String())
 }
 
-func TestSandboxListCmd_OAuthValidatesExplicitLiveAccount(t *testing.T) {
-	cleanup := setupSandboxTestConfig(t)
-	defer cleanup()
-
-	require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte("oak_list_test"), "test uat"))
-	require.NoError(t, config.SaveActiveContext("acct_live", true))
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"accounts": []map[string]interface{}{
-				{"id": "acct_live", "name": "Live account", "modes": []string{"live", "test"}},
-				{"id": "acct_sandbox", "name": "Authorized sandbox", "modes": []string{"test"}},
-			},
-		})
-	}))
-	defer server.Close()
-
-	originalAccessBaseURL := Config.Profile.OAuthAccessBaseURL
-	Config.Profile.OAuthAccessBaseURL = server.URL
-	t.Cleanup(func() { Config.Profile.OAuthAccessBaseURL = originalAccessBaseURL })
-
+func TestSandboxListCmd_ClientError(t *testing.T) {
 	cmd := newSandboxListCmd()
-	cmd.stripeAccount = "acct_sandbox"
-	cmd.cmd.SetContext(context.Background())
-	err := cmd.runSandboxListCmd(cmd.cmd, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no accessible live account matches acct_sandbox")
+	cmd.client = fakeSandboxListClient{err: fmt.Errorf("could not list accessible sandboxes")}
+
+	var stdout, stderr bytes.Buffer
+	cmd.cmd.SetOut(&stdout)
+	cmd.cmd.SetErr(&stderr)
+	cmd.cmd.SilenceUsage = true
+	cmd.cmd.SilenceErrors = true
+
+	err := cmd.cmd.Execute()
+	require.EqualError(t, err, "could not list accessible sandboxes")
+	assert.Empty(t, stdout.String())
+	assert.Empty(t, stderr.String())
 }
 
-func TestSandboxListCmd_OAuthProactivelyRefreshesToken(t *testing.T) {
-	cleanup := setupSandboxTestConfig(t)
-	defer cleanup()
+func TestSandboxListCmd_Surface(t *testing.T) {
+	cmd := newSandboxListCmd()
+	assert.True(t, cmd.cmd.Hidden)
+	require.NotNil(t, cmd.cmd.Flags().Lookup("api-base"))
+	assert.Nil(t, cmd.cmd.Flags().Lookup("stripe-account"))
+	assert.Nil(t, cmd.cmd.Flags().Lookup("stripe-version"))
 
-	require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte("oak_expiring"), "test uat"))
-	require.NoError(t, config.SaveActiveContext("acct_live", true))
-	require.NoError(t, config.SaveUATExpiresAt(time.Now().Add(30*time.Second)))
+	var stdout, stderr bytes.Buffer
+	cmd.client = fakeSandboxListClient{}
+	cmd.cmd.SetOut(&stdout)
+	cmd.cmd.SetErr(&stderr)
+	cmd.cmd.SilenceUsage = true
+	cmd.cmd.SilenceErrors = true
+	cmd.cmd.SetArgs([]string{"--api-base=http://example.test"})
+	require.NoError(t, cmd.cmd.Execute())
+	assert.Equal(t, "No sandboxes found.\n", stdout.String())
+	assert.Empty(t, stderr.String())
 
-	originalRefresher := config.OAuthTokenRefresher
-	refreshes := 0
-	config.OAuthTokenRefresher = func(profile *config.Profile) error {
-		refreshes++
-		profile.UAT = "oak_refreshed"
-		require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte(profile.UAT), "refreshed uat"))
-		return config.SaveUATExpiresAt(time.Now().Add(time.Hour))
+	for _, args := range [][]string{{"acct_123"}, {"--stripe-account=acct_123"}, {"--stripe-version=2026-01-01"}} {
+		cmd := newSandboxListCmd()
+		cmd.client = fakeSandboxListClient{}
+		cmd.cmd.SilenceUsage = true
+		cmd.cmd.SilenceErrors = true
+		cmd.cmd.SetArgs(args)
+		require.Error(t, cmd.cmd.Execute())
 	}
-	t.Cleanup(func() { config.OAuthTokenRefresher = originalRefresher })
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "Bearer oak_refreshed", r.Header.Get("Authorization"))
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{"accounts": []map[string]interface{}{}})
-	}))
-	defer server.Close()
-
-	originalAccessBaseURL := Config.Profile.OAuthAccessBaseURL
-	Config.Profile.OAuthAccessBaseURL = server.URL
-	t.Cleanup(func() { Config.Profile.OAuthAccessBaseURL = originalAccessBaseURL })
-
-	cmd := newSandboxListCmd()
-	cmd.cmd.SetContext(context.Background())
-	require.NoError(t, cmd.runSandboxListCmd(cmd.cmd, nil))
-	assert.Equal(t, 1, refreshes)
-}
-
-func TestSandboxListCmd_OAuthRetriesUnauthorizedOnce(t *testing.T) {
-	cleanup := setupSandboxTestConfig(t)
-	defer cleanup()
-
-	require.NoError(t, config.KeyRing.Set(config.UATKeychainItemKey, []byte("oak_expired"), "test uat"))
-	require.NoError(t, config.SaveActiveContext("acct_live", true))
-
-	originalRefresher := config.OAuthTokenRefresher
-	refreshes := 0
-	config.OAuthTokenRefresher = func(profile *config.Profile) error {
-		refreshes++
-		profile.UAT = "oak_refreshed"
-		return config.KeyRing.Set(config.UATKeychainItemKey, []byte(profile.UAT), "refreshed uat")
-	}
-	t.Cleanup(func() { config.OAuthTokenRefresher = originalRefresher })
-
-	requests := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests++
-		w.WriteHeader(http.StatusUnauthorized)
-		json.NewEncoder(w).Encode(map[string]interface{}{"error": "unauthorized"})
-	}))
-	defer server.Close()
-
-	originalAccessBaseURL := Config.Profile.OAuthAccessBaseURL
-	Config.Profile.OAuthAccessBaseURL = server.URL
-	t.Cleanup(func() { Config.Profile.OAuthAccessBaseURL = originalAccessBaseURL })
-
-	cmd := newSandboxListCmd()
-	cmd.cmd.SetContext(context.Background())
-	err := cmd.runSandboxListCmd(cmd.cmd, nil)
-	require.Error(t, err)
-	assert.Equal(t, 1, refreshes)
-	assert.Equal(t, 2, requests)
-}
-
-func TestSandboxListCmd_RejectsOrg(t *testing.T) {
-	cleanup := setupSandboxTestConfig(t)
-	defer cleanup()
-
-	err := config.KeyRing.Set(config.UATKeychainItemKey, []byte("keyinfo_live_faketoken"), "test uat")
-	require.NoError(t, err)
-
-	_, err = executeCommand(
-		rootCmd,
-		"sandbox", "list",
-		"--stripe-account=org_123",
-	)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not an organization")
-}
-
-func TestSandboxListCmd_NoUAT(t *testing.T) {
-	cleanup := setupSandboxTestConfig(t)
-	defer cleanup()
-
-	_, err := executeCommand(
-		rootCmd,
-		"sandbox", "list",
-	)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "stripe login")
 }
 
 func TestSandboxDeleteCmd_Success(t *testing.T) {


### PR DESCRIPTION
### Summary

Wire the hidden OAuth `stripe sandbox list` command to the merged sandbox management client. Render the agreed `NAME`, `ACCOUNT`, and `ACCESS LEVEL` columns with canonical access-level labels while preserving the client's deterministic ordering.

cc @stripe/sandboxes-engineering 
https://jira.corp.stripe.com/browse/SBX-4100

### Motivation

Replace the temporary list-only account heuristic and raw request path with the shared active-live OAuth and GUAS discovery flow from M3b. Keep the create and delete proof-of-concept helpers unchanged.

### Test plan

- [x] All changes in PR are covered by tests
- [x] Failures and edge cases tested

Validated with the cached Go 1.26.7 toolchain:

- `go test ./pkg/cmd -run '^TestSandboxListCmd_' -count=1`
- `go test ./pkg/cmd -count=1`
- `go test ./pkg/sandbox -count=1`
- `go test ./pkg/cmd ./pkg/sandbox -count=1`
- `make fmt`
- `make lint`

The hidden list flow has not been tested end to end against QA. M2 deployment remains the integration gate for workspace resolution, OAuth authorization, GUAS, and CLI rendering.

### Rollout/revert plan

Safe to revert. After M2 is deployed, validate the hidden list flow with an existing OAuth grant before exposing the command publicly.
