### PR TITLE
Redesign stripe listen event selection flags

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -54,6 +54,14 @@ type listenCmd struct {
 	events                []string
 	allSnapshot           bool
 	allThin               bool
+
+	// Deprecated event flags. Still functional so that published commands keep
+	// working; they also cover the one case --forward-to can't express, a
+	// separate destination per payload style.
+	thinEvents            []string
+	forwardThinURL        string
+	forwardThinConnectURL string
+
 	latestAPIVersion      bool
 	livemode              bool
 	useConfiguredWebhooks bool
@@ -106,14 +114,14 @@ Stripe account.`,
 	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward. Ex: \"Key1:Value1, Key2:Value2\"")
 	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect events to (default: same as --forward-to)")
 
-	// Removed flags. They stay registered but hidden so that using one gives a
-	// message naming its replacement instead of cobra's "unknown flag".
-	lc.cmd.Flags().StringSlice("thin-events", []string{}, "")
-	lc.cmd.Flags().MarkHidden("thin-events") // #nosec G104
-	lc.cmd.Flags().String("forward-thin-to", "", "")
-	lc.cmd.Flags().MarkHidden("forward-thin-to") // #nosec G104
-	lc.cmd.Flags().String("forward-thin-connect-to", "", "")
-	lc.cmd.Flags().MarkHidden("forward-thin-connect-to") // #nosec G104
+	// Deprecated flags. MarkDeprecated warns on use and hides them from help,
+	// but they keep working; they'll be removed once the docs have migrated.
+	lc.cmd.Flags().StringSliceVar(&lc.thinEvents, "thin-events", []string{}, "A comma-separated list of thin events to listen for.")
+	lc.cmd.Flags().MarkDeprecated("thin-events", "use --events, which accepts both snapshot and thin event types, or --all-thin for all thin events.")
+	lc.cmd.Flags().StringVar(&lc.forwardThinURL, "forward-thin-to", "", "The URL to forward thin events to")
+	lc.cmd.Flags().MarkDeprecated("forward-thin-to", "use --forward-to together with --all-thin (or --events naming thin event types). Snapshot and thin events cannot share one destination.")
+	lc.cmd.Flags().StringVar(&lc.forwardThinConnectURL, "forward-thin-connect-to", "", "The URL to forward thin Connect events to")
+	lc.cmd.Flags().MarkDeprecated("forward-thin-connect-to", "use --events-from @accounts with --all-thin (or --events naming thin event types) and --forward-to <url>.")
 
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
 	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test)")
@@ -221,16 +229,18 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 
 	snapshotEvents, thinEvents := lc.resolveEvents()
 	directURL, connectURL := lc.resolveForwardURLs()
+	thinURL, thinConnectURL := lc.resolveThinForwardURLs(directURL, connectURL)
+	lc.warnUnforwardedThinEvents(logger)
 
 	p, err := proxy.Init(ctx, &proxy.Config{
 		Client:                client,
 		DeviceName:            deviceName,
 		DeviceToken:           &lc.deviceToken,
 		ForwardURL:            directURL,
-		ForwardThinURL:        directURL,
+		ForwardThinURL:        thinURL,
 		ForwardHeaders:        lc.forwardHeaders,
 		ForwardConnectURL:     connectURL,
-		ForwardThinConnectURL: connectURL,
+		ForwardThinConnectURL: thinConnectURL,
 		ForwardConnectHeaders: lc.forwardConnectHeaders,
 		UseConfiguredWebhooks: lc.useConfiguredWebhooks,
 		WebSocketFeatures:     lc.getFeatures(),
@@ -402,29 +412,16 @@ func (lc *listenCmd) createVisitor(logger *log.Logger, format string, printJSON 
 	}
 }
 
+// getFeatures derives the websocket features from the resolved subscription, so
+// that the channels opened always match the events actually subscribed to.
 func (lc *listenCmd) getFeatures() []string {
-	needsSnapshot := lc.allSnapshot
-	needsThin := lc.allThin
-
-	for _, e := range lc.events {
-		if isThinEvent(e) {
-			needsThin = true
-		} else {
-			needsSnapshot = true
-		}
-	}
-
-	// A bare "stripe listen" with no event flags opens both channels.
-	if !needsSnapshot && !needsThin {
-		needsSnapshot = true
-		needsThin = true
-	}
+	snapshotEvents, thinEvents := lc.resolveEvents()
 
 	features := []string{}
-	if needsSnapshot {
+	if len(snapshotEvents) > 0 {
 		features = append(features, webhooksWebSocketFeature)
 	}
-	if needsThin {
+	if len(thinEvents) > 0 {
 		features = append(features, destinationsWebSocketFeature)
 	}
 
@@ -435,14 +432,52 @@ func isThinEvent(eventType string) bool {
 	return thinEventPattern.MatchString(eventType)
 }
 
-// resolveEvents splits the --events list into the snapshot and thin event lists
+// usesDeprecatedThinFlags reports whether the invocation drives the thin side
+// through the deprecated flags rather than --events / --forward-to.
+func (lc *listenCmd) usesDeprecatedThinFlags() bool {
+	return len(lc.thinEvents) > 0 || lc.forwardThinURL != "" || lc.forwardThinConnectURL != ""
+}
+
+// namesSnapshotEvents reports whether --events named any snapshot event type.
+func (lc *listenCmd) namesSnapshotEvents() bool {
+	for _, e := range lc.events {
+		if !isThinEvent(e) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// resolveEvents splits the event flags into the snapshot and thin event lists
 // the proxy subscribes with.
 func (lc *listenCmd) resolveEvents() (snapshotEvents []string, thinEvents []string) {
-	return splitEventsByType(lc.events, lc.allSnapshot, lc.allThin)
+	allSnapshot := lc.allSnapshot
+	allThin := lc.allThin
+
+	// Deprecated --thin-events folds into the thin subscription. Its values are
+	// thin by declaration, so they skip the event-type sniffing below.
+	var legacyThin []string
+	for _, e := range lc.thinEvents {
+		if e == "*" {
+			allThin = true
+			continue
+		}
+		legacyThin = append(legacyThin, e)
+	}
+
+	// The deprecated flags ran alongside an --events default of "*", so a legacy
+	// invocation that never named snapshot events still subscribed to them all.
+	if lc.usesDeprecatedThinFlags() && !allSnapshot && !lc.namesSnapshotEvents() {
+		allSnapshot = true
+	}
+
+	return splitEventsByType(lc.events, allSnapshot, allThin, legacyThin...)
 }
 
 // splitEventsByType separates an event list into snapshot and thin event lists.
-func splitEventsByType(events []string, allSnapshot, allThin bool) (snapshotEvents []string, thinEvents []string) {
+// extraThin holds event types already known to be thin.
+func splitEventsByType(events []string, allSnapshot, allThin bool, extraThin ...string) (snapshotEvents []string, thinEvents []string) {
 	if allSnapshot {
 		snapshotEvents = append(snapshotEvents, "*")
 	}
@@ -457,6 +492,8 @@ func splitEventsByType(events []string, allSnapshot, allThin bool) (snapshotEven
 			snapshotEvents = append(snapshotEvents, e)
 		}
 	}
+
+	thinEvents = append(thinEvents, extraThin...)
 
 	// A bare "stripe listen" with no event flags subscribes to everything.
 	if len(snapshotEvents) == 0 && len(thinEvents) == 0 {
@@ -491,13 +528,48 @@ func (lc *listenCmd) resolveForwardURLs() (directURL, connectURL string) {
 	return
 }
 
+// resolveThinForwardURLs determines where thin events go. Normally they follow
+// --forward-to alongside snapshot events.
+//
+// A deprecated invocation instead forwards thin events only to the destinations
+// --forward-thin-to / --forward-thin-connect-to name. That covers the one
+// arrangement the unified --forward-to can't express, a separate endpoint per
+// payload style, and it keeps --thin-events with a bare --forward-to behaving as
+// it always did: thin events were printed but never forwarded there.
+func (lc *listenCmd) resolveThinForwardURLs(directURL, connectURL string) (thinURL, thinConnectURL string) {
+	if !lc.usesDeprecatedThinFlags() {
+		return directURL, connectURL
+	}
+
+	thinURL = lc.forwardThinURL
+	thinConnectURL = lc.forwardThinConnectURL
+	if thinConnectURL == "" {
+		thinConnectURL = thinURL
+	}
+
+	return
+}
+
+// warnUnforwardedThinEvents flags the one deprecated shape that silently drops
+// events: --thin-events with a forwarding destination that only snapshot events
+// reach. Previously this printed thin events and forwarded nothing; say so
+// rather than leaving the user to notice the gap.
+func (lc *listenCmd) warnUnforwardedThinEvents(logger *log.Logger) {
+	if !lc.usesDeprecatedThinFlags() || lc.forwardThinURL != "" || lc.forwardThinConnectURL != "" {
+		return
+	}
+
+	directURL, connectURL := lc.resolveForwardURLs()
+	if directURL == "" && connectURL == "" {
+		return
+	}
+
+	logger.Warn("--thin-events without --forward-thin-to does not forward thin events; they are only printed here. Use --all-thin (or --events with thin event types) and --forward-to to forward them.")
+}
+
 // validateFlags rejects flag combinations that are contradictory, ambiguous, or
 // no longer supported.
 func (lc *listenCmd) validateFlags() error {
-	if err := lc.checkRemovedFlags(); err != nil {
-		return err
-	}
-
 	if err := lc.validateEvents(); err != nil {
 		return err
 	}
@@ -513,28 +585,6 @@ func (lc *listenCmd) validateFlags() error {
 	}
 
 	return lc.validateForwardingConfig()
-}
-
-// checkRemovedFlags reports the replacement for each flag that this command used
-// to accept.
-func (lc *listenCmd) checkRemovedFlags() error {
-	if lc.cmd.Flags().Changed("thin-events") {
-		thinEvents, err := lc.cmd.Flags().GetStringSlice("thin-events")
-		if err == nil && len(thinEvents) == 1 && thinEvents[0] == "*" {
-			return errorcategory.UserInputErrorf("--thin-events is no longer supported. Use --all-thin to subscribe to all thin events.")
-		}
-		return errorcategory.UserInputErrorf("--thin-events is no longer supported. Use --events instead, which accepts both snapshot and thin event types.")
-	}
-
-	if lc.cmd.Flags().Changed("forward-thin-to") {
-		return errorcategory.UserInputErrorf("--forward-thin-to is no longer supported. Use --forward-to instead, which forwards both snapshot and thin events.")
-	}
-
-	if lc.cmd.Flags().Changed("forward-thin-connect-to") {
-		return errorcategory.UserInputErrorf("--forward-thin-connect-to is no longer supported. Use --events-from @accounts --forward-to <url> instead.")
-	}
-
-	return nil
 }
 
 // validateEvents rejects the "*" wildcard, which used to mean "all snapshot
@@ -566,8 +616,9 @@ func (lc *listenCmd) validateForwardingConfig() error {
 	}
 
 	// Forwarding requires an explicit subscription. Defaulting to everything
-	// would POST every event on the account to the user's endpoint.
-	if !lc.allSnapshot && !lc.allThin && len(lc.events) == 0 {
+	// would POST every event on the account to the user's endpoint. The
+	// deprecated flags carry their own subscription, so they satisfy this too.
+	if !lc.allSnapshot && !lc.allThin && len(lc.events) == 0 && !lc.usesDeprecatedThinFlags() {
 		return errorcategory.UserInputErrorf("must specify events to forward using --events, --all-snapshot, or --all-thin")
 	}
 
@@ -585,14 +636,16 @@ func (lc *listenCmd) validateForwardingConfig() error {
 	}
 
 	// The two payload styles are framed differently, so a single endpoint can't
-	// receive both.
+	// receive both. Distinct destinations are fine, which is what the deprecated
+	// --forward-thin-to still buys.
 	snapshotEvents, thinEvents := lc.resolveEvents()
 	if len(snapshotEvents) > 0 && len(thinEvents) > 0 {
 		directURL, connectURL := lc.resolveForwardURLs()
-		if directURL != "" {
+		thinURL, thinConnectURL := lc.resolveThinForwardURLs(directURL, connectURL)
+		if directURL != "" && directURL == thinURL {
 			return errorcategory.UserInputErrorf("cannot forward both snapshot and thin events to the same destination")
 		}
-		if connectURL != "" {
+		if connectURL != "" && connectURL == thinConnectURL {
 			return errorcategory.UserInputErrorf("cannot forward both snapshot and thin events to the same connect destination")
 		}
 	}

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -26,24 +27,33 @@ import (
 	"github.com/stripe/stripe-cli/pkg/websocket"
 )
 
+// thinEventPattern matches thin event types, which are namespaced by API
+// version (e.g. v1.billing.meter.no_meter_found, v2.core.account.created).
+var thinEventPattern = regexp.MustCompile(`^v\d+\.`)
+
 const (
 	webhooksWebSocketFeature     = "webhooks"
 	destinationsWebSocketFeature = "v2_events"
 	timeLayout                   = "2006-01-02 15:04:05"
 	outputFormatJSON             = "JSON"
+
+	// Accepted values for --events-from.
+	eventsFromSelf     = "@self"
+	eventsFromAccounts = "@accounts"
+	eventsFromAll      = "all"
 )
 
 type listenCmd struct {
 	cmd *cobra.Command
 
 	forwardURL            string
-	forwardThinURL        string
 	forwardHeaders        []string
 	forwardConnectHeaders []string
 	forwardConnectURL     string
-	forwardThinConnectURL string
+	eventsFrom            string
 	events                []string
-	thinEvents            []string
+	allSnapshot           bool
+	allThin               bool
 	latestAPIVersion      bool
 	livemode              bool
 	useConfiguredWebhooks bool
@@ -70,10 +80,14 @@ local machine by connecting directly to Stripe's API. You can test the latest
 API version, filter events, or even load your saved webhook endpoints from your
 Stripe account.`,
 		Example: `stripe listen
-  stripe listen --events charge.captured,charge.updated \
+  stripe listen --all-snapshot --forward-to localhost:3000/events
+  stripe listen --all-thin --forward-to localhost:3000/events
+  stripe listen --events charge.captured,customer.created \
     --forward-to localhost:3000/events
-  stripe listen --thin-events v1.billing.meter.no_meter_found \
-    --forward-thin-to localhost:3000/thin-events`,
+  stripe listen --events v1.billing.meter.no_meter_found \
+    --forward-to localhost:3000/events
+  stripe listen --all-thin --events-from @accounts \
+    --forward-to localhost:3000/events`,
 		Annotations: map[string]string{
 			AIAgentHelpAnnotationKey: "  Use `--forward-to` to specify where events are sent, e.g. localhost:4242/webhook.\n" +
 				"  Use `--events` to filter to specific event types, e.g. `--events checkout.session.completed`.\n" +
@@ -84,13 +98,23 @@ Stripe account.`,
 	}
 
 	lc.cmd.Flags().StringSliceVar(&lc.forwardConnectHeaders, "connect-headers", []string{}, "A comma-separated list of custom headers to forward for Connect. Ex: \"Key1:Value1, Key2:Value2\"")
