### PR TITLE
Remove the word "context" from user facing messages

### DIFF
--- a/pkg/cmd/data.go
+++ b/pkg/cmd/data.go
@@ -187,7 +187,7 @@ https://docs.stripe.com/api/v2/data/analytics/metric-query-results/create?api-ve
 	c.cmd.Flags().IntVar(&c.limit, "limit", 0, "Maximum number of rows to return (1–1000). Default is all rows.")
 
 	c.cmd.Flags().BoolVar(&c.rb.DryRun, "dry-run", false, "Preview the request without sending it")
-	c.cmd.Flags().BoolVarP(&c.rb.Livemode, "live", "", false, "Make a live request (default: test). Requires your active context to be in live mode — check with 'stripe whoami', switch with 'stripe switch'")
+	c.cmd.Flags().BoolVarP(&c.rb.Livemode, "live", "", false, "Make a live request (default: test). Requires that you're logged in to live mode — check with 'stripe whoami', switch with 'stripe switch'")
 	c.cmd.Flags().BoolVarP(&c.rb.DarkStyle, "dark-style", "", false, "Use a darker color scheme better suited for lighter command-lines")
 
 	// --api-base overrides the API host (used for local/dev testing); it's hidden

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -92,7 +92,7 @@ Stripe account.`,
 	lc.cmd.Flags().StringVar(&lc.forwardThinURL, "forward-thin-to", "", "The URL to forward thin events to")
 	lc.cmd.Flags().StringVar(&lc.forwardThinConnectURL, "forward-thin-connect-to", "", "The URL to forward thin Connect events to")
 	lc.cmd.Flags().BoolVarP(&lc.latestAPIVersion, "latest", "l", false, "Receive events formatted with the latest API version (default: your account's default API version)")
-	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test). Requires your active context to be in live mode — check with 'stripe whoami', switch with 'stripe switch'")
+	lc.cmd.Flags().BoolVar(&lc.livemode, "live", false, "Receive live events (default: test). Requires that you're logged in to live mode — check with 'stripe whoami', switch with 'stripe switch'")
 	lc.cmd.Flags().BoolVarP(&lc.printJSON, "print-json", "j", false, "Print full JSON objects to stdout.")
 	lc.cmd.Flags().MarkDeprecated("print-json", "Please use `--format json` instead and use `jq` if you need to process the JSON in the terminal.")
 	lc.cmd.Flags().StringVar(&lc.format, "format", "", `Specifies the output format of webhook events

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -359,7 +359,7 @@ func (lc *loginSwitchCmd) switchLoggedInAccountCmd(cmd *cobra.Command, args []st
 			return err
 		}
 		if result != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "Active context: %s · %s (%s)\n", result.Account.Name, result.DisplayMode(), result.Account.ID)
+			fmt.Fprintf(cmd.OutOrStdout(), "Logged in to: %s · %s (%s)\n", result.Account.Name, result.DisplayMode(), result.Account.ID)
 		}
 		return nil
 	}

--- a/pkg/cmd/reporting.go
+++ b/pkg/cmd/reporting.go
@@ -123,7 +123,7 @@ reference (--result_options.compress_file). Prefer the dedicated
 	cc.cmd.SetFlagErrorFunc(flagErrorWithNestedAPIHint)
 
 	cc.cmd.Flags().BoolVar(&cc.rb.DryRun, "dry-run", false, "Preview the request without sending it")
