### PR TITLE
Add deprecation message for removed CLI commands

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -190,6 +190,8 @@ func Execute(ctx context.Context) {
 		switch {
 		case errors.Is(err, errNotAuthenticated):
 			// whoami already printed output; just exit non-zero
+		case errors.Is(err, errCommandRemoved):
+			// the shim already printed the downgrade guidance; just exit non-zero
 		case requests.IsAPIKeyExpiredError(err):
 			fmt.Fprintln(os.Stderr, apiKeyExpiredMessage(projectNameFlag))
 		case isLoginRequiredError && projectNameFlag != "default":
@@ -319,6 +321,8 @@ func init() {
 	rootCmd.AddCommand(newOpenCmd().cmd)
 	rootCmd.AddCommand(newReauthCmd().cmd)
 	rootCmd.AddCommand(newResourcesCmd().cmd)
+	rootCmd.AddCommand(newSamplesCmd())
+	rootCmd.AddCommand(newServeCmd())
 	rootCmd.AddCommand(newSwitchCmd().cmd)
 	rootCmd.AddCommand(newTriggerCmd().cmd)
 	rootCmd.AddCommand(newVersionCmd().cmd)
@@ -329,6 +333,9 @@ func init() {
 	rootCmd.AddCommand(newSandboxCmd().cmd)
 	rootCmd.AddCommand(newPluginCmd().cmd)
 	resources.AddAllResourcesCmds(rootCmd, &Config)
+	if terminalCmd, ok := cmdutil.FindSubCmd(rootCmd, "terminal"); ok {
+		terminalCmd.AddCommand(newTerminalQuickstartCmd())
+	}
 	registerHTTPCmds(rootCmd)
 	err := resource.AddDatabasesCmd(rootCmd, &Config)
 	if err != nil {

--- a/pkg/cmd/samples.go
+++ b/pkg/cmd/samples.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+)
+
+// errCommandRemoved is returned by the shims for commands removed in v1.60.0.
+// root.go recognizes this sentinel to suppress duplicate error output and error
+// reporting while still exiting non-zero, so callers that scripted a removed
+// command see a failure rather than a silent no-op.
+var errCommandRemoved = errorcategory.New(errorcategory.UserInput, "command removed")
+
+func deprecatedCommandMessage(command string) string {
+	return fmt.Sprintf("The `%s` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.", command)
+}
+
+func newDeprecatedCommand(use, command string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                use,
+		Hidden:             true,
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Fprintln(cmd.ErrOrStderr(), deprecatedCommandMessage(command))
+			// Flag parsing is disabled so the removed commands' old flags don't
+			// produce an unknown-flag error, which also routes -h and --help
+			// here instead of to cobra's help handling. Asking for help is not
+			// a failed invocation, so exit zero, matching `stripe help <cmd>`.
+			if isHelpRequest(args) {
+				return nil
+			}
+			return errCommandRemoved
+		},
+	}
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		fmt.Fprintln(cmd.ErrOrStderr(), deprecatedCommandMessage(command))
+	})
+	return cmd
+}
+
+func newSamplesCmd() *cobra.Command {
+	return newDeprecatedCommand("samples", "stripe samples")
+}
+
+func newServeCmd() *cobra.Command {
+	cmd := newDeprecatedCommand("serve", "stripe serve")
+	cmd.Aliases = []string{"srv"}
+	return cmd
+}
+
+func newTerminalQuickstartCmd() *cobra.Command {
+	return newDeprecatedCommand("quickstart", "stripe terminal quickstart")
+}

