### PR TITLE
Handle error when fetching endpoints during `stripe listen -a`

### DIFF
--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -277,7 +277,11 @@ func (lc *listenCmd) createVisitor(logger *log.Logger, format string, printJSON 
 				// Don't exit program
 				return nil
 			default:
-				logger.Fatal(ee.Error)
+				if isMorePermissionsRequiredError(ee.Error) {
+					logger.Fatal(morePermissionsRequiredMessage)
+				} else {
+					logger.Fatal(ee.Error)
+				}
 				return ee.Error
 			}
 		},

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -278,7 +278,7 @@ func (lc *listenCmd) createVisitor(logger *log.Logger, format string, printJSON 
 				return nil
 			default:
 				if isMorePermissionsRequiredError(ee.Error) {
-					logger.Fatal(morePermissionsRequiredMessage)
+					logger.Fatal(morePermissionsRequiredMessage(ee.Error))
 				} else {
 					logger.Fatal(ee.Error)
 				}

--- a/pkg/cmd/listen.go
+++ b/pkg/cmd/listen.go
@@ -278,10 +278,9 @@ func (lc *listenCmd) createVisitor(logger *log.Logger, format string, printJSON 
 				return nil
 			default:
 				if isMorePermissionsRequiredError(ee.Error) {
-					logger.Fatal(morePermissionsRequiredMessage(ee.Error))
-				} else {
-					logger.Fatal(ee.Error)
+					return ee.Error
 				}
+				logger.Fatal(ee.Error)
 				return ee.Error
 			}
 		},

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stripe/stripe-cli/pkg/plugins"
 	"github.com/stripe/stripe-cli/pkg/requests"
 	"github.com/stripe/stripe-cli/pkg/stripe"
+	"github.com/stripe/stripe-cli/pkg/stripeauth"
 	"github.com/stripe/stripe-cli/pkg/useragent"
 	"github.com/stripe/stripe-cli/pkg/validators"
 	"github.com/stripe/stripe-cli/pkg/version"
@@ -192,6 +193,8 @@ func Execute(ctx context.Context) {
 			// whoami already printed output; just exit non-zero
 		case requests.IsAPIKeyExpiredError(err):
 			fmt.Fprintln(os.Stderr, apiKeyExpiredMessage(projectNameFlag))
+		case isMorePermissionsRequiredError(err):
+			fmt.Fprintln(os.Stderr, morePermissionsRequiredMessage)
 		case isLoginRequiredError && projectNameFlag != "default":
 			fmt.Fprintf(os.Stderr, "You provided the project name \"%[1]s\" (either via the \"--project-name\" flag or the \"STRIPE_PROJECT_NAME\" environment variable), but no config for that project was found.\nPlease run `stripe login --project-name=%[1]s` to enable commands for this project.\n", projectNameFlag)
 		case isLoginRequiredError:
@@ -243,6 +246,18 @@ func apiKeyExpiredMessage(profileName string) string {
 	}
 	return fmt.Sprintf("The API key for profile %q has expired. Run `stripe login --project-name=%s` to re-authenticate.", profileName, profileName)
 }