-	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{"*"}, "A comma-separated list of specific events to listen for. For a list of all possible events, see: https://stripe.com/docs/api/events/types")
-	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward webhook events to")
+	lc.cmd.Flags().StringSliceVarP(&lc.events, "events", "e", []string{}, "A comma-separated list of specific events to listen for. Accepts both snapshot events (e.g. charge.captured) and thin events (e.g. v1.billing.meter.no_meter_found). For a list of all possible events, see: https://stripe.com/docs/api/events/types")
+	lc.cmd.Flags().BoolVar(&lc.allSnapshot, "all-snapshot", false, "Subscribe to all snapshot events")
+	lc.cmd.Flags().BoolVar(&lc.allThin, "all-thin", false, "Subscribe to all thin events")
+	lc.cmd.Flags().StringVar(&lc.eventsFrom, "events-from", eventsFromAll, "Which accounts to receive events from: '@self' (your account only), '@accounts' (connected accounts only), or 'all'")
+	lc.cmd.Flags().StringVarP(&lc.forwardURL, "forward-to", "f", "", "The URL to forward events to")
 	lc.cmd.Flags().StringSliceVarP(&lc.forwardHeaders, "headers", "H", []string{}, "A comma-separated list of custom headers to forward. Ex: \"Key1:Value1, Key2:Value2\"")