--- a/pkg/cmd/samples_test.go
+++ b/pkg/cmd/samples_test.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stripe/stripe-cli/pkg/cmdutil"
+)
+
+func newRootWithDeprecatedCmds() *cobra.Command {
+	// Mirror the real root's silencing so the shims' output is what a user
+	// actually sees; without it cobra appends its own error and usage block.
+	root := &cobra.Command{Use: "stripe", SilenceUsage: true, SilenceErrors: true}
+	terminal := &cobra.Command{Use: "terminal"}
+	terminal.AddCommand(newTerminalQuickstartCmd())
+	root.AddCommand(newSamplesCmd(), newServeCmd(), terminal)
+	return root
+}
+
+func TestDeprecatedCommands(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "samples",
+			args:     []string{"samples", "create", "checkout", "--force", "--integration", "react"},
+			expected: "The `stripe samples` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.\n",
+		},
+		{
+			name:     "serve",
+			args:     []string{"serve", ".", "--port", "8080"},
+			expected: "The `stripe serve` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.\n",
+		},
+		{
+			name:     "serve alias",
+			args:     []string{"srv", "."},
+			expected: "The `stripe serve` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.\n",
+		},
+		{
+			name:     "terminal quickstart",
+			args:     []string{"terminal", "quickstart", "--api-key", "example"},
+			expected: "The `stripe terminal quickstart` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := executeCommand(newRootWithDeprecatedCmds(), tt.args...)
+
+			// Invoking a removed command fails, so anything that scripted it
+			// sees a non-zero exit rather than a silent no-op.
+			require.ErrorIs(t, err, errCommandRemoved)
+			require.Equal(t, tt.expected, output)
+		})
+	}
+}
+
+func TestDeprecatedCommandHelp(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "samples",
+			args:     []string{"help", "samples"},
+			expected: "The `stripe samples` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.\n",
+		},
+		{
+			name:     "samples help flag",
+			args:     []string{"samples", "--help"},
+			expected: "The `stripe samples` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.\n",
+		},
+		{
+			name:     "samples help shorthand",
+			args:     []string{"samples", "-h"},
+			expected: "The `stripe samples` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.\n",
+		},
+		{
+			name:     "serve",
+			args:     []string{"help", "serve"},
+			expected: "The `stripe serve` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.\n",
+		},
+		{
+			name:     "serve help flag",
+			args:     []string{"serve", "--help"},
+			expected: "The `stripe serve` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.\n",
+		},
+		{
+			name:     "terminal quickstart",
+			args:     []string{"help", "terminal", "quickstart"},
+			expected: "The `stripe terminal quickstart` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.\n",
+		},
+		{
+			name:     "terminal quickstart help flag",
+			args:     []string{"terminal", "quickstart", "--help"},
+			expected: "The `stripe terminal quickstart` command is no longer available in Stripe CLI v1.60.0 and later. To use it, install a version earlier than v1.60.0.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := executeCommand(newRootWithDeprecatedCmds(), tt.args...)
+
+			// Asking for help is not a failed invocation.
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, output)
+		})
+	}
+}
+
+func TestDeprecatedCommandsHidden(t *testing.T) {
+	root := newRootWithDeprecatedCmds()
+
+	rootHelp, err := executeCommand(root, "--help")
+	require.NoError(t, err)
+	require.NotContains(t, rootHelp, "samples")
+	require.NotContains(t, rootHelp, "serve")
+
+	terminalHelp, err := executeCommand(root, "terminal", "--help")
+	require.NoError(t, err)
+	require.NotContains(t, terminalHelp, "quickstart")
+}
+
+// The tests above build their own root, so they can't catch the shims falling
+// out of the real command tree. In particular quickstart is attached by looking
+// up `terminal` in root.go, which silently attaches nothing if that lookup ever
+// stops resolving.
+func TestDeprecatedCommandsRegisteredOnRoot(t *testing.T) {
+	paths := [][]string{
+		{"samples"},
+		{"serve"},
+		{"srv"},
+		{"terminal", "quickstart"},
+	}
+
+	for _, path := range paths {
+		t.Run(strings.Join(path, " "), func(t *testing.T) {
+			cmd, ok := cmdutil.FindSubCmd(rootCmd, path...)
+
+			require.True(t, ok, "expected `stripe %s` to be registered", strings.Join(path, " "))
+			require.True(t, cmd.Hidden, "expected `stripe %s` to stay out of help", strings.Join(path, " "))
+			require.NotNil(t, cmd.RunE)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- register hidden compatibility shims for the removed `samples`, `serve`, and `terminal quickstart` commands
- direct users to install a CLI version earlier than v1.60.0
- handle legacy arguments and prefix-style help consistently
- keep removed commands out of normal help and command-map output

## Testing
- `go test ./pkg/cmd/...`
- `go vet ./...`
- `make lint`
- local build and manual command verification