### PR TITLE
Read the plugin auto-update setting

### DIFF
--- a/pkg/cmd/plugin/auto_update.go
+++ b/pkg/cmd/plugin/auto_update.go
@@ -60,9 +60,9 @@ func (ac *AutoUpdateCmd) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	value := "off"
+	value := config.PluginConfigOff
 	if ac.enable {
-		value = "on"
+		value = config.PluginConfigOn
 	}
 
 	return ac.cfg.WriteConfigField(config.PluginConfigKey(scope, config.PluginConfigUpdatesField), value)

--- a/pkg/config/plugin_configs.go
+++ b/pkg/config/plugin_configs.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/spf13/viper"
+
 const (
 	// PluginConfigGlobalScope is used as the scope when a setting applies to all plugins.
 	PluginConfigGlobalScope = "__global"
@@ -10,6 +12,12 @@ const (
 	// PluginConfigsKey is the top-level table holding every plugin config
 	// section. It is a CLI setting, not a profile.
 	PluginConfigsKey = "plugin_configs"
+
+	// PluginConfigOn and PluginConfigOff are the values a plugin config toggle
+	// holds. They are named because the writer and the reader live in different
+	// packages and have to agree on the exact string.
+	PluginConfigOn  = "on"
+	PluginConfigOff = "off"
 )
 
 // isPluginConfigSection reports whether v is a plugin config section,
@@ -30,4 +38,41 @@ func isPluginConfigSection(v interface{}) bool {
 // Example: PluginConfigKey("apps", "updates") to read or set the updates setting for the "apps" plugin
 func PluginConfigKey(scope, field string) string {
 	return PluginConfigsKey + "." + scope + "." + field
+}
+
+// PluginUpdatesEnabled reports whether automatic updates are enabled for the
+// named plugin, per `stripe plugin auto-update`.
+//
+// Updates are off unless the user turned them on. Nothing should download a new
+// plugin version on its own just because no one said otherwise.
+func PluginUpdatesEnabled(pluginName string) bool {
+	return pluginUpdatesEnabled(viper.GetViper(), pluginName)
+}
+
+func pluginUpdatesEnabled(v *viper.Viper, pluginName string) bool {
+	// A setting on the plugin itself answers alone, so `--disable` on one plugin
+	// holds under a global `--enable` and the reverse. A value that is neither "on"
+	// nor "off" counts as set: the user configured this plugin, which is enough to
+	// keep the global setting from speaking for it, and anything unreadable as "on"
+	// leaves updates off.
+	if pluginName != "" {
+		if enabled, isSet := pluginConfigToggle(v, pluginName, PluginConfigUpdatesField); isSet {
+			return enabled
+		}
+	}
+
+	enabled, _ := pluginConfigToggle(v, PluginConfigGlobalScope, PluginConfigUpdatesField)
+	return enabled
+}
+
+// pluginConfigToggle reads one on/off plugin config field. isSet distinguishes a
+// field the user turned off from one they never touched, which is what lets a
+// per-plugin setting take precedence over the global one.
+func pluginConfigToggle(v *viper.Viper, scope, field string) (enabled, isSet bool) {
+	key := PluginConfigKey(scope, field)
+	if !v.IsSet(key) {
+		return false, false
+	}
+
+	return v.GetString(key) == PluginConfigOn, true
 }

--- a/pkg/config/plugin_configs_test.go
+++ b/pkg/config/plugin_configs_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginUpdatesEnabledPrecedence(t *testing.T) {
+	const plugin = "apps"
+
+	tests := []struct {
+		name         string
+		pluginValue  interface{}
+		globalValue  interface{}
+		wantForApps  bool
+		wantForOther bool
+	}{
+		{
+			name:         "unset defaults to off",
+			wantForApps:  false,
+			wantForOther: false,
+		},
+		{
+			name:         "global on applies to every plugin",
+			globalValue:  PluginConfigOn,
+			wantForApps:  true,
+			wantForOther: true,
+		},
+		{
+			name:         "global off applies to every plugin",
+			globalValue:  PluginConfigOff,
+			wantForApps:  false,
+			wantForOther: false,
+		},
+		{
+			name:         "plugin on with no global setting",
+			pluginValue:  PluginConfigOn,
+			wantForApps:  true,
+			wantForOther: false,
+		},
+		{
+			name:         "plugin off overrides global on",
+			pluginValue:  PluginConfigOff,
+			globalValue:  PluginConfigOn,
+			wantForApps:  false,
+			wantForOther: true,
+		},
+		{
+			name:         "plugin on overrides global off",
+			pluginValue:  PluginConfigOn,
+			globalValue:  PluginConfigOff,
+			wantForApps:  true,
+			wantForOther: false,
+		},
+		{
+			// A value we cannot read as "on" leaves updates off, and still keeps the
+			// global setting from answering for a plugin the user configured.
+			name:         "unrecognized plugin value does not fall through to global on",
+			pluginValue:  "yes",
+			globalValue:  PluginConfigOn,
+			wantForApps:  false,
+			wantForOther: true,
+		},
+		{
+			// Hand-editing the config file is how a non-string value gets here.
+			name:         "non-string plugin value is not on",
+			pluginValue:  true,
+			wantForApps:  false,
+			wantForOther: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := viper.New()
+			if tt.pluginValue != nil {
+				v.Set(PluginConfigKey(plugin, PluginConfigUpdatesField), tt.pluginValue)
+			}
+			if tt.globalValue != nil {
+				v.Set(PluginConfigKey(PluginConfigGlobalScope, PluginConfigUpdatesField), tt.globalValue)
+			}
+
+			require.Equal(t, tt.wantForApps, pluginUpdatesEnabled(v, plugin))
+			require.Equal(t, tt.wantForOther, pluginUpdatesEnabled(v, "projects"))
+		})
+	}
+}
+
+// An empty plugin name would build the key "plugin_configs..updates", so it has
+// to be dropped rather than looked up. Callers should always name a plugin; this
+// pins the behavior if one ever doesn't.
+func TestPluginUpdatesEnabledIgnoresEmptyPluginName(t *testing.T) {
+	v := viper.New()
+	v.Set(PluginConfigKey(PluginConfigGlobalScope, PluginConfigUpdatesField), PluginConfigOn)
+
+	require.True(t, pluginUpdatesEnabled(v, ""))
+
+	v.Set(PluginConfigKey(PluginConfigGlobalScope, PluginConfigUpdatesField), PluginConfigOff)
+
+	require.False(t, pluginUpdatesEnabled(v, ""))
+}
+
+// The setting is written by `stripe plugin auto-update` and read here, from two
+// different packages. Go through the real write path to prove they agree.
+func TestPluginUpdatesEnabledReadsWhatAutoUpdateWrites(t *testing.T) {
+	c, _, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	require.False(t, PluginUpdatesEnabled("apps"))
+
+	require.NoError(t, c.WriteConfigField(PluginConfigKey(PluginConfigGlobalScope, PluginConfigUpdatesField), PluginConfigOn))
+	require.True(t, PluginUpdatesEnabled("apps"))
+
+	require.NoError(t, c.WriteConfigField(PluginConfigKey("apps", PluginConfigUpdatesField), PluginConfigOff))
+	require.False(t, PluginUpdatesEnabled("apps"))
+	require.True(t, PluginUpdatesEnabled("projects"))
+}


### PR DESCRIPTION
### Reviewers
  r? @
  cc @stripe/developer-products

  ### Summary

  `stripe plugin auto-update` writes settings to `plugin_configs.<scope>.updates`, but nothing currently reads them.

  This PR adds `config.PluginUpdatesEnabled`, which:

  - Defaults automatic updates to off.
  - Applies the global setting when no plugin-specific setting exists.
  - Gives plugin-specific settings precedence over the global setting.
  - Treats unrecognized values as disabled.

  It also defines shared constants for the `on` and `off` values used by the reader and writer. The auto-upgrade path will consume
  this reader in a follow-up.

  Label: `skip-release-notes`

  ### Test plan

  `go test -race ./pkg/config ./pkg/cmd/plugin ./pkg/plugins`

  Tests cover global and plugin-specific precedence, unset and malformed values, and reading values written through the real config
  write path.

  ### Monitoring plan

  None. This PR only adds the setting reader; it does not yet change runtime update behavior.