-	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect webhook events to (default: same as normal events)")
-	lc.cmd.Flags().StringSliceVar(&lc.thinEvents, "thin-events", []string{}, "A comma-separated list of thin events to listen for.")
-	lc.cmd.Flags().StringVar(&lc.forwardThinURL, "forward-thin-to", "", "The URL to forward thin events to")
-	lc.cmd.Flags().StringVar(&lc.forwardThinConnectURL, "forward-thin-connect-to", "", "The URL to forward thin Connect events to")
+	lc.cmd.Flags().StringVarP(&lc.forwardConnectURL, "forward-connect-to", "c", "", "The URL to forward Connect events to (default: same as --forward-to)")
+
+	// Removed flags. They stay registered but hidden so that using one gives a
+	// message naming its replacement instead of cobra's "unknown flag".
+	lc.cmd.Flags().StringSlice("thin-events", []string{}, "")
+	lc.cmd.Flags().MarkHidden("thin-events") // #nosec G104
+	lc.cmd.Flags().String("forward-thin-to", "", "")
+	lc.cmd.Flags().MarkHidden("forward-thin-to") // #nosec G104
+	lc.cmd.Flags().String("forward-thin-connect-to", "", "")
+	lc.cmd.Flags().MarkHidden("forward-thin-connect-to") // #nosec G104
+
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
 	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test)")
 	lc.cmd.Flags().BoolVarP(&lc.printJSON, "print-json", "j", false, "Print full JSON objects to stdout.")