-	cc.cmd.Flags().BoolVarP(&cc.rb.Livemode, "live", "", false, "Make a live request (default: test). Requires your active context to be in live mode — check with 'stripe whoami', switch with 'stripe switch'")
+	cc.cmd.Flags().BoolVarP(&cc.rb.Livemode, "live", "", false, "Make a live request (default: test). Requires that you're logged in to live mode — check with 'stripe whoami', switch with 'stripe switch'")
 	cc.cmd.Flags().BoolVarP(&cc.rb.DarkStyle, "dark-style", "", false, "Use a darker color scheme better suited for lighter command-lines")
 
 	cc.cmd.Flags().StringVar(&cc.rb.APIBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")
@@ -157,7 +157,7 @@ used to download the query output.`,
 		RunE: rc.runReportingQueryRunsRetrieveCmd,
 	}
 
-	rc.cmd.Flags().BoolVarP(&rc.rb.Livemode, "live", "", false, "Make a live request (default: test). Requires your active context to be in live mode — check with 'stripe whoami', switch with 'stripe switch'")
+	rc.cmd.Flags().BoolVarP(&rc.rb.Livemode, "live", "", false, "Make a live request (default: test). Requires that you're logged in to live mode — check with 'stripe whoami', switch with 'stripe switch'")
 	rc.cmd.Flags().BoolVarP(&rc.rb.DarkStyle, "dark-style", "", false, "Use a darker color scheme better suited for lighter command-lines")
 
 	rc.cmd.Flags().StringVar(&rc.rb.APIBaseURL, "api-base", stripe.DefaultAPIBaseURL, "Sets the API base URL")

--- a/pkg/cmd/switch.go
+++ b/pkg/cmd/switch.go
@@ -37,8 +37,8 @@ func newSwitchCmd() *switchCmd {
 	sc.cmd = &cobra.Command{
 		Use:   "switch [account_id]",
 		Args:  validators.MaximumNArgs(1),
-		Short: "Switch to a different authorized account context",
-		Long: `Switch to a different authorized account context.
+		Short: "Switch to a different authorized account in live mode or a sandbox",
+		Long: `Switch to a different authorized account in live mode or a sandbox.
 
 Without an argument, shows an interactive list of your authorized accounts and
 modes. Navigate with ↑↓, confirm with enter, or cancel with esc.
@@ -58,7 +58,7 @@ With an account ID, switches directly to that account. Add --live to switch to l
 	legacyCtxCmd := &cobra.Command{
 		Use:    "context [account_id]",
 		Args:   validators.MaximumNArgs(1),
-		Short:  "Switch to a different authorized account context",
+		Short:  "Switch to a different authorized account in live mode or a sandbox",
 		Hidden: true,
 		RunE:   ctxCmd.run,
 	}
@@ -108,6 +108,6 @@ func (sc *switchContextCmd) run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Printf("Active context: %s · %s (%s)\n", result.Account.Name, result.DisplayMode(), result.Account.ID)
+	fmt.Printf("Logged in to: %s · %s (%s)\n", result.Account.Name, result.DisplayMode(), result.Account.ID)
 	return nil
 }

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -70,14 +70,15 @@ func newWhoamiCmd() *whoamiCmd {
 	wc.cmd = &cobra.Command{
 		Use:   "whoami",
 		Args:  validators.NoArgs,
-		Short: "Show the current Stripe auth context",
-		Long: `Display the current authentication context for the Stripe CLI.
+		Short: "Show whether you're logged in to live mode or a sandbox",
+		Long: `Display whether the Stripe CLI is logged in to live mode or a sandbox.
 
 Reads credentials from the config file and keychain — no API calls are made.
 
 Use --format json for output suitable for scripting or agent consumption. The
 schema is stable: test_mode_key and live_mode_key are always present regardless
-of auth context, and authenticated: false indicates no usable credentials exist.
+of whether you're logged in to live mode or a sandbox, and authenticated: false
+indicates no usable credentials exist.
 
 Exit codes:
   0  Authenticated (at least one key is available)
@@ -184,9 +185,9 @@ func (wc *whoamiCmd) runWhoamiOAuth(cmd *cobra.Command, uat string) error {
 			fmt.Fprintf(tw, "User\t%s\n", out.Email)
 		}
 		if out.DisplayName != ac.AccountID {
-			fmt.Fprintf(tw, "Context\t%s · %s (%s)\n", out.DisplayName, displayModeText(out.Mode), ac.AccountID)
+			fmt.Fprintf(tw, "Account\t%s · %s (%s)\n", out.DisplayName, displayModeText(out.Mode), ac.AccountID)
 		} else {
-			fmt.Fprintf(tw, "Context\t%s · %s\n", out.DisplayName, displayModeText(out.Mode))
+			fmt.Fprintf(tw, "Account\t%s · %s\n", out.DisplayName, displayModeText(out.Mode))
 		}
 		if out.Role != "" {
 			fmt.Fprintf(tw, "Role\t%s\n", out.Role)
@@ -199,6 +200,9 @@ func (wc *whoamiCmd) runWhoamiOAuth(cmd *cobra.Command, uat string) error {
 	}
 
 	login.PrintAuthorizedContextsList(accounts)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Run 'stripe login' to change permissions or authorize access to additional accounts or sandboxes.")
+	fmt.Fprintln(w, "Run 'stripe switch' to switch to a different account, or between live mode and a sandbox.")
 	return nil
 }
 

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -70,18 +70,13 @@ func newWhoamiCmd() *whoamiCmd {
 	wc.cmd = &cobra.Command{
 		Use:   "whoami",
 		Args:  validators.NoArgs,
-		Short: "Show whether you're logged in to live mode or a sandbox",
-		Long: `Display whether the Stripe CLI is logged in to live mode or a sandbox.
+		Short: "Show what account you're logged in to and accounts you've authorized",
+		Long: `Show what account you're logged in to and the accounts you've authorized.
 
-Reads credentials from the config file and keychain — no API calls are made.
-
-Use --format json for output suitable for scripting or agent consumption. The
-schema is stable: test_mode_key and live_mode_key are always present regardless
-of whether you're logged in to live mode or a sandbox, and authenticated: false
-indicates no usable credentials exist.
+Use --format json for output suitable for scripting or agent consumption.
 
 Exit codes:
-  0  Authenticated (at least one key is available)
+  0  Authenticated
   1  Not authenticated, or an error occurred`,
 		Example: `stripe whoami
   stripe whoami --format json

--- a/pkg/login/oauth_accounts.go
+++ b/pkg/login/oauth_accounts.go
@@ -106,7 +106,7 @@ func PrintAuthorizedContextsList(accounts []config.AuthorizedAccount) {
 	}
 
 	color := ansi.Color(os.Stdout)
-	fmt.Printf("Authorized contexts (%d):\n", len(rows))
+	fmt.Printf("Authorized (%d accounts):\n", len(rows))
 	for _, r := range rows {
 		if r.active {
 			fmt.Printf("  %-*s  %-*s  %-7s  %s\n", nameW, r.name, idW, r.id, r.mode, color.Green("● active"))

--- a/pkg/login/oauth_device.go
+++ b/pkg/login/oauth_device.go
@@ -333,12 +333,12 @@ func printAuthorizedSummary(accounts []config.AuthorizedAccount, activeID string
 		r := rows[0]
 		ctx := fmt.Sprintf("%s · %s", r.name, displayMode(r.mode))
 		fmt.Printf("%s Done! The Stripe CLI is authorized for %s (%s)\n", color.Green("✓"), ctx, r.id)
-		fmt.Printf("  Active context: %s\n\n", ctx)
+		fmt.Printf("  Logged in to: %s\n\n", ctx)
 		fmt.Println("Run 'stripe login' to change permissions or authorize access to additional accounts or sandboxes.")
 		return
 	}
 
-	fmt.Printf("%s Done! The Stripe CLI is authorized for %d contexts.\n\n", color.Green("✓"), len(rows))
+	fmt.Printf("%s Done! The Stripe CLI is authorized for %d accounts in live mode or a sandbox.\n\n", color.Green("✓"), len(rows))
 
 	nameW, modeW, idW := 0, 0, 0
 	for _, r := range rows {
@@ -363,7 +363,7 @@ func printAuthorizedSummary(accounts []config.AuthorizedAccount, activeID string
 	}
 
 	fmt.Println()
-	fmt.Println("Run 'stripe switch' to change your active context.")
+	fmt.Println("Run 'stripe switch' to switch to a different account, or between live mode and a sandbox.")
 	fmt.Println("Run 'stripe login' to change permissions or authorize access to additional accounts or sandboxes.")
 }
 

--- a/pkg/login/oauth_reauth.go
+++ b/pkg/login/oauth_reauth.go
@@ -56,7 +56,7 @@ func Reauth(ctx context.Context, accessBaseURL, accessToken string) error {
 	fmt.Println()
 	if !isSSH() && canOpenBrowser() {
 		browserOpened = make(chan struct{})
-		fmt.Printf("To authorize more contexts, visit %s\n\n", reauthURL)
+		fmt.Printf("To authorize more accounts in live mode or a sandbox, visit %s\n\n", reauthURL)
 		fmt.Println("Press enter to open the browser (^C to quit)")
 		go func() {
 			fmt.Scanln() //nolint:errcheck
@@ -162,7 +162,7 @@ func waitForReauthCompletion(ctx context.Context, accessBaseURL, accessToken str
 		switch {
 		case errors.Is(err, context.Canceled):
 			ansi.ClearLine(os.Stdout)
-			fmt.Println("Canceled. Run 'stripe whoami' to see your authorized contexts or 'stripe login --new-session' to log in as a different user.")
+			fmt.Println("Canceled. Run 'stripe whoami' to see the accounts you're logged in to or 'stripe login --new-session' to log in as a different user.")
 			return nil
 		case errors.Is(err, errReauthTimeout):
 			fmt.Println("Still waiting on the re-authorization. Run 'stripe whoami' once you've finished.")

--- a/pkg/logout/logout.go
+++ b/pkg/logout/logout.go
@@ -33,7 +33,7 @@ func Logout(ctx context.Context, accessBaseURL string, cfg *config.Config) error
 			return err
 		}
 		color := ansi.Color(os.Stdout)
-		fmt.Printf("%s Logged out of all contexts and revoked session.\n", color.Green("✓"))
+		fmt.Printf("%s Logged out of all accounts and revoked session.\n", color.Green("✓"))
 		return nil
 	}
 

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -203,7 +203,7 @@ func (rb *Base) InitFlags() {
 	rb.Cmd.Flags().StringVar(&rb.Parameters.stripeAccount, "stripe-account", "", "Set a header identifying the connected account")
 	rb.Cmd.Flags().StringVar(&rb.Parameters.stripeContext, "stripe-context", "", "Set a header identifying the compartment context")
 	rb.Cmd.Flags().BoolVarP(&rb.showHeaders, "show-headers", "s", false, "Show response headers")
-	rb.Cmd.Flags().BoolVar(&rb.Livemode, "live", false, "Make a live request (default: test). Requires your active context to be in live mode — check with 'stripe whoami', switch with 'stripe switch'")
+	rb.Cmd.Flags().BoolVar(&rb.Livemode, "live", false, "Make a live request (default: test). Requires that you're logged in to live mode — check with 'stripe whoami', switch with 'stripe switch'")
 	rb.Cmd.Flags().BoolVar(&rb.DarkStyle, "dark-style", false, "Use a darker color scheme better suited for lighter command-lines")
 	rb.Cmd.Flags().BoolVar(&rb.DryRun, "dry-run", false, "Preview the request without sending it")
 


### PR DESCRIPTION
What it says on the tin. "Context" is not a user-facing term. According to folks, we usually spell out what it is ("live mode and sandbox") or refer to it as an "account."