+
+// isMorePermissionsRequiredError reports whether err was caused by a Stripe
+// API request failing because the API key's role lacks the permissions
+// required for that request. Requests made through pkg/requests surface this
+// as a requests.RequestError; the websocket session-auth flows used by
+// `stripe listen` and `stripe logs tail` surface it as a
+// stripeauth.AuthorizeHTTPError instead.
+func isMorePermissionsRequiredError(err error) bool {
+	return requests.IsMorePermissionsRequiredError(err) || stripeauth.IsMorePermissionsRequiredError(err)
+}
+
+const morePermissionsRequiredMessage = "You don't have permission to do this with your current role. Ask an account administrator to assign you a different role with more permissions."
 
 var keysToReBind []string
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -194,7 +194,7 @@ func Execute(ctx context.Context) {
 		case requests.IsAPIKeyExpiredError(err):
 			fmt.Fprintln(os.Stderr, apiKeyExpiredMessage(projectNameFlag))
 		case isMorePermissionsRequiredError(err):
-			fmt.Fprintln(os.Stderr, morePermissionsRequiredMessage)
+			fmt.Fprintln(os.Stderr, morePermissionsRequiredMessage(err))
 		case isLoginRequiredError && projectNameFlag != "default":
 			fmt.Fprintf(os.Stderr, "You provided the project name \"%[1]s\" (either via the \"--project-name\" flag or the \"STRIPE_PROJECT_NAME\" environment variable), but no config for that project was found.\nPlease run `stripe login --project-name=%[1]s` to enable commands for this project.\n", projectNameFlag)
 		case isLoginRequiredError:
@@ -257,7 +257,25 @@ func isMorePermissionsRequiredError(err error) bool {
 	return requests.IsMorePermissionsRequiredError(err) || stripeauth.IsMorePermissionsRequiredError(err)
 }
 
-const morePermissionsRequiredMessage = "You don't have permission to do this with your current role. Ask an account administrator to assign you a different role with more permissions."
+// morePermissionsRequiredMessage returns the message to show the user for a
+// more_permissions_required error. Requests authenticated with a plain API
+// key have no notion of "role", so the raw message from the Stripe API is
+// shown instead of the role-reassignment message.
+func morePermissionsRequiredMessage(err error) string {
+	var reqErr requests.RequestError
+	if errors.As(err, &reqErr) && reqErr.UsesAPIKey {
+		return reqErr.Message
+	}
+
+	var authErr *stripeauth.AuthorizeHTTPError
+	if errors.As(err, &authErr) && authErr.UsesAPIKey {
+		return authErr.Message
+	}
+
+	return morePermissionsRequiredRoleMessage
+}
+
+const morePermissionsRequiredRoleMessage = "You don't have permission to do this with your current role. Ask an account administrator to assign you a different role with more permissions."
 
 var keysToReBind []string
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -263,12 +263,12 @@ func isMorePermissionsRequiredError(err error) bool {
 // shown instead of the role-reassignment message.
 func morePermissionsRequiredMessage(err error) string {
 	var reqErr requests.RequestError
-	if errors.As(err, &reqErr) && reqErr.UsesAPIKey {
+	if errors.As(err, &reqErr) && !reqErr.HasOAKContext {
 		return reqErr.Message
 	}
 
 	var authErr *stripeauth.AuthorizeHTTPError
-	if errors.As(err, &authErr) && authErr.UsesAPIKey {
+	if errors.As(err, &authErr) && !authErr.HasOAKContext {
 		return authErr.Message
 	}
 

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +17,9 @@ import (
 
 	"github.com/stripe/stripe-cli/pkg/cmd/resource"
 	"github.com/stripe/stripe-cli/pkg/config"
+	"github.com/stripe/stripe-cli/pkg/errorcategory"
+	"github.com/stripe/stripe-cli/pkg/requests"
+	"github.com/stripe/stripe-cli/pkg/stripeauth"
 )
 
 func executeCommand(root *cobra.Command, args ...string) (output string, err error) {
@@ -209,4 +214,20 @@ func TestDatabasesHiddenButDirectlyAddressable(t *testing.T) {
 	require.Contains(t, output, "Manage StripeDB")
 	require.Contains(t, output, "unstable preview APIs")
 	require.Contains(t, output, "users")
+}
+
+func TestIsMorePermissionsRequiredError(t *testing.T) {
+	require.False(t, isMorePermissionsRequiredError(fmt.Errorf("other")))
+
+	// requests.RequestError, as returned by resource commands, trigger, fixtures, etc.
+	reqErr := requests.RequestError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required"}
+	require.True(t, isMorePermissionsRequiredError(reqErr))
+	require.False(t, isMorePermissionsRequiredError(requests.RequestError{StatusCode: http.StatusForbidden, ErrorCode: "resource_missing"}))
+
+	// stripeauth.AuthorizeHTTPError, as returned by the `stripe listen` / `stripe logs tail`
+	// session-auth flow. It's wrapped with errorcategory.Errorf(..., "%w", err) the same way
+	// proxy.go and logtailing/tailer.go wrap it before sending it out over the OutCh channel.
+	authErr := &stripeauth.AuthorizeHTTPError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required"}
+	wrapped := errorcategory.Errorf(errorcategory.Auth, "Error while authenticating with Stripe: %w", authErr)
+	require.True(t, isMorePermissionsRequiredError(wrapped))
 }

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -231,3 +231,27 @@ func TestIsMorePermissionsRequiredError(t *testing.T) {
 	wrapped := errorcategory.Errorf(errorcategory.Auth, "Error while authenticating with Stripe: %w", authErr)
 	require.True(t, isMorePermissionsRequiredError(wrapped))
 }
+
+func TestMorePermissionsRequiredMessage(t *testing.T) {
+	t.Run("requests.RequestError, API key", func(t *testing.T) {
+		reqErr := requests.RequestError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", UsesAPIKey: true}
+		require.Equal(t, "raw error message", morePermissionsRequiredMessage(reqErr))
+	})
+
+	t.Run("requests.RequestError, OAuth/UAT", func(t *testing.T) {
+		reqErr := requests.RequestError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", UsesAPIKey: false}
+		require.Equal(t, morePermissionsRequiredRoleMessage, morePermissionsRequiredMessage(reqErr))
+	})
+
+	t.Run("stripeauth.AuthorizeHTTPError, API key", func(t *testing.T) {
+		authErr := &stripeauth.AuthorizeHTTPError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", UsesAPIKey: true}
+		wrapped := errorcategory.Errorf(errorcategory.Auth, "Error while authenticating with Stripe: %w", authErr)
+		require.Equal(t, "raw error message", morePermissionsRequiredMessage(wrapped))
+	})
+
+	t.Run("stripeauth.AuthorizeHTTPError, OAuth/UAT", func(t *testing.T) {
+		authErr := &stripeauth.AuthorizeHTTPError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", UsesAPIKey: false}
+		wrapped := errorcategory.Errorf(errorcategory.Auth, "Error while authenticating with Stripe: %w", authErr)
+		require.Equal(t, morePermissionsRequiredRoleMessage, morePermissionsRequiredMessage(wrapped))
+	})
+}

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -234,23 +234,23 @@ func TestIsMorePermissionsRequiredError(t *testing.T) {
 
 func TestMorePermissionsRequiredMessage(t *testing.T) {
 	t.Run("requests.RequestError, API key", func(t *testing.T) {
-		reqErr := requests.RequestError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", UsesAPIKey: true}
+		reqErr := requests.RequestError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", HasOAKContext: false}
 		require.Equal(t, "raw error message", morePermissionsRequiredMessage(reqErr))
 	})
 
 	t.Run("requests.RequestError, OAuth/UAT", func(t *testing.T) {
-		reqErr := requests.RequestError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", UsesAPIKey: false}
+		reqErr := requests.RequestError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", HasOAKContext: true}
 		require.Equal(t, morePermissionsRequiredRoleMessage, morePermissionsRequiredMessage(reqErr))
 	})
 
 	t.Run("stripeauth.AuthorizeHTTPError, API key", func(t *testing.T) {
-		authErr := &stripeauth.AuthorizeHTTPError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", UsesAPIKey: true}
+		authErr := &stripeauth.AuthorizeHTTPError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", HasOAKContext: false}
 		wrapped := errorcategory.Errorf(errorcategory.Auth, "Error while authenticating with Stripe: %w", authErr)
 		require.Equal(t, "raw error message", morePermissionsRequiredMessage(wrapped))
 	})
 
 	t.Run("stripeauth.AuthorizeHTTPError, OAuth/UAT", func(t *testing.T) {
-		authErr := &stripeauth.AuthorizeHTTPError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", UsesAPIKey: false}
+		authErr := &stripeauth.AuthorizeHTTPError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required", Message: "raw error message", HasOAKContext: true}
 		wrapped := errorcategory.Errorf(errorcategory.Auth, "Error while authenticating with Stripe: %w", authErr)
 		require.Equal(t, morePermissionsRequiredRoleMessage, morePermissionsRequiredMessage(wrapped))
 	})

--- a/pkg/logtailing/tailer.go
+++ b/pkg/logtailing/tailer.go
@@ -116,7 +116,7 @@ func (t *Tailer) Run(ctx context.Context) error {
 
 		if err != nil {
 			t.cfg.OutCh <- websocket.ErrorElement{
-				Error: errorcategory.Errorf(errorcategory.Auth, "error while authenticating with Stripe: %v", err),
+				Error: errorcategory.Errorf(errorcategory.Auth, "error while authenticating with Stripe: %w", err),
 			}
 			return err
 		}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -391,11 +391,13 @@ func Init(ctx context.Context, cfg *Config) (*Proxy, error) {
 	var endpointRoutes []EndpointRoute
 	if cfg.UseConfiguredWebhooks {
 		// build from user's API config
-		endpoints := getEndpointsFromAPI(ctx, cfg.Client)
+		endpoints, err := getEndpointsFromAPI(ctx, cfg.Client)
+		if err != nil {
+			return nil, err
+		}
 		if len(endpoints.Data) == 0 {
 			return nil, errorcategory.New(errorcategory.UserInput, "you have not defined any webhook endpoints on your account, go to the Stripe Dashboard to add some: https://dashboard.stripe.com/test/webhooks")
 		}
-		var err error
 		endpointRoutes, err = buildEndpointRoutes(endpoints, parseURL(cfg.ForwardURL), parseURL(cfg.ForwardConnectURL), cfg.ForwardHeaders, cfg.ForwardConnectHeaders)
 		if err != nil {
 			return nil, err
@@ -583,7 +585,7 @@ func parseURL(url string) string {
 	return url
 }
 
-func getEndpointsFromAPI(ctx context.Context, client stripe.RequestPerformer) requests.WebhookEndpointList {
+func getEndpointsFromAPI(ctx context.Context, client stripe.RequestPerformer) (requests.WebhookEndpointList, error) {
 	return requests.WebhookEndpointsListWithClient(ctx, client, stripe.APIVersion, &config.Profile{})
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -162,7 +162,7 @@ func (p *Proxy) Run(ctx context.Context) error {
 		session, err := p.createSession(ctx)
 		if err != nil {
 			p.cfg.OutCh <- websocket.ErrorElement{
-				Error: errorcategory.Errorf(errorcategory.Auth, "Error while authenticating with Stripe: %v", err),
+				Error: errorcategory.Errorf(errorcategory.Auth, "Error while authenticating with Stripe: %w", err),
 			}
 			return err
 		}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -91,6 +91,48 @@ func TestBuildEndpointRoutes(t *testing.T) {
 	require.Equal(t, []string{"*"}, output[1].EventTypes)
 }
 
+func TestInit_UseConfiguredWebhooks_APIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/webhook_endpoints", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"internal_server_error"}`))
+	}))
+	defer ts.Close()
+
+	baseURL, _ := url.Parse(ts.URL)
+
+	cfg := Config{
+		Client:                &stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL},
+		UseConfiguredWebhooks: true,
+		ForwardURL:            "http://localhost:1234",
+	}
+
+	_, err := Init(context.Background(), &cfg)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "you have not defined any webhook endpoints")
+}
+
+func TestInit_UseConfiguredWebhooks_NoEndpoints(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/webhook_endpoints", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer ts.Close()
+
+	baseURL, _ := url.Parse(ts.URL)
+
+	cfg := Config{
+		Client:                &stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL},
+		UseConfiguredWebhooks: true,
+		ForwardURL:            "http://localhost:1234",
+	}
+
+	_, err := Init(context.Background(), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "you have not defined any webhook endpoints")
+}
+
 func TestBuildForwardURL(t *testing.T) {
 	f, err := url.Parse("http://example.com/foo/bar.php")
 	require.NoError(t, err)

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -76,13 +76,13 @@ func (r *RequestParameters) SetVersion(value string) {
 
 // RequestError captures the response of the request that resulted in an error
 type RequestError struct {
-	msg        string
-	StatusCode int
-	ErrorType  string
-	ErrorCode  string
-	Message    string      // the human-readable "message" field from the error response body
-	UsesAPIKey bool        // true if the request was authenticated with a plain API key rather than an OAuth/UAT token
-	Body       interface{} // the raw response body
+	msg           string
+	StatusCode    int
+	ErrorType     string
+	ErrorCode     string
+	Message       string      // the human-readable "message" field from the error response body
+	HasOAKContext bool        // true if the request was authenticated with an OAuth/UAT token rather than a plain API key
+	Body          interface{} // the raw response body
 }
 
 func (e RequestError) Error() string {
@@ -370,7 +370,7 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 
 	if resp.StatusCode == 401 || (errOnStatus && resp.StatusCode >= 300) {
 		requestError := compileRequestError(body, resp.StatusCode)
-		requestError.UsesAPIKey = creds.OAKContext == ""
+		requestError.HasOAKContext = creds.OAKContext != ""
 
 		// For OAK tokens, "unauthorized" means the token was manually revoked
 		// or otherwise invalidated server-side. Attempt a transparent refresh

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -99,6 +99,20 @@ func IsAPIKeyExpiredError(err error) bool {
 	return false
 }
 
+// MorePermissionsRequiredErrorCode is the Stripe API error code returned
+// when the API key's role does not have permission to perform a request.
+const MorePermissionsRequiredErrorCode = "more_permissions_required"
+
+// IsMorePermissionsRequiredError returns true if the provided error was
+// caused by a request returning a `more_permissions_required` error code.
+func IsMorePermissionsRequiredError(err error) bool {
+	var reqErr RequestError
+	if errors.As(err, &reqErr) {
+		return reqErr.StatusCode == http.StatusForbidden && reqErr.ErrorCode == MorePermissionsRequiredErrorCode
+	}
+	return false
+}
+
 // Base encapsulates the required information needed to make requests to the API
 type Base struct {
 	Cmd *cobra.Command

--- a/pkg/requests/base.go
+++ b/pkg/requests/base.go
@@ -80,6 +80,8 @@ type RequestError struct {
 	StatusCode int
 	ErrorType  string
 	ErrorCode  string
+	Message    string      // the human-readable "message" field from the error response body
+	UsesAPIKey bool        // true if the request was authenticated with a plain API key rather than an OAuth/UAT token
 	Body       interface{} // the raw response body
 }
 
@@ -368,6 +370,7 @@ func (rb *Base) performRequest(ctx context.Context, client stripe.RequestPerform
 
 	if resp.StatusCode == 401 || (errOnStatus && resp.StatusCode >= 300) {
 		requestError := compileRequestError(body, resp.StatusCode)
+		requestError.UsesAPIKey = creds.OAKContext == ""
 
 		// For OAK tokens, "unauthorized" means the token was manually revoked
 		// or otherwise invalidated server-side. Attempt a transparent refresh
@@ -595,8 +598,9 @@ func setNestedValue(m map[string]interface{}, key string, value string) {
 
 func compileRequestError(body []byte, statusCode int) RequestError {
 	type requestErrorContent struct {
-		Code string `json:"code"`
-		Type string `json:"type"`
+		Code    string `json:"code"`
+		Type    string `json:"type"`
+		Message string `json:"message"`
 	}
 
 	type requestErrorBody struct {
@@ -612,6 +616,7 @@ func compileRequestError(body []byte, statusCode int) RequestError {
 		StatusCode: statusCode,
 		ErrorType:  errorBody.Content.Type,
 		ErrorCode:  errorBody.Content.Code,
+		Message:    errorBody.Content.Message,
 		Body:       string(body),
 	}
 }

--- a/pkg/requests/base_test.go
+++ b/pkg/requests/base_test.go
@@ -401,6 +401,36 @@ func TestIsAPIKeyExpiredError(t *testing.T) {
 	})
 }
 
+func TestIsMorePermissionsRequiredError(t *testing.T) {
+	for _, tt := range []struct {
+		statusCode int
+		errorCode  string
+		want       bool
+	}{
+		{200, "", false},
+		{403, "resource_missing", false},
+		{500, "more_permissions_required", false},
+		{403, "more_permissions_required", true},
+	} {
+		t.Run(fmt.Sprintf("status=%v,code=%q", tt.statusCode, tt.errorCode), func(t *testing.T) {
+			err := RequestError{
+				StatusCode: tt.statusCode,
+				ErrorCode:  tt.errorCode,
+			}
+			require.Equal(t, tt.want, IsMorePermissionsRequiredError(err))
+		})
+	}
+
+	t.Run("non-RequestError", func(t *testing.T) {
+		require.False(t, IsMorePermissionsRequiredError(fmt.Errorf("other")))
+	})
+
+	t.Run("wrapped", func(t *testing.T) {
+		err := fmt.Errorf("could not fetch resource: %w", RequestError{StatusCode: 403, ErrorCode: "more_permissions_required"})
+		require.True(t, IsMorePermissionsRequiredError(err))
+	})
+}
+
 func TestComputeVersionHeader(t *testing.T) {
 	t.Run("explicit version", func(t *testing.T) {
 		rb := Base{}

--- a/pkg/requests/base_test.go
+++ b/pkg/requests/base_test.go
@@ -452,7 +452,7 @@ func TestMakeRequest_MorePermissionsRequired(t *testing.T) {
 
 		var reqErr RequestError
 		require.True(t, errors.As(err, &reqErr))
-		require.True(t, reqErr.UsesAPIKey)
+		require.False(t, reqErr.HasOAKContext)
 		require.Equal(t, "The provided key does not have the required permissions for this endpoint.", reqErr.Message)
 	})
 
@@ -464,7 +464,7 @@ func TestMakeRequest_MorePermissionsRequired(t *testing.T) {
 
 		var reqErr RequestError
 		require.True(t, errors.As(err, &reqErr))
-		require.False(t, reqErr.UsesAPIKey)
+		require.True(t, reqErr.HasOAKContext)
 	})
 }
 

--- a/pkg/requests/base_test.go
+++ b/pkg/requests/base_test.go
@@ -3,6 +3,7 @@ package requests
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -428,6 +429,42 @@ func TestIsMorePermissionsRequiredError(t *testing.T) {
 	t.Run("wrapped", func(t *testing.T) {
 		err := fmt.Errorf("could not fetch resource: %w", RequestError{StatusCode: 403, ErrorCode: "more_permissions_required"})
 		require.True(t, IsMorePermissionsRequiredError(err))
+	})
+}
+
+func TestMakeRequest_MorePermissionsRequired(t *testing.T) {
+	body := `{"error":{"code":"more_permissions_required","message":"The provided key does not have the required permissions for this endpoint.","type":"invalid_request_error"}}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(body))
+	}))
+	defer ts.Close()
+
+	rb := Base{APIBaseURL: ts.URL}
+	rb.Method = http.MethodGet
+	params := &RequestParameters{}
+
+	t.Run("api key", func(t *testing.T) {
+		_, err := rb.MakeRequest(context.Background(), stripe.NewAPIKeyCredentials("sk_test_1234"), "/foo/bar", params, make(map[string]interface{}), true, nil)
+		require.Error(t, err)
+		require.True(t, IsMorePermissionsRequiredError(err))
+
+		var reqErr RequestError
+		require.True(t, errors.As(err, &reqErr))
+		require.True(t, reqErr.UsesAPIKey)
+		require.Equal(t, "The provided key does not have the required permissions for this endpoint.", reqErr.Message)
+	})
+
+	t.Run("oak credentials", func(t *testing.T) {
+		creds := stripe.NewOAKCredentials("oak_test_123", "acct_a", false)
+		_, err := rb.MakeRequest(context.Background(), creds, "/foo/bar", params, make(map[string]interface{}), true, nil)
+		require.Error(t, err)
+		require.True(t, IsMorePermissionsRequiredError(err))
+
+		var reqErr RequestError
+		require.True(t, errors.As(err, &reqErr))
+		require.False(t, reqErr.UsesAPIKey)
 	})
 }
 

--- a/pkg/requests/webhook_endpoints.go
+++ b/pkg/requests/webhook_endpoints.go
@@ -50,7 +50,7 @@ func WebhookEndpointsList(ctx context.Context, baseURL, apiVersion string, profi
 }
 
 // WebhookEndpointsListWithClient returns all the webhook endpoints on a users' account
-func WebhookEndpointsListWithClient(ctx context.Context, client stripe.RequestPerformer, apiVersion string, profile *config.Profile) WebhookEndpointList {
+func WebhookEndpointsListWithClient(ctx context.Context, client stripe.RequestPerformer, apiVersion string, profile *config.Profile) (WebhookEndpointList, error) {
 	params := &RequestParameters{
 		data:    []string{"limit=30"},
 		version: apiVersion,
@@ -61,11 +61,16 @@ func WebhookEndpointsListWithClient(ctx context.Context, client stripe.RequestPe
 		Method:         http.MethodGet,
 		SuppressOutput: true,
 	}
-	resp, _ := base.MakeRequestWithClient(ctx, client, "/v1/webhook_endpoints", params, make(map[string]interface{}), true, nil)
+	resp, err := base.MakeRequestWithClient(ctx, client, "/v1/webhook_endpoints", params, make(map[string]interface{}), true, nil)
+	if err != nil {
+		return WebhookEndpointList{}, err
+	}
 	data := WebhookEndpointList{}
-	json.Unmarshal(resp, &data)
+	if err := json.Unmarshal(resp, &data); err != nil {
+		return WebhookEndpointList{}, err
+	}
 
-	return data
+	return data, nil
 }
 
 // WebhookEndpointCreate creates a new webhook endpoint

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -20,6 +20,7 @@ const stripeCLISessionPath = "/v1/stripecli/sessions"
 type AuthorizeHTTPError struct {
 	StatusCode int
 	Body       string
+	ErrorCode  string
 }
 
 func (e *AuthorizeHTTPError) Error() string {
@@ -108,6 +109,7 @@ func (c *Client) Authorize(ctx context.Context, req CreateSessionRequest) (*Stri
 		return nil, &AuthorizeHTTPError{
 			StatusCode: resp.StatusCode,
 			Body:       string(body),
+			ErrorCode:  parseErrorCode(body),
 		}
 	}
 
@@ -152,4 +154,29 @@ func IsAuthorizationClientError(err error) (*AuthorizeHTTPError, bool) {
 		return clientError, true
 	}
 	return nil, false
+}
+
+// MorePermissionsRequiredErrorCode is the Stripe API error code returned
+// when the API key's role does not have permission to perform a request.
+const MorePermissionsRequiredErrorCode = "more_permissions_required"
+
+// IsMorePermissionsRequiredError returns true if the provided error was
+// caused by a session authorization request returning a
+// `more_permissions_required` error code.
+func IsMorePermissionsRequiredError(err error) bool {
+	var authErr *AuthorizeHTTPError
+	if errors.As(err, &authErr) {
+		return authErr.StatusCode == http.StatusForbidden && authErr.ErrorCode == MorePermissionsRequiredErrorCode
+	}
+	return false
+}
+
+func parseErrorCode(body []byte) string {
+	var errorBody struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	json.Unmarshal(body, &errorBody) // #nosec G104
+	return errorBody.Error.Code
 }

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -18,11 +18,11 @@ import (
 const stripeCLISessionPath = "/v1/stripecli/sessions"
 
 type AuthorizeHTTPError struct {
-	StatusCode int
-	Body       string
-	ErrorCode  string
-	Message    string // the human-readable "message" field from the error response body
-	UsesAPIKey bool   // true if the request was authenticated with a plain API key rather than an OAuth/UAT token
+	StatusCode    int
+	Body          string
+	ErrorCode     string
+	Message       string // the human-readable "message" field from the error response body
+	HasOAKContext bool   // true if the request was authenticated with an OAuth/UAT token rather than a plain API key
 }
 
 func (e *AuthorizeHTTPError) Error() string {
@@ -109,16 +109,16 @@ func (c *Client) Authorize(ctx context.Context, req CreateSessionRequest) (*Stri
 
 	if resp.StatusCode != http.StatusOK {
 		code, message := parseErrorCodeAndMessage(body)
-		usesAPIKey := true
+		var hasOAKContext bool
 		if stripeClient, ok := c.client.(*stripe.Client); ok {
-			usesAPIKey = stripeClient.Credentials.OAKContext == ""
+			hasOAKContext = stripeClient.Credentials.OAKContext != ""
 		}
 		return nil, &AuthorizeHTTPError{
-			StatusCode: resp.StatusCode,
-			Body:       string(body),
-			ErrorCode:  code,
-			Message:    message,
-			UsesAPIKey: usesAPIKey,
+			StatusCode:    resp.StatusCode,
+			Body:          string(body),
+			ErrorCode:     code,
+			Message:       message,
+			HasOAKContext: hasOAKContext,
 		}
 	}
 

--- a/pkg/stripeauth/client.go
+++ b/pkg/stripeauth/client.go
@@ -21,6 +21,8 @@ type AuthorizeHTTPError struct {
 	StatusCode int
 	Body       string
 	ErrorCode  string
+	Message    string // the human-readable "message" field from the error response body
+	UsesAPIKey bool   // true if the request was authenticated with a plain API key rather than an OAuth/UAT token
 }
 
 func (e *AuthorizeHTTPError) Error() string {
@@ -106,10 +108,17 @@ func (c *Client) Authorize(ctx context.Context, req CreateSessionRequest) (*Stri
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		code, message := parseErrorCodeAndMessage(body)
+		usesAPIKey := true
+		if stripeClient, ok := c.client.(*stripe.Client); ok {
+			usesAPIKey = stripeClient.Credentials.OAKContext == ""
+		}
 		return nil, &AuthorizeHTTPError{
 			StatusCode: resp.StatusCode,
 			Body:       string(body),
-			ErrorCode:  parseErrorCode(body),
+			ErrorCode:  code,
+			Message:    message,
+			UsesAPIKey: usesAPIKey,
 		}
 	}
 
@@ -171,12 +180,13 @@ func IsMorePermissionsRequiredError(err error) bool {
 	return false
 }
 
-func parseErrorCode(body []byte) string {
+func parseErrorCodeAndMessage(body []byte) (code, message string) {
 	var errorBody struct {
 		Error struct {
-			Code string `json:"code"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
 		} `json:"error"`
 	}
 	json.Unmarshal(body, &errorBody) // #nosec G104
-	return errorBody.Error.Code
+	return errorBody.Error.Code, errorBody.Error.Message
 }

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -179,6 +179,33 @@ func TestAuthorizeMorePermissionsRequiredError(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, http.StatusForbidden, clientError.StatusCode)
 	require.Equal(t, "more_permissions_required", clientError.ErrorCode)
+	require.True(t, clientError.UsesAPIKey)
+	require.Equal(t, "The provided key does not have the required permissions for this endpoint.", clientError.Message)
+}
+
+func TestAuthorizeMorePermissionsRequiredError_OAKCredentials(t *testing.T) {
+	body := `{"error":{"code":"more_permissions_required","message":"The provided key does not have the required permissions for this endpoint.","type":"invalid_request_error"}}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(body))
+	}))
+	defer ts.Close()
+
+	baseURL, _ := url.Parse(ts.URL)
+	client := NewClient(&stripe.Client{Credentials: stripe.NewOAKCredentials("oak_test_123", "acct_a", false), BaseURL: baseURL}, nil)
+
+	_, err := client.Authorize(context.Background(), CreateSessionRequest{
+		DeviceName:        "my-device",
+		WebSocketFeatures: []string{"webhooks"},
+	})
+
+	require.Error(t, err)
+	require.True(t, IsMorePermissionsRequiredError(err))
+
+	clientError, ok := IsAuthorizationClientError(err)
+	require.True(t, ok)
+	require.False(t, clientError.UsesAPIKey)
 }
 
 func TestAuthorizeServerError(t *testing.T) {

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -3,6 +3,7 @@ package stripeauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -154,6 +155,32 @@ func TestAuthorizeClientError(t *testing.T) {
 	require.Equal(t, `{"error":"too_many_requests"}`, clientError.Body)
 }
 
+func TestAuthorizeMorePermissionsRequiredError(t *testing.T) {
+	body := `{"error":{"code":"more_permissions_required","message":"The provided key does not have the required permissions for this endpoint.","request_log_url":"https://dashboard.stripe.com/acct_123/workbench/logs?object=req_123","type":"invalid_request_error"}}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(body))
+	}))
+	defer ts.Close()
+
+	baseURL, _ := url.Parse(ts.URL)
+	client := NewClient(&stripe.Client{Credentials: stripe.NewAPIKeyCredentials("sk_test_123"), BaseURL: baseURL}, nil)
+
+	_, err := client.Authorize(context.Background(), CreateSessionRequest{
+		DeviceName:        "my-device",
+		WebSocketFeatures: []string{"webhooks"},
+	})
+
+	require.Error(t, err)
+	require.True(t, IsMorePermissionsRequiredError(err))
+
+	clientError, ok := IsAuthorizationClientError(err)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, clientError.StatusCode)
+	require.Equal(t, "more_permissions_required", clientError.ErrorCode)
+}
+
 func TestAuthorizeServerError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -174,4 +201,12 @@ func TestAuthorizeServerError(t *testing.T) {
 	clientError, ok := IsAuthorizationClientError(err)
 	require.False(t, ok)
 	require.Nil(t, clientError)
+}
+
+func TestIsMorePermissionsRequiredError(t *testing.T) {
+	require.False(t, IsMorePermissionsRequiredError(nil))
+	require.False(t, IsMorePermissionsRequiredError(errors.New("other")))
+	require.False(t, IsMorePermissionsRequiredError(&AuthorizeHTTPError{StatusCode: http.StatusTooManyRequests, ErrorCode: "too_many_requests"}))
+	require.False(t, IsMorePermissionsRequiredError(&AuthorizeHTTPError{StatusCode: http.StatusInternalServerError, ErrorCode: "more_permissions_required"}))
+	require.True(t, IsMorePermissionsRequiredError(&AuthorizeHTTPError{StatusCode: http.StatusForbidden, ErrorCode: "more_permissions_required"}))
 }

--- a/pkg/stripeauth/client_test.go
+++ b/pkg/stripeauth/client_test.go
@@ -179,7 +179,7 @@ func TestAuthorizeMorePermissionsRequiredError(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, http.StatusForbidden, clientError.StatusCode)
 	require.Equal(t, "more_permissions_required", clientError.ErrorCode)
-	require.True(t, clientError.UsesAPIKey)
+	require.False(t, clientError.HasOAKContext)
 	require.Equal(t, "The provided key does not have the required permissions for this endpoint.", clientError.Message)
 }
 
@@ -205,7 +205,7 @@ func TestAuthorizeMorePermissionsRequiredError_OAKCredentials(t *testing.T) {
 
 	clientError, ok := IsAuthorizationClientError(err)
 	require.True(t, ok)
-	require.False(t, clientError.UsesAPIKey)
+	require.True(t, clientError.HasOAKContext)
 }
 
 func TestAuthorizeServerError(t *testing.T) {


### PR DESCRIPTION
When you run `stripe listen -a` it loads webhook endpoints via the API. Previously, it would swallow errors and give the user a misleading error message:
```
you have not defined any webhook endpoints on your account...
```

This fixes it by showing the error response.

Here's the before and after:

```
stripe listen -a --forward-to localhost:1234 --api-key ...
you have not defined any webhook endpoints on your account, go to the Stripe Dashboard to add some: https://dashboard.stripe.com/test/webhooks
```
```
go run cmd/stripe/main.go listen -a --forward-to localhost:1234 --api-key ...     
Permission denied. The provided key 'rk_live_...tdxQ' does not have the required permissions for this endpoint on account 'acct_1NRKwLLJDmqA11cn'. Enabling Webhook Endpoints, Event Destinations Read ('webhook_read') permissions on this key would allow thisrequest to continue. You can edit permissions at https://dashboard.stripe.com/b/acct_1NRKwLLJDmqA11cn?destination=%2Fapikeys%2Fmk_1UEd7ELJDmqA11cnG4gZSEXA%2Fedit
```

With OAuth, we show a custom error message because the resolution is different:
```
go run cmd/stripe/main.go listen -a --live --forward-to localhost:1234                                                                                                                      
You don't have permission to do this with your current role. Ask an account administrator to assign you a different role with more permissions.
```