@@ -127,6 +151,12 @@ Stripe account.`,
 // Normally, this function would be listed alphabetically with the others declared in this file,
 // but since it's acting as the core functionality for the cmd above, I'm keeping it close.
 func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
+	// Validate flags before touching credentials or the network, so a bad flag
+	// combination reports itself rather than failing on something downstream.
+	if err := lc.validateFlags(); err != nil {
+		return err
+	}
+
 	if err := stripe.ValidateAPIBaseURL(lc.apiBaseURL); err != nil {
 		return err
 	}
@@ -189,15 +219,18 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	proxyVisitor := lc.createVisitor(logger, lc.format, lc.printJSON)
 	proxyOutCh := make(chan websocket.IElement)
 
+	snapshotEvents, thinEvents := lc.resolveEvents()
+	directURL, connectURL := lc.resolveForwardURLs()
+
 	p, err := proxy.Init(ctx, &proxy.Config{
 		Client:                client,
 		DeviceName:            deviceName,
 		DeviceToken:           &lc.deviceToken,
-		ForwardURL:            lc.forwardURL,
-		ForwardThinURL:        lc.forwardThinURL,
+		ForwardURL:            directURL,
+		ForwardThinURL:        directURL,
 		ForwardHeaders:        lc.forwardHeaders,
-		ForwardConnectURL:     lc.forwardConnectURL,
-		ForwardThinConnectURL: lc.forwardThinConnectURL,
+		ForwardConnectURL:     connectURL,
+		ForwardThinConnectURL: connectURL,
 		ForwardConnectHeaders: lc.forwardConnectHeaders,
 		UseConfiguredWebhooks: lc.useConfiguredWebhooks,
 		WebSocketFeatures:     lc.getFeatures(),
@@ -207,10 +240,11 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 		Log:                   logger,
 		NoWSS:                 lc.noWSS,
 		Timeout:               lc.timeout,
-		Events:                lc.events,
-		ThinEvents:            lc.thinEvents,
+		Events:                snapshotEvents,
+		ThinEvents:            thinEvents,
 		OutCh:                 proxyOutCh,
 		LoggedInAccountID:     accountID,
+		EventsFrom:            lc.eventsFrom,
 	})
 	if err != nil {
 		return err
@@ -369,15 +403,199 @@ func (lc *listenCmd) createVisitor(logger *log.Logger, format string, printJSON 
 }
 
 func (lc *listenCmd) getFeatures() []string {
-	features := []string{}
+	needsSnapshot := lc.allSnapshot
+	needsThin := lc.allThin
 
-	if len(lc.events) > 0 {
-		features = append(features, webhooksWebSocketFeature)
+	for _, e := range lc.events {
+		if isThinEvent(e) {
+			needsThin = true
+		} else {
+			needsSnapshot = true
+		}
 	}
 
-	if len(lc.thinEvents) > 0 {
+	// A bare "stripe listen" with no event flags opens both channels.
+	if !needsSnapshot && !needsThin {
+		needsSnapshot = true
+		needsThin = true
+	}
+
+	features := []string{}
+	if needsSnapshot {
+		features = append(features, webhooksWebSocketFeature)
+	}
+	if needsThin {
 		features = append(features, destinationsWebSocketFeature)
 	}
 
 	return features
+}
+
+func isThinEvent(eventType string) bool {
+	return thinEventPattern.MatchString(eventType)
+}
+
+// resolveEvents splits the --events list into the snapshot and thin event lists
+// the proxy subscribes with.
+func (lc *listenCmd) resolveEvents() (snapshotEvents []string, thinEvents []string) {
+	return splitEventsByType(lc.events, lc.allSnapshot, lc.allThin)
+}
+
+// splitEventsByType separates an event list into snapshot and thin event lists.
+func splitEventsByType(events []string, allSnapshot, allThin bool) (snapshotEvents []string, thinEvents []string) {
+	if allSnapshot {
+		snapshotEvents = append(snapshotEvents, "*")
+	}
+	if allThin {
+		thinEvents = append(thinEvents, "*")
+	}
+
+	for _, e := range events {
+		if isThinEvent(e) {
+			thinEvents = append(thinEvents, e)
+		} else {
+			snapshotEvents = append(snapshotEvents, e)
+		}
+	}
+
+	// A bare "stripe listen" with no event flags subscribes to everything.
+	if len(snapshotEvents) == 0 && len(thinEvents) == 0 {
+		snapshotEvents = []string{"*"}
+		thinEvents = []string{"*"}
+	}
+
+	return
+}
+
+// resolveForwardURLs determines the direct and Connect forwarding URLs from
+// --events-from, --forward-to, and --forward-connect-to.
+func (lc *listenCmd) resolveForwardURLs() (directURL, connectURL string) {
+	switch lc.eventsFrom {
+	case eventsFromSelf:
+		directURL = lc.forwardURL
+		connectURL = ""
+	case eventsFromAccounts:
+		directURL = ""
+		connectURL = lc.forwardURL
+		if lc.forwardConnectURL != "" {
+			connectURL = lc.forwardConnectURL
+		}
+	default: // eventsFromAll
+		directURL = lc.forwardURL
+		connectURL = lc.forwardConnectURL
+		if connectURL == "" {
+			connectURL = lc.forwardURL
+		}
+	}
+
+	return
+}
+
+// validateFlags rejects flag combinations that are contradictory, ambiguous, or
+// no longer supported.
+func (lc *listenCmd) validateFlags() error {
+	if err := lc.checkRemovedFlags(); err != nil {
+		return err
+	}
+
+	if err := lc.validateEvents(); err != nil {
+		return err
+	}
+
+	if err := lc.validateEventsFrom(); err != nil {
+		return err
+	}
+
+	// --print-secret exits before forwarding anything, so don't hold it to the
+	// forwarding rules.
+	if lc.onlyPrintSecret {
+		return nil
+	}
+
+	return lc.validateForwardingConfig()
+}
+
+// checkRemovedFlags reports the replacement for each flag that this command used
+// to accept.
+func (lc *listenCmd) checkRemovedFlags() error {
+	if lc.cmd.Flags().Changed("thin-events") {
+		thinEvents, err := lc.cmd.Flags().GetStringSlice("thin-events")
+		if err == nil && len(thinEvents) == 1 && thinEvents[0] == "*" {
+			return errorcategory.UserInputErrorf("--thin-events is no longer supported. Use --all-thin to subscribe to all thin events.")
+		}
+		return errorcategory.UserInputErrorf("--thin-events is no longer supported. Use --events instead, which accepts both snapshot and thin event types.")
+	}
+
+	if lc.cmd.Flags().Changed("forward-thin-to") {
+		return errorcategory.UserInputErrorf("--forward-thin-to is no longer supported. Use --forward-to instead, which forwards both snapshot and thin events.")
+	}
+
+	if lc.cmd.Flags().Changed("forward-thin-connect-to") {
+		return errorcategory.UserInputErrorf("--forward-thin-connect-to is no longer supported. Use --events-from @accounts --forward-to <url> instead.")
+	}
+
+	return nil
+}
+
+// validateEvents rejects the "*" wildcard, which used to mean "all snapshot
+// events" and is ambiguous now that --events also accepts thin events.
+func (lc *listenCmd) validateEvents() error {
+	for _, e := range lc.events {
+		if e == "*" {
+			return errorcategory.UserInputErrorf("--events '*' is no longer supported. Use --all-snapshot for all snapshot events, or --all-thin for all thin events.")
+		}
+	}
+
+	return nil
+}
+
+func (lc *listenCmd) validateEventsFrom() error {
+	switch lc.eventsFrom {
+	case eventsFromSelf, eventsFromAccounts, eventsFromAll:
+		return nil
+	default:
+		return errorcategory.UserInputErrorf("invalid --events-from value %q: must be one of '@self', '@accounts', or 'all'", lc.eventsFrom)
+	}
+}
+
+// validateForwardingConfig checks that the forwarding flags name exactly one
+// destination for exactly one payload style.
+func (lc *listenCmd) validateForwardingConfig() error {
+	if lc.forwardURL == "" && lc.forwardConnectURL == "" {
+		return nil
+	}
+
+	// Forwarding requires an explicit subscription. Defaulting to everything
+	// would POST every event on the account to the user's endpoint.
+	if !lc.allSnapshot && !lc.allThin && len(lc.events) == 0 {
+		return errorcategory.UserInputErrorf("must specify events to forward using --events, --all-snapshot, or --all-thin")
+	}
+
+	// --events-from @self drops Connect events, so a Connect destination would
+	// never receive anything.
+	if lc.eventsFrom == eventsFromSelf && lc.forwardConnectURL != "" {
+		return errorcategory.UserInputErrorf("--forward-connect-to cannot be used with --events-from @self, which excludes events from connected accounts")
+	}
+
+	// Under @accounts both flags name the same destination, so two different
+	// URLs is ambiguous.
+	if lc.eventsFrom == eventsFromAccounts &&
+		lc.forwardURL != "" && lc.forwardConnectURL != "" && lc.forwardURL != lc.forwardConnectURL {
+		return errorcategory.UserInputErrorf("--forward-to and --forward-connect-to name the same destination when --events-from is @accounts: specify only one")
+	}
+
+	// The two payload styles are framed differently, so a single endpoint can't
+	// receive both.
+	snapshotEvents, thinEvents := lc.resolveEvents()
+	if len(snapshotEvents) > 0 && len(thinEvents) > 0 {
+		directURL, connectURL := lc.resolveForwardURLs()
+		if directURL != "" {
+			return errorcategory.UserInputErrorf("cannot forward both snapshot and thin events to the same destination")
+		}
+		if connectURL != "" {
+			return errorcategory.UserInputErrorf("cannot forward both snapshot and thin events to the same connect destination")
+		}
+	}
+
+	return nil
 }

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -1,0 +1,558 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsThinEvent(t *testing.T) {
+	tests := []struct {
+		eventType string
+		want      bool
+	}{
+		{"v1.billing.meter.no_meter_found", true},
+		{"v2.core.account.created", true},
+		{"v1.some.event", true},
+		{"v1.", true},
+		{"charge.captured", false},
+		{"customer.created", false},
+		{"payment_intent.succeeded", false},
+		{"*", false},
+		{"", false},
+		{"v1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.eventType, func(t *testing.T) {
+			assert.Equal(t, tt.want, isThinEvent(tt.eventType))
+		})
+	}
+}
+
+func TestSplitEventsByType(t *testing.T) {
+	tests := []struct {
+		name         string
+		events       []string
+		allSnapshot  bool
+		allThin      bool
+		wantSnapshot []string
+		wantThin     []string
+	}{
+		{
+			name:         "bare listen with no flags subscribes to everything",
+			events:       []string{},
+			wantSnapshot: []string{"*"},
+			wantThin:     []string{"*"},
+		},
+		{
+			name:         "all-snapshot adds wildcard for snapshot",
+			allSnapshot:  true,
+			events:       []string{},
+			wantSnapshot: []string{"*"},
+			wantThin:     nil,
+		},
+		{
+			name:         "all-thin adds wildcard for thin",
+			allThin:      true,
+			events:       []string{},
+			wantSnapshot: nil,
+			wantThin:     []string{"*"},
+		},
+		{
+			name:         "both all-snapshot and all-thin",
+			allSnapshot:  true,
+			allThin:      true,
+			events:       []string{},
+			wantSnapshot: []string{"*"},
+			wantThin:     []string{"*"},
+		},
+		{
+			name:         "all-snapshot with specific thin events",
+			allSnapshot:  true,
+			events:       []string{"v1.billing.meter.no_meter_found"},
+			wantSnapshot: []string{"*"},
+			wantThin:     []string{"v1.billing.meter.no_meter_found"},
+		},
+		{
+			name:         "all-thin with specific snapshot events",
+			allThin:      true,
+			events:       []string{"charge.captured"},
+			wantSnapshot: []string{"charge.captured"},
+			wantThin:     []string{"*"},
+		},
+		{
+			name:         "snapshot events only",
+			events:       []string{"charge.captured", "customer.created"},
+			wantSnapshot: []string{"charge.captured", "customer.created"},
+			wantThin:     nil,
+		},
+		{
+			name:         "thin events only",
+			events:       []string{"v1.billing.meter.no_meter_found", "v2.core.account.created"},
+			wantSnapshot: nil,
+			wantThin:     []string{"v1.billing.meter.no_meter_found", "v2.core.account.created"},
+		},
+		{
+			name:         "mixed events",
+			events:       []string{"charge.captured", "v1.billing.meter.no_meter_found"},
+			wantSnapshot: []string{"charge.captured"},
+			wantThin:     []string{"v1.billing.meter.no_meter_found"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot, thin := splitEventsByType(tt.events, tt.allSnapshot, tt.allThin)
+			assert.Equal(t, tt.wantSnapshot, snapshot)
+			assert.Equal(t, tt.wantThin, thin)
+		})
+	}
+}
+
+func TestGetFeatures(t *testing.T) {
+	tests := []struct {
+		name        string
+		events      []string
+		allSnapshot bool
+		allThin     bool
+		want        []string
+	}{
+		{
+			name: "bare listen opens both channels",
+			want: []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
+		},
+		{
+			name:        "all-snapshot opens webhooks only",
+			allSnapshot: true,
+			want:        []string{webhooksWebSocketFeature},
+		},
+		{
+			name:    "all-thin opens v2_events only",
+			allThin: true,
+			want:    []string{destinationsWebSocketFeature},
+		},
+		{
+			name:        "both all flags open both channels",
+			allSnapshot: true,
+			allThin:     true,
+			want:        []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
+		},
+		{
+			name:   "snapshot events only opens webhooks",
+			events: []string{"charge.captured"},
+			want:   []string{webhooksWebSocketFeature},
+		},
+		{
+			name:   "thin events only opens v2_events",
+			events: []string{"v1.billing.meter.no_meter_found"},
+			want:   []string{destinationsWebSocketFeature},
+		},
+		{
+			name:   "mixed events opens both",
+			events: []string{"charge.captured", "v1.billing.meter.no_meter_found"},
+			want:   []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := &listenCmd{
+				events:      tt.events,
+				allSnapshot: tt.allSnapshot,
+				allThin:     tt.allThin,
+			}
+			assert.Equal(t, tt.want, lc.getFeatures())
+		})
+	}
+}
+
+func TestResolveForwardURLs(t *testing.T) {
+	tests := []struct {
+		name           string
+		eventsFrom     string
+		forwardURL     string
+		forwardConnect string
+		wantDirect     string
+		wantConnect    string
+	}{
+		{
+			name:        "@self routes to direct only",
+			eventsFrom:  eventsFromSelf,
+			forwardURL:  "http://localhost:3000",
+			wantDirect:  "http://localhost:3000",
+			wantConnect: "",
+		},
+		{
+			name:        "@accounts routes to connect",
+			eventsFrom:  eventsFromAccounts,
+			forwardURL:  "http://localhost:3000",
+			wantDirect:  "",
+			wantConnect: "http://localhost:3000",
+		},
+		{
+			name:           "@accounts prefers forward-connect-to if set",
+			eventsFrom:     eventsFromAccounts,
+			forwardConnect: "http://localhost:4000",
+			wantDirect:     "",
+			wantConnect:    "http://localhost:4000",
+		},
+		{
+			name:        "all routes to both using forward-to",
+			eventsFrom:  eventsFromAll,
+			forwardURL:  "http://localhost:3000",
+			wantDirect:  "http://localhost:3000",
+			wantConnect: "http://localhost:3000",
+		},
+		{
+			name:           "all uses forward-connect-to for connect if set",
+			eventsFrom:     eventsFromAll,
+			forwardURL:     "http://localhost:3000",
+			forwardConnect: "http://localhost:4000",
+			wantDirect:     "http://localhost:3000",
+			wantConnect:    "http://localhost:4000",
+		},
+		{
+			name:        "empty events-from behaves like all",
+			eventsFrom:  "",
+			forwardURL:  "http://localhost:3000",
+			wantDirect:  "http://localhost:3000",
+			wantConnect: "http://localhost:3000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := &listenCmd{
+				eventsFrom:        tt.eventsFrom,
+				forwardURL:        tt.forwardURL,
+				forwardConnectURL: tt.forwardConnect,
+			}
+			direct, connect := lc.resolveForwardURLs()
+			assert.Equal(t, tt.wantDirect, direct)
+			assert.Equal(t, tt.wantConnect, connect)
+		})
+	}
+}
+
+func TestValidateForwardingConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		lc      listenCmd
+		wantErr string
+	}{
+		{
+			name: "not forwarding: no error even without events",
+			lc:   listenCmd{eventsFrom: eventsFromAll},
+		},
+		{
+			name:    "forwarding without specifying events",
+			lc:      listenCmd{eventsFrom: eventsFromAll, forwardURL: "http://localhost:3000"},
+			wantErr: "must specify events to forward using --events, --all-snapshot, or --all-thin",
+		},
+		{
+			name:    "forwarding to connect without specifying events",
+			lc:      listenCmd{eventsFrom: eventsFromAll, forwardConnectURL: "http://localhost:3000"},
+			wantErr: "must specify events to forward using --events, --all-snapshot, or --all-thin",
+		},
+		{
+			name: "forwarding with --all-snapshot",
+			lc:   listenCmd{eventsFrom: eventsFromAll, forwardURL: "http://localhost:3000", allSnapshot: true},
+		},
+		{
+			name: "forwarding with --all-thin",
+			lc:   listenCmd{eventsFrom: eventsFromAll, forwardURL: "http://localhost:3000", allThin: true},
+		},
+		{
+			name: "forwarding specific snapshot events",
+			lc: listenCmd{
+				eventsFrom: eventsFromAll,
+				forwardURL: "http://localhost:3000",
+				events:     []string{"charge.captured"},
+			},
+		},
+		{
+			name: "forwarding specific thin events",
+			lc: listenCmd{
+				eventsFrom: eventsFromAll,
+				forwardURL: "http://localhost:3000",
+				events:     []string{"v1.billing.meter.no_meter_found"},
+			},
+		},
+		{
+			name: "snapshot and thin to the same destination",
+			lc: listenCmd{
+				eventsFrom:  eventsFromAll,
+				forwardURL:  "http://localhost:3000",
+				allSnapshot: true,
+				allThin:     true,
+			},
+			wantErr: "cannot forward both snapshot and thin events to the same destination",
+		},
+		{
+			name: "mixed specific events to the same destination",
+			lc: listenCmd{
+				eventsFrom: eventsFromAll,
+				forwardURL: "http://localhost:3000",
+				events:     []string{"charge.captured", "v1.billing.meter.no_meter_found"},
+			},
+			wantErr: "cannot forward both snapshot and thin events to the same destination",
+		},
+		{
+			name: "snapshot and thin to the same connect destination",
+			lc: listenCmd{
+				eventsFrom:        eventsFromAll,
+				forwardConnectURL: "http://localhost:3000",
+				allSnapshot:       true,
+				allThin:           true,
+			},
+			wantErr: "cannot forward both snapshot and thin events to the same connect destination",
+		},
+		{
+			name: "--forward-connect-to with --events-from @self",
+			lc: listenCmd{
+				eventsFrom:        eventsFromSelf,
+				forwardURL:        "http://localhost:3000",
+				forwardConnectURL: "http://localhost:4000",
+				allSnapshot:       true,
+			},
+			wantErr: "--forward-connect-to cannot be used with --events-from @self",
+		},
+		{
+			name: "conflicting destinations with --events-from @accounts",
+			lc: listenCmd{
+				eventsFrom:        eventsFromAccounts,
+				forwardURL:        "http://localhost:3000",
+				forwardConnectURL: "http://localhost:4000",
+				allSnapshot:       true,
+			},
+			wantErr: "name the same destination when --events-from is @accounts",
+		},
+		{
+			name: "identical destinations with --events-from @accounts",
+			lc: listenCmd{
+				eventsFrom:        eventsFromAccounts,
+				forwardURL:        "http://localhost:3000",
+				forwardConnectURL: "http://localhost:3000",
+				allSnapshot:       true,
+			},
+		},
+		{
+			name: "--forward-connect-to alone with --events-from @accounts",
+			lc: listenCmd{
+				eventsFrom:        eventsFromAccounts,
+				forwardConnectURL: "http://localhost:4000",
+				allThin:           true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.lc.validateForwardingConfig()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateEvents(t *testing.T) {
+	tests := []struct {
+		name    string
+		events  []string
+		wantErr bool
+	}{
+		{name: "no events is valid", events: []string{}},
+		{name: "snapshot event is valid", events: []string{"charge.captured"}},
+		{name: "thin event is valid", events: []string{"v1.billing.meter.no_meter_found"}},
+		{name: "bare wildcard is rejected", events: []string{"*"}, wantErr: true},
+		{name: "wildcard among other events is rejected", events: []string{"charge.captured", "*"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := &listenCmd{events: tt.events}
+			err := lc.validateEvents()
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "--events '*' is no longer supported. Use --all-snapshot")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateEventsFrom(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "@self is valid", value: "@self"},
+		{name: "@accounts is valid", value: "@accounts"},
+		{name: "all is valid", value: "all"},
+		{name: "@everyone is invalid", value: "@everyone", wantErr: true},
+		{name: "empty string is invalid", value: "", wantErr: true},
+		{name: "self without @ is invalid", value: "self", wantErr: true},
+		{name: "accounts without @ is invalid", value: "accounts", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := &listenCmd{eventsFrom: tt.value}
+			err := lc.validateEventsFrom()
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "invalid --events-from value")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestEventsFromDefaultsToAll(t *testing.T) {
+	lc := newListenCmd()
+	require.NoError(t, lc.cmd.ParseFlags([]string{}))
+	assert.Equal(t, eventsFromAll, lc.eventsFrom)
+	assert.NoError(t, lc.validateEventsFrom())
+}
+
+func TestCheckRemovedFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "--thin-events points at --events",
+			args:    []string{"--thin-events", "v1.billing.meter.no_meter_found"},
+			wantErr: "--thin-events is no longer supported. Use --events instead",
+		},
+		{
+			name:    "--thin-events wildcard points at --all-thin",
+			args:    []string{"--thin-events", "*"},
+			wantErr: "--thin-events is no longer supported. Use --all-thin",
+		},
+		{
+			name:    "--thin-events wildcard among other events points at --events",
+			args:    []string{"--thin-events", "*,v2.core.account.created"},
+			wantErr: "--thin-events is no longer supported. Use --events instead",
+		},
+		{
+			name:    "--forward-thin-to points at --forward-to",
+			args:    []string{"--forward-thin-to", "http://localhost:3000"},
+			wantErr: "--forward-thin-to is no longer supported. Use --forward-to instead",
+		},
+		{
+			name:    "--forward-thin-connect-to points at --events-from @accounts",
+			args:    []string{"--forward-thin-connect-to", "http://localhost:3000"},
+			wantErr: "--forward-thin-connect-to is no longer supported. Use --events-from @accounts --forward-to <url> instead.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := newListenCmd()
+			require.NoError(t, lc.cmd.ParseFlags(tt.args))
+			assert.ErrorContains(t, lc.checkRemovedFlags(), tt.wantErr)
+		})
+	}
+}
+
+func TestCheckRemovedFlagsAllowsSupportedFlags(t *testing.T) {
+	lc := newListenCmd()
+	require.NoError(t, lc.cmd.ParseFlags([]string{
+		"--events", "charge.captured",
+		"--forward-to", "http://localhost:3000",
+		"--forward-connect-to", "http://localhost:4000",
+	}))
+	assert.NoError(t, lc.checkRemovedFlags())
+}
+
+// The removed flags are registered so that using one produces a message naming
+// its replacement rather than cobra's "unknown flag" error.
+func TestRemovedFlagsParseButAreHidden(t *testing.T) {
+	for _, name := range []string{"thin-events", "forward-thin-to", "forward-thin-connect-to"} {
+		t.Run(name, func(t *testing.T) {
+			flag := newListenCmd().cmd.Flags().Lookup(name)
+			require.NotNil(t, flag, "removed flag should stay registered")
+			assert.True(t, flag.Hidden, "removed flag should not appear in help")
+		})
+	}
+}
+
+func TestValidateFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "bare listen",
+			args: []string{},
+		},
+		{
+			name: "snapshot events to a destination",
+			args: []string{"--events", "charge.captured", "--forward-to", "http://localhost:3000"},
+		},
+		{
+			name: "thin events to a destination",
+			args: []string{"--events", "v1.billing.meter.no_meter_found", "--forward-to", "http://localhost:3000"},
+		},
+		{
+			name: "connect events to a destination",
+			args: []string{"--events", "customer.created", "--events-from", "@accounts", "--forward-to", "http://localhost:3000"},
+		},
+		{
+			name:    "removed flag beats other validation errors",
+			args:    []string{"--thin-events", "v2.core.account.created", "--forward-to", "http://localhost:3000"},
+			wantErr: "--thin-events is no longer supported",
+		},
+		{
+			name:    "wildcard events",
+			args:    []string{"--events", "*", "--forward-to", "http://localhost:3000"},
+			wantErr: "--events '*' is no longer supported",
+		},
+		{
+			name:    "invalid events-from",
+			args:    []string{"--events-from", "everyone"},
+			wantErr: "invalid --events-from value",
+		},
+		{
+			name:    "forwarding without events",
+			args:    []string{"--forward-to", "http://localhost:3000"},
+			wantErr: "must specify events to forward",
+		},
+		{
+			name:    "mixed payload styles to one destination",
+			args:    []string{"--all-snapshot", "--all-thin", "--forward-to", "http://localhost:3000"},
+			wantErr: "cannot forward both snapshot and thin events to the same destination",
+		},
+		{
+			name: "--print-secret is exempt from the forwarding rules",
+			args: []string{"--print-secret", "--forward-to", "http://localhost:3000"},
+		},
+		{
+			name:    "--print-secret still rejects removed flags",
+			args:    []string{"--print-secret", "--forward-thin-to", "http://localhost:3000"},
+			wantErr: "--forward-thin-to is no longer supported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lc := newListenCmd()
+			require.NoError(t, lc.cmd.ParseFlags(tt.args))
+			err := lc.validateFlags()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/cmd/listen_test.go
+++ b/pkg/cmd/listen_test.go
@@ -421,36 +421,78 @@ func TestEventsFromDefaultsToAll(t *testing.T) {
 	assert.NoError(t, lc.validateEventsFrom())
 }
 
-func TestCheckRemovedFlags(t *testing.T) {
+// The deprecated flags keep working: published commands that use them must
+// resolve to the same subscription and destinations they did before the redesign.
+func TestDeprecatedThinFlagsStillWork(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    []string
-		wantErr string
+		name            string
+		args            []string
+		wantSnapshot    []string
+		wantThin        []string
+		wantThinURL     string
+		wantThinConnect string
+		wantFeatures    []string
 	}{
 		{
-			name:    "--thin-events points at --events",
-			args:    []string{"--thin-events", "v1.billing.meter.no_meter_found"},
-			wantErr: "--thin-events is no longer supported. Use --events instead",
+			// The docs' most common thin invocation.
+			name:            "--thin-events wildcard forwards all thin events",
+			args:            []string{"--thin-events", "*", "--forward-thin-to", "http://localhost:3000"},
+			wantSnapshot:    []string{"*"},
+			wantThin:        []string{"*"},
+			wantThinURL:     "http://localhost:3000",
+			wantThinConnect: "http://localhost:3000",
+			wantFeatures:    []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
 		},
 		{
-			name:    "--thin-events wildcard points at --all-thin",
-			args:    []string{"--thin-events", "*"},
-			wantErr: "--thin-events is no longer supported. Use --all-thin",
+			name:            "specific thin events",
+			args:            []string{"--thin-events", "v1.billing.meter.no_meter_found", "--forward-thin-to", "http://localhost:3000"},
+			wantSnapshot:    []string{"*"},
+			wantThin:        []string{"v1.billing.meter.no_meter_found"},
+			wantThinURL:     "http://localhost:3000",
+			wantThinConnect: "http://localhost:3000",
+			wantFeatures:    []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
 		},
 		{
-			name:    "--thin-events wildcard among other events points at --events",
-			args:    []string{"--thin-events", "*,v2.core.account.created"},
-			wantErr: "--thin-events is no longer supported. Use --events instead",
+			// --forward-to can't express this, which is why the flags stay.
+			name:            "a separate destination per payload style",
+			args:            []string{"--events", "charge.succeeded", "--forward-to", "http://a", "--thin-events", "v1.billing.meter.no_meter_found", "--forward-thin-to", "http://b"},
+			wantSnapshot:    []string{"charge.succeeded"},
+			wantThin:        []string{"v1.billing.meter.no_meter_found"},
+			wantThinURL:     "http://b",
+			wantThinConnect: "http://b",
+			wantFeatures:    []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
 		},
 		{
-			name:    "--forward-thin-to points at --forward-to",
-			args:    []string{"--forward-thin-to", "http://localhost:3000"},
-			wantErr: "--forward-thin-to is no longer supported. Use --forward-to instead",
+			name:            "--forward-thin-connect-to routes only connect thin events",
+			args:            []string{"--thin-events", "*", "--forward-thin-connect-to", "http://c"},
+			wantSnapshot:    []string{"*"},
+			wantThin:        []string{"*"},
+			wantThinURL:     "",
+			wantThinConnect: "http://c",
+			wantFeatures:    []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
 		},
 		{
-			name:    "--forward-thin-connect-to points at --events-from @accounts",
-			args:    []string{"--forward-thin-connect-to", "http://localhost:3000"},
-			wantErr: "--forward-thin-connect-to is no longer supported. Use --events-from @accounts --forward-to <url> instead.",
+			// Before the redesign this forwarded snapshot events and only printed
+			// thin ones, since --forward-thin-to was what built a thin route. It
+			// keeps doing that instead of erroring on a destination the user never
+			// pointed thin events at.
+			name:            "--thin-events with a bare --forward-to still forwards only snapshot events",
+			args:            []string{"--thin-events", "*", "--forward-to", "http://a"},
+			wantSnapshot:    []string{"*"},
+			wantThin:        []string{"*"},
+			wantThinURL:     "",
+			wantThinConnect: "",
+			wantFeatures:    []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
+		},
+		{
+			// Values are thin by declaration, so shape doesn't decide.
+			name:            "a thin event that doesn't look versioned",
+			args:            []string{"--thin-events", "unusual.event.shape"},
+			wantSnapshot:    []string{"*"},
+			wantThin:        []string{"unusual.event.shape"},
+			wantThinURL:     "",
+			wantThinConnect: "",
+			wantFeatures:    []string{webhooksWebSocketFeature, destinationsWebSocketFeature},
 		},
 	}
 
@@ -458,29 +500,41 @@ func TestCheckRemovedFlags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lc := newListenCmd()
 			require.NoError(t, lc.cmd.ParseFlags(tt.args))
-			assert.ErrorContains(t, lc.checkRemovedFlags(), tt.wantErr)
+			require.NoError(t, lc.validateFlags())
+
+			snapshotEvents, thinEvents := lc.resolveEvents()
+			assert.Equal(t, tt.wantSnapshot, snapshotEvents)
+			assert.Equal(t, tt.wantThin, thinEvents)
+
+			directURL, connectURL := lc.resolveForwardURLs()
+			thinURL, thinConnectURL := lc.resolveThinForwardURLs(directURL, connectURL)
+			assert.Equal(t, tt.wantThinURL, thinURL)
+			assert.Equal(t, tt.wantThinConnect, thinConnectURL)
+
+			assert.Equal(t, tt.wantFeatures, lc.getFeatures())
 		})
 	}
 }
 
-func TestCheckRemovedFlagsAllowsSupportedFlags(t *testing.T) {
+// Without the deprecated flags, thin events follow --forward-to.
+func TestThinForwardURLsDefaultToForwardTo(t *testing.T) {
 	lc := newListenCmd()
-	require.NoError(t, lc.cmd.ParseFlags([]string{
-		"--events", "charge.captured",
-		"--forward-to", "http://localhost:3000",
-		"--forward-connect-to", "http://localhost:4000",
-	}))
-	assert.NoError(t, lc.checkRemovedFlags())
+	require.NoError(t, lc.cmd.ParseFlags([]string{"--all-thin", "--forward-to", "http://a"}))
+
+	directURL, connectURL := lc.resolveForwardURLs()
+	thinURL, thinConnectURL := lc.resolveThinForwardURLs(directURL, connectURL)
+	assert.Equal(t, "http://a", thinURL)
+	assert.Equal(t, "http://a", thinConnectURL)
 }
 
-// The removed flags are registered so that using one produces a message naming
-// its replacement rather than cobra's "unknown flag" error.
-func TestRemovedFlagsParseButAreHidden(t *testing.T) {
+// MarkDeprecated warns on use and keeps the flags out of help, but they still work.
+func TestDeprecatedFlagsAreMarkedDeprecated(t *testing.T) {
 	for _, name := range []string{"thin-events", "forward-thin-to", "forward-thin-connect-to"} {
 		t.Run(name, func(t *testing.T) {
 			flag := newListenCmd().cmd.Flags().Lookup(name)
-			require.NotNil(t, flag, "removed flag should stay registered")
-			assert.True(t, flag.Hidden, "removed flag should not appear in help")
+			require.NotNil(t, flag, "deprecated flag should stay registered")
+			assert.NotEmpty(t, flag.Deprecated, "flag should warn when used")
+			assert.True(t, flag.Hidden, "deprecated flag should not appear in help")
 		})
 	}
 }
@@ -508,9 +562,23 @@ func TestValidateFlags(t *testing.T) {
 			args: []string{"--events", "customer.created", "--events-from", "@accounts", "--forward-to", "http://localhost:3000"},
 		},
 		{
-			name:    "removed flag beats other validation errors",
-			args:    []string{"--thin-events", "v2.core.account.created", "--forward-to", "http://localhost:3000"},
-			wantErr: "--thin-events is no longer supported",
+			name: "deprecated thin flags satisfy the subscription requirement",
+			args: []string{"--thin-events", "*", "--forward-thin-to", "http://localhost:3000"},
+		},
+		{
+			name: "deprecated flags name a separate destination per payload style",
+			args: []string{"--events", "charge.succeeded", "--forward-to", "http://a", "--thin-events", "v1.billing.meter.no_meter_found", "--forward-thin-to", "http://b"},
+		},
+		{
+			name:    "deprecated flags pointing both payload styles at one destination",
+			args:    []string{"--events", "charge.succeeded", "--forward-to", "http://a", "--thin-events", "v1.billing.meter.no_meter_found", "--forward-thin-to", "http://a"},
+			wantErr: "cannot forward both snapshot and thin events to the same destination",
+		},
+		{
+			// The mixed-destination rule applies to what --events subscribes to,
+			// not to a deprecated thin subscription that reaches no destination.
+			name: "deprecated --thin-events alongside a bare --forward-to",
+			args: []string{"--thin-events", "*", "--forward-to", "http://a"},
 		},
 		{
 			name:    "wildcard events",
@@ -537,9 +605,8 @@ func TestValidateFlags(t *testing.T) {
 			args: []string{"--print-secret", "--forward-to", "http://localhost:3000"},
 		},
 		{
-			name:    "--print-secret still rejects removed flags",
-			args:    []string{"--print-secret", "--forward-thin-to", "http://localhost:3000"},
-			wantErr: "--forward-thin-to is no longer supported",
+			name: "--print-secret with deprecated flags",
+			args: []string{"--print-secret", "--forward-thin-to", "http://localhost:3000"},
 		},
 	}
 

--- a/pkg/proxy/filter_by_source_test.go
+++ b/pkg/proxy/filter_by_source_test.go
@@ -1,0 +1,128 @@
+package proxy
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stripe/stripe-cli/pkg/websocket"
+)
+
+func newProcessorWithEventsFrom(eventsFrom string) *WebhookEventProcessor {
+	return &WebhookEventProcessor{
+		cfg: &WebhookEventProcessorConfig{
+			Log:        log.StandardLogger(),
+			OutCh:      make(chan websocket.IElement, 1),
+			EventsFrom: eventsFrom,
+		},
+	}
+}
+
+func TestFilterBySource(t *testing.T) {
+	tests := []struct {
+		name       string
+		eventsFrom string
+		account    string
+		wantSkip   bool
+	}{
+		{
+			name:       "@self skips connect events",
+			eventsFrom: "@self",
+			account:    "acct_123",
+			wantSkip:   true,
+		},
+		{
+			name:       "@self allows self events",
+			eventsFrom: "@self",
+			account:    "",
+			wantSkip:   false,
+		},
+		{
+			name:       "@accounts skips self events",
+			eventsFrom: "@accounts",
+			account:    "",
+			wantSkip:   true,
+		},
+		{
+			name:       "@accounts allows connect events",
+			eventsFrom: "@accounts",
+			account:    "acct_123",
+			wantSkip:   false,
+		},
+		{
+			name:       "all allows self events",
+			eventsFrom: "all",
+			account:    "",
+			wantSkip:   false,
+		},
+		{
+			name:       "all allows connect events",
+			eventsFrom: "all",
+			account:    "acct_123",
+			wantSkip:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newProcessorWithEventsFrom(tt.eventsFrom)
+			evt := &StripeEvent{Account: tt.account}
+			assert.Equal(t, tt.wantSkip, p.filterBySource(evt))
+		})
+	}
+}
+
+func TestFilterByV2Source(t *testing.T) {
+	tests := []struct {
+		name       string
+		eventsFrom string
+		context    string
+		wantSkip   bool
+	}{
+		{
+			name:       "@self skips connect v2 events",
+			eventsFrom: "@self",
+			context:    "acct_123",
+			wantSkip:   true,
+		},
+		{
+			name:       "@self allows self v2 events",
+			eventsFrom: "@self",
+			context:    "",
+			wantSkip:   false,
+		},
+		{
+			name:       "@accounts skips self v2 events",
+			eventsFrom: "@accounts",
+			context:    "",
+			wantSkip:   true,
+		},
+		{
+			name:       "@accounts allows connect v2 events",
+			eventsFrom: "@accounts",
+			context:    "acct_123",
+			wantSkip:   false,
+		},
+		{
+			name:       "all allows self v2 events",
+			eventsFrom: "all",
+			context:    "",
+			wantSkip:   false,
+		},
+		{
+			name:       "all allows connect v2 events",
+			eventsFrom: "all",
+			context:    "acct_123",
+			wantSkip:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newProcessorWithEventsFrom(tt.eventsFrom)
+			evt := &V2EventPayload{Context: tt.context}
+			assert.Equal(t, tt.wantSkip, p.filterByV2Source(evt))
+		})
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -117,6 +117,9 @@ type Config struct {
 
 	// LoggedInAccountID is the currently logged-in account ID
 	LoggedInAccountID string
+
+	// EventsFrom filters events by source: "@self", "@accounts", or "all"
+	EventsFrom string
 }
 
 // A Proxy opens a websocket connection with Stripe, listens for incoming
@@ -362,14 +365,13 @@ func Init(ctx context.Context, cfg *Config) (*Proxy, error) {
 
 	if len(cfg.ThinEvents) > 0 {
 		for _, event := range cfg.ThinEvents {
+			if event == "*" {
+				cfg.Log.Infof("--all-thin is only supported in the CLI; thin event destinations do not support selecting all event types\n")
+				continue
+			}
 			if _, found := validThinEvents[event]; !found {
-				// If not found in validThinEvents, check in validPreviewThinEvents
 				if _, foundInPreview := validPreviewThinEvents[event]; !foundInPreview {
-					if event == "*" {
-						cfg.Log.Infof("* is only supported in the CLI, thin event destinations do not support selecting all event types\n")
-					} else {
-						cfg.Log.Warningf("You're attempting to listen for \"%s\", which isn't a valid thin event or preview event\n", event)
-					}
+					cfg.Log.Warningf("You're attempting to listen for \"%s\", which isn't a valid thin event or preview event\n", event)
 				}
 			}
 		}
@@ -453,6 +455,7 @@ func Init(ctx context.Context, cfg *Config) (*Proxy, error) {
 		SkipVerify:          cfg.SkipVerify,
 		Timeout:             cfg.Timeout,
 		LoggedInAccountID:   cfg.LoggedInAccountID,
+		EventsFrom:          cfg.EventsFrom,
 	}
 
 	p := &Proxy{

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -366,7 +366,7 @@ func Init(ctx context.Context, cfg *Config) (*Proxy, error) {
 	if len(cfg.ThinEvents) > 0 {
 		for _, event := range cfg.ThinEvents {
 			if event == "*" {
-				cfg.Log.Infof("--all-thin is only supported in the CLI; thin event destinations do not support selecting all event types\n")
+				cfg.Log.Infof("Subscribing to all thin events is only supported in the CLI; thin event destinations do not support selecting all event types")
 				continue
 			}
 			if _, found := validThinEvents[event]; !found {

--- a/pkg/proxy/webhook_event_processor.go
+++ b/pkg/proxy/webhook_event_processor.go
@@ -38,6 +38,9 @@ type WebhookEventProcessorConfig struct {
 
 	// LoggedInAccountID is the currently logged-in account ID
 	LoggedInAccountID string
+
+	// EventsFrom filters events by source: "@self", "@accounts", or "all"
+	EventsFrom string
 }
 
 // WebhookEventProcessor encapsulates logic around processing and forwarding
@@ -150,6 +153,10 @@ func (p *WebhookEventProcessor) processEvent(webhookEvent *websocket.WebhookEven
 		return
 	}
 
+	if p.filterBySource(&evt) {
+		return
+	}
+
 	evtCtx := eventContext{
 		webhookID:             webhookEvent.WebhookID,
 		webhookConversationID: webhookEvent.WebhookConversationID,
@@ -196,6 +203,10 @@ func (p *WebhookEventProcessor) processV2Event(v2Event *websocket.StripeV2Event)
 		return
 	}
 
+	if p.filterByV2Source(&evt) {
+		return
+	}
+
 	// notify consumers
 	p.cfg.OutCh <- websocket.DataElement{
 		Data: evt,
@@ -235,6 +246,28 @@ func (p *WebhookEventProcessor) filterWebhookEvent(msg *websocket.WebhookEvent) 
 	}
 
 	return false
+}
+
+func (p *WebhookEventProcessor) filterBySource(evt *StripeEvent) bool {
+	switch p.cfg.EventsFrom {
+	case "@self":
+		return evt.IsConnect()
+	case "@accounts":
+		return !evt.IsConnect()
+	default:
+		return false
+	}
+}
+
+func (p *WebhookEventProcessor) filterByV2Source(evt *V2EventPayload) bool {
+	switch p.cfg.EventsFrom {
+	case "@self":
+		return evt.IsConnect()
+	case "@accounts":
+		return !evt.IsConnect()
+	default:
+		return false
+	}
 }
 
 func (p *WebhookEventProcessor) processEndpointResponse(evtCtx eventContext, forwardURL string, resp *http.Response) {


### PR DESCRIPTION
Unifies the separate snapshot and thin event flags on `stripe listen` into one set:

- `--events` accepts both snapshot and thin event types, and the CLI infers which websocket features to subscribe to
- `--forward-to` / `--forward-connect-to` forward both payload styles
- `--all-snapshot` / `--all-thin` replace `--events '*'`, which became ambiguous once thin events existed
- `--events-from @self|@accounts|all` selects which accounts to receive events from

Users previously had to learn `--thin-events`, `--forward-thin-to`, and `--forward-thin-connect-to` as a parallel vocabulary, with no coherent way to combine them with the snapshot equivalents. Those flags are deprecated rather than removed: they warn and name their replacement, stay out of `--help`, and keep working, so published commands and existing scripts still run. They will be rejected outright in a later release, once the docs have been updated to the new flags. Flag combinations are validated before credentials are resolved, so a bad invocation reports itself rather than failing on something downstream.

The redesign originally landed on the `v2` branch and is ported here now that it ships in a v1 minor release. The PRs it consolidates:

- #1763 Unify snapshot and thin event flags into `--events` and `--forward-to`
- #1764 Add `--events-from` flag to control event source filtering
- #1765 Add `--all-snapshot` and `--all-thin` flags for event subscriptions
- #1789 Deprecate the old thin event flags (removal deferred until the docs are updated)
- #1798 Add validation errors for forwarding configuration
- #1857 Filter events by source in `--events-from` for terminal display
- #1882 Validate `--events-from` flag and reject invalid values
- #1883 Replace confusing `'*'` with `--all-thin` in INFO message
- #1885 Fix help example that mixes snapshot and thin events to same destination
- #1891 Simplify error message when mixing snapshot and thin events to same destination
