### PR TITLE
[sandboxes cli] show sandbox sharing access in list

### DIFF
--- a/pkg/cmd/sandbox.go
+++ b/pkg/cmd/sandbox.go
@@ -981,21 +981,21 @@ func (slc *sandboxListCmd) runSandboxListCmd(cmd *cobra.Command, args []string) 
 	}
 
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tACCOUNT\tACCESS LEVEL")
+	fmt.Fprintln(w, "NAME\tACCOUNT\tACCESS")
 	for i, managedSandbox := range sandboxes {
 		fmt.Fprintf(w, "%s\t%s\t%s\n", managedSandbox.Name, managedSandbox.AccountID, accessLevels[i])
 	}
 	return w.Flush()
 }
 
-func sandboxAccessLevelLabel(accessLevel sandbox.AccessLevel) (string, bool) {
+func sandboxAccessLevelLabel(accessLevel sandbox.SandboxAccessLevel) (string, bool) {
 	switch accessLevel {
-	case sandbox.AccessLevelDirect:
-		return "DIRECT_ACCESS", true
-	case sandbox.AccessLevelSandboxChildren:
-		return "ACCESS_TO_SANDBOX_CHILDREN", true
-	case sandbox.AccessLevelNone:
-		return "NO_ACCESS", true
+	case sandbox.SandboxAccessLevelPrivate:
+		return "Private", true
+	case sandbox.SandboxAccessLevelGlobal:
+		return "All team members", true
+	case sandbox.SandboxAccessLevelDeveloper:
+		return "Developer", true
 	default:
 		return "", false
 	}

--- a/pkg/cmd/sandbox_test.go
+++ b/pkg/cmd/sandbox_test.go
@@ -1452,9 +1452,9 @@ func TestSandboxListCmd_PresentsSandboxes(t *testing.T) {
 	cmd := newSandboxListCmd()
 	cmd.client = fakeSandboxListClient{
 		sandboxes: []sandbox.ManagedSandbox{
-			{WorkspaceID: "wksp_test_z", AccountID: "acct_z", Name: "Zeta", AccessLevel: sandbox.AccessLevelNone},
-			{WorkspaceID: "wksp_test_a", AccountID: "acct_a", Name: "Alpha", AccessLevel: sandbox.AccessLevelDirect},
-			{WorkspaceID: "wksp_test_b", AccountID: "acct_b", Name: "Beta", AccessLevel: sandbox.AccessLevelSandboxChildren},
+			{WorkspaceID: "wksp_test_z", AccountID: "acct_z", Name: "Zeta", AccessLevel: sandbox.SandboxAccessLevelPrivate},
+			{WorkspaceID: "wksp_test_a", AccountID: "acct_a", Name: "Alpha", AccessLevel: sandbox.SandboxAccessLevelGlobal},
+			{WorkspaceID: "wksp_test_b", AccountID: "acct_b", Name: "Beta", AccessLevel: sandbox.SandboxAccessLevelDeveloper},
 		},
 	}
 
@@ -1466,10 +1466,10 @@ func TestSandboxListCmd_PresentsSandboxes(t *testing.T) {
 
 	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
 	require.Len(t, lines, 4)
-	assert.Equal(t, []string{"NAME", "ACCOUNT", "ACCESS", "LEVEL"}, strings.Fields(lines[0]))
-	assert.Equal(t, []string{"Zeta", "acct_z", "NO_ACCESS"}, strings.Fields(lines[1]))
-	assert.Equal(t, []string{"Alpha", "acct_a", "DIRECT_ACCESS"}, strings.Fields(lines[2]))
-	assert.Equal(t, []string{"Beta", "acct_b", "ACCESS_TO_SANDBOX_CHILDREN"}, strings.Fields(lines[3]))
+	assert.Equal(t, []string{"NAME", "ACCOUNT", "ACCESS"}, strings.Fields(lines[0]))
+	assert.Equal(t, []string{"Zeta", "acct_z", "Private"}, strings.Fields(lines[1]))
+	assert.Equal(t, []string{"Alpha", "acct_a", "All", "team", "members"}, strings.Fields(lines[2]))
+	assert.Equal(t, []string{"Beta", "acct_b", "Developer"}, strings.Fields(lines[3]))
 	assert.NotContains(t, stdout.String(), "wksp_")
 	assert.Empty(t, stderr.String())
 }

--- a/pkg/sandbox/management.go
+++ b/pkg/sandbox/management.go
@@ -23,13 +23,13 @@ const (
 	accountIDPrefix         = "acct_"
 )
 
-// AccessLevel describes the OAuth account's access in the workspace hierarchy.
-type AccessLevel int
+// SandboxAccessLevel describes the sandbox's default team access setting.
+type SandboxAccessLevel int
 
 const (
-	AccessLevelDirect          AccessLevel = 1
-	AccessLevelSandboxChildren AccessLevel = 2
-	AccessLevelNone            AccessLevel = 3
+	SandboxAccessLevelPrivate SandboxAccessLevel = iota + 1
+	SandboxAccessLevelGlobal
+	SandboxAccessLevelDeveloper
 )
 
 // ManagedSandbox is the normalized representation shared by sandbox list and
@@ -39,7 +39,7 @@ type ManagedSandbox struct {
 	WorkspaceID string
 	AccountID   string
 	Name        string
-	AccessLevel AccessLevel
+	AccessLevel SandboxAccessLevel
 }
 
 // ManagementClient discovers sandboxes authorized by the active live OAuth
@@ -135,46 +135,64 @@ type accessibleSandboxesResponse struct {
 }
 
 type sandboxOrganization struct {
-	Workspaces []accessibleSandbox `json:"workspaces"`
+	Workspaces        []accessibleSandbox `json:"workspaces"`
+	CompartmentLabels []compartmentLabel  `json:"compartment_labels"`
 }
 
 type accessibleSandbox struct {
-	WorkspaceID string                       `json:"id"`
-	AccountID   string                       `json:"merchant_id"`
-	Name        string                       `json:"name"`
-	AccessLevel accessibleSandboxAccessLevel `json:"access_level"`
+	WorkspaceID       string             `json:"id"`
+	AccountID         string             `json:"merchant_id"`
+	Name              string             `json:"name"`
+	CompartmentLabels []compartmentLabel `json:"compartment_labels"`
 }
 
-type accessibleSandboxAccessLevel string
+type compartmentLabel struct {
+	UsageType string `json:"usage_type"`
+}
 
 const (
-	accessibleSandboxAccessLevelDirect          accessibleSandboxAccessLevel = "direct_access"
-	accessibleSandboxAccessLevelSandboxChildren accessibleSandboxAccessLevel = "access_to_sandbox_children"
-	accessibleSandboxAccessLevelNone            accessibleSandboxAccessLevel = "no_access"
+	sandboxAccessLabelPrivate   = "sandbox_access_level_private"
+	sandboxAccessLabelGlobal    = "sandbox_access_level_global"
+	sandboxAccessLabelDeveloper = "sandbox_access_level_developer"
 )
 
 func normalizeAccessibleSandboxes(response accessibleSandboxesResponse) ([]ManagedSandbox, error) {
-	records := make([]accessibleSandbox, 0, len(response.Workspaces))
-	records = append(records, response.Workspaces...)
+	type sandboxWithAccessLabels struct {
+		sandbox      accessibleSandbox
+		accessLabels []compartmentLabel
+	}
+
+	records := make([]sandboxWithAccessLabels, 0, len(response.Workspaces))
+	for _, workspace := range response.Workspaces {
+		records = append(records, sandboxWithAccessLabels{
+			sandbox:      workspace,
+			accessLabels: workspace.CompartmentLabels,
+		})
+	}
 	for _, organization := range response.Organizations {
-		records = append(records, organization.Workspaces...)
+		// Account sandboxes in a sandbox organization inherit the organization's
+		// default access setting, which is also how Dashboard renders them.
+		for _, workspace := range organization.Workspaces {
+			records = append(records, sandboxWithAccessLabels{
+				sandbox:      workspace,
+				accessLabels: organization.CompartmentLabels,
+			})
+		}
 	}
 
 	validated := make([]ManagedSandbox, 0, len(records))
 	for _, record := range records {
-		accessLevel, validAccessLevel := normalizeAccessLevel(record.AccessLevel)
-		if !validTestmodeWorkspaceID(record.WorkspaceID) ||
-			!validAccountID(record.AccountID) ||
-			strings.TrimSpace(record.Name) == "" ||
-			!validAccessLevel {
+		if !validTestmodeWorkspaceID(record.sandbox.WorkspaceID) ||
+			!validAccountID(record.sandbox.AccountID) ||
+			strings.TrimSpace(record.sandbox.Name) == "" {
 			return nil, errorcategory.New(errorcategory.API, "could not list accessible sandboxes: the response contained an invalid sandbox")
 		}
 
 		validated = append(validated, ManagedSandbox{
-			WorkspaceID: record.WorkspaceID,
-			AccountID:   record.AccountID,
-			Name:        record.Name,
-			AccessLevel: accessLevel,
+			WorkspaceID: record.sandbox.WorkspaceID,
+			AccountID:   record.sandbox.AccountID,
+			Name:        record.sandbox.Name,
+			AccessLevel: sandboxAccessLevelFromLabels(record.accessLabels),
 		})
 	}
 
@@ -208,17 +226,18 @@ func normalizeAccessibleSandboxes(response accessibleSandboxesResponse) ([]Manag
 	return result, nil
 }
 
-func normalizeAccessLevel(accessLevel accessibleSandboxAccessLevel) (AccessLevel, bool) {
-	switch accessLevel {
-	case accessibleSandboxAccessLevelDirect:
-		return AccessLevelDirect, true
-	case accessibleSandboxAccessLevelSandboxChildren:
-		return AccessLevelSandboxChildren, true
-	case accessibleSandboxAccessLevelNone:
-		return AccessLevelNone, true
-	default:
-		return 0, false
+func sandboxAccessLevelFromLabels(labels []compartmentLabel) SandboxAccessLevel {
+	for _, label := range labels {
+		if label.UsageType == sandboxAccessLabelGlobal {
+			return SandboxAccessLevelGlobal
+		}
 	}
+	for _, label := range labels {
+		if label.UsageType == sandboxAccessLabelDeveloper {
+			return SandboxAccessLevelDeveloper
+		}
+	}
+	return SandboxAccessLevelPrivate
 }
 
 func validLiveWorkspaceID(id string) bool {

--- a/pkg/sandbox/management.go
+++ b/pkg/sandbox/management.go
@@ -139,11 +139,19 @@ type sandboxOrganization struct {
 }
 
 type accessibleSandbox struct {
-	WorkspaceID string      `json:"id"`
-	AccountID   string      `json:"merchant_id"`
-	Name        string      `json:"name"`
-	AccessLevel AccessLevel `json:"access_level"`
+	WorkspaceID string                       `json:"id"`
+	AccountID   string                       `json:"merchant_id"`
+	Name        string                       `json:"name"`
+	AccessLevel accessibleSandboxAccessLevel `json:"access_level"`
 }
+
+type accessibleSandboxAccessLevel string
+
+const (
+	accessibleSandboxAccessLevelDirect          accessibleSandboxAccessLevel = "direct_access"
+	accessibleSandboxAccessLevelSandboxChildren accessibleSandboxAccessLevel = "access_to_sandbox_children"
+	accessibleSandboxAccessLevelNone            accessibleSandboxAccessLevel = "no_access"
+)
 
 func normalizeAccessibleSandboxes(response accessibleSandboxesResponse) ([]ManagedSandbox, error) {
 	records := make([]accessibleSandbox, 0, len(response.Workspaces))
@@ -154,15 +162,20 @@ func normalizeAccessibleSandboxes(response accessibleSandboxesResponse) ([]Manag
 
 	validated := make([]ManagedSandbox, 0, len(records))
 	for _, record := range records {
+		accessLevel, validAccessLevel := normalizeAccessLevel(record.AccessLevel)
 		if !validTestmodeWorkspaceID(record.WorkspaceID) ||
 			!validAccountID(record.AccountID) ||
 			strings.TrimSpace(record.Name) == "" ||
-			record.AccessLevel < AccessLevelDirect ||
-			record.AccessLevel > AccessLevelNone {
+			!validAccessLevel {
 			return nil, errorcategory.New(errorcategory.API, "could not list accessible sandboxes: the response contained an invalid sandbox")
 		}
 
-		validated = append(validated, ManagedSandbox(record))
+		validated = append(validated, ManagedSandbox{
+			WorkspaceID: record.WorkspaceID,
+			AccountID:   record.AccountID,
+			Name:        record.Name,
+			AccessLevel: accessLevel,
+		})
 	}
 
 	byWorkspaceID := make(map[string]ManagedSandbox, len(validated))
@@ -193,6 +206,19 @@ func normalizeAccessibleSandboxes(response accessibleSandboxesResponse) ([]Manag
 	})
 
 	return result, nil
+}
+
+func normalizeAccessLevel(accessLevel accessibleSandboxAccessLevel) (AccessLevel, bool) {
+	switch accessLevel {
+	case accessibleSandboxAccessLevelDirect:
+		return AccessLevelDirect, true
+	case accessibleSandboxAccessLevelSandboxChildren:
+		return AccessLevelSandboxChildren, true
+	case accessibleSandboxAccessLevelNone:
+		return AccessLevelNone, true
+	default:
+		return 0, false
+	}
 }
 
 func validLiveWorkspaceID(id string) bool {

--- a/pkg/sandbox/management_test.go
+++ b/pkg/sandbox/management_test.go
@@ -39,12 +39,15 @@ func TestManagementClientListAccessible(t *testing.T) {
 			require.Empty(t, body)
 			_, _ = w.Write([]byte(`{
   "workspaces": [
-    {"id":"wksp_test_z","merchant_id":"acct_z","name":"Zeta","access_level":"no_access"},
-    {"id":"wksp_test_b","merchant_id":"acct_b","name":"Alpha","access_level":"direct_access"}
+    {"id":"wksp_test_z","merchant_id":"acct_z","name":"Zeta","access_level":"direct_access","compartment_labels":[]},
+    {"id":"wksp_test_b","merchant_id":"acct_b","name":"Alpha","access_level":"direct_access","compartment_labels":[{"usage_type":"sandbox_access_level_global"}]}
   ],
-  "organizations": [{"workspaces": [
-    {"id":"wksp_test_a","merchant_id":"acct_a","name":"alpha","access_level":"access_to_sandbox_children"},
-    {"id":"wksp_test_b","merchant_id":"acct_b","name":"Alpha","access_level":"direct_access"}
+  "organizations": [{
+    "access_level":"direct_access",
+    "compartment_labels":[{"usage_type":"sandbox_access_level_global"}],
+    "workspaces": [
+    {"id":"wksp_test_a","merchant_id":"acct_a","name":"alpha","access_level":"direct_access","compartment_labels":[{"usage_type":"sandbox_access_level_private"}]},
+    {"id":"wksp_test_b","merchant_id":"acct_b","name":"Alpha","access_level":"direct_access","compartment_labels":[{"usage_type":"sandbox_access_level_private"}]}
   ]}]
 }`))
 		default:
@@ -57,10 +60,30 @@ func TestManagementClientListAccessible(t *testing.T) {
 	got, err := client.ListAccessible(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, []ManagedSandbox{
-		{WorkspaceID: "wksp_test_a", AccountID: "acct_a", Name: "alpha", AccessLevel: AccessLevelSandboxChildren},
-		{WorkspaceID: "wksp_test_b", AccountID: "acct_b", Name: "Alpha", AccessLevel: AccessLevelDirect},
-		{WorkspaceID: "wksp_test_z", AccountID: "acct_z", Name: "Zeta", AccessLevel: AccessLevelNone},
+		{WorkspaceID: "wksp_test_a", AccountID: "acct_a", Name: "alpha", AccessLevel: SandboxAccessLevelGlobal},
+		{WorkspaceID: "wksp_test_b", AccountID: "acct_b", Name: "Alpha", AccessLevel: SandboxAccessLevelGlobal},
+		{WorkspaceID: "wksp_test_z", AccountID: "acct_z", Name: "Zeta", AccessLevel: SandboxAccessLevelPrivate},
 	}, got)
+}
+
+func TestSandboxAccessLevelFromLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []compartmentLabel
+		want   SandboxAccessLevel
+	}{
+		{name: "missing defaults to private", want: SandboxAccessLevelPrivate},
+		{name: "explicit private", labels: []compartmentLabel{{UsageType: sandboxAccessLabelPrivate}}, want: SandboxAccessLevelPrivate},
+		{name: "unrelated defaults to private", labels: []compartmentLabel{{UsageType: "testmode_app_developer"}}, want: SandboxAccessLevelPrivate},
+		{name: "developer", labels: []compartmentLabel{{UsageType: sandboxAccessLabelDeveloper}}, want: SandboxAccessLevelDeveloper},
+		{name: "global", labels: []compartmentLabel{{UsageType: sandboxAccessLabelGlobal}}, want: SandboxAccessLevelGlobal},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, sandboxAccessLevelFromLabels(test.labels))
+		})
+	}
 }
 
 func TestManagementClientListAccessibleEmpty(t *testing.T) {
@@ -205,16 +228,13 @@ func TestManagementClientRejectsInvalidSandboxResponses(t *testing.T) {
 		response string
 	}{
 		{name: "malformed JSON", response: `{"workspaces":`},
-		{name: "missing workspace id", response: `{"workspaces":[{"merchant_id":"acct_1","name":"one","access_level":"direct_access"}]}`},
-		{name: "missing account id", response: `{"workspaces":[{"id":"wksp_test_1","name":"one","access_level":"direct_access"}]}`},
-		{name: "missing name", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","access_level":"direct_access"}]}`},
-		{name: "live workspace", response: `{"workspaces":[{"id":"wksp_live_1","merchant_id":"acct_1","name":"one","access_level":"direct_access"}]}`},
-		{name: "missing access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one"}]}`},
-		{name: "unknown access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":"unknown_access"}]}`},
-		{name: "numeric access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":1}]}`},
+		{name: "missing workspace id", response: `{"workspaces":[{"merchant_id":"acct_1","name":"one"}]}`},
+		{name: "missing account id", response: `{"workspaces":[{"id":"wksp_test_1","name":"one"}]}`},
+		{name: "missing name", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1"}]}`},
+		{name: "live workspace", response: `{"workspaces":[{"id":"wksp_live_1","merchant_id":"acct_1","name":"one"}]}`},
 		{name: "conflicting duplicate", response: `{"workspaces":[
-  {"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":"direct_access"},
-  {"id":"wksp_test_1","merchant_id":"acct_2","name":"one","access_level":"direct_access"}
+  {"id":"wksp_test_1","merchant_id":"acct_1","name":"one"},
+  {"id":"wksp_test_1","merchant_id":"acct_2","name":"one"}
 ]}`},
 	}
 

--- a/pkg/sandbox/management_test.go
+++ b/pkg/sandbox/management_test.go
@@ -39,12 +39,12 @@ func TestManagementClientListAccessible(t *testing.T) {
 			require.Empty(t, body)
 			_, _ = w.Write([]byte(`{
   "workspaces": [
-    {"id":"wksp_test_z","merchant_id":"acct_z","name":"Zeta","access_level":3},
-    {"id":"wksp_test_b","merchant_id":"acct_b","name":"Alpha","access_level":1}
+    {"id":"wksp_test_z","merchant_id":"acct_z","name":"Zeta","access_level":"no_access"},
+    {"id":"wksp_test_b","merchant_id":"acct_b","name":"Alpha","access_level":"direct_access"}
   ],
   "organizations": [{"workspaces": [
-    {"id":"wksp_test_a","merchant_id":"acct_a","name":"alpha","access_level":2},
-    {"id":"wksp_test_b","merchant_id":"acct_b","name":"Alpha","access_level":1}
+    {"id":"wksp_test_a","merchant_id":"acct_a","name":"alpha","access_level":"access_to_sandbox_children"},
+    {"id":"wksp_test_b","merchant_id":"acct_b","name":"Alpha","access_level":"direct_access"}
   ]}]
 }`))
 		default:
@@ -205,16 +205,16 @@ func TestManagementClientRejectsInvalidSandboxResponses(t *testing.T) {
 		response string
 	}{
 		{name: "malformed JSON", response: `{"workspaces":`},
-		{name: "missing workspace id", response: `{"workspaces":[{"merchant_id":"acct_1","name":"one","access_level":1}]}`},
-		{name: "missing account id", response: `{"workspaces":[{"id":"wksp_test_1","name":"one","access_level":1}]}`},
-		{name: "missing name", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","access_level":1}]}`},
-		{name: "live workspace", response: `{"workspaces":[{"id":"wksp_live_1","merchant_id":"acct_1","name":"one","access_level":1}]}`},
-		{name: "zero access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":0}]}`},
-		{name: "unknown access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":4}]}`},
-		{name: "string access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":"DIRECT"}]}`},
+		{name: "missing workspace id", response: `{"workspaces":[{"merchant_id":"acct_1","name":"one","access_level":"direct_access"}]}`},
+		{name: "missing account id", response: `{"workspaces":[{"id":"wksp_test_1","name":"one","access_level":"direct_access"}]}`},
+		{name: "missing name", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","access_level":"direct_access"}]}`},
+		{name: "live workspace", response: `{"workspaces":[{"id":"wksp_live_1","merchant_id":"acct_1","name":"one","access_level":"direct_access"}]}`},
+		{name: "missing access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one"}]}`},
+		{name: "unknown access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":"unknown_access"}]}`},
+		{name: "numeric access level", response: `{"workspaces":[{"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":1}]}`},
 		{name: "conflicting duplicate", response: `{"workspaces":[
-  {"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":1},
-  {"id":"wksp_test_1","merchant_id":"acct_2","name":"one","access_level":1}
+  {"id":"wksp_test_1","merchant_id":"acct_1","name":"one","access_level":"direct_access"},
+  {"id":"wksp_test_1","merchant_id":"acct_2","name":"one","access_level":"direct_access"}
 ]}`},
 	}
 


### PR DESCRIPTION
### Summary

Show the sandbox product access setting in `stripe sandbox list` using the access labels already returned by GUAS. The command now renders `Private`, `Developer`, or `All team members`, matching Dashboard. Account sandboxes inside a sandbox organization inherit the organization access labels.

cc @stripe/sandboxes-engineering
https://jira.corp.stripe.com/browse/SBX-4107

### Motivation

End-to-end QA exposed that GUAS `access_level` is the caller hierarchy relationship, not the sandbox sharing setting. GUAS marks returned workspace rows as `direct_access`, while the product setting is carried separately in `compartment_labels`. Presenting `DIRECT_ACCESS` therefore described why the caller could see the sandbox rather than who receives default sandbox access.

### Test plan

- [x] All changes in PR are covered by tests
- [x] Failures and edge cases tested

- `go test ./pkg/sandbox ./pkg/cmd -count=1`
- `make lint`
- Fresh local build through `make build`
- End-to-end QA against `qa-api`: the hidden command returned the expected sandbox as `Private`, excluded the active live account, and emitted no internal compartment IDs.

### Rollout/revert plan

Safe to revert. The command remains hidden on the `sandboxes-cli` branch.
