### PR TITLE
Enhancements for the context switching behavior

### DIFF
--- a/pkg/cmd/data.go
+++ b/pkg/cmd/data.go
@@ -187,7 +187,7 @@ https://docs.stripe.com/api/v2/data/analytics/metric-query-results/create?api-ve
 	c.cmd.Flags().IntVar(&c.limit, "limit", 0, "Maximum number of rows to return (1–1000). Default is all rows.")
 
 	c.cmd.Flags().BoolVar(&c.rb.DryRun, "dry-run", false, "Preview the request without sending it")
-	c.cmd.Flags().BoolVarP(&c.rb.Livemode, "live", "", false, "Make a live request (default: test)")
+	c.cmd.Flags().BoolVarP(&c.rb.Livemode, "live", "", false, "Make a live request (default: test). Requires your active context to be in live mode — check with 'stripe whoami', switch with 'stripe switch'")
 	c.cmd.Flags().BoolVarP(&c.rb.DarkStyle, "dark-style", "", false, "Use a darker color scheme better suited for lighter command-lines")
 
 	// --api-base overrides the API host (used for local/dev testing); it's hidden

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -92,7 +92,7 @@ Stripe account.`,
 	lc.cmd.Flags().StringVar(&lc.forwardThinURL, "forward-thin-to", "", "The URL to forward thin events to")
 	lc.cmd.Flags().StringVar(&lc.forwardThinConnectURL, "forward-thin-connect-to", "", "The URL to forward thin Connect events to")
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
-	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test)")
+	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test). Requires your active context to be in live mode — check with 'stripe whoami', switch with 'stripe switch'")
 	lc.cmd.Flags().BoolVarP(&lc.printJSON, "print-json", "j", false, "Print full JSON objects to stdout.")
 	lc.cmd.Flags().MarkDeprecated("print-json", "Please use `--format json` instead and use `jq` if you need to process the JSON in the terminal.")
 	lc.cmd.Flags().StringVar(&lc.format, "format", "", `Specifies the output format of webhook events
@@ -144,9 +144,9 @@ func (lc *listenCmd) runListenCmd(cmd *cobra.Command, args []string) error {
 	var mismatch *config.ActiveContextLivemodeMismatchError
 	if errors.As(err, &mismatch) {
 		if mismatch.ActiveLivemode {
-			return errorcategory.UserInputErrorf("You're in live mode. Add --live to run the command, or run 'stripe switch context' to select a sandbox.")
+			return errorcategory.UserInputErrorf("You're in live mode. Add --live to run the command, or run 'stripe switch' to select a sandbox.")
 		}
-		return errorcategory.UserInputErrorf("You're in a sandbox. Remove --live to run the command, or run 'stripe switch context' to select a live account.")
+		return errorcategory.UserInputErrorf("You're in a sandbox. Remove --live to run the command, or run 'stripe switch' to select a live account.")
 	}
 	if err != nil {
 		return err

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -155,7 +155,7 @@ works here too, printing a browser_url and a next_step of
 	switchCmd.cmd = &cobra.Command{
 		Use:     "switch [account_id]",
 		Args:    validators.MaximumNArgs(1),
-		Short:   "Alias for 'stripe switch context'",
+		Short:   "Alias for 'stripe switch'",
 		Example: `stripe login switch\n  stripe login switch acct_1234\n  stripe login switch acct_1234 --live`,
 		RunE:    switchCmd.switchLoggedInAccountCmd,
 	}

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -64,7 +64,7 @@ func newLoginCmd() *loginCmd {
 		Short: "Log in to your Stripe account",
 		Long: `Log in to your Stripe account to set up the CLI.
 
-By default (when stdin is a terminal), this opens a browser-based OAuth flow: it
+By default (when stdin is a terminal), this opens a browser-based login flow: it
 prints a pairing code, launches your browser to the Stripe Dashboard, and waits for
 you to approve the request before saving your credentials.
 
@@ -119,7 +119,7 @@ works here too, printing a browser_url and a next_step of
 	lc.cmd.Flags().BoolVarP(&lc.interactive, "interactive", "i", false, "Run interactive configuration mode if you cannot open a browser")
 	lc.cmd.Flags().BoolVar(&lc.nonInteractive, "non-interactive", false, "Print login URL and verification code as JSON and exit; immediately run the next_step command from the output to poll while the user approves in the browser")
 	lc.cmd.Flags().StringVar(&lc.completeURL, "complete", "", "Complete a browser login by polling the given URL (from 'stripe login --non-interactive')")
-	lc.cmd.Flags().BoolVar(&lc.completeDevice, "complete-device", false, "Complete an OAuth device authorization started by 'stripe login --non-interactive'")
+	lc.cmd.Flags().BoolVar(&lc.completeDevice, "complete-device", false, "Complete a device authorization started by 'stripe login --non-interactive'")
 	lc.cmd.Flags().MarkHidden("complete-device") // #nosec G104
 	lc.cmd.Flags().BoolVar(&lc.completeReauth, "complete-reauth", false, "Complete a reauthorization started by 'stripe login --non-interactive'")
 	lc.cmd.Flags().MarkHidden("complete-reauth") // #nosec G104

--- a/pkg/cmd/logs/tail.go
+++ b/pkg/cmd/logs/tail.go
@@ -174,7 +174,7 @@ func (tailCmd *TailCmd) runTailCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if ac, acErr := config.GetActiveContext(); acErr == nil && ac != nil && ac.Livemode {
-		return errorcategory.UserInputErrorf("'stripe logs tail' only works in sandboxes, but you're in live mode. Run 'stripe switch context' to select a sandbox.")
+		return errorcategory.UserInputErrorf("'stripe logs tail' only works in sandboxes, but you're in live mode. Run 'stripe switch' to select a sandbox.")
 	}
 
 	creds, err := tailCmd.cfg.Profile.ResolveCredentials(false)

--- a/pkg/cmd/reauth.go
+++ b/pkg/cmd/reauth.go
@@ -20,13 +20,13 @@ func newReauthCmd() *reauthCmd {
 	rc.cmd = &cobra.Command{
 		Use:   "reauth",
 		Args:  validators.NoArgs,
-		Short: "Re-authorize the CLI for the current OAuth session",
+		Short: "Re-authorize the CLI for the current session",
 		Long: `Re-authorize the CLI to change permissions or authorize access to
 additional accounts or sandboxes.
 
-Opens the Stripe Dashboard so you can re-consent for the current OAuth session.
+Opens the browser so you can re-consent for the current session.
 
-Deprecated: running 'stripe login' with a valid OAuth session now does this
+Deprecated: running 'stripe login' with a valid session now does this
 directly, so this command is hidden.`,
 		Example: `stripe reauth`,
 		Hidden:  true,
@@ -43,7 +43,7 @@ func (rc *reauthCmd) runReauthCmd(cmd *cobra.Command, args []string) error {
 	}
 	uat, _ := Config.Profile.GetUAT()
 	if !strings.HasPrefix(uat, "oak_") {
-		return errorcategory.Errorf(errorcategory.Auth, "reauth requires an OAuth session; run 'stripe login' to authenticate")
+		return errorcategory.Errorf(errorcategory.Auth, "reauth requires a valid session; run 'stripe login' to authenticate")
 	}
 	return login.Reauth(cmd.Context(), rc.accessBaseURL, uat)
 }

--- a/pkg/cmd/reporting.go
+++ b/pkg/cmd/reporting.go
@@ -123,7 +123,7 @@ reference (--result_options.compress_file). Prefer the dedicated
 	cc.cmd.SetFlagErrorFunc(flagErrorWithNestedAPIHint)
 
 	cc.cmd.Flags().BoolVar(&cc.rb.DryRun, "dry-run", false, "Preview the request without sending it")
-	cc.cmd.Flags().BoolVarP(&cc.rb.Livemode, "live", "", false, "Make a live request (default: test)")
+	cc.cmd.Flags().BoolVarP(&cc.rb.Livemode, "live", "", false, "Make a live request (default: test). Requires your active context to be in live mode — check with 'stripe whoami', switch with 'stripe switch'")
 	cc.cmd.Flags().BoolVarP(&cc.rb.DarkStyle, "dark-style", "", false, "Use a darker color scheme better suited for lighter command-lines")
 
 	cc.cmd.Flags().StringVar(&cc.rb.APIBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
@@ -157,7 +157,7 @@ used to download the query output.`,
 		RunE: rc.runReportingQueryRunsRetrieveCmd,
 	}
 
-	rc.cmd.Flags().BoolVarP(&rc.rb.Livemode, "live", "", false, "Make a live request (default: test)")
+	rc.cmd.Flags().BoolVarP(&rc.rb.Livemode, "live", "", false, "Make a live request (default: test). Requires your active context to be in live mode — check with 'stripe whoami', switch with 'stripe switch'")
 	rc.cmd.Flags().BoolVarP(&rc.rb.DarkStyle, "dark-style", "", false, "Use a darker color scheme better suited for lighter command-lines")
 
 	rc.cmd.Flags().StringVar(&rc.rb.APIBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")

--- a/pkg/cmd/switch.go
+++ b/pkg/cmd/switch.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
 	"github.com/stripe/stripe-cli/pkg/login"
 	"github.com/stripe/stripe-cli/pkg/validators"
 )
@@ -17,18 +20,22 @@ type switchContextCmd struct {
 	cmd           *cobra.Command
 	livemode      bool
 	accessBaseURL string
+	format        string
+}
+
+// switchOutput is the stable JSON schema for `stripe switch --format json`.
+type switchOutput struct {
+	AccountID   string `json:"account_id"`
+	DisplayName string `json:"display_name"`
+	Mode        string `json:"mode"`
 }
 
 func newSwitchCmd() *switchCmd {
 	sc := &switchCmd{}
-	sc.cmd = &cobra.Command{
-		Use:   "switch",
-		Short: "Switch active context or profile",
-	}
-
 	ctxCmd := &switchContextCmd{}
-	ctxCmd.cmd = &cobra.Command{
-		Use:   "context [account_id]",
+
+	sc.cmd = &cobra.Command{
+		Use:   "switch [account_id]",
 		Args:  validators.MaximumNArgs(1),
 		Short: "Switch to a different authorized account context",
 		Long: `Switch to a different authorized account context.
@@ -37,17 +44,35 @@ Without an argument, shows an interactive list of your authorized accounts and
 modes. Navigate with ↑↓, confirm with enter, or cancel with esc.
 
 With an account ID, switches directly to that account. Add --live to switch to live mode.`,
-		Example: `  stripe switch context
-  stripe switch context acct_1234
-  stripe switch context acct_1234 --live`,
+		Example: `  stripe switch
+  stripe switch acct_1234
+  stripe switch acct_1234 --live
+  stripe switch acct_1234 --format json`,
 		RunE: ctxCmd.run,
 	}
-	ctxCmd.cmd.Flags().BoolVar(&ctxCmd.livemode, "live", false, "Select live mode for the given account")
-	ctxCmd.cmd.Flags().StringVar(&ctxCmd.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
-	ctxCmd.cmd.Flags().MarkHidden("access-base") //nolint:errcheck
+	ctxCmd.cmd = sc.cmd
+	addSwitchContextFlags(sc.cmd, ctxCmd)
 
-	sc.cmd.AddCommand(ctxCmd.cmd)
+	// Kept as a hidden alias for backwards compatibility; 'stripe switch' is
+	// now the preferred way to switch context.
+	legacyCtxCmd := &cobra.Command{
+		Use:    "context [account_id]",
+		Args:   validators.MaximumNArgs(1),
+		Short:  "Switch to a different authorized account context",
+		Hidden: true,
+		RunE:   ctxCmd.run,
+	}
+	addSwitchContextFlags(legacyCtxCmd, ctxCmd)
+
+	sc.cmd.AddCommand(legacyCtxCmd)
 	return sc
+}
+
+func addSwitchContextFlags(cmd *cobra.Command, ctxCmd *switchContextCmd) {
+	cmd.Flags().BoolVar(&ctxCmd.livemode, "live", false, "Select live mode for the given account")
+	cmd.Flags().StringVar(&ctxCmd.format, "format", "", "Output format: 'json' for a stable JSON schema (suitable for scripting)")
+	cmd.Flags().StringVar(&ctxCmd.accessBaseURL, "access-base", login.DefaultAccessBaseURL, "Sets the access base URL")
+	cmd.Flags().MarkHidden("access-base") //nolint:errcheck
 }
 
 func (sc *switchContextCmd) run(cmd *cobra.Command, args []string) error {
@@ -58,12 +83,31 @@ func (sc *switchContextCmd) run(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		accountID = args[0]
 	}
+	if accountID == "" && strings.EqualFold(sc.format, "json") {
+		return errorcategory.UserInputErrorf("--format json requires an account_id argument; the interactive selector isn't scriptable")
+	}
 	result, err := login.SwitchContext(cmd.Context(), sc.accessBaseURL, &Config, accountID, sc.livemode)
 	if err != nil {
 		return err
 	}
-	if result != nil {
-		fmt.Printf("Active context: %s · %s (%s)\n", result.Account.Name, result.DisplayMode(), result.Account.ID)
+	if result == nil {
+		return nil
 	}
+
+	if strings.EqualFold(sc.format, "json") {
+		out := switchOutput{
+			AccountID:   result.Account.ID,
+			DisplayName: result.Account.Name,
+			Mode:        result.Mode,
+		}
+		b, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(b))
+		return nil
+	}
+
+	fmt.Printf("Active context: %s · %s (%s)\n", result.Account.Name, result.DisplayMode(), result.Account.ID)
 	return nil
 }

--- a/pkg/cmd/switch.go
+++ b/pkg/cmd/switch.go
@@ -44,7 +44,7 @@ Without an argument, shows an interactive list of your authorized accounts and
 modes. Navigate with ↑↓, confirm with enter, or cancel with esc.
 
 With an account ID, switches directly to that account. Add --live to switch to live mode.`,
-		Example: `  stripe switch
+		Example: `stripe switch
   stripe switch acct_1234
   stripe switch acct_1234 --live
   stripe switch acct_1234 --format json`,

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -919,7 +919,7 @@ func SaveActiveContext(accountID string, livemode bool) error {
 	if err != nil {
 		return err
 	}
-	return KeyRing.Set(OAuthActiveContextKeychainKey, data, "Stripe CLI OAuth active context")
+	return KeyRing.Set(OAuthActiveContextKeychainKey, data, "Stripe CLI active context")
 }
 
 // SaveUATExpiresAt persists the UAT expiry time in the keyring.
@@ -927,7 +927,7 @@ func SaveUATExpiresAt(t time.Time) error {
 	if KeyRing == nil {
 		return nil
 	}
-	return KeyRing.Set(OAuthUATExpiresAtKeychainKey, []byte(t.UTC().Format(time.RFC3339)), "Stripe CLI OAuth token expiry")
+	return KeyRing.Set(OAuthUATExpiresAtKeychainKey, []byte(t.UTC().Format(time.RFC3339)), "Stripe CLI token expiry")
 }
 
 // GetUATExpiresAt retrieves the stored UAT expiry time from the keyring.

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -1011,9 +1011,9 @@ type ActiveContextLivemodeMismatchError struct {
 
 func (e *ActiveContextLivemodeMismatchError) Error() string {
 	if e.ActiveLivemode {
-		return "You're in live mode. Run 'stripe switch context' to select a sandbox."
+		return "You're in live mode. Run 'stripe switch' to select a sandbox."
 	}
-	return "You're in a sandbox. Run 'stripe switch context' to select a live account."
+	return "You're in a sandbox. Run 'stripe switch' to select a live account."
 }
 
 // ResolveCredentials returns the credentials for the given mode. If an OAK

--- a/pkg/login/oauth_credentials.go
+++ b/pkg/login/oauth_credentials.go
@@ -30,7 +30,7 @@ func UpdateOAuthTokens(cfg *config.Config, resp *OAuthTokenResponse) error {
 	}
 
 	if resp.RefreshToken != "" {
-		if err := config.KeyRing.Set(OAuthRefreshTokenKeychainKey, []byte(resp.RefreshToken), "Stripe CLI OAuth refresh token"); err != nil {
+		if err := config.KeyRing.Set(OAuthRefreshTokenKeychainKey, []byte(resp.RefreshToken), "Stripe CLI refresh token"); err != nil {
 			return err
 		}
 	}

--- a/pkg/login/oauth_device.go
+++ b/pkg/login/oauth_device.go
@@ -363,7 +363,7 @@ func printAuthorizedSummary(accounts []config.AuthorizedAccount, activeID string
 	}
 
 	fmt.Println()
-	fmt.Println("Run 'stripe switch context' to change your active context.")
+	fmt.Println("Run 'stripe switch' to change your active context.")
 	fmt.Println("Run 'stripe login' to change permissions or authorize access to additional accounts or sandboxes.")
 }
 

--- a/pkg/login/oauth_device.go
+++ b/pkg/login/oauth_device.go
@@ -325,7 +325,7 @@ func printAuthorizedSummary(accounts []config.AuthorizedAccount, activeID string
 	rows := buildContextRows(accounts, activeID, activeLivemode)
 
 	if len(rows) == 0 {
-		fmt.Printf("%s Done! The Stripe CLI is configured with your OAuth credentials.\n", color.Green("✓"))
+		fmt.Printf("%s Done! The Stripe CLI is configured with your credentials.\n", color.Green("✓"))
 		return
 	}
 

--- a/pkg/login/oauth_pending.go
+++ b/pkg/login/oauth_pending.go
@@ -40,13 +40,13 @@ func loadPendingDeviceAuth() (*oauthContinuation, error) {
 	data, err := os.ReadFile(pendingDeviceAuthPath())
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, errorcategory.New(errorcategory.UserInput, "no pending OAuth login found; run 'stripe login --non-interactive' first")
+			return nil, errorcategory.New(errorcategory.UserInput, "no pending login found; run 'stripe login --non-interactive' first")
 		}
 		return nil, err
 	}
 	var cont oauthContinuation
 	if err := json.Unmarshal(data, &cont); err != nil {
-		return nil, fmt.Errorf("invalid pending OAuth state: %w", err)
+		return nil, fmt.Errorf("invalid pending login state: %w", err)
 	}
 	return &cont, nil
 }

--- a/pkg/login/oauth_refresh.go
+++ b/pkg/login/oauth_refresh.go
@@ -60,7 +60,7 @@ func refreshOAuthToken(p *config.Profile) error {
 	}
 
 	if tokenResp.RefreshToken != "" {
-		if err := config.KeyRing.Set(config.OAuthRefreshTokenKeychainKey, []byte(tokenResp.RefreshToken), "Stripe CLI OAuth refresh token"); err != nil {
+		if err := config.KeyRing.Set(config.OAuthRefreshTokenKeychainKey, []byte(tokenResp.RefreshToken), "Stripe CLI refresh token"); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/login/switch_context.go
+++ b/pkg/login/switch_context.go
@@ -35,7 +35,7 @@ func SwitchContext(ctx context.Context, accessBaseURL string, cfg *config.Config
 		return nil, err
 	}
 	if !strings.HasPrefix(uat, "oak_") {
-		return nil, errorcategory.Errorf(errorcategory.Auth, "not logged in with OAuth; run 'stripe login' first")
+		return nil, errorcategory.Errorf(errorcategory.Auth, "not logged in; run 'stripe login' first")
 	}
 
 	accounts, err := ListAuthorizedAccounts(ctx, accessBaseURL, uat)

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -203,7 +203,7 @@ func (rb *Base) InitFlags() {
 	rb.Cmd.Flags().StringVar(&rb.Parameters.stripeAccount, "stripe-account", "", "Set a header identifying the connected account")
 	rb.Cmd.Flags().StringVar(&rb.Parameters.stripeContext, "stripe-context", "", "Set a header identifying the compartment context")
 	rb.Cmd.Flags().BoolVarP(&rb.showHeaders, "show-headers", "s", false, "Show response headers")
-	rb.Cmd.Flags().BoolVar(&rb.Livemode, "live", false, "Make a live request (default: test)")
+	rb.Cmd.Flags().BoolVar(&rb.Livemode, "live", false, "Make a live request (default: test). Requires your active context to be in live mode — check with 'stripe whoami', switch with 'stripe switch'")
 	rb.Cmd.Flags().BoolVar(&rb.DarkStyle, "dark-style", false, "Use a darker color scheme better suited for lighter command-lines")
 	rb.Cmd.Flags().BoolVar(&rb.DryRun, "dry-run", false, "Preview the request without sending it")
 
@@ -235,9 +235,9 @@ func (rb *Base) ResolveCredentials() (stripe.Credentials, error) {
 	var mismatch *config.ActiveContextLivemodeMismatchError
 	if errors.As(err, &mismatch) {
 		if mismatch.ActiveLivemode {
-			return stripe.Credentials{}, errorcategory.UserInputErrorf("You're in live mode. Add --live to run the command, or run 'stripe switch context' to select a sandbox.")
+			return stripe.Credentials{}, errorcategory.UserInputErrorf("You're in live mode. Add --live to run the command, or run 'stripe switch' to select a sandbox.")
 		}
-		return stripe.Credentials{}, errorcategory.UserInputErrorf("You're in a sandbox. Remove --live to run the command, or run 'stripe switch context' to select a live account.")
+		return stripe.Credentials{}, errorcategory.UserInputErrorf("You're in a sandbox. Remove --live to run the command, or run 'stripe switch' to select a live account.")
 	}
 	return creds, err
 }

--- a/pkg/rpcservice/login.go
+++ b/pkg/rpcservice/login.go
@@ -22,7 +22,7 @@ func (srv *RPCService) Login(ctx context.Context, req *rpc.LoginRequest) (*rpc.L
 		return nil, err
 	}
 	if useOAuth {
-		return nil, errorcategory.Errorf(errorcategory.Auth, "OAuth login required; use 'stripe login' in a terminal to complete browser authorization")
+		return nil, errorcategory.Errorf(errorcategory.Auth, "valid session required; use 'stripe login' in a terminal to complete browser authorization")
 	}
 
 	return &rpc.LoginResponse{


### PR DESCRIPTION
### Summary

Clarifies what the `--live` flag does and how to use it in the help text, for each command that supports it

<img width="782" height="396" alt="Screenshot 2026-09-09 at 4 58 51 PM" src="https://github.com/user-attachments/assets/a7f982db-79de-4f7f-996e-537c6913bdef" />

Simplifies `stripe switch context` into just `stripe switch`, and keep `stripe switch context` available but hidden

Adds `--format json` support to `stripe switch`

<img width="917" height="214" alt="Screenshot 2026-09-09 at 5 02 34 PM" src="https://github.com/user-attachments/assets/ad60baf7-3592-44f2-b8b9-9f95fc5fe7a2" />

Other changes:
- Removes mention of "OAuth" in user facing messages since it's an implementation detail
- Removes some extra whitespace in `stripe switch --help`